### PR TITLE
refactor: rename CLI from sry to sentry-cli-next

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Guide
 
-This guide explains how to develop and test the sry CLI and OAuth proxy locally.
+This guide explains how to develop and test the Sentry CLI and OAuth proxy locally.
 
 ## Prerequisites
 
@@ -10,11 +10,11 @@ This guide explains how to develop and test the sry CLI and OAuth proxy locally.
 ## Project Structure
 
 ```
-sry/
+sentry-cli-next/
 ├── apps/
 │   └── oauth-proxy/     # Hono server for device flow OAuth
 └── packages/
-    └── cli/             # The sry CLI
+    └── cli/             # The Sentry CLI
 ```
 
 ## Setup
@@ -28,8 +28,8 @@ bun install
 2. Create a `.env` file in the project root:
 
 ```
-SRY_CLIENT_ID=your-sentry-oauth-client-id
-SRY_CLIENT_SECRET=your-sentry-oauth-client-secret
+SENTRY_CLIENT_ID=your-sentry-oauth-client-id
+SENTRY_CLIENT_SECRET=your-sentry-oauth-client-secret
 ```
 
 Get these from your Sentry OAuth application settings.
@@ -51,7 +51,7 @@ This starts the proxy on `http://127.0.0.1:8723` (matching your Sentry OAuth app
 
 ```bash
 cd packages/cli
-SRY_OAUTH_PROXY_URL=http://127.0.0.1:8723 bun run src/bin.ts auth login
+SENTRY_OAUTH_PROXY_URL=http://127.0.0.1:8723 bun run src/bin.ts auth login
 ```
 
 ## Testing the Device Flow
@@ -62,7 +62,7 @@ SRY_OAUTH_PROXY_URL=http://127.0.0.1:8723 bun run src/bin.ts auth login
 
 ```bash
 cd packages/cli
-SRY_OAUTH_PROXY_URL=http://127.0.0.1:8723 bun run src/bin.ts auth login
+SENTRY_OAUTH_PROXY_URL=http://127.0.0.1:8723 bun run src/bin.ts auth login
 ```
 
 3. You'll see output like:
@@ -104,16 +104,16 @@ When creating your Sentry OAuth application, set:
 
 ### OAuth Proxy
 
-| Variable            | Description                    |
-| ------------------- | ------------------------------ |
-| `SRY_CLIENT_ID`     | Sentry OAuth app client ID     |
-| `SRY_CLIENT_SECRET` | Sentry OAuth app client secret |
+| Variable               | Description                    |
+| ---------------------- | ------------------------------ |
+| `SENTRY_CLIENT_ID`     | Sentry OAuth app client ID     |
+| `SENTRY_CLIENT_SECRET` | Sentry OAuth app client secret |
 
 ### CLI
 
-| Variable              | Description     | Default                        |
-| --------------------- | --------------- | ------------------------------ |
-| `SRY_OAUTH_PROXY_URL` | OAuth proxy URL | `https://sry-oauth.vercel.app` |
+| Variable                 | Description     | Default                        |
+| ------------------------ | --------------- | ------------------------------ |
+| `SENTRY_OAUTH_PROXY_URL` | OAuth proxy URL | `https://sry-oauth.vercel.app` |
 
 ## Deploying the OAuth Proxy
 
@@ -122,8 +122,8 @@ cd apps/oauth-proxy
 bunx vercel
 
 # Set environment variables in Vercel dashboard or via CLI:
-bunx vercel env add SRY_CLIENT_ID
-bunx vercel env add SRY_CLIENT_SECRET
+bunx vercel env add SENTRY_CLIENT_ID
+bunx vercel env add SENTRY_CLIENT_SECRET
 ```
 
 After deployment, update the default `OAUTH_PROXY_URL` in `packages/cli/src/lib/oauth.ts` to your Vercel URL.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sry
+# sentry-cli-next
 
 A gh-like CLI for Sentry.
 
@@ -6,7 +6,7 @@ A gh-like CLI for Sentry.
 
 ```bash
 # Login via OAuth (device flow)
-sry auth login
+sentry auth login
 ```
 
 You'll be given a URL and a code to enter. Once you authorize, the CLI will automatically receive your token.
@@ -14,7 +14,7 @@ You'll be given a URL and a code to enter. Once you authorize, the CLI will auto
 Or use an API token directly:
 
 ```bash
-sry auth login --token YOUR_SENTRY_API_TOKEN
+sentry auth login --token YOUR_SENTRY_API_TOKEN
 ```
 
 ## Commands
@@ -22,47 +22,47 @@ sry auth login --token YOUR_SENTRY_API_TOKEN
 ### Auth
 
 ```bash
-sry auth login      # Login via OAuth device flow
-sry auth logout     # Logout
-sry auth status     # Check auth status
+sentry auth login      # Login via OAuth device flow
+sentry auth logout     # Logout
+sentry auth status     # Check auth status
 ```
 
 ### Organizations
 
 ```bash
-sry org list                 # List all orgs
-sry org list --json          # Output as JSON
+sentry org list                 # List all orgs
+sentry org list --json          # Output as JSON
 ```
 
 ### Projects
 
 ```bash
-sry project list                        # List all projects
-sry project list my-org                 # List projects in org
-sry project list --platform javascript  # Filter by platform
+sentry project list                        # List all projects
+sentry project list my-org                 # List projects in org
+sentry project list --platform javascript  # Filter by platform
 ```
 
 ### Issues
 
 ```bash
-sry issue list --org my-org --project my-project     # List issues
-sry issue list --org my-org --project my-project --json
-sry issue get 123456789                              # Get issue by ID
-sry issue get 123456789 --event                      # Include latest event
+sentry issue list --org my-org --project my-project     # List issues
+sentry issue list --org my-org --project my-project --json
+sentry issue get 123456789                              # Get issue by ID
+sentry issue get 123456789 --event                      # Include latest event
 ```
 
 ### API
 
 ```bash
-sry api /organizations/                              # GET request
-sry api /issues/123/ --method PUT --field status=resolved
-sry api /organizations/ --include                    # Show headers
+sentry api /organizations/                              # GET request
+sentry api /issues/123/ --method PUT --field status=resolved
+sentry api /organizations/ --include                    # Show headers
 ```
 
 ## Development
 
 This is a Turborepo monorepo with:
-- `packages/cli` - The sry CLI
+- `packages/cli` - The Sentry CLI
 - `apps/oauth-proxy` - OAuth proxy server (deployed on Vercel)
 
 ```bash
@@ -76,4 +76,4 @@ bun run build                         # Build binary
 
 ## Config
 
-Stored in `~/.sry/config.json` (mode 600).
+Stored in `~/.sentry-cli-next/config.json` (mode 600).

--- a/apps/oauth-proxy/api/index.ts
+++ b/apps/oauth-proxy/api/index.ts
@@ -17,8 +17,8 @@ const SENTRY_OAUTH_AUTHORIZE = "https://sentry.io/oauth/authorize/";
 const SENTRY_OAUTH_TOKEN = "https://sentry.io/oauth/token/";
 
 // These are set in Vercel environment variables
-const CLIENT_ID = process.env.SRY_CLIENT_ID ?? "";
-const CLIENT_SECRET = process.env.SRY_CLIENT_SECRET ?? "";
+const CLIENT_ID = process.env.SENTRY_CLIENT_ID ?? "";
+const CLIENT_SECRET = process.env.SENTRY_CLIENT_SECRET ?? "";
 
 // Device flow configuration
 const DEVICE_CODE_EXPIRES_IN = 900; // 15 minutes
@@ -157,13 +157,13 @@ function authorizePage(error?: string): string {
   return `<!DOCTYPE html>
 <html>
 <head>
-	<title>sry CLI - Authorize</title>
+	<title>Sentry CLI - Authorize</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<style>${HTML_STYLE}</style>
 </head>
 <body>
 	<div class="container">
-		<h1>🔐 sry CLI</h1>
+		<h1>🔐 Sentry CLI</h1>
 		<p class="subtitle">Enter the code shown in your terminal</p>
 		<form method="GET" action="/device/verify">
 			<input type="text" name="user_code" placeholder="XXXX-0000" maxlength="9" required autofocus>
@@ -179,7 +179,7 @@ function successPage(): string {
   return `<!DOCTYPE html>
 <html>
 <head>
-	<title>sry CLI - Success</title>
+	<title>Sentry CLI - Success</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<style>${HTML_STYLE}</style>
 </head>
@@ -196,7 +196,7 @@ function errorPage(message: string): string {
   return `<!DOCTYPE html>
 <html>
 <head>
-	<title>sry CLI - Error</title>
+	<title>Sentry CLI - Error</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<style>${HTML_STYLE}</style>
 </head>
@@ -220,7 +220,7 @@ const app = new Hono();
 app.use("*", cors());
 
 // Health check
-app.get("/", (c) => c.json({ status: "ok", service: "sry-oauth-proxy" }));
+app.get("/", (c) => c.json({ status: "ok", service: "sentry-oauth-proxy" }));
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Device Flow Endpoints

--- a/apps/oauth-proxy/dev.ts
+++ b/apps/oauth-proxy/dev.ts
@@ -17,8 +17,8 @@ const PORT = Number(process.env.PORT) || 8723;
 const SENTRY_OAUTH_AUTHORIZE = "https://sentry.io/oauth/authorize/";
 const SENTRY_OAUTH_TOKEN = "https://sentry.io/oauth/token/";
 
-const CLIENT_ID = process.env.SRY_CLIENT_ID ?? "";
-const CLIENT_SECRET = process.env.SRY_CLIENT_SECRET ?? "";
+const CLIENT_ID = process.env.SENTRY_CLIENT_ID ?? "";
+const CLIENT_SECRET = process.env.SENTRY_CLIENT_SECRET ?? "";
 
 const DEVICE_CODE_EXPIRES_IN = 900;
 const POLLING_INTERVAL = 5;
@@ -39,7 +39,7 @@ const SCOPES = [
 
 if (!(CLIENT_ID && CLIENT_SECRET)) {
   console.error(
-    "❌ Missing SRY_CLIENT_ID or SRY_CLIENT_SECRET. Create a .env file in the project root."
+    "❌ Missing SENTRY_CLIENT_ID or SENTRY_CLIENT_SECRET. Create a .env file in the project root."
   );
   process.exit(1);
 }
@@ -158,13 +158,13 @@ function authorizePage(error?: string): string {
   return `<!DOCTYPE html>
 <html>
 <head>
-	<title>sry CLI - Authorize</title>
+	<title>Sentry CLI - Authorize</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<style>${HTML_STYLE}</style>
 </head>
 <body>
 	<div class="container">
-		<h1>🔐 sry CLI</h1>
+		<h1>🔐 Sentry CLI</h1>
 		<p class="subtitle">Enter the code shown in your terminal</p>
 		<form method="GET" action="/device/verify">
 			<input type="text" name="user_code" placeholder="XXXX-0000" maxlength="9" required autofocus>
@@ -180,7 +180,7 @@ function successPage(): string {
   return `<!DOCTYPE html>
 <html>
 <head>
-	<title>sry CLI - Success</title>
+	<title>Sentry CLI - Success</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<style>${HTML_STYLE}</style>
 </head>
@@ -197,7 +197,7 @@ function errorPage(message: string): string {
   return `<!DOCTYPE html>
 <html>
 <head>
-	<title>sry CLI - Error</title>
+	<title>Sentry CLI - Error</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<style>${HTML_STYLE}</style>
 </head>
@@ -220,7 +220,7 @@ const app = new Hono();
 app.use("*", cors());
 
 app.get("/", (c) =>
-  c.json({ status: "ok", service: "sry-oauth-proxy", mode: "development" })
+  c.json({ status: "ok", service: "sentry-oauth-proxy", mode: "development" })
 );
 
 app.post("/device/code", (c) => {
@@ -422,7 +422,7 @@ Endpoints:
 
 To test with the CLI:
   cd packages/cli
-  SRY_OAUTH_PROXY_URL=http://127.0.0.1:${PORT} bun run src/bin.ts auth login
+  SENTRY_OAUTH_PROXY_URL=http://127.0.0.1:${PORT} bun run src/bin.ts auth login
 `);
 
 export default {

--- a/apps/oauth-proxy/package.json
+++ b/apps/oauth-proxy/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@sry/oauth-proxy",
+  "name": "@sentry/oauth-proxy",
   "version": "0.1.0",
-  "description": "OAuth proxy server for sry CLI device flow",
+  "description": "OAuth proxy server for Sentry CLI device flow",
   "type": "module",
   "scripts": {
     "dev": "bun run --env-file=../../.env dev.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sry",
+  "name": "sentry-cli-next",
   "version": "0.1.0",
   "private": true,
   "description": "A gh-like CLI for Sentry",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "@sry/cli",
+  "name": "@sentry/cli",
   "version": "0.1.0",
   "description": "A gh-like CLI for Sentry",
   "type": "module",
   "bin": {
-    "sry": "./src/bin.ts"
+    "sentry": "./src/bin.ts"
   },
   "scripts": {
     "dev": "bun run src/bin.ts",
-    "build": "fossilize -o sry src/bin.ts",
-    "build:all": "FOSSILIZE_PLATFORMS=darwin-arm64,darwin-x64,linux-x64,linux-arm64,win-x64 fossilize -o sry src/bin.ts",
+    "build": "fossilize -o sentry src/bin.ts",
+    "build:all": "FOSSILIZE_PLATFORMS=darwin-arm64,darwin-x64,linux-x64,linux-arm64,win-x64 fossilize -o sentry src/bin.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/cli/src/app.ts
+++ b/packages/cli/src/app.ts
@@ -16,14 +16,14 @@ const routes = buildRouteMap({
   docs: {
     brief: "A gh-like CLI for Sentry",
     fullDescription:
-      "sry is a command-line interface for interacting with Sentry. " +
+      "sentry is a command-line interface for interacting with Sentry. " +
       "It provides commands for authentication, viewing issues, and making API calls.",
     hideRoute: {},
   },
 });
 
 export const app = buildApplication(routes, {
-  name: "sry",
+  name: "sentry",
   versionInfo: {
     currentVersion: "0.1.0",
   },

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -1,12 +1,12 @@
 /**
- * sry api
+ * sentry api
  *
  * Make raw authenticated API requests to Sentry.
  * Similar to 'gh api' for GitHub.
  */
 
 import { buildCommand } from "@stricli/core";
-import type { SryContext } from "../context.js";
+import type { SentryContext } from "../context.js";
 import { rawApiRequest } from "../lib/api-client.js";
 
 type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
@@ -162,9 +162,9 @@ export const apiCommand = buildCommand({
       "The endpoint should start with '/api/0/' or be a full URL. " +
       "Authentication is handled automatically using your stored credentials.\n\n" +
       "Examples:\n" +
-      "  sry api /api/0/organizations/\n" +
-      "  sry api /api/0/issues/123/ --method PUT --field status=resolved\n" +
-      "  sry api /api/0/projects/my-org/my-project/issues/",
+      "  sentry api /api/0/organizations/\n" +
+      "  sentry api /api/0/issues/123/ --method PUT --field status=resolved\n" +
+      "  sentry api /api/0/projects/my-org/my-project/issues/",
   },
   parameters: {
     positional: {
@@ -211,7 +211,7 @@ export const apiCommand = buildCommand({
     },
   },
   async func(
-    this: SryContext,
+    this: SentryContext,
     flags: ApiFlags,
     endpoint: string
   ): Promise<void> {

--- a/packages/cli/src/commands/auth/index.ts
+++ b/packages/cli/src/commands/auth/index.ts
@@ -12,8 +12,8 @@ export const authRoute = buildRouteMap({
   docs: {
     brief: "Authenticate with Sentry",
     fullDescription:
-      "Manage authentication with Sentry. Use 'sry auth login' to authenticate, " +
-      "'sry auth logout' to remove credentials, and 'sry auth status' to check your authentication status.",
+      "Manage authentication with Sentry. Use 'sentry auth login' to authenticate, " +
+      "'sentry auth logout' to remove credentials, and 'sentry auth status' to check your authentication status.",
     hideRoute: {},
   },
 });

--- a/packages/cli/src/commands/auth/login.ts
+++ b/packages/cli/src/commands/auth/login.ts
@@ -1,5 +1,5 @@
 import { buildCommand, numberParser } from "@stricli/core";
-import type { SryContext } from "../../context.js";
+import type { SentryContext } from "../../context.js";
 import { getConfigPath, isAuthenticated } from "../../lib/config.js";
 import {
   completeOAuthFlow,
@@ -37,13 +37,13 @@ export const loginCommand = buildCommand({
       },
     },
   },
-  async func(this: SryContext, flags: LoginFlags): Promise<void> {
+  async func(this: SentryContext, flags: LoginFlags): Promise<void> {
     const { process } = this;
 
     // Check if already authenticated
     if (isAuthenticated()) {
       process.stdout.write(
-        "You are already authenticated. Use 'sry auth logout' first to re-authenticate.\n"
+        "You are already authenticated. Use 'sentry auth logout' first to re-authenticate.\n"
       );
       return;
     }

--- a/packages/cli/src/commands/auth/logout.ts
+++ b/packages/cli/src/commands/auth/logout.ts
@@ -1,11 +1,11 @@
 /**
- * sry auth logout
+ * sentry auth logout
  *
  * Clear stored authentication credentials.
  */
 
 import { buildCommand } from "@stricli/core";
-import type { SryContext } from "../../context.js";
+import type { SentryContext } from "../../context.js";
 import { clearAuth, getConfigPath, isAuthenticated } from "../../lib/config.js";
 
 export const logoutCommand = buildCommand({
@@ -17,7 +17,7 @@ export const logoutCommand = buildCommand({
   parameters: {
     flags: {},
   },
-  func(this: SryContext): void {
+  func(this: SentryContext): void {
     const { process } = this;
     const { stdout } = process;
 

--- a/packages/cli/src/commands/auth/status.ts
+++ b/packages/cli/src/commands/auth/status.ts
@@ -1,11 +1,11 @@
 /**
- * sry auth status
+ * sentry auth status
  *
  * Display authentication status and verify credentials.
  */
 
 import { buildCommand } from "@stricli/core";
-import type { SryContext } from "../../context.js";
+import type { SentryContext } from "../../context.js";
 import { listOrganizations } from "../../lib/api-client.js";
 import {
   getConfigPath,
@@ -15,7 +15,7 @@ import {
   readConfig,
 } from "../../lib/config.js";
 import { formatExpiration, maskToken } from "../../lib/formatters/human.js";
-import type { SryConfig } from "../../types/index.js";
+import type { SentryConfig } from "../../types/index.js";
 
 type StatusFlags = {
   readonly showToken: boolean;
@@ -26,7 +26,7 @@ type StatusFlags = {
  */
 function writeTokenInfo(
   stdout: NodeJS.WriteStream,
-  config: SryConfig,
+  config: SentryConfig,
   showToken: boolean
 ): void {
   if (!config.auth?.token) {
@@ -104,7 +104,7 @@ export const statusCommand = buildCommand({
       },
     },
   },
-  async func(this: SryContext, flags: StatusFlags): Promise<void> {
+  async func(this: SentryContext, flags: StatusFlags): Promise<void> {
     const { process } = this;
     const { stdout } = process;
 
@@ -115,7 +115,7 @@ export const statusCommand = buildCommand({
 
     if (!authenticated) {
       stdout.write("Status: Not authenticated\n");
-      stdout.write("\nRun 'sry auth login' to authenticate.\n");
+      stdout.write("\nRun 'sentry auth login' to authenticate.\n");
       return;
     }
 

--- a/packages/cli/src/commands/issue/get.ts
+++ b/packages/cli/src/commands/issue/get.ts
@@ -1,11 +1,11 @@
 /**
- * sry issue get
+ * sentry issue get
  *
  * Get detailed information about a Sentry issue.
  */
 
 import { buildCommand } from "@stricli/core";
-import type { SryContext } from "../../context.js";
+import type { SentryContext } from "../../context.js";
 import {
   getIssue,
   getIssueByShortId,
@@ -137,7 +137,7 @@ export const getCommand = buildCommand({
     },
   },
   async func(
-    this: SryContext,
+    this: SentryContext,
     flags: GetFlags,
     issueId: string
   ): Promise<void> {
@@ -155,7 +155,7 @@ export const getCommand = buildCommand({
           stderr.write(
             "Error: Organization is required for short ID lookup.\n\n" +
               "Please specify it using:\n" +
-              `  sry issue get ${issueId} --org <org-slug>\n\n` +
+              `  sentry issue get ${issueId} --org <org-slug>\n\n` +
               "Or set SENTRY_DSN environment variable for automatic detection.\n"
           );
           process.exitCode = 1;

--- a/packages/cli/src/commands/issue/index.ts
+++ b/packages/cli/src/commands/issue/index.ts
@@ -11,7 +11,7 @@ export const issueRoute = buildRouteMap({
     brief: "Manage Sentry issues",
     fullDescription:
       "View and manage issues from your Sentry projects. " +
-      "Use 'sry issue list' to list issues and 'sry issue get <id>' to view issue details.",
+      "Use 'sentry issue list' to list issues and 'sentry issue get <id>' to view issue details.",
     hideRoute: {},
   },
 });

--- a/packages/cli/src/commands/issue/list.ts
+++ b/packages/cli/src/commands/issue/list.ts
@@ -1,11 +1,11 @@
 /**
- * sry issue list
+ * sentry issue list
  *
  * List issues from a Sentry project.
  */
 
 import { buildCommand, numberParser } from "@stricli/core";
-import type { SryContext } from "../../context.js";
+import type { SentryContext } from "../../context.js";
 import { getProject, listIssues } from "../../lib/api-client.js";
 import {
   getCachedProject,
@@ -143,7 +143,7 @@ function writeIssueRows(
  */
 function writeListFooter(stdout: NodeJS.WriteStream): void {
   stdout.write(
-    "\nTip: Use 'sry issue get <SHORT_ID>' to view issue details.\n"
+    "\nTip: Use 'sentry issue get <SHORT_ID>' to view issue details.\n"
   );
 }
 
@@ -152,7 +152,7 @@ export const listCommand = buildCommand({
     brief: "List issues in a project",
     fullDescription:
       "List issues from a Sentry project. Use --org and --project to specify " +
-      "the target, or set defaults with 'sry config set'.",
+      "the target, or set defaults with 'sentry config set'.",
   },
   parameters: {
     flags: {
@@ -193,7 +193,7 @@ export const listCommand = buildCommand({
       },
     },
   },
-  async func(this: SryContext, flags: ListFlags): Promise<void> {
+  async func(this: SentryContext, flags: ListFlags): Promise<void> {
     const { process, cwd } = this;
     const { stdout, stderr } = process;
 
@@ -237,10 +237,10 @@ export const listCommand = buildCommand({
       stderr.write(
         "Error: Organization and project are required.\n\n" +
           "Please specify them using:\n" +
-          "  sry issue list --org <org-slug> --project <project-slug>\n\n" +
+          "  sentry issue list --org <org-slug> --project <project-slug>\n\n" +
           "Or set defaults:\n" +
-          "  sry config set defaults.organization <org-slug>\n" +
-          "  sry config set defaults.project <project-slug>\n\n" +
+          "  sentry config set defaults.organization <org-slug>\n" +
+          "  sentry config set defaults.project <project-slug>\n\n" +
           "Or set SENTRY_DSN environment variable for automatic detection.\n"
       );
       process.exitCode = 1;

--- a/packages/cli/src/commands/org/list.ts
+++ b/packages/cli/src/commands/org/list.ts
@@ -1,11 +1,11 @@
 /**
- * sry org list
+ * sentry org list
  *
  * List organizations the user has access to.
  */
 
 import { buildCommand, numberParser } from "@stricli/core";
-import type { SryContext } from "../../context.js";
+import type { SentryContext } from "../../context.js";
 import { listOrganizations } from "../../lib/api-client.js";
 import {
   calculateOrgSlugWidth,
@@ -24,9 +24,9 @@ export const listCommand = buildCommand({
     fullDescription:
       "List organizations that you have access to.\n\n" +
       "Examples:\n" +
-      "  sry org list\n" +
-      "  sry org list --limit 10\n" +
-      "  sry org list --json",
+      "  sentry org list\n" +
+      "  sentry org list --limit 10\n" +
+      "  sentry org list --json",
   },
   parameters: {
     flags: {
@@ -43,7 +43,7 @@ export const listCommand = buildCommand({
       },
     },
   },
-  async func(this: SryContext, flags: ListFlags): Promise<void> {
+  async func(this: SentryContext, flags: ListFlags): Promise<void> {
     const { process } = this;
     const { stdout, stderr } = process;
 

--- a/packages/cli/src/commands/project/list.ts
+++ b/packages/cli/src/commands/project/list.ts
@@ -1,11 +1,11 @@
 /**
- * sry project list
+ * sentry project list
  *
  * List projects in an organization.
  */
 
 import { buildCommand, numberParser } from "@stricli/core";
-import type { SryContext } from "../../context.js";
+import type { SentryContext } from "../../context.js";
 import { listOrganizations, listProjects } from "../../lib/api-client.js";
 import { getDefaultOrganization } from "../../lib/config.js";
 import {
@@ -97,11 +97,11 @@ export const listCommand = buildCommand({
       "List projects in an organization. If no organization is specified, " +
       "uses the default organization or lists projects from all accessible organizations.\n\n" +
       "Examples:\n" +
-      "  sry project list\n" +
-      "  sry project list --org my-org\n" +
-      "  sry project list --limit 10\n" +
-      "  sry project list --json\n" +
-      "  sry project list --platform javascript",
+      "  sentry project list\n" +
+      "  sentry project list --org my-org\n" +
+      "  sentry project list --limit 10\n" +
+      "  sentry project list --json\n" +
+      "  sentry project list --platform javascript",
   },
   parameters: {
     positional: {
@@ -141,7 +141,7 @@ export const listCommand = buildCommand({
     },
   },
   async func(
-    this: SryContext,
+    this: SentryContext,
     flags: ListFlags,
     orgArg?: string
   ): Promise<void> {

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -9,16 +9,16 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import type { StricliContext } from "@stricli/core";
 
-export interface SryContext extends StricliContext {
+export interface SentryContext extends StricliContext {
   readonly env: NodeJS.ProcessEnv;
   readonly cwd: string;
   readonly homeDir: string;
   readonly configDir: string;
 }
 
-export function buildContext(process: NodeJS.Process): SryContext {
+export function buildContext(process: NodeJS.Process): SentryContext {
   const homeDir = homedir();
-  const configDir = join(homeDir, ".sry");
+  const configDir = join(homeDir, ".sentry-cli-next");
 
   return {
     process,

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -90,7 +90,7 @@ function getAuthHeaders(): Record<string, string> {
 
   if (!token) {
     throw new SentryApiError(
-      "Not authenticated. Run 'sry auth login' first.",
+      "Not authenticated. Run 'sentry auth login' first.",
       401
     );
   }
@@ -143,7 +143,7 @@ export async function apiRequest<T>(
 }
 
 /**
- * Make a raw API request (for the 'sry api' command)
+ * Make a raw API request (for the 'sentry api' command)
  */
 export async function rawApiRequest(
   endpoint: string,

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,7 +1,7 @@
 /**
  * Configuration Management
  *
- * Handles reading/writing the ~/.sry/config.json file.
+ * Handles reading/writing the ~/.sentry-cli-next/config.json file.
  * Permissions follow SSH conventions for sensitive files.
  *
  * @see https://superuser.com/a/215506/26230
@@ -10,9 +10,9 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { CachedProject, SryConfig } from "../types/index.js";
+import type { CachedProject, SentryConfig } from "../types/index.js";
 
-const CONFIG_DIR = join(homedir(), ".sry");
+const CONFIG_DIR = join(homedir(), ".sentry-cli-next");
 const CONFIG_FILE = join(CONFIG_DIR, "config.json");
 
 /**
@@ -31,13 +31,13 @@ function ensureConfigDir(): void {
 /**
  * Read the configuration file
  */
-export function readConfig(): SryConfig {
+export function readConfig(): SentryConfig {
   try {
     if (!existsSync(CONFIG_FILE)) {
       return {};
     }
     const content = readFileSync(CONFIG_FILE, "utf-8");
-    return JSON.parse(content) as SryConfig;
+    return JSON.parse(content) as SentryConfig;
   } catch {
     return {};
   }
@@ -46,7 +46,7 @@ export function readConfig(): SryConfig {
 /**
  * Write the configuration file
  */
-export function writeConfig(config: SryConfig): void {
+export function writeConfig(config: SentryConfig): void {
   ensureConfigDir();
   writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), {
     mode: 0o600,
@@ -56,7 +56,7 @@ export function writeConfig(config: SryConfig): void {
 /**
  * Update specific fields in the configuration
  */
-export function updateConfig(updates: Partial<SryConfig>): SryConfig {
+export function updateConfig(updates: Partial<SentryConfig>): SentryConfig {
   const config = readConfig();
   const newConfig = { ...config, ...updates };
   writeConfig(newConfig);

--- a/packages/cli/src/lib/oauth.ts
+++ b/packages/cli/src/lib/oauth.ts
@@ -14,7 +14,7 @@ import { setAuthToken } from "./config.js";
 
 // OAuth proxy server URL - handles the actual OAuth flow with Sentry
 const OAUTH_PROXY_URL =
-  process.env.SRY_OAUTH_PROXY_URL ?? "https://sry-oauth.vercel.app";
+  process.env.SENTRY_OAUTH_PROXY_URL ?? "https://sry-oauth.vercel.app";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -180,7 +180,7 @@ export async function performDeviceFlow(
         // Token expired
         if (error.code === "expired_token") {
           throw new Error(
-            "Device code expired. Please run 'sry auth login' again."
+            "Device code expired. Please run 'sentry auth login' again."
           );
         }
 

--- a/packages/cli/src/types/config.ts
+++ b/packages/cli/src/types/config.ts
@@ -1,12 +1,12 @@
 /**
  * Configuration Types
  *
- * Types for the sry CLI configuration file.
+ * Types for the Sentry CLI configuration file.
  */
 
 import type { CachedProject } from "./dsn.js";
 
-export type SryConfig = {
+export type SentryConfig = {
   auth?: {
     token?: string;
     refreshToken?: string;

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -1,11 +1,11 @@
 /**
- * Type definitions for the sry CLI
+ * Type definitions for the Sentry CLI
  *
  * Re-exports all types from domain-specific modules.
  */
 
 // Configuration types
-export type { SryConfig } from "./config.js";
+export type { SentryConfig } from "./config.js";
 
 // DSN types
 export type {


### PR DESCRIPTION
## Summary

- Rename monorepo from `sry` to `sentry-cli-next`
- Rename CLI binary from `sry` to `sentry`
- Rename npm packages to `@sentry/cli` and `@sentry/oauth-proxy`

## Changes

### Package Names
- Root: `sry` → `sentry-cli-next`
- CLI: `@sry/cli` → `@sentry/cli`
- OAuth Proxy: `@sry/oauth-proxy` → `@sentry/oauth-proxy`

### Config & Environment
- Config directory: `~/.sry/` → `~/.sentry-cli-next/`
- Environment variables: `SRY_*` → `SENTRY_*`

### Types
- `SryConfig` → `SentryConfig`
- `SryContext` → `SentryContext`

### Documentation
- Updated all command examples and references in README.md and DEVELOPMENT.md