### PR TITLE
fix(install): use correct download URL without 'v' prefix

### DIFF
--- a/install
+++ b/install
@@ -75,10 +75,10 @@ else
   version="$requested_version"
 fi
 
-# Strip leading 'v' if present for display, ensure URL has 'v' prefix
+# Strip leading 'v' if present (releases use version without 'v' prefix)
 version="${version#v}"
 filename="sentry-${os}-${arch}${suffix}"
-url="https://github.com/getsentry/cli/releases/download/v${version}/${filename}"
+url="https://github.com/getsentry/cli/releases/download/${version}/${filename}"
 
 # Install
 install_dir="$HOME/.sentry/bin"


### PR DESCRIPTION
## Summary

Fixes a bug in the install script where all downloads would 404 because the URL used `v0.2.0` instead of `0.2.0`. GitHub releases for this repo use version tags without the `v` prefix.

## Test Plan

```bash
./install --version 0.2.0
$HOME/.sentry/bin/sentry --version  # should output 0.2.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)