### PR TITLE
feat(api): add custom User-Agent header to API requests

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,8 @@ import { issueRoute } from "./commands/issue/index.js";
 import { orgRoute } from "./commands/org/index.js";
 import { projectRoute } from "./commands/project/index.js";
 
+import { CLI_VERSION } from "./lib/constants.js";
+
 /** Top-level route map containing all CLI commands */
 export const routes = buildRouteMap({
   routes: {
@@ -26,12 +28,6 @@ export const routes = buildRouteMap({
       "It provides commands for authentication, viewing issues, and making API calls.",
   },
 });
-
-declare const SENTRY_CLI_VERSION: string;
-
-/** CLI version string, available for help output and other uses */
-export const CLI_VERSION =
-  typeof SENTRY_CLI_VERSION !== "undefined" ? SENTRY_CLI_VERSION : "0.0.0";
 
 export const app = buildApplication(routes, {
   name: "sentry",

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -20,6 +20,7 @@ import {
   type TraceSpan,
 } from "../types/index.js";
 import type { AutofixResponse, AutofixState } from "../types/seer.js";
+import { getUserAgent } from "./constants.js";
 import { refreshToken } from "./db/auth.js";
 import { ApiError } from "./errors.js";
 
@@ -91,6 +92,7 @@ async function createApiClient(): Promise<KyInstance> {
     headers: {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
+      "User-Agent": getUserAgent(),
     },
     hooks: {
       afterResponse: [

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,6 +2,28 @@
  * Runtime constants for the CLI.
  */
 
+/** Build-time constant injected by esbuild/bun */
+declare const SENTRY_CLI_VERSION: string | undefined;
+
+/** CLI version string, available for help output and other uses */
+export const CLI_VERSION =
+  typeof SENTRY_CLI_VERSION !== "undefined" ? SENTRY_CLI_VERSION : "0.0.0-dev";
+
+/**
+ * Generate the User-Agent string for API requests.
+ * Format: sentry-cli/<version> (<os>-<arch>) <runtime>/<version>
+ *
+ * @example "sentry-cli/0.5.0 (linux-x64) bun/1.3.3"
+ * @example "sentry-cli/0.5.0 (darwin-arm64) node/22.12.0"
+ */
+export function getUserAgent(): string {
+  const runtime =
+    typeof process.versions.bun !== "undefined"
+      ? `bun/${process.versions.bun}`
+      : `node/${process.versions.node}`;
+  return `sentry-cli/${CLI_VERSION} (${process.platform}-${process.arch}) ${runtime}`;
+}
+
 /**
  * DSN for CLI telemetry (error tracking and usage metrics).
  *

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -11,13 +11,7 @@
 
 // biome-ignore lint/performance/noNamespaceImport: Sentry SDK recommends namespace import
 import * as Sentry from "@sentry/node";
-import { SENTRY_CLI_DSN } from "./constants.js";
-
-/**
- * Build-time constant injected by esbuild/bun.
- * This is undefined when running unbundled in development.
- */
-declare const SENTRY_CLI_VERSION: string | undefined;
+import { CLI_VERSION, SENTRY_CLI_DSN } from "./constants.js";
 
 /**
  * Wrap CLI execution with telemetry tracking.
@@ -73,11 +67,6 @@ export async function withTelemetry<T>(
  * @internal Exported for testing
  */
 export function initSentry(enabled: boolean): Sentry.NodeClient | undefined {
-  // Build-time constants, with dev defaults
-  const version =
-    typeof SENTRY_CLI_VERSION !== "undefined"
-      ? SENTRY_CLI_VERSION
-      : "0.0.0-dev";
   const environment = process.env.NODE_ENV ?? "development";
 
   const client = Sentry.init({
@@ -91,7 +80,7 @@ export function initSentry(enabled: boolean): Sentry.NodeClient | undefined {
     // Sample all events for CLI telemetry (low volume)
     tracesSampleRate: 1,
     sampleRate: 1,
-    release: version,
+    release: CLI_VERSION,
     // Don't propagate traces to external services
     tracePropagationTargets: [],
 


### PR DESCRIPTION
## Summary

Add a custom User-Agent header to all Sentry API requests.

**Format:** `sentry-cli/<version> (<os>-<arch>) <runtime>/<runtime-version>`

**Examples:**
- `sentry-cli/0.5.0 (linux-x64) bun/1.3.3`
- `sentry-cli/0.5.0 (darwin-arm64) node/22.12.0`

## Changes

- Add `getUserAgent()` function in `constants.ts`
- Centralize `CLI_VERSION` in `constants.ts` to avoid circular dependencies
- Add `User-Agent` header to the ky HTTP client in `api-client.ts`
- Update `telemetry.ts` to use centralized `CLI_VERSION`

Closes #124