### PR TITLE
feat(event): add event get command and refactor target resolution

### DIFF
--- a/packages/cli/src/app.ts
+++ b/packages/cli/src/app.ts
@@ -1,6 +1,7 @@
 import { buildApplication, buildRouteMap } from "@stricli/core";
 import { apiCommand } from "./commands/api.js";
 import { authRoute } from "./commands/auth/index.js";
+import { eventRoute } from "./commands/event/index.js";
 import { issueRoute } from "./commands/issue/index.js";
 import { orgRoute } from "./commands/org/index.js";
 import { projectRoute } from "./commands/project/index.js";
@@ -11,6 +12,7 @@ const routes = buildRouteMap({
     org: orgRoute,
     project: projectRoute,
     issue: issueRoute,
+    event: eventRoute,
     api: apiCommand,
   },
   docs: {

--- a/packages/cli/src/commands/event/get.ts
+++ b/packages/cli/src/commands/event/get.ts
@@ -1,0 +1,117 @@
+/**
+ * sentry event get
+ *
+ * Get detailed information about a Sentry event.
+ */
+
+import { buildCommand } from "@stricli/core";
+import type { SentryContext } from "../../context.js";
+import { getEvent } from "../../lib/api-client.js";
+import { formatEventDetails } from "../../lib/formatters/human.js";
+import { writeJson } from "../../lib/formatters/json.js";
+import { resolveOrgAndProject } from "../../lib/resolve-target.js";
+import type { SentryEvent } from "../../types/index.js";
+
+type GetFlags = {
+  readonly org?: string;
+  readonly project?: string;
+  readonly json: boolean;
+};
+
+/**
+ * Write human-readable event output to stdout.
+ *
+ * @param stdout - Output stream
+ * @param event - The event to display
+ * @param detectedFrom - Optional source description for auto-detection
+ */
+function writeHumanOutput(
+  stdout: NodeJS.WriteStream,
+  event: SentryEvent,
+  detectedFrom?: string
+): void {
+  const lines = formatEventDetails(event, `Event ${event.eventID}`);
+
+  // Skip leading empty line for standalone display
+  const output = lines.slice(1);
+  stdout.write(`${output.join("\n")}\n`);
+
+  if (detectedFrom) {
+    stdout.write(`\nDetected from ${detectedFrom}\n`);
+  }
+}
+
+export const getCommand = buildCommand({
+  docs: {
+    brief: "Get details of a specific event",
+    fullDescription:
+      "Retrieve detailed information about a Sentry event by its ID.\n\n" +
+      "The organization and project are resolved from:\n" +
+      "  1. --org and --project flags\n" +
+      "  2. Config defaults\n" +
+      "  3. SENTRY_DSN environment variable or source code detection",
+  },
+  parameters: {
+    positional: {
+      kind: "tuple",
+      parameters: [
+        {
+          brief:
+            "Event ID (hexadecimal, e.g., 9999aaaaca8b46d797c23c6077c6ff01)",
+          parse: String,
+        },
+      ],
+    },
+    flags: {
+      org: {
+        kind: "parsed",
+        parse: String,
+        brief: "Organization slug",
+        optional: true,
+      },
+      project: {
+        kind: "parsed",
+        parse: String,
+        brief: "Project slug",
+        optional: true,
+      },
+      json: {
+        kind: "boolean",
+        brief: "Output as JSON",
+        default: false,
+      },
+    },
+  },
+  async func(
+    this: SentryContext,
+    flags: GetFlags,
+    eventId: string
+  ): Promise<void> {
+    const { process, cwd } = this;
+    const { stdout } = process;
+
+    const target = await resolveOrgAndProject({
+      org: flags.org,
+      project: flags.project,
+      cwd,
+    });
+
+    if (!target) {
+      throw new Error(
+        "Organization and project are required to fetch an event.\n\n" +
+          "Please specify them using:\n" +
+          `  sentry event get ${eventId} --org <org-slug> --project <project-slug>\n\n` +
+          "Or set SENTRY_DSN environment variable for automatic detection."
+      );
+    }
+
+    const event = await getEvent(target.org, target.project, eventId);
+
+    if (flags.json) {
+      writeJson(stdout, event);
+      return;
+    }
+
+    writeHumanOutput(stdout, event, target.detectedFrom);
+  },
+});

--- a/packages/cli/src/commands/event/index.ts
+++ b/packages/cli/src/commands/event/index.ts
@@ -1,0 +1,15 @@
+import { buildRouteMap } from "@stricli/core";
+import { getCommand } from "./get.js";
+
+export const eventRoute = buildRouteMap({
+  routes: {
+    get: getCommand,
+  },
+  docs: {
+    brief: "View Sentry events",
+    fullDescription:
+      "View detailed event data from Sentry. " +
+      "Use 'sentry event get <event-id>' to view a specific event.",
+    hideRoute: {},
+  },
+});

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -279,6 +279,20 @@ export function getLatestEvent(issueId: string): Promise<SentryEvent> {
 }
 
 /**
+ * Get a specific event by ID
+ * @see https://docs.sentry.io/api/events/retrieve-an-event-for-a-project/
+ */
+export function getEvent(
+  orgSlug: string,
+  projectSlug: string,
+  eventId: string
+): Promise<SentryEvent> {
+  return apiRequest<SentryEvent>(
+    `/projects/${orgSlug}/${projectSlug}/events/${eventId}/`
+  );
+}
+
+/**
  * Update an issue's status
  */
 export function updateIssueStatus(

--- a/packages/cli/src/lib/formatters/human.ts
+++ b/packages/cli/src/lib/formatters/human.ts
@@ -181,13 +181,20 @@ export function formatIssueDetails(issue: SentryIssue): string[] {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Format event details
+ * Format event details for display.
+ *
+ * @param event - The Sentry event to format
+ * @param header - Optional header text (defaults to "Latest Event")
+ * @returns Array of formatted lines
  */
-export function formatEventDetails(event: SentryEvent): string[] {
+export function formatEventDetails(
+  event: SentryEvent,
+  header = "Latest Event"
+): string[] {
   const lines: string[] = [];
 
   lines.push("");
-  lines.push("─── Latest Event ───");
+  lines.push(`─── ${header} ───`);
   lines.push("");
   lines.push(`Event ID:   ${event.eventID}`);
   lines.push(`Received:   ${new Date(event.dateReceived).toLocaleString()}`);

--- a/packages/cli/test/e2e/event.test.ts
+++ b/packages/cli/test/e2e/event.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Event Command E2E Tests
+ *
+ * Tests for sentry event get command.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { setAuthToken } from "../../src/lib/config.js";
+import { runCli } from "../fixture.js";
+
+const TEST_TOKEN = process.env.SENTRY_TEST_AUTH_TOKEN;
+const TEST_ORG = process.env.SENTRY_TEST_ORG;
+const TEST_PROJECT = process.env.SENTRY_TEST_PROJECT;
+
+if (!(TEST_TOKEN && TEST_ORG && TEST_PROJECT)) {
+  throw new Error(
+    "SENTRY_TEST_AUTH_TOKEN, SENTRY_TEST_ORG, and SENTRY_TEST_PROJECT environment variables are required for E2E tests"
+  );
+}
+
+let testConfigDir: string;
+let originalConfigDir: string | undefined;
+
+beforeEach(() => {
+  originalConfigDir = process.env.SENTRY_CLI_CONFIG_DIR;
+  testConfigDir = join(
+    process.env.SENTRY_CLI_CONFIG_DIR || "/tmp",
+    `e2e-event-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(testConfigDir, { recursive: true });
+  process.env.SENTRY_CLI_CONFIG_DIR = testConfigDir;
+});
+
+afterEach(() => {
+  try {
+    rmSync(testConfigDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+  if (originalConfigDir) {
+    process.env.SENTRY_CLI_CONFIG_DIR = originalConfigDir;
+  } else {
+    delete process.env.SENTRY_CLI_CONFIG_DIR;
+  }
+});
+
+describe("sentry event get", () => {
+  test("requires authentication", async () => {
+    const result = await runCli(
+      ["event", "get", "abc123", "--org", TEST_ORG, "--project", TEST_PROJECT],
+      { env: { SENTRY_CLI_CONFIG_DIR: testConfigDir } }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr + result.stdout).toMatch(/not authenticated|login/i);
+  });
+
+  test("requires org and project without DSN", async () => {
+    await setAuthToken(TEST_TOKEN);
+
+    const result = await runCli(["event", "get", "abc123"], {
+      env: { SENTRY_CLI_CONFIG_DIR: testConfigDir },
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr + result.stdout).toMatch(/organization|project/i);
+  });
+
+  test("handles non-existent event", async () => {
+    await setAuthToken(TEST_TOKEN);
+
+    const result = await runCli(
+      [
+        "event",
+        "get",
+        "nonexistent123",
+        "--org",
+        TEST_ORG,
+        "--project",
+        TEST_PROJECT,
+      ],
+      { env: { SENTRY_CLI_CONFIG_DIR: testConfigDir } }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr + result.stdout).toMatch(/not found|error|404/i);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `sentry event get <event-id>` command and makes `sentry issue get` always include the latest event. Also extracts shared org/project resolution logic to reduce duplication across commands.

## Changes

- New `sentry event get` command with hybrid resolution (flags → config defaults → DSN detection)
- `sentry issue get` now always fetches the latest event (removed `--event` flag)
- Extracted target resolution to `lib/resolve-target.ts` for reuse across commands
- Added validation: providing only `--org` or `--project` (but not both) now errors with a helpful message
- Added E2E tests for the new event command

## Test Plan

```bash
# Run tests
bun test

# Test event get (requires auth)
sentry event get <event-id> --org <org> --project <project>

# Test issue get always includes event
sentry issue get <issue-id> --json  # should have "event" field

# Test partial flag validation
sentry event get abc --org my-org  # should error
```