### PR TITLE
docs(issue): update list command tips to reference view instead of get

### DIFF
--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -104,17 +104,17 @@ function writeListFooter(
   switch (mode) {
     case "single":
       stdout.write(
-        "\nTip: Use 'sentry issue get <ID>' to view details (bold part works as shorthand).\n"
+        "\nTip: Use 'sentry issue view <ID>' to view details (bold part works as shorthand).\n"
       );
       break;
     case "multi":
       stdout.write(
-        "\nTip: Use 'sentry issue get <ALIAS>' to view details (see ALIAS column).\n"
+        "\nTip: Use 'sentry issue view <ALIAS>' to view details (see ALIAS column).\n"
       );
       break;
     default:
       stdout.write(
-        "\nTip: Use 'sentry issue get <SHORT_ID>' to view issue details.\n"
+        "\nTip: Use 'sentry issue view <SHORT_ID>' to view issue details.\n"
       );
   }
 }


### PR DESCRIPTION
## Summary

The `writeListFooter()` function in `sentry issue list` was displaying tips that referenced `sentry issue get`, which doesn't exist. The correct command is `sentry issue view`.

## Changes

Updated all three tip messages in `writeListFooter()` to reference the correct command:
- `sentry issue view <ID>` (single project mode)
- `sentry issue view <ALIAS>` (multi-project mode)
- `sentry issue view <SHORT_ID>` (default mode)
