### PR TITLE
docs(readme): add installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
 
 A gh-like CLI for Sentry.
 
+## Installation
+
+Install globally with your preferred package manager:
+
+```bash
+# npm
+npm install -g sentry
+
+# pnpm
+pnpm add -g sentry
+
+# yarn
+yarn global add sentry
+
+# bun
+bun add -g sentry
+```
+
+Or run directly without installing:
+
+```bash
+npx sentry --help
+pnpm dlx sentry --help
+yarn dlx sentry --help
+bunx sentry --help
+```
+
 ## Setup
 
 ```bash


### PR DESCRIPTION
## Summary

Adds an installation section to the README before the setup/auth section. Users need to install the CLI before they can run `sentry auth login`.

## Changes

- Added installation instructions for npm, pnpm, yarn, and bun
- Added one-off runner examples (npx, bunx)
- Moved setup (auth login) to come after installation