### PR TITLE
fix(auth): display user info on login and status commands

### DIFF
--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -17,14 +17,30 @@ import {
   getDefaultProject,
 } from "../../lib/db/defaults.js";
 import { getDbPath } from "../../lib/db/index.js";
+import { getUserInfo } from "../../lib/db/user.js";
 import { AuthError } from "../../lib/errors.js";
-import { error, success } from "../../lib/formatters/colors.js";
-import { formatExpiration, maskToken } from "../../lib/formatters/human.js";
+import { error, muted, success } from "../../lib/formatters/colors.js";
+import {
+  formatExpiration,
+  formatUserIdentity,
+  maskToken,
+} from "../../lib/formatters/human.js";
 import type { Writer } from "../../types/index.js";
 
 type StatusFlags = {
   readonly showToken: boolean;
 };
+
+/**
+ * Write user identity information
+ */
+function writeUserInfo(stdout: Writer): void {
+  const user = getUserInfo();
+  if (!user) {
+    return;
+  }
+  stdout.write(`User: ${muted(formatUserIdentity(user))}\n`);
+}
 
 /**
  * Write token information
@@ -123,13 +139,15 @@ export const statusCommand = buildCommand({
     const auth = await getAuthConfig();
     const authenticated = await isAuthenticated();
 
-    stdout.write(`Config: ${getDbPath()}\n\n`);
+    stdout.write(`Config: ${getDbPath()}\n`);
 
     if (!authenticated) {
       throw new AuthError("not_authenticated");
     }
 
-    stdout.write(`Status: Authenticated ${success("✓")}\n\n`);
+    stdout.write(`Status: Authenticated ${success("✓")}\n`);
+    writeUserInfo(stdout);
+    stdout.write("\n");
 
     writeTokenInfo(stdout, auth, flags.showToken);
     await writeDefaults(stdout);

--- a/src/lib/db/user.ts
+++ b/src/lib/db/user.ts
@@ -11,12 +11,15 @@ export type UserInfo = {
   userId: string;
   email?: string;
   username?: string;
+  /** Display name (different from username) */
+  name?: string;
 };
 
 type UserRow = {
   user_id: string;
   email: string | null;
   username: string | null;
+  name: string | null;
 };
 
 /**
@@ -37,6 +40,7 @@ export function getUserInfo(): UserInfo | undefined {
     userId: row.user_id,
     email: row.email ?? undefined,
     username: row.username ?? undefined,
+    name: row.name ?? undefined,
   };
 }
 
@@ -56,6 +60,7 @@ export function setUserInfo(info: UserInfo): void {
       user_id: info.userId,
       email: info.email ?? null,
       username: info.username ?? null,
+      name: info.name ?? null,
       updated_at: now,
     },
     ["id"]

--- a/src/lib/formatters/human.ts
+++ b/src/lib/formatters/human.ts
@@ -1473,6 +1473,50 @@ export function formatProjectDetails(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// User Identity Formatting
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * User identity fields for display formatting.
+ * Accepts both UserInfo (userId) and token response user (id) shapes.
+ */
+type UserIdentityInput = {
+  /** User ID (from token response) */
+  id?: string;
+  /** User ID (from stored UserInfo) */
+  userId?: string;
+  email?: string;
+  username?: string;
+  /** Display name (different from username) */
+  name?: string;
+};
+
+/**
+ * Format user identity for display.
+ * Prefers name over username, handles missing fields gracefully.
+ *
+ * @param user - User identity object (supports both id and userId fields)
+ * @returns Formatted string like "Name <email>" or fallback to available fields
+ */
+export function formatUserIdentity(user: UserIdentityInput): string {
+  const { name, username, email, id, userId } = user;
+  const displayName = name ?? username;
+  const finalId = id ?? userId;
+
+  if (displayName && email) {
+    return `${displayName} <${email}>`;
+  }
+  if (displayName) {
+    return displayName;
+  }
+  if (email) {
+    return email;
+  }
+  // Fallback to user ID if no name/username/email
+  return `user ${finalId}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Token Formatting
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/test/lib/db/user.test.ts
+++ b/test/lib/db/user.test.ts
@@ -36,10 +36,28 @@ describe("getUserInfo", () => {
       userId: "12345",
       email: "test@example.com",
       username: "testuser",
+      name: undefined,
     });
   });
 
-  test("handles missing email and username", () => {
+  test("returns stored user info with name", () => {
+    setUserInfo({
+      userId: "12345",
+      email: "test@example.com",
+      username: "testuser",
+      name: "Test User",
+    });
+
+    const result = getUserInfo();
+    expect(result).toEqual({
+      userId: "12345",
+      email: "test@example.com",
+      username: "testuser",
+      name: "Test User",
+    });
+  });
+
+  test("handles missing email, username, and name", () => {
     setUserInfo({ userId: "12345" });
 
     const result = getUserInfo();
@@ -47,6 +65,7 @@ describe("getUserInfo", () => {
       userId: "12345",
       email: undefined,
       username: undefined,
+      name: undefined,
     });
   });
 });
@@ -57,21 +76,24 @@ describe("setUserInfo", () => {
       userId: "user123",
       email: "user@test.com",
       username: "myuser",
+      name: "My User",
     });
 
     const result = getUserInfo();
     expect(result?.userId).toBe("user123");
     expect(result?.email).toBe("user@test.com");
     expect(result?.username).toBe("myuser");
+    expect(result?.name).toBe("My User");
   });
 
   test("overwrites existing user info", () => {
-    setUserInfo({ userId: "first", email: "first@test.com" });
-    setUserInfo({ userId: "second", email: "second@test.com" });
+    setUserInfo({ userId: "first", email: "first@test.com", name: "First" });
+    setUserInfo({ userId: "second", email: "second@test.com", name: "Second" });
 
     const result = getUserInfo();
     expect(result?.userId).toBe("second");
     expect(result?.email).toBe("second@test.com");
+    expect(result?.name).toBe("Second");
   });
 
   test("stores user info with only userId", () => {
@@ -81,5 +103,20 @@ describe("setUserInfo", () => {
     expect(result?.userId).toBe("minimal");
     expect(result?.email).toBeUndefined();
     expect(result?.username).toBeUndefined();
+    expect(result?.name).toBeUndefined();
+  });
+
+  test("stores user info with name but no username", () => {
+    setUserInfo({
+      userId: "user456",
+      email: "user@test.com",
+      name: "Display Name",
+    });
+
+    const result = getUserInfo();
+    expect(result?.userId).toBe("user456");
+    expect(result?.email).toBe("user@test.com");
+    expect(result?.username).toBeUndefined();
+    expect(result?.name).toBe("Display Name");
   });
 });


### PR DESCRIPTION
- Use user info from OAuth token response instead of calling /users/me/
  (which returns 403 for OAuth tokens)
- Add user info display to status command via getUserInfo()
- Add 'name' field to UserInfo type and database schema
- Clean up excessive newlines in command output
