### PR TITLE
fix(cli): use package.json version as fallback instead of 0.0.0

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import { buildApplication, buildRouteMap } from "@stricli/core";
+import pkg from "../package.json";
 import { apiCommand } from "./commands/api.js";
 import { authRoute } from "./commands/auth/index.js";
 import { eventRoute } from "./commands/event/index.js";
@@ -31,7 +32,7 @@ declare const SENTRY_CLI_VERSION: string;
 
 /** CLI version string, available for help output and other uses */
 export const CLI_VERSION =
-  typeof SENTRY_CLI_VERSION !== "undefined" ? SENTRY_CLI_VERSION : "0.0.0";
+  typeof SENTRY_CLI_VERSION !== "undefined" ? SENTRY_CLI_VERSION : pkg.version;
 
 export const app = buildApplication(routes, {
   name: "sentry",


### PR DESCRIPTION
## Summary

Fixes `sentry --version` showing `0.0.0` in dev mode. The build-time constant `SENTRY_CLI_VERSION` isn't defined when running via `bun run dev`, so now we fall back to `package.json` version instead of a hardcoded `0.0.0`.

## Test plan

- [x] Run `bun run dev -- --version` → shows `0.4.0-dev.0`
- [x] Production builds unaffected (version still injected at build time)