### PR TITLE
fix(ci): correct Craft version tag (no v prefix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         token: ${{ steps.token.outputs.token }}
         fetch-depth: 0
     - name: Prepare release
-      uses: getsentry/craft@2.19.0
+      uses: getsentry/craft@v2
       env:
         GITHUB_TOKEN: ${{ steps.token.outputs.token }}
       with:


### PR DESCRIPTION
Craft tags don't use the `v` prefix - should be `2.19.0` not `v2.19.0`.