### PR TITLE
docs: Update base path for cli.sentry.dev domain

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -64,4 +64,5 @@ jobs:
           source-dir: docs/dist/
           preview-branch: gh-pages
           umbrella-dir: pr-preview
+          pages-base-url: cli.sentry.dev
           action: auto

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -2,10 +2,10 @@ import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 
 // Allow base path override via environment variable for PR previews
-const base = process.env.DOCS_BASE_PATH || "/cli";
+const base = process.env.DOCS_BASE_PATH || "/";
 
 export default defineConfig({
-  site: "https://getsentry.github.io",
+  site: "https://cli.sentry.dev",
   base,
   integrations: [
     starlight({
@@ -59,8 +59,8 @@ export default defineConfig({
               
               function isLandingPage() {
                 const path = window.location.pathname;
-                // Works with both /cli (prod) and /pr-preview/pr-XX (preview)
-                return path === '/cli' || path === '/cli/' || 
+                // Works with both / (prod) and /pr-preview/pr-XX (preview)
+                return path === '/' || 
                        /^\\/pr-preview\\/pr-\\d+\\/?$/.test(path);
               }
               


### PR DESCRIPTION
## Summary

The docs site has moved from `getsentry.github.io/cli` to `cli.sentry.dev`. This caused assets to fail loading as they were still being served from `/cli/`.

## Changes

- Change default base path from `/cli` to `/`
- Update site URL to `https://cli.sentry.dev`
- Update landing page detection to work with root path
- Add `pages-base-url` to preview workflow

PR previews continue to work via `DOCS_BASE_PATH` environment variable override in the workflow.

Based on https://github.com/getsentry/craft/pull/734