### PR TITLE
docs(skill): add well-known skills discovery endpoint

### DIFF
--- a/.github/workflows/generate-skill.yml
+++ b/.github/workflows/generate-skill.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
-          if git diff --quiet plugins/sentry-cli/skills/sentry-cli/SKILL.md docs/public/.well-known/skills/sentry-cli/SKILL.md; then
+          if git diff --quiet plugins/sentry-cli/skills/sentry-cli/SKILL.md; then
             echo "changed=false" >> $GITHUB_OUTPUT
             echo "SKILL.md is already up to date"
           else
@@ -50,6 +50,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add plugins/sentry-cli/skills/sentry-cli/SKILL.md docs/public/.well-known/skills/sentry-cli/SKILL.md
+          git add plugins/sentry-cli/skills/sentry-cli/SKILL.md
           git commit -m "chore: Regenerate SKILL.md"
           git push

--- a/docs/public/.well-known/skills/sentry-cli/SKILL.md
+++ b/docs/public/.well-known/skills/sentry-cli/SKILL.md
@@ -1,0 +1,1 @@
+../../../../../plugins/sentry-cli/skills/sentry-cli/SKILL.md

--- a/script/generate-skill.ts
+++ b/script/generate-skill.ts
@@ -15,7 +15,6 @@
 import { routes } from "../src/app.js";
 
 const OUTPUT_PATH = "plugins/sentry-cli/skills/sentry-cli/SKILL.md";
-const WELL_KNOWN_PATH = "docs/public/.well-known/skills/sentry-cli/SKILL.md";
 const DOCS_PATH = "docs/src/content/docs";
 
 /** Regex to match YAML frontmatter at the start of a file */
@@ -773,7 +772,5 @@ async function generateSkillMarkdown(routeMap: RouteMap): Promise<string> {
 
 const content = await generateSkillMarkdown(routes as unknown as RouteMap);
 await Bun.write(OUTPUT_PATH, content);
-await Bun.write(WELL_KNOWN_PATH, content);
 
 console.log(`Generated ${OUTPUT_PATH}`);
-console.log(`Generated ${WELL_KNOWN_PATH}`);


### PR DESCRIPTION
## Summary
- Add `/.well-known/skills/index.json` endpoint for agent skills auto-discovery
- Update `generate-skill.ts` to output SKILL.md to both plugin and well-known paths
- Follows the [Cloudflare Agent Skills Discovery RFC](https://github.com/cloudflare/agent-skills-discovery-rfc) pattern

## Test plan
- [x] Verify `bun run docs:dev` serves `/.well-known/skills/index.json` with valid JSON
- [x] Verify `/.well-known/skills/sentry-cli/SKILL.md` returns the skill file
- [x] Verify `bun run build` includes files in dist output
- [ ] After deploy, test with `npx skills add https://cli.sentry.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)