### PR TITLE
ci: allow PRs to merge when CI jobs are skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,12 +290,13 @@ jobs:
   ci-status:
     name: CI Status
     if: always()
-    needs: [check-skill, merge-artifacts]
+    needs: [changes, check-skill, merge-artifacts]
     runs-on: ubuntu-latest
     permissions: {}
     steps:
       - name: Check CI status
         run: |
+          # Check for explicit failures or cancellations
           results="${{ needs.check-skill.result }} ${{ needs.merge-artifacts.result }}"
           for result in $results; do
             if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
@@ -303,4 +304,16 @@ jobs:
               exit 1
             fi
           done
+
+          # Detect upstream failures: if changes were detected but jobs were skipped,
+          # it means an upstream job failed (skipped jobs cascade to dependents)
+          if [[ "${{ needs.changes.outputs.code }}" == "true" && "${{ needs.merge-artifacts.result }}" == "skipped" ]]; then
+            echo "::error::CI failed - upstream job failed causing merge-artifacts to be skipped"
+            exit 1
+          fi
+          if [[ "${{ needs.changes.outputs.skill }}" == "true" && "${{ needs.check-skill.result }}" == "skipped" ]]; then
+            echo "::error::CI failed - upstream job failed causing check-skill to be skipped"
+            exit 1
+          fi
+
           echo "CI passed"


### PR DESCRIPTION
## Summary

Fixes the issue where PRs that don't change relevant files (e.g., only README.md) cannot be merged because required CI checks are skipped rather than passing.

## Changes

- **Add `changes` job**: Uses `dorny/paths-filter` (SHA-pinned to v3.0.2) to detect which files changed
- **Conditional job execution**: First-tier jobs (`check-skill`, `lint`, `test-unit`) check the filter outputs; downstream jobs inherit skip behavior from their dependencies
- **Add `ci-status` job**: Single required check that runs with `if: always()` and passes when jobs are skipped, fails if any job failed/cancelled
- **Release branch handling**: Always run full CI on `release/**` branches regardless of changed paths

## Post-Merge Action

Update branch protection rules for `main`:
1. Remove individual job checks (lint, test-unit, build-binary, etc.)
2. Add `CI Status` as the only required check