### PR TITLE
fix(release): add Node.js 22 setup for type stripping support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
       with:
         token: ${{ steps.token.outputs.token }}
         fetch-depth: 0
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22
     - name: Prepare release
       uses: getsentry/craft@v2
       env:


### PR DESCRIPTION
## Summary

The release scripts use `node --experimental-strip-types` which requires Node.js 22.6+. The default Node.js on GitHub Actions runners is older, causing the pre-release command to fail with:

```
node: bad option: --experimental-strip-types
```

## Changes

- Add `actions/setup-node@v4` with `node-version: 22` to ensure type stripping works