### PR TITLE
fix(build): use unique platform-specific binary names for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,15 +114,15 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.target }}" == "windows-x64" ]]; then
-            ./dist/sentry-windows-x64/bin/sentry.exe --help
+            ./dist-bin/sentry-windows-x64.exe --help
           else
-            ./dist/sentry-${{ matrix.target }}/bin/sentry --help
+            ./dist-bin/sentry-${{ matrix.target }} --help
           fi
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: sentry-${{ matrix.target }}
-          path: dist/sentry-*/bin/sentry*
+          path: dist-bin/sentry-*
 
   build-npm:
     name: Build npm Package (Node ${{ matrix.node }})

--- a/script/build.ts
+++ b/script/build.ts
@@ -11,12 +11,12 @@
  *   bun run script/build.ts --target darwin-x64    # Build for specific target (cross-compile)
  *
  * Output structure:
- *   dist/
- *     sentry-darwin-arm64/
- *       bin/sentry
- *     sentry-darwin-x64/
- *       bin/sentry
- *     ...
+ *   dist-bin/
+ *     sentry-darwin-arm64
+ *     sentry-darwin-x64
+ *     sentry-linux-arm64
+ *     sentry-linux-x64
+ *     sentry-windows-x64.exe
  */
 
 import { $ } from "bun";
@@ -55,13 +55,14 @@ function getBunTarget(target: BuildTarget): string {
 /** Build for a single target */
 async function buildTarget(target: BuildTarget): Promise<boolean> {
   const packageName = getPackageName(target);
-  const binaryName = target.os === "win32" ? "sentry.exe" : "sentry";
-  const outfile = `dist/${packageName}/bin/${binaryName}`;
+  const extension = target.os === "win32" ? ".exe" : "";
+  const binaryName = `${packageName}${extension}`;
+  const outfile = `dist-bin/${binaryName}`;
 
   console.log(`  Building ${packageName}...`);
 
   // Create directory structure
-  await $`mkdir -p dist/${packageName}/bin`;
+  await $`mkdir -p dist-bin`;
 
   const result = await Bun.build({
     entrypoints: ["./src/bin.ts"],
@@ -159,8 +160,8 @@ async function build(): Promise<void> {
     console.log(`\nBuilding for ${targets.length} targets`);
   }
 
-  // Clean dist directory
-  await $`rm -rf dist`;
+  // Clean output directory
+  await $`rm -rf dist-bin`;
 
   console.log("");
 


### PR DESCRIPTION
## Summary

Fixes GitHub Release upload failures caused by all binaries having the same name (`sentry` or `sentry.exe`).

Binary names now include the platform suffix to ensure uniqueness:
- `sentry-darwin-arm64`
- `sentry-darwin-x64`
- `sentry-linux-arm64`
- `sentry-linux-x64`
- `sentry-windows-x64.exe`

These names also satisfy the existing `.craft.yml` requirement pattern `/^sentry-.+$/`.