### PR TITLE
fix(ci): wrap pre/post release commands in bash -c for proper variable expansion

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,12 +1,16 @@
 minVersion: '2.14.0'
 changelog:
   policy: auto
-preReleaseCommand: npm --no-git-tag-version version ${CRAFT_NEW_VERSION}
+preReleaseCommand: >-
+  node -p "
+    const {execSync} = require('child_process');
+    execSync('npm --no-git-tag-version version ' + process.env.CRAFT_NEW_VERSION).toString();
+  "
 postReleaseCommand: >-
-  npm --no-git-tag-version version preminor --preid=dev &&
-  git diff --quiet || (git commit -anm "meta: Bump new development version
-
-  #skip-changelog" && git pull --rebase && git push)
+  node -p "
+    const {execSync} = require('child_process');
+    execSync('npm --no-git-tag-version version preminor --preid=dev');
+    execSync('git diff --quiet || (git commit -anm \'meta: Bump new development version\\n\\n#skip-changelog\' && git pull --rebase && git push)').toString();"
 requireNames:
   - /^sentry-.+$/
   - /^sentry-.*\.tgz$/


### PR DESCRIPTION
The `preReleaseCommand` was failing because the `${CRAFT_NEW_VERSION}` variable wasn't being expanded correctly. Wrapping in `bash -c` ensures proper shell variable expansion.