### PR TITLE
fix(issue): use correct fallback for unrecognized alias-suffix inputs

### DIFF
--- a/src/commands/issue/view.ts
+++ b/src/commands/issue/view.ts
@@ -241,8 +241,8 @@ export const viewCommand = buildCommand({
         aliasSuffix.suffix,
         cwd
       );
-      resolved =
-        aliasResult ?? (await resolveShortSuffixId(issueId, flags, cwd));
+      // If alias not found, treat as full short ID (e.g., "CRAFT-G" where "craft" isn't a known alias)
+      resolved = aliasResult ?? (await resolveFullShortId(issueId, flags, cwd));
     } else if (isShortSuffix(issueId)) {
       resolved = await resolveShortSuffixId(issueId, flags, cwd);
     } else if (isShortId(issueId)) {


### PR DESCRIPTION
Fixes issue ID resolution for standard short IDs like CRAFT-G when the prefix is not a known alias. The fallback now correctly calls resolveFullShortId instead of resolveShortSuffixId.