### PR TITLE
ci(release): grant required permissions to reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     uses: ./.github/workflows/ci.yml
     permissions:
       contents: read
+      actions: read
+      pull-requests: write
     secrets: inherit
 
   release:


### PR DESCRIPTION
When release.yml calls ci.yml as a reusable workflow, the nested jobs
are constrained by the caller's permissions. The test job in ci.yml
needs actions:read and pull-requests:write for codecov, but release.yml
only granted contents:read.
