### PR TITLE
feat(install): auto-add sentry to PATH on install

### DIFF
--- a/docs/public/install
+++ b/docs/public/install
@@ -117,19 +117,19 @@ XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-$HOME/.config}
 current_shell=$(basename "${SHELL:-sh}")
 case $current_shell in
   fish)
-    config_files=("$HOME/.config/fish/config.fish")
+    config_files=("$XDG_CONFIG_HOME/fish/config.fish")
     ;;
   zsh)
     config_files=("$HOME/.zshrc" "$HOME/.zshenv" "$XDG_CONFIG_HOME/zsh/.zshrc" "$XDG_CONFIG_HOME/zsh/.zshenv")
     ;;
   bash)
-    config_files=("$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile" "$XDG_CONFIG_HOME/bash/.bashrc" "$XDG_CONFIG_HOME/bash/.bash_profile")
+    config_files=("$HOME/.bash_profile" "$HOME/.bashrc" "$HOME/.profile" "$XDG_CONFIG_HOME/bash/.bash_profile" "$XDG_CONFIG_HOME/bash/.bashrc")
     ;;
   ash|sh)
     config_files=("$HOME/.profile" "/etc/profile")
     ;;
   *)
-    config_files=("$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile")
+    config_files=("$HOME/.bash_profile" "$HOME/.bashrc" "$HOME/.profile")
     ;;
 esac
 
@@ -162,6 +162,16 @@ if [[ "$no_modify_path" != "true" ]]; then
         ;;
     esac
   fi
+else
+  echo -e "${MUTED}Skipping PATH modification. Manually add to your shell config:${NC}"
+  case $current_shell in
+    fish)
+      echo "  fish_add_path \"$install_dir\""
+      ;;
+    *)
+      echo "  export PATH=\"$install_dir\":\$PATH"
+      ;;
+  esac
 fi
 
 if [[ -n "${GITHUB_ACTIONS:-}" ]] && [[ "${GITHUB_ACTIONS}" == "true" ]] && [[ -n "${GITHUB_PATH:-}" ]]; then


### PR DESCRIPTION
## Summary

Users can now run `sentry` immediately after install (in a new terminal) without manually editing their shell config. The install script automatically adds the bin directory to PATH.

## Changes

- Detects current shell (zsh, bash, fish, ash/sh) and finds the appropriate config file
- Writes `export PATH=/path/to/.sentry/bin:$PATH` (or fish equivalent) to the config
- Supports XDG config locations (e.g., `~/.config/zsh/.zshrc`)
- Skips if PATH is already configured or file isn't writable
- Adds `--no-modify-path` flag for users who prefer manual setup
- Handles GitHub Actions by appending to `$GITHUB_PATH`

Uses expanded absolute paths (matching opencode's approach) rather than `$HOME` variables in the export line.

## Test Plan

1. Run the install script locally
2. Check that the correct line was added to `~/.zshrc` (or appropriate shell config)
3. Open a new terminal and verify `sentry --help` works
4. Test `--no-modify-path` flag skips modification