### PR TITLE
fix(ci): install bun in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
       with:
         token: ${{ steps.token.outputs.token }}
         fetch-depth: 0
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
     - name: Prepare release
       uses: getsentry/craft@v2
       env:


### PR DESCRIPTION
## Summary

Fixes the release workflow failing with `Process "bun" errored with code ENOENT`.

The `.craft.yml` preReleaseCommand uses `bun run script/bump-version.ts`, but bun wasn't installed in the GitHub Actions runner.

## Changes

Adds `oven-sh/setup-bun@v2` step before the Craft release step.

## Test Plan

- Re-run the release workflow via workflow_dispatch
- The preReleaseCommand should complete without ENOENT errors

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)