### PR TITLE
docs: add install script section to getting started guide

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -3,9 +3,19 @@ title: Installation
 description: How to install and set up the Sentry CLI
 ---
 
-import PackageManagerCode from '../../components/PackageManagerCode.astro';
+import PackageManagerCode from "../../components/PackageManagerCode.astro";
 
 ## Installation
+
+### Install Script
+
+Install the Sentry CLI using the install script:
+
+```bash
+curl https://cli.sentry.dev/install -fsS | bash
+```
+
+### Package Managers
 
 Install globally with your preferred package manager:
 


### PR DESCRIPTION
Enhances the installation documentation by including a new section for installing the Sentry CLI using a curl command. This addition provides users with an easy one-liner for installation, complementing the existing package manager instructions.