### PR TITLE
refactor(errors): unify error hierarchy with central handler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,25 +147,24 @@ if (result.success) {
 
 ### Error Handling
 
-```typescript
-// Custom error classes extend Error
-export class SentryApiError extends Error {
-  readonly status: number;
-  constructor(message: string, status: number) {
-    super(message);
-    this.name = "SentryApiError";
-    this.status = status;
-  }
-}
+All CLI errors extend the `CliError` base class from `src/lib/errors.ts`:
 
-// In commands: catch and write to stderr
-try {
-  // ...
-} catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`Error: ${message}\n`);
-  process.exitCode = 1;
-}
+```typescript
+// Error hierarchy in src/lib/errors.ts
+CliError (base)
+├── ApiError (HTTP/API failures - status, detail, endpoint)
+├── AuthError (authentication - reason: 'not_authenticated' | 'expired' | 'invalid')
+├── ConfigError (configuration - suggestion?)
+├── ValidationError (input validation - field?)
+└── DeviceFlowError (OAuth flow - code)
+
+// Usage: throw specific error types
+import { ApiError, AuthError } from "../lib/errors.js";
+throw new AuthError("not_authenticated");
+throw new ApiError("Request failed", 404, "Not found");
+
+// In commands: let errors propagate to central handler
+// The bin.ts entry point catches and formats all errors consistently
 ```
 
 ### Async Config Functions

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -2,5 +2,11 @@
 import { run } from "@stricli/core";
 import { app } from "./app.js";
 import { buildContext } from "./context.js";
+import { formatError, getExitCode } from "./lib/errors.js";
 
-await run(app, process.argv.slice(2), buildContext(process));
+try {
+  await run(app, process.argv.slice(2), buildContext(process));
+} catch (error) {
+  process.stderr.write(`Error: ${formatError(error)}\n`);
+  process.exit(getExitCode(error));
+}

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -217,43 +217,36 @@ export const apiCommand = buildCommand({
     endpoint: string
   ): Promise<void> {
     const { process } = this;
-    const { stdout, stderr } = process;
+    const { stdout } = process;
 
-    try {
-      const body =
-        flags.field?.length > 0 ? parseFields(flags.field) : undefined;
-      const headers =
-        flags.header?.length > 0 ? parseHeaders(flags.header) : undefined;
+    const body = flags.field?.length > 0 ? parseFields(flags.field) : undefined;
+    const headers =
+      flags.header?.length > 0 ? parseHeaders(flags.header) : undefined;
 
-      const response = await rawApiRequest(endpoint, {
-        method: flags.method,
-        body,
-        headers,
-      });
+    const response = await rawApiRequest(endpoint, {
+      method: flags.method,
+      body,
+      headers,
+    });
 
-      // Silent mode - only set exit code
-      if (flags.silent) {
-        if (response.status >= 400) {
-          process.exitCode = 1;
-        }
-        return;
-      }
-
-      // Output headers if requested
-      if (flags.include) {
-        writeResponseHeaders(stdout, response.status, response.headers);
-      }
-
-      // Output body
-      writeResponseBody(stdout, response.body);
-
-      // Set exit code for error responses
+    // Silent mode - only set exit code
+    if (flags.silent) {
       if (response.status >= 400) {
         process.exitCode = 1;
       }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      stderr.write(`Error: ${message}\n`);
+      return;
+    }
+
+    // Output headers if requested
+    if (flags.include) {
+      writeResponseHeaders(stdout, response.status, response.headers);
+    }
+
+    // Output body
+    writeResponseBody(stdout, response.body);
+
+    // Set exit code for error responses
+    if (response.status >= 400) {
       process.exitCode = 1;
     }
   },

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -1,0 +1,201 @@
+/**
+ * CLI Error Hierarchy
+ *
+ * Unified error classes for consistent error handling across the CLI.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Base Error
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Base class for all CLI errors.
+ *
+ * @param message - Error message for display
+ * @param exitCode - Process exit code (default: 1)
+ */
+export class CliError extends Error {
+  readonly exitCode: number;
+
+  constructor(message: string, exitCode = 1) {
+    super(message);
+    this.name = "CliError";
+    this.exitCode = exitCode;
+  }
+
+  /**
+   * Format error for user display. Override in subclasses to add details.
+   */
+  format(): string {
+    return this.message;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// API Errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * API request errors from Sentry.
+ *
+ * @param message - Error summary
+ * @param status - HTTP status code
+ * @param detail - Detailed error message from API response
+ * @param endpoint - API endpoint that failed
+ */
+export class ApiError extends CliError {
+  readonly status: number;
+  readonly detail?: string;
+  readonly endpoint?: string;
+
+  constructor(
+    message: string,
+    status: number,
+    detail?: string,
+    endpoint?: string
+  ) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.detail = detail;
+    this.endpoint = endpoint;
+  }
+
+  override format(): string {
+    let msg = this.message;
+    if (this.detail && this.detail !== this.message) {
+      msg += `\n  ${this.detail}`;
+    }
+    return msg;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Authentication Errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type AuthErrorReason = "not_authenticated" | "expired" | "invalid";
+
+/**
+ * Authentication errors.
+ *
+ * @param reason - Type of auth failure
+ * @param message - Custom message (uses default if not provided)
+ */
+export class AuthError extends CliError {
+  readonly reason: AuthErrorReason;
+
+  constructor(reason: AuthErrorReason, message?: string) {
+    const defaultMessages: Record<AuthErrorReason, string> = {
+      not_authenticated: "Not authenticated. Run 'sentry auth login' first.",
+      expired:
+        "Authentication expired. Run 'sentry auth login' to re-authenticate.",
+      invalid: "Invalid authentication token.",
+    };
+    super(message ?? defaultMessages[reason]);
+    this.name = "AuthError";
+    this.reason = reason;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Configuration Errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Configuration or DSN errors.
+ *
+ * @param message - Error description
+ * @param suggestion - Helpful hint for resolving the error
+ */
+export class ConfigError extends CliError {
+  readonly suggestion?: string;
+
+  constructor(message: string, suggestion?: string) {
+    super(message);
+    this.name = "ConfigError";
+    this.suggestion = suggestion;
+  }
+
+  override format(): string {
+    let msg = this.message;
+    if (this.suggestion) {
+      msg += `\n\nSuggestion: ${this.suggestion}`;
+    }
+    return msg;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation Errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Input validation errors.
+ *
+ * @param message - Validation failure description
+ * @param field - Name of the invalid field
+ */
+export class ValidationError extends CliError {
+  readonly field?: string;
+
+  constructor(message: string, field?: string) {
+    super(message);
+    this.name = "ValidationError";
+    this.field = field;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OAuth Device Flow Errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * OAuth device flow errors (RFC 8628).
+ *
+ * @param code - OAuth error code (e.g., "authorization_pending", "slow_down")
+ * @param description - Human-readable error description
+ */
+export class DeviceFlowError extends CliError {
+  readonly code: string;
+
+  constructor(code: string, description?: string) {
+    super(description ?? code);
+    this.name = "DeviceFlowError";
+    this.code = code;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error Utilities
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Format any error for user display.
+ * Uses CliError.format() for CLI errors, message for standard errors.
+ *
+ * @param error - Any thrown value
+ * @returns Formatted error string
+ */
+export function formatError(error: unknown): string {
+  if (error instanceof CliError) {
+    return error.format();
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+/**
+ * Get process exit code for an error.
+ *
+ * @param error - Any thrown value
+ * @returns Exit code (from CliError.exitCode or 1 for other errors)
+ */
+export function getExitCode(error: unknown): number {
+  if (error instanceof CliError) {
+    return error.exitCode;
+  }
+  return 1;
+}

--- a/packages/cli/src/lib/oauth.ts
+++ b/packages/cli/src/lib/oauth.ts
@@ -11,6 +11,7 @@ import type {
   TokenResponse,
 } from "../types/index.js";
 import { setAuthToken } from "./config.js";
+import { DeviceFlowError } from "./errors.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Configuration
@@ -140,19 +141,6 @@ async function pollForToken(deviceCode: string): Promise<TokenResponse> {
 
   // Return the error response to be handled by the caller
   throw new DeviceFlowError(data.error, data.error_description);
-}
-
-/**
- * Custom error class for device flow errors
- */
-class DeviceFlowError extends Error {
-  readonly code: string;
-
-  constructor(code: string, description?: string) {
-    super(description ?? code);
-    this.name = "DeviceFlowError";
-    this.code = code;
-  }
 }
 
 type PollResult =


### PR DESCRIPTION
## Summary

Introduces a unified error hierarchy and central error handler to fix inconsistent error handling across the CLI. All CLI errors now extend `CliError`, which provides consistent formatting and exit codes.

## Problem

Error handling was inconsistent:
- Multiple unrelated error classes (`SentryApiError`, `DeviceFlowError`, plain `Error`)
- Some commands caught errors and wrote to stderr, others threw
- `detail` field from API errors was never displayed to users
- Mixed output streams (some stderr, some stdout)

## Solution

New error hierarchy in `packages/cli/src/lib/errors.ts`:

```
CliError (base)
├── ApiError (HTTP failures - status, detail, endpoint)
├── AuthError (auth issues - reason: not_authenticated | expired | invalid)
├── ConfigError (config errors - suggestion)
├── ValidationError (input validation - field)
└── DeviceFlowError (OAuth flow - code)
```

Central error handler in `bin.ts` catches unhandled errors and formats them consistently.

## Changes

| File | Change |
|------|--------|
| `src/lib/errors.ts` | New unified error hierarchy |
| `src/lib/api-client.ts` | Use `ApiError`/`AuthError` instead of `SentryApiError` |
| `src/lib/oauth.ts` | Import `DeviceFlowError` from errors module |
| `src/bin.ts` | Add central error handler |
| `src/commands/api.ts` | Remove manual error handling, let errors propagate |
| `src/commands/auth/login.ts` | Use `AuthError` for invalid tokens |
| `src/commands/auth/status.ts` | Use `AuthError`, write errors to stderr |
| `AGENTS.md` | Update error handling documentation |

## Testing

```bash
# Auth error formatting
HOME=/nonexistent sentry auth status
# Should show: "Not authenticated. Run 'sentry auth login' first."

# API error with detail
sentry api /nonexistent
# Should show API error with detail from response

# Exit codes
sentry auth status; echo $?  # Should be 1 on error
```