### PR TITLE
fix(release): use Node.js instead of Bun for release scripts

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -3,8 +3,8 @@ changelog:
   policy: auto
 versioning:
   policy: auto
-preReleaseCommand: bun run script/bump-version.ts --pre
-postReleaseCommand: bun run script/bump-version.ts --post
+preReleaseCommand: node --experimental-strip-types script/bump-version.ts --pre
+postReleaseCommand: node --experimental-strip-types script/bump-version.ts --post
 requireNames:
   - /^sentry-.+$/
   - /^sentry-.*\.tgz$/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,6 @@ jobs:
       with:
         token: ${{ steps.token.outputs.token }}
         fetch-depth: 0
-    - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
     - name: Prepare release
       uses: getsentry/craft@v2
       env:


### PR DESCRIPTION
## Summary

The Craft Docker container (used for publish/post-publish) doesn't have Bun installed, causing release script failures. This PR converts the release scripts to use Node.js instead.

## Changes

- Convert `script/bump-version.ts` to use Node.js APIs (`child_process`, `fs`) instead of Bun-specific APIs
- Update `.craft.yml` to use `node --experimental-strip-types` for pre/post release commands
- Remove the `setup-bun` action from the release workflow (no longer needed)

The script remains TypeScript, leveraging Node.js 22's built-in type stripping feature.