### PR TITLE
ci(release): Fix changelog-preview permissions

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
 
 jobs:
   changelog-preview:


### PR DESCRIPTION
The changelog-preview reusable workflow now requires `statuses: write`
permission to function correctly with GitHub App installations that
declare permissions statically.