### PR TITLE
feat(telemetry): add is_self_hosted tag

### DIFF
--- a/src/lib/sentry-urls.ts
+++ b/src/lib/sentry-urls.ts
@@ -5,7 +5,7 @@
  * Supports self-hosted instances via SENTRY_URL environment variable.
  */
 
-const DEFAULT_SENTRY_URL = "https://sentry.io";
+import { DEFAULT_SENTRY_HOST, DEFAULT_SENTRY_URL } from "./constants.js";
 
 /**
  * Get the Sentry web base URL.
@@ -13,6 +13,27 @@ const DEFAULT_SENTRY_URL = "https://sentry.io";
  */
 export function getSentryBaseUrl(): string {
   return process.env.SENTRY_URL ?? DEFAULT_SENTRY_URL;
+}
+
+/**
+ * Check if a URL is a Sentry SaaS domain.
+ *
+ * Used to determine if multi-region support should be enabled and to
+ * validate region URLs before sending authenticated requests.
+ *
+ * @param url - URL string to validate
+ * @returns true if the hostname is sentry.io or a subdomain of sentry.io
+ */
+export function isSentrySaasUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname === DEFAULT_SENTRY_HOST ||
+      parsed.hostname.endsWith(`.${DEFAULT_SENTRY_HOST}`)
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -12,6 +12,7 @@
 // biome-ignore lint/performance/noNamespaceImport: Sentry SDK recommends namespace import
 import * as Sentry from "@sentry/bun";
 import { CLI_VERSION, SENTRY_CLI_DSN } from "./constants.js";
+import { getSentryBaseUrl, isSentrySaasUrl } from "./sentry-urls.js";
 
 export type { Span } from "@sentry/bun";
 
@@ -158,6 +159,9 @@ export function initSentry(enabled: boolean): Sentry.BunClient | undefined {
     const runtime =
       typeof process.versions.bun !== "undefined" ? "bun" : "node";
     Sentry.setTag("cli.runtime", runtime);
+
+    // Tag whether targeting self-hosted Sentry (not SaaS)
+    Sentry.setTag("is_self_hosted", !isSentrySaasUrl(getSentryBaseUrl()));
   }
 
   return client;

--- a/test/lib/region.test.ts
+++ b/test/lib/region.test.ts
@@ -11,10 +11,10 @@ import { setAuthToken } from "../../src/lib/db/auth.js";
 import { CONFIG_DIR_ENV_VAR, closeDatabase } from "../../src/lib/db/index.js";
 import { setOrgRegion } from "../../src/lib/db/regions.js";
 import {
-  getDefaultBaseUrl,
   isMultiRegionEnabled,
   resolveOrgRegion,
 } from "../../src/lib/region.js";
+import { getSentryBaseUrl } from "../../src/lib/sentry-urls.js";
 
 const testBaseDir = process.env[CONFIG_DIR_ENV_VAR]!;
 
@@ -37,15 +37,15 @@ afterEach(() => {
   delete process.env.SENTRY_URL;
 });
 
-describe("getDefaultBaseUrl", () => {
+describe("getSentryBaseUrl", () => {
   test("returns sentry.io by default", () => {
     delete process.env.SENTRY_URL;
-    expect(getDefaultBaseUrl()).toBe("https://sentry.io");
+    expect(getSentryBaseUrl()).toBe("https://sentry.io");
   });
 
   test("respects SENTRY_URL env var", () => {
     process.env.SENTRY_URL = "https://sentry.mycompany.com";
-    expect(getDefaultBaseUrl()).toBe("https://sentry.mycompany.com");
+    expect(getSentryBaseUrl()).toBe("https://sentry.mycompany.com");
   });
 });
 


### PR DESCRIPTION
## Summary

Adds an `is_self_hosted` boolean tag to Sentry telemetry to distinguish between SaaS and self-hosted instances.

## Changes

- Add `is_self_hosted` tag in `initSentry()` based on `SENTRY_URL` configuration
- Consolidate URL utilities in `sentry-urls.ts`:
  - Move `isSentrySaasUrl` from `region.ts` to `sentry-urls.ts`
  - Use `DEFAULT_SENTRY_HOST` from `constants.ts` (removes duplicate)
- Remove `getDefaultBaseUrl` and `isSentrySaasUrl` from `region.ts`

## Behavior

| SENTRY_URL | `is_self_hosted` |
|------------|------------------|
| (default: `https://sentry.io`) | `false` |
| `https://us.sentry.io` | `false` |
| `https://sentry.mycompany.com` | `true` |