### PR TITLE
test: add model-based and property-based testing with fast-check

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@types/semver": "^7.7.1",
         "chalk": "^5.6.2",
         "esbuild": "^0.25.0",
+        "fast-check": "^4.5.3",
         "ky": "^1.14.2",
         "qrcode-terminal": "^0.12.0",
         "semver": "^7.7.3",
@@ -327,6 +328,8 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "fast-check": ["fast-check@4.5.3", "", { "dependencies": { "pure-rand": "^7.0.0" } }, "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
@@ -422,6 +425,8 @@
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "pure-rand": ["pure-rand@7.0.1", "", {}, "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ=="],
 
     "qrcode-terminal": ["qrcode-terminal@0.12.0", "", { "bin": { "qrcode-terminal": "./bin/qrcode-terminal.js" } }, "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="],
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/semver": "^7.7.1",
     "chalk": "^5.6.2",
     "esbuild": "^0.25.0",
+    "fast-check": "^4.5.3",
     "ky": "^1.14.2",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.7.3",

--- a/test/lib/alias.property.test.ts
+++ b/test/lib/alias.property.test.ts
@@ -1,0 +1,441 @@
+/**
+ * Property-Based Tests for Alias Generation
+ *
+ * Uses fast-check to verify properties that should always hold true
+ * for the alias generation functions, regardless of input.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  array,
+  constantFrom,
+  assert as fcAssert,
+  property,
+  tuple,
+  uniqueArray,
+} from "fast-check";
+import {
+  buildOrgAwareAliases,
+  findCommonWordPrefix,
+  findShortestUniquePrefixes,
+  type OrgProjectPair,
+} from "../../src/lib/alias.js";
+import { DEFAULT_NUM_RUNS } from "../model-based/helpers.js";
+
+// Arbitraries
+
+/** Generate valid slug characters */
+const slugChars = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+/** Generate simple slugs (no hyphens) */
+const simpleSlugArb = array(constantFrom(...slugChars.split("")), {
+  minLength: 1,
+  maxLength: 15,
+}).map((chars) => chars.join(""));
+
+/** Generate slugs that may contain hyphens */
+const slugWithHyphensArb = array(constantFrom(...`${slugChars}-`.split("")), {
+  minLength: 2,
+  maxLength: 20,
+})
+  .map((chars) => chars.join(""))
+  .filter((s) => !(s.startsWith("-") || s.endsWith("-") || s.includes("--")));
+
+/** Generate org slugs */
+const orgSlugArb = simpleSlugArb;
+
+/** Generate project slugs (may have hyphens like "spotlight-electron") */
+const projectSlugArb = slugWithHyphensArb;
+
+/** Generate org/project pairs */
+const orgProjectPairArb = tuple(orgSlugArb, projectSlugArb).map(
+  ([org, project]): OrgProjectPair => ({ org, project })
+);
+
+/** Generate arrays of unique strings */
+const uniqueStringsArb = uniqueArray(simpleSlugArb, {
+  minLength: 1,
+  maxLength: 10,
+  comparator: (a, b) => a.toLowerCase() === b.toLowerCase(),
+});
+
+/** Generate strings with common word prefix (like spotlight-*) */
+const commonPrefixStringsArb = tuple(
+  simpleSlugArb,
+  uniqueArray(simpleSlugArb, { minLength: 2, maxLength: 5 })
+).map(([prefix, suffixes]) => suffixes.map((s) => `${prefix}-${s}`));
+
+// Properties for findShortestUniquePrefixes
+
+describe("property: findShortestUniquePrefixes", () => {
+  test("every input string gets a prefix", () => {
+    fcAssert(
+      property(uniqueStringsArb, (strings) => {
+        const prefixes = findShortestUniquePrefixes(strings);
+        expect(prefixes.size).toBe(strings.length);
+
+        for (const str of strings) {
+          expect(prefixes.has(str)).toBe(true);
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("prefixes are unique within the set", () => {
+    fcAssert(
+      property(uniqueStringsArb, (strings) => {
+        const prefixes = findShortestUniquePrefixes(strings);
+        const prefixValues = [...prefixes.values()];
+        const uniquePrefixValues = new Set(prefixValues);
+
+        // All prefixes should be unique
+        expect(uniquePrefixValues.size).toBe(prefixValues.length);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("prefix is always a prefix of the original string", () => {
+    fcAssert(
+      property(uniqueStringsArb, (strings) => {
+        const prefixes = findShortestUniquePrefixes(strings);
+
+        for (const [str, prefix] of prefixes) {
+          expect(str.toLowerCase().startsWith(prefix)).toBe(true);
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("prefix is lowercase", () => {
+    fcAssert(
+      property(uniqueStringsArb, (strings) => {
+        const prefixes = findShortestUniquePrefixes(strings);
+
+        for (const prefix of prefixes.values()) {
+          expect(prefix).toBe(prefix.toLowerCase());
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("prefix is minimal (can't be shorter and still unique)", () => {
+    fcAssert(
+      property(uniqueStringsArb, (strings) => {
+        if (strings.length < 2) return;
+
+        const prefixes = findShortestUniquePrefixes(strings);
+
+        for (const [str, prefix] of prefixes) {
+          if (prefix.length <= 1) continue;
+
+          // Check that a shorter prefix would NOT be unique
+          const shorterPrefix = prefix.slice(0, -1);
+          const wouldCollide = strings.some(
+            (other) =>
+              other !== str && other.toLowerCase().startsWith(shorterPrefix)
+          );
+
+          expect(wouldCollide).toBe(true);
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("single string gets first character as prefix", () => {
+    fcAssert(
+      property(simpleSlugArb, (str) => {
+        const prefixes = findShortestUniquePrefixes([str]);
+        expect(prefixes.get(str)).toBe(str.charAt(0).toLowerCase());
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("empty array returns empty map", () => {
+    const prefixes = findShortestUniquePrefixes([]);
+    expect(prefixes.size).toBe(0);
+  });
+});
+
+// Properties for findCommonWordPrefix
+
+describe("property: findCommonWordPrefix", () => {
+  test("returns common prefix for strings with shared word boundary", () => {
+    fcAssert(
+      property(commonPrefixStringsArb, (strings) => {
+        const prefix = findCommonWordPrefix(strings);
+
+        // Should find the common prefix
+        expect(prefix.length).toBeGreaterThan(0);
+
+        // All strings with boundaries should start with the prefix
+        for (const str of strings) {
+          expect(str.toLowerCase().startsWith(prefix)).toBe(true);
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns empty string for strings without common boundary prefix", () => {
+    fcAssert(
+      property(
+        uniqueArray(simpleSlugArb, { minLength: 2, maxLength: 5 }),
+        (strings) => {
+          // Simple slugs have no hyphens, so no common word prefix
+          const prefix = findCommonWordPrefix(strings);
+          expect(prefix).toBe("");
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns empty string for single element arrays", () => {
+    fcAssert(
+      property(slugWithHyphensArb, (str) => {
+        const prefix = findCommonWordPrefix([str]);
+        expect(prefix).toBe("");
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns empty string for empty arrays", () => {
+    const prefix = findCommonWordPrefix([]);
+    expect(prefix).toBe("");
+  });
+
+  test("prefix ends with boundary character if found", () => {
+    fcAssert(
+      property(commonPrefixStringsArb, (strings) => {
+        const prefix = findCommonWordPrefix(strings);
+
+        if (prefix.length > 0) {
+          // Should end with hyphen or underscore
+          const lastChar = prefix.at(-1);
+          expect(lastChar === "-" || lastChar === "_").toBe(true);
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("prefix is lowercase", () => {
+    fcAssert(
+      property(commonPrefixStringsArb, (strings) => {
+        const prefix = findCommonWordPrefix(strings);
+        expect(prefix).toBe(prefix.toLowerCase());
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});
+
+// Properties for buildOrgAwareAliases
+
+describe("property: buildOrgAwareAliases", () => {
+  test("every input pair gets an alias", () => {
+    fcAssert(
+      property(
+        array(orgProjectPairArb, { minLength: 1, maxLength: 10 }),
+        (pairs) => {
+          const { aliasMap } = buildOrgAwareAliases(pairs);
+
+          // Each unique org/project pair should have an alias
+          const uniqueKeys = new Set(pairs.map((p) => `${p.org}/${p.project}`));
+          expect(aliasMap.size).toBe(uniqueKeys.size);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("aliases are unique within the result", () => {
+    fcAssert(
+      property(
+        array(orgProjectPairArb, { minLength: 1, maxLength: 10 }),
+        (pairs) => {
+          const { aliasMap } = buildOrgAwareAliases(pairs);
+          const aliases = [...aliasMap.values()];
+          const uniqueAliases = new Set(aliases);
+
+          expect(uniqueAliases.size).toBe(aliases.length);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("aliases are lowercase", () => {
+    fcAssert(
+      property(
+        array(orgProjectPairArb, { minLength: 1, maxLength: 10 }),
+        (pairs) => {
+          const { aliasMap } = buildOrgAwareAliases(pairs);
+
+          for (const alias of aliasMap.values()) {
+            expect(alias).toBe(alias.toLowerCase());
+          }
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("aliases are non-empty", () => {
+    fcAssert(
+      property(
+        array(orgProjectPairArb, { minLength: 1, maxLength: 10 }),
+        (pairs) => {
+          const { aliasMap } = buildOrgAwareAliases(pairs);
+
+          for (const alias of aliasMap.values()) {
+            expect(alias.length).toBeGreaterThan(0);
+          }
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("empty input returns empty map", () => {
+    const { aliasMap } = buildOrgAwareAliases([]);
+    expect(aliasMap.size).toBe(0);
+  });
+
+  test("colliding slugs get org-prefixed aliases", () => {
+    // Create pairs with same project slug in different orgs
+    fcAssert(
+      property(
+        tuple(simpleSlugArb, simpleSlugArb, simpleSlugArb),
+        ([org1, org2, project]) => {
+          if (org1 === org2) return; // Need different orgs
+
+          const pairs: OrgProjectPair[] = [
+            { org: org1, project },
+            { org: org2, project },
+          ];
+
+          const { aliasMap } = buildOrgAwareAliases(pairs);
+
+          // Both should have aliases
+          expect(aliasMap.has(`${org1}/${project}`)).toBe(true);
+          expect(aliasMap.has(`${org2}/${project}`)).toBe(true);
+
+          // Aliases should be different
+          const alias1 = aliasMap.get(`${org1}/${project}`);
+          const alias2 = aliasMap.get(`${org2}/${project}`);
+          expect(alias1).not.toBe(alias2);
+
+          // Colliding aliases should contain "/" (org prefix)
+          expect(alias1?.includes("/")).toBe(true);
+          expect(alias2?.includes("/")).toBe(true);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("non-colliding slugs get simple prefixes (no org)", () => {
+    fcAssert(
+      property(
+        tuple(
+          simpleSlugArb,
+          uniqueArray(simpleSlugArb, { minLength: 2, maxLength: 5 })
+        ),
+        ([org, projects]) => {
+          const pairs: OrgProjectPair[] = projects.map((p) => ({
+            org,
+            project: p,
+          }));
+          const { aliasMap } = buildOrgAwareAliases(pairs);
+
+          // All aliases should be simple (no "/")
+          for (const alias of aliasMap.values()) {
+            expect(alias.includes("/")).toBe(false);
+          }
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("deterministic results for same input", () => {
+    fcAssert(
+      property(
+        array(orgProjectPairArb, { minLength: 1, maxLength: 10 }),
+        (pairs) => {
+          const result1 = buildOrgAwareAliases(pairs);
+          const result2 = buildOrgAwareAliases(pairs);
+
+          expect(result1.aliasMap.size).toBe(result2.aliasMap.size);
+
+          for (const [key, alias1] of result1.aliasMap) {
+            expect(result2.aliasMap.get(key)).toBe(alias1);
+          }
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});
+
+// Cross-function Properties
+
+describe("property: cross-function invariants", () => {
+  test("common prefix stripping improves alias brevity", () => {
+    fcAssert(
+      property(commonPrefixStringsArb, (projects) => {
+        // All in same org, all share prefix
+        const pairs: OrgProjectPair[] = projects.map((p) => ({
+          org: "acme",
+          project: p,
+        }));
+
+        const { aliasMap } = buildOrgAwareAliases(pairs);
+
+        // Aliases should be shorter than full project slugs
+        for (const [key, alias] of aliasMap) {
+          const project = key.split("/")[1]!;
+          expect(alias.length).toBeLessThanOrEqual(project.length);
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("findShortestUniquePrefixes is consistent with buildOrgAwareAliases for unique slugs", () => {
+    fcAssert(
+      property(
+        tuple(
+          simpleSlugArb,
+          uniqueArray(simpleSlugArb, { minLength: 2, maxLength: 5 })
+        ),
+        ([org, projects]) => {
+          // Build aliases through the full function
+          const pairs: OrgProjectPair[] = projects.map((p) => ({
+            org,
+            project: p,
+          }));
+          const { aliasMap } = buildOrgAwareAliases(pairs);
+
+          // Get prefixes directly
+          const directPrefixes = findShortestUniquePrefixes(projects);
+
+          // Aliases should match direct prefixes for simple unique slugs
+          for (const [key, alias] of aliasMap) {
+            const project = key.split("/")[1]!;
+            expect(directPrefixes.get(project)).toBe(alias);
+          }
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});

--- a/test/lib/db/model-based.test.ts
+++ b/test/lib/db/model-based.test.ts
@@ -1,0 +1,835 @@
+/**
+ * Model-Based Testing for SQLite Database Layer
+ *
+ * Uses fast-check to generate random sequences of database operations
+ * and verify the system behaves correctly against a simplified model.
+ *
+ * This catches edge cases that handwritten tests miss, such as:
+ * - Unexpected state transitions
+ * - Race conditions in caching logic
+ * - Invariant violations (e.g., clearAuth also clears regions)
+ */
+
+// biome-ignore-all lint/suspicious/noMisplacedAssertion: Model-based testing uses expect() inside command classes, not directly in test() functions. This is the standard fast-check pattern for stateful testing.
+
+import { describe, expect, test } from "bun:test";
+import {
+  type AsyncCommand,
+  array,
+  asyncModelRun,
+  asyncProperty,
+  boolean,
+  commands,
+  constant,
+  constantFrom,
+  assert as fcAssert,
+  integer,
+  nat,
+  option,
+  property,
+  string,
+  tuple,
+} from "fast-check";
+import {
+  clearAuth,
+  getAuthConfig,
+  getAuthToken,
+  isAuthenticated,
+  setAuthToken,
+} from "../../../src/lib/db/auth.js";
+import {
+  clearProjectAliases,
+  getProjectAliases,
+  getProjectByAlias,
+  setProjectAliases,
+} from "../../../src/lib/db/project-aliases.js";
+import {
+  clearOrgRegions,
+  getAllOrgRegions,
+  getOrgRegion,
+  setOrgRegion,
+  setOrgRegions,
+} from "../../../src/lib/db/regions.js";
+import {
+  getVersionCheckInfo,
+  setVersionCheckInfo,
+} from "../../../src/lib/db/version-check.js";
+import {
+  createIsolatedDbContext,
+  DEFAULT_NUM_RUNS,
+} from "../../model-based/helpers.js";
+
+/**
+ * Model representing the expected state of the database.
+ * This is a simplified version of the real database state.
+ */
+type DbModel = {
+  auth: {
+    token: string | null;
+    refreshToken: string | null;
+    expiresAt: number | null;
+    issuedAt: number | null;
+  };
+  regions: Map<string, string>;
+  aliases: {
+    entries: Map<string, { orgSlug: string; projectSlug: string }>;
+    fingerprint: string | null;
+  };
+  versionCheck: {
+    lastChecked: number | null;
+    latestVersion: string | null;
+  };
+};
+
+/** Real database handle (we just use the module functions directly) */
+type RealDb = Record<string, never>;
+
+/** Create initial empty model */
+function createEmptyModel(): DbModel {
+  return {
+    auth: {
+      token: null,
+      refreshToken: null,
+      expiresAt: null,
+      issuedAt: null,
+    },
+    regions: new Map(),
+    aliases: {
+      entries: new Map(),
+      fingerprint: null,
+    },
+    versionCheck: {
+      lastChecked: null,
+      latestVersion: null,
+    },
+  };
+}
+
+// Auth Commands (All async for asyncModelRun compatibility)
+
+class SetAuthTokenCommand implements AsyncCommand<DbModel, RealDb> {
+  readonly token: string;
+  readonly expiresIn: number | undefined;
+  readonly refreshToken: string | undefined;
+
+  constructor(
+    token: string,
+    expiresIn: number | undefined,
+    refreshToken: string | undefined
+  ) {
+    this.token = token;
+    this.expiresIn = expiresIn;
+    this.refreshToken = refreshToken;
+  }
+
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    const now = Date.now();
+
+    // Apply to real system
+    setAuthToken(this.token, this.expiresIn, this.refreshToken);
+
+    // Update model
+    model.auth.token = this.token;
+    model.auth.refreshToken = this.refreshToken ?? null;
+
+    // Use truthy check to match real setAuthToken behavior (0 is treated as no expiry)
+    if (this.expiresIn) {
+      model.auth.expiresAt = now + this.expiresIn * 1000;
+      model.auth.issuedAt = now;
+    } else {
+      model.auth.expiresAt = null;
+      model.auth.issuedAt = null;
+    }
+  }
+
+  toString(): string {
+    return `setAuthToken("${this.token}", ${this.expiresIn}, ${this.refreshToken ? `"${this.refreshToken}"` : undefined})`;
+  }
+}
+
+class GetAuthTokenCommand implements AsyncCommand<DbModel, RealDb> {
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    const realToken = getAuthToken();
+
+    // Token should be undefined if:
+    // 1. No token set
+    // 2. Token is expired (expiresAt < now)
+    const now = Date.now();
+    const expectedToken =
+      model.auth.token &&
+      (model.auth.expiresAt === null || model.auth.expiresAt > now)
+        ? model.auth.token
+        : undefined;
+
+    expect(realToken).toBe(expectedToken);
+  }
+
+  toString = () => "getAuthToken()";
+}
+
+class GetAuthConfigCommand implements AsyncCommand<DbModel, RealDb> {
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    const realConfig = getAuthConfig();
+
+    if (model.auth.token === null) {
+      expect(realConfig).toBeUndefined();
+    } else {
+      expect(realConfig).toBeDefined();
+      expect(realConfig?.token).toBe(model.auth.token);
+      expect(realConfig?.refreshToken).toBe(
+        model.auth.refreshToken ?? undefined
+      );
+      // Note: expiresAt/issuedAt may have slight timing differences, so we check presence
+      if (model.auth.expiresAt !== null) {
+        expect(realConfig?.expiresAt).toBeDefined();
+      }
+    }
+  }
+
+  toString = () => "getAuthConfig()";
+}
+
+class ClearAuthCommand implements AsyncCommand<DbModel, RealDb> {
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    clearAuth();
+
+    // Clear auth state
+    model.auth.token = null;
+    model.auth.refreshToken = null;
+    model.auth.expiresAt = null;
+    model.auth.issuedAt = null;
+
+    // KEY INVARIANT: clearAuth also clears org regions!
+    // This is specified in auth.ts lines 101-103
+    model.regions.clear();
+  }
+
+  toString = () => "clearAuth()";
+}
+
+class IsAuthenticatedCommand implements AsyncCommand<DbModel, RealDb> {
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    const realResult = await isAuthenticated();
+
+    // Should be authenticated if we have a valid, non-expired token
+    const now = Date.now();
+    const expectedResult =
+      model.auth.token !== null &&
+      (model.auth.expiresAt === null || model.auth.expiresAt > now);
+
+    expect(realResult).toBe(expectedResult);
+  }
+
+  toString = () => "isAuthenticated()";
+}
+
+// Region Commands
+
+class SetOrgRegionCommand implements AsyncCommand<DbModel, RealDb> {
+  readonly orgSlug: string;
+  readonly regionUrl: string;
+
+  constructor(orgSlug: string, regionUrl: string) {
+    this.orgSlug = orgSlug;
+    this.regionUrl = regionUrl;
+  }
+
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    await setOrgRegion(this.orgSlug, this.regionUrl);
+    model.regions.set(this.orgSlug, this.regionUrl);
+  }
+
+  toString(): string {
+    return `setOrgRegion("${this.orgSlug}", "${this.regionUrl}")`;
+  }
+}
+
+class GetOrgRegionCommand implements AsyncCommand<DbModel, RealDb> {
+  readonly orgSlug: string;
+
+  constructor(orgSlug: string) {
+    this.orgSlug = orgSlug;
+  }
+
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    const realRegion = await getOrgRegion(this.orgSlug);
+    const expectedRegion = model.regions.get(this.orgSlug);
+
+    expect(realRegion).toBe(expectedRegion);
+  }
+
+  toString(): string {
+    return `getOrgRegion("${this.orgSlug}")`;
+  }
+}
+
+class SetOrgRegionsCommand implements AsyncCommand<DbModel, RealDb> {
+  readonly entries: [string, string][];
+
+  constructor(entries: [string, string][]) {
+    this.entries = entries;
+  }
+
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    await setOrgRegions(this.entries);
+
+    for (const [orgSlug, regionUrl] of this.entries) {
+      model.regions.set(orgSlug, regionUrl);
+    }
+  }
+
+  toString(): string {
+    return `setOrgRegions([${this.entries.map(([o, r]) => `["${o}", "${r}"]`).join(", ")}])`;
+  }
+}
+
+class GetAllOrgRegionsCommand implements AsyncCommand<DbModel, RealDb> {
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    const realRegions = await getAllOrgRegions();
+
+    expect(realRegions.size).toBe(model.regions.size);
+
+    for (const [orgSlug, regionUrl] of model.regions) {
+      expect(realRegions.get(orgSlug)).toBe(regionUrl);
+    }
+  }
+
+  toString = () => "getAllOrgRegions()";
+}
+
+class ClearOrgRegionsCommand implements AsyncCommand<DbModel, RealDb> {
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    await clearOrgRegions();
+    model.regions.clear();
+  }
+
+  toString = () => "clearOrgRegions()";
+}
+
+// Alias Commands
+
+class SetProjectAliasesCommand implements AsyncCommand<DbModel, RealDb> {
+  readonly aliases: Record<string, { orgSlug: string; projectSlug: string }>;
+  readonly fingerprint: string | undefined;
+
+  constructor(
+    aliases: Record<string, { orgSlug: string; projectSlug: string }>,
+    fingerprint: string | undefined
+  ) {
+    this.aliases = aliases;
+    this.fingerprint = fingerprint;
+  }
+
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    await setProjectAliases(this.aliases, this.fingerprint);
+
+    // Clear and replace all aliases (this is the documented behavior)
+    model.aliases.entries.clear();
+    for (const [alias, entry] of Object.entries(this.aliases)) {
+      // Aliases are stored lowercase
+      model.aliases.entries.set(alias.toLowerCase(), entry);
+    }
+    model.aliases.fingerprint = this.fingerprint ?? null;
+  }
+
+  toString(): string {
+    const aliasStr = Object.entries(this.aliases)
+      .map(
+        ([a, e]) => `"${a}": {org: "${e.orgSlug}", project: "${e.projectSlug}"}`
+      )
+      .join(", ");
+    return `setProjectAliases({${aliasStr}}, ${this.fingerprint ? `"${this.fingerprint}"` : undefined})`;
+  }
+}
+
+class GetProjectAliasesCommand implements AsyncCommand<DbModel, RealDb> {
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    const realAliases = await getProjectAliases();
+
+    if (model.aliases.entries.size === 0) {
+      expect(realAliases).toBeUndefined();
+    } else {
+      expect(realAliases).toBeDefined();
+      expect(Object.keys(realAliases!).length).toBe(model.aliases.entries.size);
+
+      for (const [alias, entry] of model.aliases.entries) {
+        expect(realAliases![alias]).toEqual(entry);
+      }
+    }
+  }
+
+  toString = () => "getProjectAliases()";
+}
+
+class GetProjectByAliasCommand implements AsyncCommand<DbModel, RealDb> {
+  readonly alias: string;
+  readonly currentFingerprint: string | undefined;
+
+  constructor(alias: string, currentFingerprint: string | undefined) {
+    this.alias = alias;
+    this.currentFingerprint = currentFingerprint;
+  }
+
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    const realProject = await getProjectByAlias(
+      this.alias,
+      this.currentFingerprint
+    );
+
+    // Lookup is case-insensitive
+    const modelEntry = model.aliases.entries.get(this.alias.toLowerCase());
+
+    if (!modelEntry) {
+      expect(realProject).toBeUndefined();
+      return;
+    }
+
+    // Fingerprint validation logic (from project-aliases.ts lines 103-109):
+    // - If currentFingerprint is undefined, skip validation (return entry)
+    // - If stored fingerprint is null, skip validation (legacy cache)
+    // - If both are defined, they must match exactly
+    const storedFp = model.aliases.fingerprint;
+    const currentFp = this.currentFingerprint;
+
+    const shouldReject =
+      currentFp !== undefined && storedFp !== null && currentFp !== storedFp;
+
+    if (shouldReject) {
+      expect(realProject).toBeUndefined();
+    } else {
+      expect(realProject).toEqual(modelEntry);
+    }
+  }
+
+  toString(): string {
+    return `getProjectByAlias("${this.alias}", ${this.currentFingerprint ? `"${this.currentFingerprint}"` : undefined})`;
+  }
+}
+
+class ClearProjectAliasesCommand implements AsyncCommand<DbModel, RealDb> {
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    await clearProjectAliases();
+    model.aliases.entries.clear();
+    model.aliases.fingerprint = null;
+  }
+
+  toString = () => "clearProjectAliases()";
+}
+
+// Version Check Commands
+
+class SetVersionCheckCommand implements AsyncCommand<DbModel, RealDb> {
+  readonly latestVersion: string;
+
+  constructor(latestVersion: string) {
+    this.latestVersion = latestVersion;
+  }
+
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    const now = Date.now();
+    setVersionCheckInfo(this.latestVersion);
+
+    model.versionCheck.lastChecked = now;
+    model.versionCheck.latestVersion = this.latestVersion;
+  }
+
+  toString(): string {
+    return `setVersionCheckInfo("${this.latestVersion}")`;
+  }
+}
+
+class GetVersionCheckCommand implements AsyncCommand<DbModel, RealDb> {
+  check = () => true;
+
+  async run(model: DbModel, _real: RealDb): Promise<void> {
+    const realInfo = getVersionCheckInfo();
+
+    expect(realInfo.latestVersion).toBe(model.versionCheck.latestVersion);
+
+    // lastChecked timing may vary slightly, so check presence
+    if (model.versionCheck.lastChecked !== null) {
+      expect(realInfo.lastChecked).not.toBeNull();
+      // Should be within 1 second of expected
+      expect(
+        Math.abs(realInfo.lastChecked! - model.versionCheck.lastChecked)
+      ).toBeLessThan(1000);
+    } else {
+      expect(realInfo.lastChecked).toBeNull();
+    }
+  }
+
+  toString = () => "getVersionCheckInfo()";
+}
+
+// Arbitraries (Random Data Generators)
+
+/** Generate valid token strings */
+const tokenArb = string({ minLength: 1, maxLength: 64 });
+
+/** Generate org/project slugs (alphanumeric with hyphens) */
+const slugChars = "abcdefghijklmnopqrstuvwxyz0123456789";
+const slugArb = array(constantFrom(...slugChars.split("")), {
+  minLength: 1,
+  maxLength: 16,
+}).map((chars) => chars.join(""));
+
+/** Generate region URLs */
+const regionUrlArb = constantFrom(
+  "https://us.sentry.io",
+  "https://de.sentry.io",
+  "https://eu.sentry.io",
+  "https://sentry.io"
+);
+
+/** Generate alias (single letter) */
+const aliasChars = "abcdefghijklmnopqrstuvwxyz";
+const aliasArb = constantFrom(...aliasChars.split(""));
+
+/** Generate alias with optional uppercase */
+const aliasWithCaseArb = tuple(aliasArb, boolean()).map(([alias, upper]) =>
+  upper ? alias.toUpperCase() : alias
+);
+
+/** Generate DSN fingerprint */
+const fingerprintArb = option(
+  tuple(nat(1000), nat(1000)).map(([a, b]) => `${a}:${b}`),
+  { nil: undefined }
+);
+
+/** Generate version string */
+const versionArb = tuple(nat(10), nat(20), nat(100)).map(
+  ([major, minor, patch]) => `${major}.${minor}.${patch}`
+);
+
+/** Generate expiresIn (seconds) - can be negative for testing expiry */
+const expiresInArb = option(integer({ min: -10, max: 7200 }), {
+  nil: undefined,
+});
+
+// Command Arbitraries
+
+const setAuthTokenCmdArb = tuple(
+  tokenArb,
+  expiresInArb,
+  option(tokenArb, { nil: undefined })
+).map(
+  ([token, expiresIn, refreshToken]) =>
+    new SetAuthTokenCommand(token, expiresIn, refreshToken)
+);
+
+const getAuthTokenCmdArb = constant(new GetAuthTokenCommand());
+
+const getAuthConfigCmdArb = constant(new GetAuthConfigCommand());
+
+const clearAuthCmdArb = constant(new ClearAuthCommand());
+
+const isAuthenticatedCmdArb = constant(new IsAuthenticatedCommand());
+
+const setOrgRegionCmdArb = tuple(slugArb, regionUrlArb).map(
+  ([org, url]) => new SetOrgRegionCommand(org, url)
+);
+
+const getOrgRegionCmdArb = slugArb.map((org) => new GetOrgRegionCommand(org));
+
+const setOrgRegionsCmdArb = array(tuple(slugArb, regionUrlArb), {
+  minLength: 0,
+  maxLength: 5,
+}).map((entries) => new SetOrgRegionsCommand(entries));
+
+const getAllOrgRegionsCmdArb = constant(new GetAllOrgRegionsCommand());
+
+const clearOrgRegionsCmdArb = constant(new ClearOrgRegionsCommand());
+
+const setProjectAliasesCmdArb = tuple(
+  array(tuple(aliasArb, slugArb, slugArb), { minLength: 0, maxLength: 5 }),
+  fingerprintArb
+).map(([entries, fp]) => {
+  const aliases: Record<string, { orgSlug: string; projectSlug: string }> = {};
+  for (const [alias, org, project] of entries) {
+    aliases[alias] = { orgSlug: org, projectSlug: project };
+  }
+  return new SetProjectAliasesCommand(aliases, fp);
+});
+
+const getProjectAliasesCmdArb = constant(new GetProjectAliasesCommand());
+
+const getProjectByAliasCmdArb = tuple(aliasWithCaseArb, fingerprintArb).map(
+  ([alias, fp]) => new GetProjectByAliasCommand(alias, fp)
+);
+
+const clearProjectAliasesCmdArb = constant(new ClearProjectAliasesCommand());
+
+const setVersionCheckCmdArb = versionArb.map(
+  (v) => new SetVersionCheckCommand(v)
+);
+
+const getVersionCheckCmdArb = constant(new GetVersionCheckCommand());
+
+// All Commands Combined
+
+const allCommands = [
+  // Auth commands
+  setAuthTokenCmdArb,
+  getAuthTokenCmdArb,
+  getAuthConfigCmdArb,
+  clearAuthCmdArb,
+  isAuthenticatedCmdArb,
+  // Region commands
+  setOrgRegionCmdArb,
+  getOrgRegionCmdArb,
+  setOrgRegionsCmdArb,
+  getAllOrgRegionsCmdArb,
+  clearOrgRegionsCmdArb,
+  // Alias commands
+  setProjectAliasesCmdArb,
+  getProjectAliasesCmdArb,
+  getProjectByAliasCmdArb,
+  clearProjectAliasesCmdArb,
+  // Version check commands
+  setVersionCheckCmdArb,
+  getVersionCheckCmdArb,
+];
+
+// Tests
+
+describe("model-based: database layer", () => {
+  test("random sequences of database operations maintain consistency", () => {
+    fcAssert(
+      asyncProperty(commands(allCommands, { size: "+1" }), async (cmds) => {
+        const cleanup = createIsolatedDbContext();
+        try {
+          const setup = () => ({
+            model: createEmptyModel(),
+            real: {} as RealDb,
+          });
+
+          await asyncModelRun(setup, cmds);
+        } finally {
+          cleanup();
+        }
+      }),
+      {
+        numRuns: DEFAULT_NUM_RUNS,
+        verbose: false, // Set to true for debugging
+      }
+    );
+  });
+
+  test("clearAuth also clears org regions (key invariant)", () => {
+    fcAssert(
+      asyncProperty(
+        array(tuple(slugArb, regionUrlArb), { minLength: 1, maxLength: 5 }),
+        async (entries) => {
+          const cleanup = createIsolatedDbContext();
+          try {
+            // Set up auth and some regions
+            setAuthToken("test-token");
+            await setOrgRegions(entries);
+
+            // Verify regions were set (use unique count since setOrgRegions uses upsert)
+            const regionsBefore = await getAllOrgRegions();
+            const uniqueOrgSlugs = new Set(entries.map(([org]) => org));
+            expect(regionsBefore.size).toBe(uniqueOrgSlugs.size);
+
+            // Clear auth
+            clearAuth();
+
+            // Verify regions were also cleared (this is the invariant!)
+            const regionsAfter = await getAllOrgRegions();
+            expect(regionsAfter.size).toBe(0);
+          } finally {
+            cleanup();
+          }
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+
+  test("alias lookup is case-insensitive", () => {
+    fcAssert(
+      asyncProperty(
+        tuple(aliasArb, slugArb, slugArb),
+        async ([alias, org, project]) => {
+          const cleanup = createIsolatedDbContext();
+          try {
+            // Set alias (stored lowercase)
+            await setProjectAliases({
+              [alias]: { orgSlug: org, projectSlug: project },
+            });
+
+            // Lookup with uppercase
+            const upper = await getProjectByAlias(alias.toUpperCase());
+            // Lookup with lowercase
+            const lower = await getProjectByAlias(alias.toLowerCase());
+            // Lookup with original
+            const original = await getProjectByAlias(alias);
+
+            // All should return the same result
+            expect(upper).toEqual(lower);
+            expect(lower).toEqual(original);
+            expect(upper?.orgSlug).toBe(org);
+            expect(upper?.projectSlug).toBe(project);
+          } finally {
+            cleanup();
+          }
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+
+  test("expired tokens return undefined", () => {
+    fcAssert(
+      property(tokenArb, (token) => {
+        const cleanup = createIsolatedDbContext();
+        try {
+          // Set token that expires immediately (negative expiresIn)
+          setAuthToken(token, -1);
+
+          // Token should be undefined because it's expired
+          const retrieved = getAuthToken();
+          expect(retrieved).toBeUndefined();
+
+          // But auth config should still have the token stored
+          const config = getAuthConfig();
+          expect(config?.token).toBe(token);
+        } finally {
+          cleanup();
+        }
+      }),
+      { numRuns: 50 }
+    );
+  });
+
+  test("fingerprint mismatch rejects alias lookup", () => {
+    // Combine all parameters into a single tuple to avoid parameter limit
+    const paramsArb = tuple(
+      aliasArb,
+      slugArb,
+      slugArb,
+      nat(1000),
+      nat(1000),
+      nat(1000),
+      nat(1000)
+    );
+
+    fcAssert(
+      asyncProperty(paramsArb, async ([alias, org, project, a, b, c, d]) => {
+        // Ensure fingerprints are different
+        const fp1 = `${a}:${b}`;
+        const fp2 = `${c}:${d}`;
+        if (fp1 === fp2) return; // Skip if same (unlikely)
+
+        const cleanup = createIsolatedDbContext();
+        try {
+          // Set alias with fingerprint 1
+          await setProjectAliases(
+            { [alias]: { orgSlug: org, projectSlug: project } },
+            fp1
+          );
+
+          // Lookup with fingerprint 2 should fail
+          const result = await getProjectByAlias(alias, fp2);
+          expect(result).toBeUndefined();
+
+          // Lookup with matching fingerprint should succeed
+          const matchingResult = await getProjectByAlias(alias, fp1);
+          expect(matchingResult?.orgSlug).toBe(org);
+        } finally {
+          cleanup();
+        }
+      }),
+      { numRuns: 50 }
+    );
+  });
+
+  test("setProjectAliases replaces all existing aliases", () => {
+    const aliasEntryArb = array(tuple(aliasArb, slugArb, slugArb), {
+      minLength: 1,
+      maxLength: 3,
+    });
+
+    fcAssert(
+      asyncProperty(
+        tuple(aliasEntryArb, aliasEntryArb),
+        async ([first, second]) => {
+          const cleanup = createIsolatedDbContext();
+          try {
+            // Set first batch
+            const aliases1: Record<
+              string,
+              { orgSlug: string; projectSlug: string }
+            > = {};
+            for (const [a, o, p] of first) {
+              aliases1[a] = { orgSlug: o, projectSlug: p };
+            }
+            await setProjectAliases(aliases1);
+
+            // Set second batch (should replace all)
+            const aliases2: Record<
+              string,
+              { orgSlug: string; projectSlug: string }
+            > = {};
+            for (const [a, o, p] of second) {
+              aliases2[a] = { orgSlug: o, projectSlug: p };
+            }
+            await setProjectAliases(aliases2);
+
+            // Only second batch should exist
+            const result = await getProjectAliases();
+            expect(result).toBeDefined();
+            expect(Object.keys(result!).length).toBe(
+              Object.keys(aliases2).length
+            );
+
+            // Check second batch aliases are present
+            for (const [alias, entry] of Object.entries(aliases2)) {
+              expect(result![alias.toLowerCase()]).toEqual(entry);
+            }
+
+            // Check first batch aliases that aren't in second batch are gone
+            for (const alias of Object.keys(aliases1)) {
+              if (!(alias in aliases2)) {
+                expect(result![alias.toLowerCase()]).toBeUndefined();
+              }
+            }
+          } finally {
+            cleanup();
+          }
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+});

--- a/test/lib/db/regions.test.ts
+++ b/test/lib/db/regions.test.ts
@@ -33,6 +33,8 @@ beforeEach(() => {
 
 afterEach(() => {
   closeDatabase();
+  // Restore original base dir to maintain test isolation
+  process.env[CONFIG_DIR_ENV_VAR] = testBaseDir;
 });
 
 describe("setOrgRegion / getOrgRegion", () => {

--- a/test/lib/dsn.property.test.ts
+++ b/test/lib/dsn.property.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Property-Based Tests for DSN Parsing
+ *
+ * Uses fast-check to verify properties that should always hold true
+ * for the DSN parsing functions, regardless of input.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  array,
+  constantFrom,
+  assert as fcAssert,
+  nat,
+  property,
+  string,
+  tuple,
+} from "fast-check";
+import {
+  createDetectedDsn,
+  createDsnFingerprint,
+  extractOrgIdFromHost,
+  inferPackagePath,
+  isValidDsn,
+  parseDsn,
+} from "../../src/lib/dsn/parser.js";
+import type { DetectedDsn } from "../../src/lib/dsn/types.js";
+import { DEFAULT_NUM_RUNS } from "../model-based/helpers.js";
+
+// Arbitraries
+
+/** Generate valid public keys (hex-like strings) */
+const publicKeyArb = array(constantFrom(..."0123456789abcdef".split("")), {
+  minLength: 8,
+  maxLength: 32,
+}).map((chars) => chars.join(""));
+
+/** Generate valid project IDs (numeric strings) */
+const projectIdArb = nat(9_999_999_999).map(String);
+
+/** Generate valid org IDs (numeric) */
+const orgIdArb = nat(9_999_999);
+
+/** Generate region codes */
+const regionArb = constantFrom("us", "de", "eu", "");
+
+/** Generate valid SaaS ingest hosts with org ID */
+const saasHostArb = tuple(orgIdArb, regionArb).map(([orgId, region]) =>
+  region ? `o${orgId}.ingest.${region}.sentry.io` : `o${orgId}.ingest.sentry.io`
+);
+
+/** Generate self-hosted hosts (no org ID pattern) */
+const selfHostedHostArb = constantFrom(
+  "sentry.mycompany.com",
+  "errors.internal.corp",
+  "sentry.localhost",
+  "my-sentry.example.org"
+);
+
+/** Generate complete valid DSN strings */
+const validDsnArb = tuple(publicKeyArb, saasHostArb, projectIdArb).map(
+  ([key, host, projectId]) => `https://${key}@${host}/${projectId}`
+);
+
+/** Generate valid self-hosted DSN strings */
+const selfHostedDsnArb = tuple(
+  publicKeyArb,
+  selfHostedHostArb,
+  projectIdArb
+).map(([key, host, projectId]) => `https://${key}@${host}/${projectId}`);
+
+/** Generate invalid DSN-like strings */
+const invalidDsnArb = constantFrom(
+  "",
+  "not-a-dsn",
+  "https://missing-key@sentry.io/",
+  "https://@sentry.io/123", // empty key
+  "ftp://key@sentry.io/123", // still valid URL, but will parse
+  "https://key@/123", // no host
+  "://key@sentry.io/123" // invalid protocol
+);
+
+/** Generate monorepo-style paths */
+const monorepoPathArb = tuple(
+  constantFrom("packages", "apps", "services", "libs"),
+  array(constantFrom(..."abcdefghijklmnopqrstuvwxyz".split("")), {
+    minLength: 1,
+    maxLength: 15,
+  }),
+  constantFrom("src/index.ts", ".env", "config.js", "main.py")
+).map(([root, pkgChars, file]) => `${root}/${pkgChars.join("")}/${file}`);
+
+/** Generate non-monorepo paths */
+const rootPathArb = constantFrom(
+  "src/index.ts",
+  ".env",
+  "config.js",
+  "main.py",
+  "index.js",
+  "app/main.ts"
+);
+
+// Properties for parseDsn
+
+describe("property: parseDsn", () => {
+  test("successfully parses all valid DSN formats", () => {
+    fcAssert(
+      property(validDsnArb, (dsn) => {
+        const result = parseDsn(dsn);
+        expect(result).not.toBeNull();
+        expect(result?.protocol).toBe("https");
+        expect(result?.publicKey).toBeDefined();
+        expect(result?.host).toBeDefined();
+        expect(result?.projectId).toBeDefined();
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("extracts orgId from SaaS hosts", () => {
+    fcAssert(
+      property(validDsnArb, (dsn) => {
+        const result = parseDsn(dsn);
+        // SaaS DSNs should have orgId extracted
+        expect(result?.orgId).toBeDefined();
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("orgId is undefined for self-hosted DSNs", () => {
+    fcAssert(
+      property(selfHostedDsnArb, (dsn) => {
+        const result = parseDsn(dsn);
+        expect(result).not.toBeNull();
+        expect(result?.orgId).toBeUndefined();
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns null for invalid DSNs", () => {
+    fcAssert(
+      property(invalidDsnArb, (dsn) => {
+        const result = parseDsn(dsn);
+        // Most invalid DSNs should return null
+        // Some edge cases like ftp:// may still parse as valid URLs
+        if (dsn === "" || dsn === "not-a-dsn" || dsn.includes("://key@/")) {
+          expect(result).toBeNull();
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("round-trip: parsed components reconstruct to equivalent DSN", () => {
+    fcAssert(
+      property(validDsnArb, (dsn) => {
+        const parsed = parseDsn(dsn);
+        if (parsed) {
+          const reconstructed = `${parsed.protocol}://${parsed.publicKey}@${parsed.host}/${parsed.projectId}`;
+          expect(reconstructed).toBe(dsn);
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});
+
+// Properties for extractOrgIdFromHost
+
+describe("property: extractOrgIdFromHost", () => {
+  test("extracts org ID from valid SaaS ingest hosts", () => {
+    fcAssert(
+      property(tuple(orgIdArb, regionArb), ([orgId, region]) => {
+        const host = region
+          ? `o${orgId}.ingest.${region}.sentry.io`
+          : `o${orgId}.ingest.sentry.io`;
+
+        const result = extractOrgIdFromHost(host);
+        expect(result).toBe(String(orgId));
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns null for self-hosted hosts", () => {
+    fcAssert(
+      property(selfHostedHostArb, (host) => {
+        const result = extractOrgIdFromHost(host);
+        expect(result).toBeNull();
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns null for malformed hosts", () => {
+    const malformedHosts = constantFrom(
+      "sentry.io",
+      "ingest.sentry.io",
+      "o.ingest.sentry.io", // no number
+      "oabc.ingest.sentry.io", // letters instead of number
+      "o123.sentry.io" // missing "ingest"
+    );
+
+    fcAssert(
+      property(malformedHosts, (host) => {
+        const result = extractOrgIdFromHost(host);
+        expect(result).toBeNull();
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});
+
+// Properties for isValidDsn
+
+describe("property: isValidDsn", () => {
+  test("returns true for all valid DSNs", () => {
+    fcAssert(
+      property(validDsnArb, (dsn) => {
+        expect(isValidDsn(dsn)).toBe(true);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns true for self-hosted DSNs", () => {
+    fcAssert(
+      property(selfHostedDsnArb, (dsn) => {
+        expect(isValidDsn(dsn)).toBe(true);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("consistent with parseDsn", () => {
+    fcAssert(
+      property(string({ maxLength: 100 }), (input) => {
+        const isValid = isValidDsn(input);
+        const parsed = parseDsn(input);
+        expect(isValid).toBe(parsed !== null);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});
+
+// Properties for createDetectedDsn
+
+describe("property: createDetectedDsn", () => {
+  test("returns null for invalid DSNs", () => {
+    fcAssert(
+      property(invalidDsnArb, (dsn) => {
+        const result = createDetectedDsn(dsn, "env");
+        // Should return null for truly invalid DSNs
+        if (parseDsn(dsn) === null) {
+          expect(result).toBeNull();
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("preserves raw DSN string", () => {
+    fcAssert(
+      property(validDsnArb, (dsn) => {
+        const result = createDetectedDsn(dsn, "code", "src/index.ts");
+        expect(result?.raw).toBe(dsn);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("preserves source metadata", () => {
+    fcAssert(
+      property(
+        tuple(
+          validDsnArb,
+          constantFrom(
+            "env" as const,
+            "env_file" as const,
+            "code" as const,
+            "config" as const
+          )
+        ),
+        ([dsn, source]) => {
+          const result = createDetectedDsn(dsn, source, "test/path.ts");
+          expect(result?.source).toBe(source);
+          expect(result?.sourcePath).toBe("test/path.ts");
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});
+
+// Properties for createDsnFingerprint
+
+describe("property: createDsnFingerprint", () => {
+  test("fingerprint is deterministic", () => {
+    fcAssert(
+      property(array(validDsnArb, { minLength: 1, maxLength: 5 }), (dsns) => {
+        const detected = dsns
+          .map((d) => createDetectedDsn(d, "code"))
+          .filter((d): d is DetectedDsn => d !== null);
+
+        const fp1 = createDsnFingerprint(detected);
+        const fp2 = createDsnFingerprint(detected);
+        expect(fp1).toBe(fp2);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("fingerprint is order-independent (sorted)", () => {
+    fcAssert(
+      property(array(validDsnArb, { minLength: 2, maxLength: 5 }), (dsns) => {
+        const detected = dsns
+          .map((d) => createDetectedDsn(d, "code"))
+          .filter((d): d is DetectedDsn => d !== null);
+
+        if (detected.length < 2) return;
+
+        const fp1 = createDsnFingerprint(detected);
+        const fp2 = createDsnFingerprint([...detected].reverse());
+        expect(fp1).toBe(fp2);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("fingerprint deduplicates same DSN from multiple sources", () => {
+    fcAssert(
+      property(validDsnArb, (dsn) => {
+        const detected1 = createDetectedDsn(dsn, "code", "src/a.ts");
+        const detected2 = createDetectedDsn(dsn, "env_file", ".env");
+
+        if (detected1 && detected2) {
+          const fpSingle = createDsnFingerprint([detected1]);
+          const fpDuplicate = createDsnFingerprint([detected1, detected2]);
+          expect(fpSingle).toBe(fpDuplicate);
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("different DSNs produce different fingerprints", () => {
+    fcAssert(
+      property(tuple(validDsnArb, validDsnArb), ([dsn1, dsn2]) => {
+        if (dsn1 === dsn2) return; // Skip if same
+
+        const detected1 = createDetectedDsn(dsn1, "code");
+        const detected2 = createDetectedDsn(dsn2, "code");
+
+        if (detected1 && detected2) {
+          const fp1 = createDsnFingerprint([detected1]);
+          const fp2 = createDsnFingerprint([detected2]);
+
+          // Different DSNs should (usually) have different fingerprints
+          // Unless they happen to have same orgId:projectId (unlikely with random data)
+          if (
+            detected1.projectId !== detected2.projectId ||
+            detected1.orgId !== detected2.orgId
+          ) {
+            expect(fp1).not.toBe(fp2);
+          }
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("empty array returns empty fingerprint", () => {
+    const fp = createDsnFingerprint([]);
+    expect(fp).toBe("");
+  });
+
+  test("fingerprint format is comma-separated key pairs", () => {
+    fcAssert(
+      property(array(validDsnArb, { minLength: 1, maxLength: 3 }), (dsns) => {
+        const detected = dsns
+          .map((d) => createDetectedDsn(d, "code"))
+          .filter((d): d is DetectedDsn => d !== null);
+
+        const fp = createDsnFingerprint(detected);
+
+        // Should be comma-separated pairs or single pair
+        if (fp.length > 0) {
+          const parts = fp.split(",");
+          for (const part of parts) {
+            // Each part should be "prefix:projectId" format
+            expect(part).toMatch(/^.+:.+$/);
+          }
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});
+
+// Properties for inferPackagePath
+
+describe("property: inferPackagePath", () => {
+  test("extracts package path from monorepo-style paths", () => {
+    fcAssert(
+      property(monorepoPathArb, (path) => {
+        const result = inferPackagePath(path);
+        expect(result).toBeDefined();
+
+        // Should be "root/package" format
+        const parts = result!.split("/");
+        expect(parts.length).toBe(2);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns undefined for root-level paths", () => {
+    fcAssert(
+      property(rootPathArb, (path) => {
+        const result = inferPackagePath(path);
+        expect(result).toBeUndefined();
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("handles edge cases gracefully", () => {
+    const edgeCases = constantFrom("", "/", "a", "a/", "/a", "a/b");
+
+    fcAssert(
+      property(edgeCases, (path) => {
+        // Should not throw
+        const result = inferPackagePath(path);
+        // Result should be either undefined or a valid path
+        if (result !== undefined) {
+          expect(result.length).toBeGreaterThan(0);
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});

--- a/test/lib/issue-id.property.test.ts
+++ b/test/lib/issue-id.property.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Property-Based Tests for Issue ID Parsing
+ *
+ * Uses fast-check to verify properties that should always hold true
+ * for the issue ID parsing functions, regardless of input.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  array,
+  constantFrom,
+  assert as fcAssert,
+  nat,
+  property,
+  string,
+  tuple,
+} from "fast-check";
+import {
+  expandToFullShortId,
+  isNumericId,
+  isShortId,
+  isShortSuffix,
+  parseAliasSuffix,
+} from "../../src/lib/issue-id.js";
+import { DEFAULT_NUM_RUNS } from "../model-based/helpers.js";
+
+// Arbitraries
+
+/** Generate pure digit strings */
+const numericArb = array(constantFrom(..."0123456789".split("")), {
+  minLength: 1,
+  maxLength: 20,
+}).map((chars) => chars.join(""));
+
+/** Generate alphanumeric strings with at least one letter */
+const alphanumericWithLetterArb = tuple(
+  array(
+    constantFrom(
+      ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".split("")
+    ),
+    {
+      minLength: 1,
+      maxLength: 10,
+    }
+  ),
+  array(constantFrom(..."0123456789".split("")), { minLength: 0, maxLength: 5 })
+).map(([letters, digits]) => [...letters, ...digits].join(""));
+
+/** Generate valid project slugs (lowercase alphanumeric with hyphens) */
+const projectSlugArb = array(
+  constantFrom(..."abcdefghijklmnopqrstuvwxyz0123456789-".split("")),
+  {
+    minLength: 1,
+    maxLength: 30,
+  }
+)
+  .map((chars) => chars.join(""))
+  .filter((s) => !(s.startsWith("-") || s.endsWith("-")) && s.length > 0);
+
+/** Generate valid short suffixes (alphanumeric, no hyphens) */
+const shortSuffixArb = array(
+  constantFrom(
+    ..."abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".split(
+      ""
+    )
+  ),
+  { minLength: 1, maxLength: 10 }
+).map((chars) => chars.join(""));
+
+/** Generate alias-suffix format strings */
+const aliasSuffixFormatArb = tuple(
+  array(constantFrom(..."abcdefghijklmnopqrstuvwxyz".split("")), {
+    minLength: 1,
+    maxLength: 10,
+  }),
+  shortSuffixArb
+).map(([aliasChars, suffix]) => `${aliasChars.join("")}-${suffix}`);
+
+// Properties for isNumericId
+
+describe("property: isNumericId", () => {
+  test("returns true for all pure digit strings", () => {
+    fcAssert(
+      property(numericArb, (digits) => {
+        expect(isNumericId(digits)).toBe(true);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns false for strings containing letters", () => {
+    fcAssert(
+      property(alphanumericWithLetterArb, (str) => {
+        expect(isNumericId(str)).toBe(false);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns false for strings containing hyphens", () => {
+    fcAssert(
+      property(tuple(numericArb, numericArb), ([a, b]) => {
+        const withHyphen = `${a}-${b}`;
+        expect(isNumericId(withHyphen)).toBe(false);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("empty string returns false", () => {
+    expect(isNumericId("")).toBe(false);
+  });
+
+  test("nat() values converted to string are always numeric", () => {
+    fcAssert(
+      property(nat(999_999_999), (n) => {
+        expect(isNumericId(String(n))).toBe(true);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});
+
+// Properties for isShortSuffix
+
+describe("property: isShortSuffix", () => {
+  test("returns true for alphanumeric strings without hyphens", () => {
+    fcAssert(
+      property(shortSuffixArb, (suffix) => {
+        expect(isShortSuffix(suffix)).toBe(true);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns false for any string containing hyphens", () => {
+    fcAssert(
+      property(tuple(shortSuffixArb, shortSuffixArb), ([a, b]) => {
+        const withHyphen = `${a}-${b}`;
+        expect(isShortSuffix(withHyphen)).toBe(false);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("pure numeric strings are valid short suffixes", () => {
+    fcAssert(
+      property(numericArb, (digits) => {
+        expect(isShortSuffix(digits)).toBe(true);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns false for strings with special characters", () => {
+    const specialChars = "!@#$%^&*()_+=[]{}|;':\",./<>?`~ ";
+    fcAssert(
+      property(
+        tuple(shortSuffixArb, constantFrom(...specialChars.split(""))),
+        ([suffix, special]) => {
+          expect(isShortSuffix(suffix + special)).toBe(false);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});
+
+// Properties for isShortId
+
+describe("property: isShortId", () => {
+  test("returns true for any string containing at least one letter", () => {
+    fcAssert(
+      property(alphanumericWithLetterArb, (str) => {
+        expect(isShortId(str)).toBe(true);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns false for pure numeric strings", () => {
+    fcAssert(
+      property(numericArb, (digits) => {
+        expect(isShortId(digits)).toBe(false);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("isShortId and isNumericId are mutually exclusive for non-empty alphanumeric strings", () => {
+    fcAssert(
+      property(
+        tuple(shortSuffixArb, constantFrom(true, false)),
+        ([base, addLetter]) => {
+          // Create either pure numeric or alphanumeric with letter
+          const str = addLetter ? base : base.replace(/[a-zA-Z]/g, "0");
+          if (str.length === 0) return; // Skip empty
+
+          // At most one can be true
+          const isShort = isShortId(str);
+          const isNumeric = isNumericId(str);
+          expect(isShort && isNumeric).toBe(false);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});
+
+// Properties for parseAliasSuffix
+
+describe("property: parseAliasSuffix", () => {
+  test("successfully parses valid alias-suffix format", () => {
+    fcAssert(
+      property(aliasSuffixFormatArb, (input) => {
+        const result = parseAliasSuffix(input);
+        expect(result).not.toBeNull();
+        expect(result?.alias).toBeDefined();
+        expect(result?.suffix).toBeDefined();
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("alias is always lowercase", () => {
+    fcAssert(
+      property(aliasSuffixFormatArb, (input) => {
+        const result = parseAliasSuffix(input);
+        if (result) {
+          expect(result.alias).toBe(result.alias.toLowerCase());
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("suffix is always uppercase", () => {
+    fcAssert(
+      property(aliasSuffixFormatArb, (input) => {
+        const result = parseAliasSuffix(input);
+        if (result) {
+          expect(result.suffix).toBe(result.suffix.toUpperCase());
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns null for strings without hyphens", () => {
+    fcAssert(
+      property(shortSuffixArb, (input) => {
+        // shortSuffixArb has no hyphens
+        const result = parseAliasSuffix(input);
+        expect(result).toBeNull();
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("parsed alias + suffix reconstruct to original input (case-insensitive)", () => {
+    fcAssert(
+      property(aliasSuffixFormatArb, (input) => {
+        const result = parseAliasSuffix(input);
+        if (result) {
+          // Verify round-trip: reconstructed form matches original input
+          const reconstructed = `${result.alias}-${result.suffix}`;
+          expect(reconstructed.toLowerCase()).toBe(input.toLowerCase());
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});
+
+// Properties for expandToFullShortId
+
+describe("property: expandToFullShortId", () => {
+  test("result is always uppercase", () => {
+    fcAssert(
+      property(
+        tuple(shortSuffixArb, projectSlugArb),
+        ([suffix, projectSlug]) => {
+          const result = expandToFullShortId(suffix, projectSlug);
+          expect(result).toBe(result.toUpperCase());
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("result contains hyphen separator", () => {
+    fcAssert(
+      property(
+        tuple(shortSuffixArb, projectSlugArb),
+        ([suffix, projectSlug]) => {
+          const result = expandToFullShortId(suffix, projectSlug);
+          expect(result).toContain("-");
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("result ends with uppercase suffix", () => {
+    fcAssert(
+      property(
+        tuple(shortSuffixArb, projectSlugArb),
+        ([suffix, projectSlug]) => {
+          const result = expandToFullShortId(suffix, projectSlug);
+          expect(result.endsWith(suffix.toUpperCase())).toBe(true);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("result starts with uppercase project slug", () => {
+    fcAssert(
+      property(
+        tuple(shortSuffixArb, projectSlugArb),
+        ([suffix, projectSlug]) => {
+          const result = expandToFullShortId(suffix, projectSlug);
+          expect(result.startsWith(projectSlug.toUpperCase())).toBe(true);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("result format is PROJECT-SUFFIX", () => {
+    fcAssert(
+      property(
+        tuple(shortSuffixArb, projectSlugArb),
+        ([suffix, projectSlug]) => {
+          const result = expandToFullShortId(suffix, projectSlug);
+          const expected = `${projectSlug.toUpperCase()}-${suffix.toUpperCase()}`;
+          expect(result).toBe(expected);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("is idempotent when inputs are already uppercase", () => {
+    fcAssert(
+      property(
+        tuple(shortSuffixArb, projectSlugArb),
+        ([suffix, projectSlug]) => {
+          const result1 = expandToFullShortId(suffix, projectSlug);
+          const result2 = expandToFullShortId(
+            suffix.toUpperCase(),
+            projectSlug.toUpperCase()
+          );
+          expect(result1).toBe(result2);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});
+
+// Cross-function Properties
+
+describe("property: cross-function invariants", () => {
+  test("expanded short IDs are always detected as short IDs", () => {
+    fcAssert(
+      property(
+        tuple(shortSuffixArb, projectSlugArb),
+        ([suffix, projectSlug]) => {
+          // Skip if suffix is pure numeric (would make the whole thing numeric)
+          if (isNumericId(suffix)) return;
+
+          const expanded = expandToFullShortId(suffix, projectSlug);
+          expect(isShortId(expanded)).toBe(true);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("parseAliasSuffix result can be expanded back", () => {
+    fcAssert(
+      property(aliasSuffixFormatArb, (input) => {
+        const parsed = parseAliasSuffix(input);
+        if (parsed) {
+          // Use alias as project slug for expansion
+          const expanded = expandToFullShortId(parsed.suffix, parsed.alias);
+          expect(expanded).toBe(
+            `${parsed.alias.toUpperCase()}-${parsed.suffix}`
+          );
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("random strings are categorized consistently", () => {
+    fcAssert(
+      property(string({ minLength: 1, maxLength: 50 }), (input) => {
+        // Every non-empty string should be categorized into at most one type:
+        // - isNumericId (pure digits)
+        // - isShortId (contains letters)
+        // - neither (empty, which we filter out)
+
+        const numeric = isNumericId(input);
+        const short = isShortId(input);
+
+        // Can't be both
+        expect(numeric && short).toBe(false);
+
+        // If it's alphanumeric, should be one or the other
+        const isAlphanumeric = /^[a-zA-Z0-9]+$/.test(input);
+        if (isAlphanumeric && input.length > 0) {
+          expect(numeric || short).toBe(true);
+        }
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});

--- a/test/model-based/helpers.ts
+++ b/test/model-based/helpers.ts
@@ -1,0 +1,45 @@
+/**
+ * Model-Based Testing Helpers
+ *
+ * Shared utilities for fast-check model-based tests.
+ */
+
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { CONFIG_DIR_ENV_VAR, closeDatabase } from "../../src/lib/db/index.js";
+
+/**
+ * Create an isolated database context for model-based tests.
+ * Each test run gets its own SQLite database to avoid interference.
+ *
+ * @returns Cleanup function to call after test completes
+ */
+export function createIsolatedDbContext(): () => void {
+  const testBaseDir = process.env[CONFIG_DIR_ENV_VAR];
+  if (!testBaseDir) {
+    throw new Error(`${CONFIG_DIR_ENV_VAR} not set - run tests via bun test`);
+  }
+
+  // Close any existing database connection
+  closeDatabase();
+
+  // Create unique subdirectory for this test run
+  const testDir = join(
+    testBaseDir,
+    `model-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(testDir, { recursive: true });
+  process.env[CONFIG_DIR_ENV_VAR] = testDir;
+
+  return () => {
+    closeDatabase();
+    // Restore original base dir for next test
+    process.env[CONFIG_DIR_ENV_VAR] = testBaseDir;
+  };
+}
+
+/**
+ * Default number of runs for property-based and model-based tests.
+ * Balance between thoroughness and CI speed.
+ */
+export const DEFAULT_NUM_RUNS = 50;


### PR DESCRIPTION
## Summary

Adds model-based and property-based testing infrastructure using [fast-check](https://fast-check.dev/) to improve test coverage with randomized inputs that find edge cases.

### Changes

- **fast-check**: Added as dev dependency (v4.5.3)
- **Model-based tests**: SQLite database layer (auth, regions, aliases, version check)
- **Property-based tests**: Pure functions for issue-id, dsn, and alias modules
- **Test isolation fix**: Fixed `version-check.test.ts` env var cleanup bug
- **Shared utilities**: `test/model-based/helpers.ts` for isolated DB contexts

### Impact

- 78 new tests with ~10,000 assertions (50 randomized runs per property)
- ~2s added to test suite runtime
- Catches edge cases that hand-written tests miss

### Future Work

Additional phases for DSN detection, issue resolution, and API client retry logic are documented in the commit notes (`git notes show HEAD`).