### PR TITLE
fix links to commands from /getting-started

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -81,8 +81,8 @@ Credentials are stored in `~/.sentry/config.json` with restricted file permissio
 
 Once authenticated, you can start using the CLI:
 
-- [Organization commands](./commands/org/) - List and view organizations
-- [Project commands](./commands/project/) - Manage projects
-- [Issue commands](./commands/issue/) - Track and manage issues
-- [Event commands](./commands/event/) - Inspect events
-- [API commands](./commands/api/) - Direct API access
+- [Organization commands](../commands/org/) - List and view organizations
+- [Project commands](../commands/project/) - Manage projects
+- [Issue commands](../commands/issue/) - Track and manage issues
+- [Event commands](../commands/event/) - Inspect events
+- [API commands](../commands/api/) - Direct API access


### PR DESCRIPTION
links used ./commands/<some-command>

changed to match repo structure

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates relative links; impact is limited to navigation/UX if paths are still incorrect.
> 
> **Overview**
> Updates `docs/src/content/docs/getting-started.mdx` “Next Steps” links to point to `../commands/*` instead of `./commands/*`, aligning relative paths with the docs directory structure so the command reference links resolve correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edee7a1c070323a433605b46803b1e6f30dbe276. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->