### PR TITLE
fix(ci): correct gh-pages.zip structure for Craft publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Package Docs
         run: |
           cp .nojekyll docs/dist/
-          zip -r gh-pages.zip docs/dist/
+          cd docs/dist && zip -r ../../gh-pages.zip .
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The zip command was creating an archive with files inside docs/dist/
directory. When Craft's gh-pages target extracts this, it only strips
one level, leaving files in a dist/ subdirectory instead of at root.

Changed to zip from inside docs/dist/ so files are at the zip root
level, matching the pattern used in getsentry/craft.
