### PR TITLE
feat(project): improve project list and view output

### DIFF
--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -8,6 +8,8 @@
 import kyHttpClient, { type KyInstance } from "ky";
 import { z } from "zod";
 import {
+  type ProjectKey,
+  ProjectKeySchema,
   type SentryEvent,
   SentryEventSchema,
   type SentryIssue,
@@ -352,6 +354,18 @@ export function getProject(
 ): Promise<SentryProject> {
   return apiRequest<SentryProject>(`/projects/${orgSlug}/${projectSlug}/`, {
     schema: SentryProjectSchema,
+  });
+}
+
+/**
+ * Get project keys (DSNs) for a project
+ */
+export function getProjectKeys(
+  orgSlug: string,
+  projectSlug: string
+): Promise<ProjectKey[]> {
+  return apiRequest<ProjectKey[]>(`/projects/${orgSlug}/${projectSlug}/keys/`, {
+    schema: z.array(ProjectKeySchema),
   });
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,6 +62,8 @@ export type {
   IssueSubstatus,
   Mechanism,
   OsContext,
+  // Project Key types
+  ProjectKey,
   Release,
   // Request types
   RequestEntry,
@@ -96,6 +98,7 @@ export {
   ISSUE_STATUSES,
   MechanismSchema,
   OsContextSchema,
+  ProjectKeySchema,
   ReleaseSchema,
   RequestEntrySchema,
   SentryEventSchema,

--- a/src/types/sentry.ts
+++ b/src/types/sentry.ts
@@ -611,3 +611,24 @@ export const SentryEventSchema = z
   .passthrough();
 
 export type SentryEvent = z.infer<typeof SentryEventSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Project Keys (DSN)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ProjectKeyDsnSchema = z.object({
+  public: z.string(),
+  secret: z.string().optional(),
+});
+
+export const ProjectKeySchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    dsn: ProjectKeyDsnSchema,
+    isActive: z.boolean(),
+    dateCreated: z.string().optional(),
+  })
+  .passthrough();
+
+export type ProjectKey = z.infer<typeof ProjectKeySchema>;

--- a/test/e2e/project.test.ts
+++ b/test/e2e/project.test.ts
@@ -17,6 +17,7 @@ import { createE2EContext, type E2EContext } from "../fixture.js";
 import { cleanupTestDir, createTestConfigDir } from "../helpers.js";
 import {
   createSentryMockServer,
+  TEST_DSN,
   TEST_ORG,
   TEST_PROJECT,
   TEST_TOKEN,
@@ -243,6 +244,26 @@ describe("sentry project view", () => {
   );
 
   test(
+    "displays DSN in human-readable output",
+    async () => {
+      await ctx.setAuthToken(TEST_TOKEN);
+
+      const result = await ctx.run([
+        "project",
+        "view",
+        TEST_PROJECT,
+        "--org",
+        TEST_ORG,
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("DSN:");
+      expect(result.stdout).toContain(TEST_DSN);
+    },
+    { timeout: 15_000 }
+  );
+
+  test(
     "supports --json output",
     async () => {
       await ctx.setAuthToken(TEST_TOKEN);
@@ -259,6 +280,27 @@ describe("sentry project view", () => {
       expect(result.exitCode).toBe(0);
       const data = JSON.parse(result.stdout);
       expect(data.slug).toBe(TEST_PROJECT);
+    },
+    { timeout: 15_000 }
+  );
+
+  test(
+    "includes DSN in JSON output",
+    async () => {
+      await ctx.setAuthToken(TEST_TOKEN);
+
+      const result = await ctx.run([
+        "project",
+        "view",
+        TEST_PROJECT,
+        "--org",
+        TEST_ORG,
+        "--json",
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const data = JSON.parse(result.stdout);
+      expect(data.dsn).toBe(TEST_DSN);
     },
     { timeout: 15_000 }
   );

--- a/test/mocks/routes.ts
+++ b/test/mocks/routes.ts
@@ -23,6 +23,20 @@ export const TEST_TOKEN = "test-auth-token-12345";
 export const TEST_ISSUE_ID = "400001";
 export const TEST_ISSUE_SHORT_ID = "TEST-PROJECT-1A";
 export const TEST_EVENT_ID = "abc123def456abc123def456abc12345";
+export const TEST_DSN = "https://abc123@o123.ingest.sentry.io/456789";
+
+const projectKeysFixture = [
+  {
+    id: "key-123",
+    name: "Default",
+    dsn: {
+      public: TEST_DSN,
+      secret: "https://abc123:secret@o123.ingest.sentry.io/456789",
+    },
+    isActive: true,
+    dateCreated: "2024-01-01T00:00:00.000Z",
+  },
+];
 
 export const apiRoutes: MockRoute[] = [
   // Organizations
@@ -76,6 +90,16 @@ export const apiRoutes: MockRoute[] = [
     response: (_req, params) => {
       if (params.orgSlug === TEST_ORG && params.projectSlug === TEST_PROJECT) {
         return { body: projectFixture };
+      }
+      return { status: 404, body: notFoundFixture };
+    },
+  },
+  {
+    method: "GET",
+    path: "/api/0/projects/:orgSlug/:projectSlug/keys/",
+    response: (_req, params) => {
+      if (params.orgSlug === TEST_ORG && params.projectSlug === TEST_PROJECT) {
+        return { body: projectKeysFixture };
       }
       return { status: 404, body: notFoundFixture };
     },


### PR DESCRIPTION
## Summary

Two improvements to project commands:

1. **DSN in project view** - Shows the project's public DSN in both human and JSON output
2. **Separate ORG column** - `project list` now shows ORG and PROJECT as separate columns instead of combined `org/project`

## Changes

**project view:**
- Fetches project keys in parallel with project details
- Displays primary DSN (first active key) 
- Graceful degradation if keys fetch fails

**project list:**
- New column order: `ORG  PROJECT  NAME  PLATFORM`
- Dynamic column widths based on content

## Example Output

```
$ sentry project view my-project --org my-org
my-project: My Project
════════════════════════════════
Slug:       my-project
Name:       My Project
ID:         123456
Platform:   javascript
DSN:        https://abc123@o123.ingest.sentry.io/456
...
```

```
$ sentry project list --org my-org
ORG     PROJECT      NAME          PLATFORM
my-org  my-project   My Project    javascript
my-org  backend      Backend API   python
```

## Test Plan

- `bun test test/e2e/project.test.ts` - all 18 tests pass
- Manual: `sentry project list --org <org>` shows new column format
- Manual: `sentry project view <project> --org <org>` shows DSN

🤖 Generated with [Claude Code](https://claude.ai/code)