### PR TITLE
feat(auth): add QR code display for mobile OAuth flow

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,20 +12,22 @@
       },
     },
     "packages/cli": {
-      "name": "@sentry/cli",
-      "version": "0.1.0",
+      "name": "@betegon/sentry",
+      "version": "0.2.0",
       "bin": {
-        "sentry": "./src/bin.ts",
+        "sentry": "./bin/sentry",
       },
       "dependencies": {
         "@ast-grep/napi": "^0.31.0",
         "@stricli/auto-complete": "^1.2.4",
         "@stricli/core": "^1.2.4",
+        "qrcode-terminal": "^0.12.0",
         "zod": "^3.24.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/node": "^20",
+        "@types/qrcode-terminal": "^0.12.2",
         "typescript": "^5",
       },
     },
@@ -50,6 +52,8 @@
     "@ast-grep/napi-win32-ia32-msvc": ["@ast-grep/napi-win32-ia32-msvc@0.31.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-PTyEPvJgNuvzj0kWyR9/0+AAL13LftvGijp5sZ0lgXIpig8MfF3czIU62Nf6AMpABhsu0h+u4KmD4DaMxdw0EA=="],
 
     "@ast-grep/napi-win32-x64-msvc": ["@ast-grep/napi-win32-x64-msvc@0.31.1", "", { "os": "win32", "cpu": "x64" }, "sha512-tEgj2Fp2Pi5qXXDLR3AWkZwQTj8yeSN3I7Pvw2DOfINu9imE2EY+Aq5kOhfvduGWVPmP8az68xUFC4b29+yrUw=="],
+
+    "@betegon/sentry": ["@betegon/sentry@workspace:packages/cli"],
 
     "@biomejs/biome": ["@biomejs/biome@2.3.8", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.8", "@biomejs/cli-darwin-x64": "2.3.8", "@biomejs/cli-linux-arm64": "2.3.8", "@biomejs/cli-linux-arm64-musl": "2.3.8", "@biomejs/cli-linux-x64": "2.3.8", "@biomejs/cli-linux-x64-musl": "2.3.8", "@biomejs/cli-win32-arm64": "2.3.8", "@biomejs/cli-win32-x64": "2.3.8" }, "bin": { "biome": "bin/biome" } }, "sha512-Qjsgoe6FEBxWAUzwFGFrB+1+M8y/y5kwmg5CHac+GSVOdmOIqsAiXM5QMVGZJ1eCUCLlPZtq4aFAQ0eawEUuUA=="],
 
@@ -77,19 +81,19 @@
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
 
-    "@sentry/cli": ["@sentry/cli@workspace:packages/cli"],
-
     "@stricli/auto-complete": ["@stricli/auto-complete@1.2.4", "", { "dependencies": { "@stricli/core": "^1.2.4" }, "bin": { "auto-complete": "dist/bin/cli.js" } }, "sha512-MxGgeBbFyH+YtzhIjJeOr68NSx0r8mn4+hWRGgWn31YTG9u0Oa2y9oGHPY+PHeoTfvS7vhgllFvOrHcTVpwTrA=="],
 
     "@stricli/core": ["@stricli/core@1.2.4", "", {}, "sha512-ujvJDQpC2FINWvlTjkFz+Qzw/vsB8p/LyZEW18idisqIyjXR6yb+sF3WTUPksl+5ZON5r4fHQnCqQWnJxeqSzg=="],
 
     "@trpc/server": ["@trpc/server@11.7.2", "", { "peerDependencies": { "typescript": ">=5.7.2" } }, "sha512-AgB26PXY69sckherIhCacKLY49rxE2XP5h38vr/KMZTbLCL1p8IuIoKPjALTcugC2kbyQ7Lbqo2JDVfRSmPmfQ=="],
 
-    "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+    "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
 
     "@types/node": ["@types/node@20.19.26", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-0l6cjgF0XnihUpndDhk+nyD3exio3iKaYROSgvh/qSevPXax3L8p5DBRFjbvalnwatGgHEQn2R88y2fA3g4irg=="],
 
-    "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+    "@types/qrcode-terminal": ["@types/qrcode-terminal@0.12.2", "", {}, "sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q=="],
+
+    "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
     "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
@@ -122,6 +126,8 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
+
+    "qrcode-terminal": ["qrcode-terminal@0.12.0", "", { "bin": { "qrcode-terminal": "./bin/qrcode-terminal.js" } }, "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,12 +19,14 @@
   "devDependencies": {
     "@types/bun": "latest",
     "@types/node": "^20",
+    "@types/qrcode-terminal": "^0.12.2",
     "typescript": "^5"
   },
   "dependencies": {
     "@ast-grep/napi": "^0.31.0",
     "@stricli/auto-complete": "^1.2.4",
     "@stricli/core": "^1.2.4",
+    "qrcode-terminal": "^0.12.0",
     "zod": "^3.24.0"
   }
 }

--- a/packages/cli/src/lib/qrcode.ts
+++ b/packages/cli/src/lib/qrcode.ts
@@ -1,0 +1,56 @@
+/**
+ * QR Code Utilities
+ *
+ * Terminal QR code generation for authentication flows.
+ * Uses qrcode-terminal for rendering QR codes in the terminal.
+ */
+
+import qrcodeTerminal from "qrcode-terminal";
+import { z } from "zod";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schema & Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * QR code generation options schema
+ */
+export const QRCodeOptionsSchema = z.object({
+  /**
+   * Use compact (small) QR code rendering.
+   * Recommended for terminal display.
+   */
+  small: z.boolean().default(true),
+});
+
+export type QRCodeOptions = z.infer<typeof QRCodeOptionsSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Generate a QR code string for terminal display
+ *
+ * @param data - The data to encode in the QR code (typically a URL)
+ * @param options - QR code generation options
+ * @returns The QR code as a string suitable for terminal output
+ *
+ * @example
+ * ```ts
+ * const qr = await generateQRCode("https://example.com/auth?code=ABC123");
+ * process.stdout.write(qr);
+ * ```
+ */
+export function generateQRCode(
+  data: string,
+  options?: Partial<QRCodeOptions>
+): Promise<string> {
+  const opts = QRCodeOptionsSchema.parse(options ?? {});
+
+  return new Promise((resolve) => {
+    qrcodeTerminal.generate(data, { small: opts.small }, (qrcode) => {
+      resolve(qrcode);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add QR code display to `sentry auth login` for mobile-friendly OAuth authentication
- Users can scan the QR code with their mobile device to complete auth without manually entering the code
- Add `--no-qr` flag to disable QR code display if terminal doesn't render it well

## Changes

- **New file:** `packages/cli/src/lib/qrcode.ts` - QR code utility with Zod schema validation
- **Updated:** `packages/cli/src/commands/auth/login.ts` - Added `--qr` flag and QR code display
- **Dependencies:** Added `qrcode-terminal` and `@types/qrcode-terminal`

## Usage

```bash
# Default: shows QR code
sentry auth login

# Disable QR code
sentry auth login --no-qr
```

## Example Output

```
Starting authentication...

Opening browser...

Scan this QR code or visit the URL below:

▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
█ ▄▄▄▄▄ █▀▄█ ▀█▀██ ▄▄▄▄▄ █
...

URL: https://sentry.io/oauth/device/
Code: ABCD-1234

Waiting for authorization...
```