### PR TITLE
fix(types): align schema types with Sentry API

### DIFF
--- a/src/lib/formatters/human.ts
+++ b/src/lib/formatters/human.ts
@@ -1282,9 +1282,11 @@ export function formatEventDetails(
     }
 
     // SDK info
-    if (event.sdk) {
+    if (event.sdk?.name || event.sdk?.version) {
       lines.push("");
-      lines.push(`SDK:        ${event.sdk.name} ${event.sdk.version}`);
+      const sdkName = event.sdk.name ?? "unknown";
+      const sdkVersion = event.sdk.version ?? "";
+      lines.push(`SDK:        ${sdkName}${sdkVersion ? ` ${sdkVersion}` : ""}`);
     }
 
     // Release info

--- a/src/types/sentry.ts
+++ b/src/types/sentry.ts
@@ -618,8 +618,8 @@ export const SentryEventSchema = z
     culprit: z.string().nullable().optional(),
     sdk: z
       .object({
-        name: z.string(),
-        version: z.string(),
+        name: z.string().nullable().optional(),
+        version: z.string().nullable().optional(),
       })
       .passthrough()
       .nullable()


### PR DESCRIPTION
## Summary

Fixes ZodError when parsing issues with annotations by aligning the CLI's Zod schemas with the official Sentry API schema.

**Issue**: https://sentry.sentry.io/issues/7237665256/

## Changes

1. **`annotations`** - Changed from `string[]` to `{displayName, url}[]` to match the actual API response structure
2. **`sdk.name` / `sdk.version`** - Made nullable to match API schema (defensive fix)

Both issues were identified by comparing our types against `/Users/bete/code/sentry-api-schema/openapi-derefed.json`.

## Test Plan

- `bun run typecheck` passes
- `bun run lint` passes  
- `bun test test/types` passes
- Verified against the original failing issue