### PR TITLE
refactor(oauth): add Zod validation for OAuth responses

### DIFF
--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -10,11 +10,16 @@ export type { DetectedDsn, DsnSource, ParsedDsn } from "../lib/dsn/types.js";
 export type { CachedProject, SentryConfig } from "./config.js";
 export { SentryConfigSchema } from "./config.js";
 
-// OAuth types
+// OAuth types and schemas
 export type {
   DeviceCodeResponse,
   TokenErrorResponse,
   TokenResponse,
+} from "./oauth.js";
+export {
+  DeviceCodeResponseSchema,
+  TokenErrorResponseSchema,
+  TokenResponseSchema,
 } from "./oauth.js";
 
 // Sentry API types and schemas

--- a/packages/cli/src/types/oauth.ts
+++ b/packages/cli/src/types/oauth.ts
@@ -1,33 +1,62 @@
 /**
  * OAuth Types
  *
- * Types for OAuth authentication flow.
+ * Types and Zod schemas for OAuth authentication flow (RFC 8628).
  */
 
-export type DeviceCodeResponse = {
-  device_code: string;
-  user_code: string;
-  verification_uri: string;
-  verification_uri_complete?: string;
-  expires_in: number;
-  interval: number;
-};
+import { z } from "zod";
 
-export type TokenResponse = {
-  access_token: string;
-  token_type: string;
-  expires_in: number;
-  expires_at?: string;
-  refresh_token?: string;
-  scope?: string;
-  user?: {
-    id: string;
-    name: string;
-    email: string;
-  };
-};
+// ─────────────────────────────────────────────────────────────────────────────
+// Device Code Response (Step 1 of Device Flow)
+// ─────────────────────────────────────────────────────────────────────────────
 
-export type TokenErrorResponse = {
-  error: string;
-  error_description?: string;
-};
+export const DeviceCodeResponseSchema = z
+  .object({
+    device_code: z.string(),
+    user_code: z.string(),
+    verification_uri: z.string(),
+    verification_uri_complete: z.string().optional(),
+    expires_in: z.number(),
+    interval: z.number(),
+  })
+  .passthrough();
+
+export type DeviceCodeResponse = z.infer<typeof DeviceCodeResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Token Response (Successful authorization)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const TokenResponseSchema = z
+  .object({
+    access_token: z.string(),
+    token_type: z.string(),
+    expires_in: z.number(),
+    expires_at: z.string().optional(),
+    refresh_token: z.string().optional(),
+    scope: z.string().optional(),
+    user: z
+      .object({
+        id: z.string(),
+        name: z.string(),
+        email: z.string(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export type TokenResponse = z.infer<typeof TokenResponseSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Token Error Response (OAuth error during polling)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const TokenErrorResponseSchema = z
+  .object({
+    error: z.string(),
+    error_description: z.string().optional(),
+  })
+  .passthrough();
+
+export type TokenErrorResponse = z.infer<typeof TokenErrorResponseSchema>;


### PR DESCRIPTION
## Summary

Adds runtime validation for OAuth device flow responses using Zod schemas. Previously, responses were cast with `as` type assertions which could hide malformed data. Now validation errors are caught and reported with helpful messages.

## Changes

- Add Zod schemas for all OAuth response types (DeviceCodeResponse, TokenResponse, TokenErrorResponse)
- Replace type assertions with `safeParse` for proper validation
- Wrap validation failures in `ApiError` with clear error messages
- Replace plain `Error` throws with proper error classes (`ConfigError`, `ApiError`, `DeviceFlowError`)
- Add `.passthrough()` to schemas so extra API fields don't cause failures

## Test plan

- Run `bun run typecheck` - passes
- Run `bun test` - existing tests pass (171 pass, failures are pre-existing config test issues)
- Manual: `sentry auth login` still works with valid OAuth server responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)