### PR TITLE
fix(issue): handle cross-org project slug collisions in alias generation

### DIFF
--- a/src/lib/formatters/human.ts
+++ b/src/lib/formatters/human.ts
@@ -369,8 +369,6 @@ export type FormatShortIdOptions = {
   projectSlug?: string;
   /** Project alias (e.g., "e", "w", "o1:d") for multi-project display */
   projectAlias?: string;
-  /** Common prefix that was stripped to compute the alias (e.g., "spotlight-") */
-  strippedPrefix?: string;
   /** Whether in multi-project mode (shows ALIAS column) */
   isMultiProject?: boolean;
 };
@@ -383,7 +381,7 @@ export type FormatShortIdOptions = {
  *   alias is shown in separate ALIAS column)
  *
  * @param shortId - Full short ID (e.g., "CRAFT-G", "SPOTLIGHT-WEBSITE-A3")
- * @param options - Formatting options (projectSlug, projectAlias, strippedPrefix)
+ * @param options - Formatting options (projectSlug, projectAlias, isMultiProject)
  * @returns Formatted short ID with underline highlights
  */
 export function formatShortId(

--- a/test/lib/alias.test.ts
+++ b/test/lib/alias.test.ts
@@ -160,7 +160,6 @@ describe("buildOrgAwareAliases", () => {
   test("returns empty map for empty input", () => {
     const result = buildOrgAwareAliases([]);
     expect(result.aliasMap.size).toBe(0);
-    expect(result.strippedPrefix).toBe("");
   });
 
   test("single org multiple projects - no collision", () => {
@@ -170,7 +169,6 @@ describe("buildOrgAwareAliases", () => {
     ]);
     expect(result.aliasMap.get("acme:frontend")).toBe("f");
     expect(result.aliasMap.get("acme:backend")).toBe("b");
-    expect(result.strippedPrefix).toBe("");
   });
 
   test("multiple orgs with unique project slugs - no collision", () => {
@@ -180,7 +178,6 @@ describe("buildOrgAwareAliases", () => {
     ]);
     expect(result.aliasMap.get("org1:frontend")).toBe("f");
     expect(result.aliasMap.get("org2:backend")).toBe("b");
-    expect(result.strippedPrefix).toBe("");
   });
 
   test("same project slug in different orgs - collision", () => {
@@ -242,9 +239,9 @@ describe("buildOrgAwareAliases", () => {
       { org: "acme", project: "spotlight-electron" },
       { org: "acme", project: "spotlight-website" },
     ]);
+    // Common prefix "spotlight-" is stripped internally, resulting in short aliases
     expect(result.aliasMap.get("acme:spotlight-electron")).toBe("e");
     expect(result.aliasMap.get("acme:spotlight-website")).toBe("w");
-    expect(result.strippedPrefix).toBe("spotlight-");
   });
 
   test("handles single project", () => {

--- a/test/lib/formatters/human.test.ts
+++ b/test/lib/formatters/human.test.ts
@@ -83,29 +83,26 @@ describe("formatShortId", () => {
       expect(stripAnsi(result)).toBe("FRONTEND-G");
     });
 
-    test("formats spotlight-website with stripped prefix", () => {
+    test("formats spotlight-website in multi-project mode", () => {
       const result = formatShortId("SPOTLIGHT-WEBSITE-2A", {
         projectSlug: "spotlight-website",
         projectAlias: "w",
-        strippedPrefix: "spotlight-",
       });
       expect(stripAnsi(result)).toBe("SPOTLIGHT-WEBSITE-2A");
     });
 
-    test("formats spotlight-electron with stripped prefix", () => {
+    test("formats spotlight-electron in multi-project mode", () => {
       const result = formatShortId("SPOTLIGHT-ELECTRON-4Y", {
         projectSlug: "spotlight-electron",
         projectAlias: "e",
-        strippedPrefix: "spotlight-",
       });
       expect(stripAnsi(result)).toBe("SPOTLIGHT-ELECTRON-4Y");
     });
 
-    test("formats spotlight (no stripped prefix applies) correctly", () => {
+    test("formats spotlight in multi-project mode", () => {
       const result = formatShortId("SPOTLIGHT-73", {
         projectSlug: "spotlight",
         projectAlias: "s",
-        strippedPrefix: "spotlight-",
       });
       expect(stripAnsi(result)).toBe("SPOTLIGHT-73");
     });
@@ -122,7 +119,6 @@ describe("formatShortId", () => {
       const result = formatShortId("spotlight-website-2a", {
         projectSlug: "spotlight-website",
         projectAlias: "w",
-        strippedPrefix: "spotlight-",
       });
       expect(stripAnsi(result)).toBe("SPOTLIGHT-WEBSITE-2A");
     });
@@ -152,7 +148,6 @@ describe("formatShortId", () => {
       const result = formatShortId("spotlight-website-2a", {
         projectSlug: "spotlight-website",
         projectAlias: "w",
-        strippedPrefix: "spotlight-",
       });
       expect(stripAnsi(result)).toBe("SPOTLIGHT-WEBSITE-2A");
     });
@@ -196,7 +191,6 @@ describe("formatShortId", () => {
       const formatted = formatShortId(shortId, {
         projectSlug: "spotlight-website",
         projectAlias: "w",
-        strippedPrefix: "spotlight-",
       });
       expect(stripAnsi(formatted).length).toBe(shortId.length);
     });
@@ -221,7 +215,6 @@ describe("formatShortId", () => {
       const formatted = formatShortId(shortId, {
         projectSlug: "spotlight-electron",
         projectAlias: "e",
-        strippedPrefix: "spotlight-",
       });
       expect(stripAnsi(formatted).length).toBe(shortId.length);
     });
@@ -232,7 +225,6 @@ describe("formatShortId", () => {
       const result = formatShortId("SPOTLIGHT-ELECTRON-4Y", {
         projectSlug: "spotlight-electron",
         projectAlias: "e",
-        strippedPrefix: "spotlight-",
       });
       expect(stripAnsi(result)).toBe("SPOTLIGHT-ELECTRON-4Y");
     });
@@ -241,7 +233,6 @@ describe("formatShortId", () => {
       const result = formatShortId("SPOTLIGHT-WEBSITE-2C", {
         projectSlug: "spotlight-website",
         projectAlias: "w",
-        strippedPrefix: "spotlight-",
       });
       expect(stripAnsi(result)).toBe("SPOTLIGHT-WEBSITE-2C");
     });
@@ -250,7 +241,6 @@ describe("formatShortId", () => {
       const result = formatShortId("SPOTLIGHT-73", {
         projectSlug: "spotlight",
         projectAlias: "s",
-        strippedPrefix: "spotlight-",
       });
       expect(stripAnsi(result)).toBe("SPOTLIGHT-73");
     });
@@ -302,11 +292,10 @@ describe("formatShortId", () => {
       }
     });
 
-    test("multi-project mode applies formatting to alias and suffix", () => {
+    test("multi-project mode applies formatting to suffix", () => {
       const result = formatShortId("SPOTLIGHT-ELECTRON-4Y", {
         projectSlug: "spotlight-electron",
         projectAlias: "e",
-        strippedPrefix: "spotlight-",
       });
       expect(stripAnsi(result)).toBe("SPOTLIGHT-ELECTRON-4Y");
       if (colorsEnabled) {


### PR DESCRIPTION
## Summary

Fixes #48 - Project alias collisions when multiple orgs have the same project slug.

## Problem

The `buildProjectAliasMap` function only considered project slugs when computing aliases, ignoring the organization. This caused collisions when two projects from different orgs had the same slug (e.g., `org1:dashboard` and `org2:dashboard` both got alias `d`), making one project's issues inaccessible via alias shortcuts.

## Solution

- Added `buildOrgAwareAliases()` function that detects cross-org slug collisions
- For colliding slugs: generates `{orgPrefix}-{projectPrefix}` format (e.g., `o1-d`, `o2-d`)
- For unique slugs: preserves existing short alias behavior (e.g., `f`, `b`)
- Stores both hyphenated (`o1-d`) and compact (`o1d`) formats for ease of use

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Single org: `acme:frontend`, `acme:backend` | `f`, `b` | `f`, `b` (unchanged) |
| Multi-org collision: `org1:dashboard`, `org2:dashboard` | Both `d` (bug) | `o1-d`, `o2-d` |

## Testing

Added 10 test cases covering collision detection, org prefix generation, and edge cases.