### PR TITLE
feat: add install script for easy CLI installation

### DIFF
--- a/docs/src/components/CommandBox.astro
+++ b/docs/src/components/CommandBox.astro
@@ -7,7 +7,7 @@ interface Props {
 
 const { 
   command = "npx sentry@latest", 
-  docsLink = "./getting-started/",
+  docsLink,
   docsText = "Read the docs"
 } = Astro.props;
 ---
@@ -24,13 +24,15 @@ const {
       <span class="copied-text">Copied!</span>
     </button>
   </div>
-  <a href={docsLink} class="docs-link">
-    {docsText}
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M5 12h14"/>
-      <path d="m12 5 7 7-7 7"/>
-    </svg>
-  </a>
+  {docsLink && (
+    <a href={docsLink} class="docs-link">
+      {docsText}
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M5 12h14"/>
+        <path d="m12 5 7 7-7 7"/>
+      </svg>
+    </a>
+  )}
 </div>
 
 <style>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -19,7 +19,9 @@ import FeatureTerminal from '../../components/FeatureTerminal.astro';
 export const base = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : import.meta.env.BASE_URL + '/';
 
 <div class="hero-command">
-<CommandBox command="npx sentry@latest" docsLink="./getting-started/" docsText="Read the docs" />
+<CommandBox command="npm install -g sentry" />
+<CommandBox command="curl https://cli.sentry.dev/install -fsS | bash" />
+<a href="./getting-started/" class="hero-docs-link">Read the docs <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg></a>
 </div>
 
 <Terminal background="custom" />

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -218,8 +218,37 @@ site-search button kbd {
 
 /* Command box in hero - tight to tagline, space below */
 .hero-command {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
   margin-top: 0.5rem;
   margin-bottom: 4rem;
+}
+
+.hero-docs-link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #fff !important;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+  margin-top: 0.5rem;
+}
+
+.hero-docs-link:hover {
+  opacity: 0.8;
+  gap: 0.75rem;
+}
+
+.hero-docs-link svg {
+  transition: transform 0.2s ease;
+}
+
+.hero-docs-link:hover svg {
+  transform: translateX(2px);
 }
 
 /* Stack container - page layout for splash */
@@ -1528,6 +1557,10 @@ nav.sidebar a[aria-current="page"] {
   .hero .tagline {
     font-size: 1rem !important;
     margin: 0 auto !important;
+  }
+
+  .hero-command {
+    align-items: center;
   }
 
   .hero-command .command-box-wrapper {


### PR DESCRIPTION
Add a second command box showing `npm install -g sentry` above the curl install command. Move "Read the docs" link to its own line below both commands. Update CommandBox component to make docsLink optional.