### PR TITLE
fix(telemetry): capture command errors to Sentry

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,5 @@
+// biome-ignore lint/performance/noNamespaceImport: Sentry SDK recommends namespace import
+import * as Sentry from "@sentry/bun";
 import {
   type ApplicationText,
   buildApplication,
@@ -11,7 +13,6 @@ import { helpCommand } from "./commands/help.js";
 import { issueRoute } from "./commands/issue/index.js";
 import { orgRoute } from "./commands/org/index.js";
 import { projectRoute } from "./commands/project/index.js";
-
 import { CLI_VERSION } from "./lib/constants.js";
 import { CliError, getExitCode } from "./lib/errors.js";
 import { error as errorColor } from "./lib/formatters/colors.js";
@@ -45,6 +46,10 @@ export const routes = buildRouteMap({
 const customText: ApplicationText = {
   ...text_en,
   exceptionWhileRunningCommand: (exc: unknown, ansiColor: boolean): string => {
+    // Report all command errors to Sentry. Stricli catches exceptions and doesn't
+    // re-throw, so we must capture here to get visibility into command failures.
+    Sentry.captureException(exc);
+
     if (exc instanceof CliError) {
       const prefix = ansiColor ? errorColor("Error:") : "Error:";
       return `${prefix} ${exc.format()}`;


### PR DESCRIPTION
## Summary

Fixes a bug where errors thrown in CLI commands were never reported to Sentry. 
Stricli catches command exceptions internally and does not re-throw them, so they 
never reached the `withTelemetry` catch block.

## Changes

Adds `Sentry.captureException(exc)` in the `exceptionWhileRunningCommand` callback 
in `src/app.ts` - this is where Stricli gives us access to the exception before 
formatting it for display.

## Test plan

Verified locally by adding a test throw and confirming the capture is called:
```bash
TEST_SENTRY_ERROR=1 bun run src/bin.ts help
# Output showed: [DEBUG] Capturing exception to Sentry: ...
```

Closes #146