### PR TITLE
docs: add agentic usage documentation

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -193,7 +193,10 @@ export default defineConfig({
         },
         {
           label: "Resources",
-          items: [{ label: "Contributing", slug: "contributing" }],
+          items: [
+            { label: "Agentic Usage", slug: "agentic-usage" },
+            { label: "Contributing", slug: "contributing" },
+          ],
         },
       ],
       customCss: ["./src/styles/custom.css"],

--- a/docs/src/content/docs/agentic-usage.md
+++ b/docs/src/content/docs/agentic-usage.md
@@ -1,0 +1,41 @@
+---
+title: Agentic Usage
+description: Enable AI coding agents to use the Sentry CLI
+---
+
+AI coding agents like Claude Code can use the Sentry CLI through the skill system. This allows agents to interact with Sentry directly from your development environment.
+
+## Adding the Skill
+
+Add the Sentry CLI skill to your agent:
+
+```bash
+npx skills add https://cli.sentry.dev
+```
+
+This registers the Sentry CLI as a skill that your agent can invoke when needed.
+
+## Capabilities
+
+With this skill, agents can:
+
+- **View issues** - List and inspect Sentry issues from your projects
+- **Inspect events** - Look at specific error events and their details
+- **Browse projects** - List projects and organizations you have access to
+- **Make API calls** - Execute arbitrary Sentry API requests
+- **Authenticate** - Help you set up CLI authentication
+
+## How It Works
+
+When you ask your agent about Sentry errors or want to investigate an issue, the agent can use this skill to fetch real data from your Sentry account. For example:
+
+- "Show me the latest issues in my project"
+- "What's the stack trace for ISSUE-123?"
+- "List all projects in my organization"
+
+The skill uses your existing CLI authentication, so you'll need to run `sentry auth login` first if you haven't already.
+
+## Requirements
+
+- An authenticated Sentry CLI installation (`sentry auth login`)
+- An AI coding agent that supports the skills system (e.g., Claude Code)

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -86,3 +86,4 @@ Once authenticated, you can start using the CLI:
 - [Issue commands](../commands/issue/) - Track and manage issues
 - [Event commands](../commands/event/) - Inspect events
 - [API commands](../commands/api/) - Direct API access
+- [Agentic Usage](../agentic-usage/) - Enable AI coding agents to use the CLI


### PR DESCRIPTION
## Summary

- Add new documentation page explaining the Sentry CLI skill for AI coding agents
- Add sidebar entry under Resources section
- Add link in Installation page's Next Steps section

## Test plan

- [x] Build completes successfully
- [ ] Preview deployment renders the new page correctly
- [ ] Sidebar shows "Agentic Usage" under Resources
- [ ] Link from Installation page works

🤖 Generated with [Claude Code](https://claude.com/claude-code)