### PR TITLE
feat: Add global help command using Stricli's defaultCommand

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import { buildApplication, buildRouteMap } from "@stricli/core";
 import { apiCommand } from "./commands/api.js";
 import { authRoute } from "./commands/auth/index.js";
 import { eventRoute } from "./commands/event/index.js";
+import { helpCommand } from "./commands/help.js";
 import { issueRoute } from "./commands/issue/index.js";
 import { orgRoute } from "./commands/org/index.js";
 import { projectRoute } from "./commands/project/index.js";
@@ -9,6 +10,7 @@ import { projectRoute } from "./commands/project/index.js";
 /** Top-level route map containing all CLI commands */
 export const routes = buildRouteMap({
   routes: {
+    help: helpCommand,
     auth: authRoute,
     org: orgRoute,
     project: projectRoute,
@@ -16,12 +18,12 @@ export const routes = buildRouteMap({
     event: eventRoute,
     api: apiCommand,
   },
+  defaultCommand: "help",
   docs: {
     brief: "A gh-like CLI for Sentry",
     fullDescription:
       "sentry is a command-line interface for interacting with Sentry. " +
       "It provides commands for authentication, viewing issues, and making API calls.",
-    hideRoute: {},
   },
 });
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -3,30 +3,13 @@ import { app } from "./app.js";
 import { buildContext } from "./context.js";
 import { formatError, getExitCode } from "./lib/errors.js";
 import { error } from "./lib/formatters/colors.js";
-import { printCustomHelp } from "./lib/help.js";
 import { withTelemetry } from "./lib/telemetry.js";
-
-/**
- * Check if the CLI should show custom help output.
- * Custom help is shown for top-level help requests (no subcommand).
- */
-function shouldShowCustomHelp(args: string[]): boolean {
-  return args.length === 0;
-}
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
   try {
-    await withTelemetry(async () => {
-      // Intercept top-level help before Stricli
-      if (shouldShowCustomHelp(args)) {
-        await printCustomHelp(process.stdout);
-        return;
-      }
-
-      return run(app, args, buildContext(process));
-    });
+    await withTelemetry(async () => run(app, args, buildContext(process)));
   } catch (err) {
     process.stderr.write(`${error("Error:")} ${formatError(err)}\n`);
     process.exit(getExitCode(err));

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -17,8 +17,5 @@ export const authRoute = buildRouteMap({
       "Manage authentication with Sentry. Use 'sentry auth login' to authenticate, " +
       "'sentry auth logout' to remove credentials, 'sentry auth refresh' to manually refresh your token, " +
       "and 'sentry auth status' to check your authentication status.",
-    hideRoute: {
-      refresh: true, // Advanced command, hide from top-level help
-    },
   },
 });

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,0 +1,47 @@
+/**
+ * Help Command
+ *
+ * Provides help information for the CLI.
+ * - `sentry help` or `sentry` (no args): Shows branded help with banner
+ * - `sentry help <command>`: Shows Stricli's detailed help (--helpAll) for that command
+ */
+
+import { buildCommand, run } from "@stricli/core";
+import type { SentryContext } from "../context.js";
+import { printCustomHelp } from "../lib/help.js";
+
+export const helpCommand = buildCommand({
+  docs: {
+    brief: "Display help for a command",
+    fullDescription:
+      "Display help information. Run 'sentry help' for an overview, " +
+      "or 'sentry help <command>' for detailed help on a specific command.",
+  },
+  parameters: {
+    flags: {},
+    positional: {
+      kind: "array",
+      parameter: {
+        brief: "Command to get help for",
+        parse: String,
+        placeholder: "command",
+      },
+    },
+  },
+  // biome-ignore lint/complexity/noBannedTypes: Stricli requires empty object for commands with no flags
+  async func(this: SentryContext, _flags: {}, ...commandPath: string[]) {
+    const { stdout } = this;
+
+    // No args: show branded help
+    if (commandPath.length === 0) {
+      await printCustomHelp(stdout);
+      return;
+    }
+
+    // With args: re-invoke with --helpAll to show full help including hidden items
+    // Use dynamic imports to avoid circular dependency (app.ts imports helpCommand)
+    const { app } = await import("../app.js");
+    const { buildContext } = await import("../context.js");
+    await run(app, [...commandPath, "--helpAll"], buildContext(this.process));
+  },
+});

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,6 +12,7 @@ import { setCommandName } from "./lib/telemetry.js";
 import type { Writer } from "./types/index.js";
 
 export interface SentryContext extends CommandContext {
+  readonly process: NodeJS.Process;
   readonly env: NodeJS.ProcessEnv;
   readonly cwd: string;
   readonly homeDir: string;


### PR DESCRIPTION
## Summary

Replaces the `args.length === 0` hack in `bin.ts` with Stricli's native `defaultCommand` feature for a cleaner implementation.

## Changes

- **New `help` command** (`src/commands/help.ts`): Shows branded help when invoked without args, or delegates to Stricli's `--helpAll` for specific commands (e.g., `sentry help auth`)
- **`defaultCommand: "help"`**: When no command is provided, Stricli now invokes the help command automatically
- **Removed all hidden routes**: `help` and `auth refresh` are now visible in help output
- **Cleaned up `bin.ts`**: Removed the `shouldShowCustomHelp()` function and related logic

## Behavior

| Command | Output |
|---------|--------|
| `sentry` | Branded help (banner + commands) |
| `sentry help` | Branded help |
| `sentry help auth` | Stricli's `--helpAll` output for auth |
| `sentry help auth login` | Stricli's `--helpAll` output for auth login |
| `sentry --help` | Stricli's standard help (includes help in command list) |
| `sentry auth --help` | Stricli's standard help for auth |