### PR TITLE
fix(ci): use Craft action directly instead of reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,20 +3,38 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version to release (semver, bump type, or "auto")
-        required: true
-        default: 'auto'
-      force:
-        description: Force release even with blockers
+        description: Version to release (or "auto")
         required: false
+      force:
+        description: Force a release even when there are release-blockers
+        required: false
+      merge_target:
+        description: Target branch to merge into
+        required: false
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   release:
-    uses: getsentry/craft/.github/workflows/release.yml@v2
-    with:
-      version: ${{ inputs.version }}
-      force: ${{ inputs.force }}
-      publish_repo: getsentry/publish
-    secrets: inherit
-    permissions:
-      contents: write
+    runs-on: ubuntu-latest
+    name: Release a new version
+    steps:
+    - name: Get auth token
+      id: token
+      uses: actions/create-github-app-token@v2.2.1
+      with:
+        app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+        private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
+    - uses: actions/checkout@v6
+      with:
+        token: ${{ steps.token.outputs.token }}
+        fetch-depth: 0
+    - name: Prepare release
+      uses: getsentry/craft@v2.19.0
+      env:
+        GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+      with:
+        version: ${{ inputs.version }}
+        force: ${{ inputs.force }}
+        merge_target: ${{ inputs.merge_target }}


### PR DESCRIPTION
## Summary

The reusable Craft workflow has a bug where it runs Craft's internal build/test jobs for external callers (see getsentry/craft#727).

Use the `getsentry/craft@v2` action directly instead, like sentry-python does.