### PR TITLE
feat(lib): add anyTrue helper for parallel-with-early-exit pattern

### DIFF
--- a/src/lib/promises.ts
+++ b/src/lib/promises.ts
@@ -1,0 +1,64 @@
+/**
+ * Promise Utilities
+ *
+ * Helpers for concurrent async operations with early-exit behavior.
+ */
+
+/**
+ * Run async predicate checks in parallel, resolve as soon as any returns true.
+ *
+ * Unlike Promise.race(), waits for a truthy result, not just the first settlement.
+ * Unlike Promise.any(), doesn't require rejection for falsy values.
+ *
+ * Errors in predicates are treated as `false` - the function continues checking
+ * other items rather than rejecting.
+ *
+ * @param items - Items to check
+ * @param predicate - Async function returning boolean for each item
+ * @returns True if any predicate returns true, false if all return false or error
+ *
+ * @example
+ * // Check if any file exists
+ * const exists = await anyTrue(filenames, (f) => Bun.file(f).exists());
+ *
+ * @example
+ * // Check if any API endpoint responds
+ * const reachable = await anyTrue(endpoints, async (url) => {
+ *   const res = await fetch(url).catch(() => null);
+ *   return res?.ok ?? false;
+ * });
+ */
+export function anyTrue<T>(
+  items: readonly T[],
+  predicate: (item: T) => Promise<boolean>
+): Promise<boolean> {
+  if (items.length === 0) {
+    return Promise.resolve(false);
+  }
+
+  return new Promise((resolve) => {
+    let pending = items.length;
+    let resolved = false;
+
+    const onComplete = (result: boolean) => {
+      if (resolved) {
+        return;
+      }
+      if (result) {
+        resolved = true;
+        resolve(true);
+      } else {
+        pending -= 1;
+        if (pending === 0) {
+          resolve(false);
+        }
+      }
+    };
+
+    for (const item of items) {
+      predicate(item)
+        .then(onComplete)
+        .catch(() => onComplete(false));
+    }
+  });
+}

--- a/test/lib/promises.test.ts
+++ b/test/lib/promises.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Promise Utilities Tests
+ */
+
+import { describe, expect, test } from "bun:test";
+import { anyTrue } from "../../src/lib/promises.js";
+
+describe("anyTrue", () => {
+  test("returns false for empty array", async () => {
+    const result = await anyTrue([], async () => true);
+    expect(result).toBe(false);
+  });
+
+  test("returns true when single item passes", async () => {
+    const result = await anyTrue([1], async () => true);
+    expect(result).toBe(true);
+  });
+
+  test("returns false when single item fails", async () => {
+    const result = await anyTrue([1], async () => false);
+    expect(result).toBe(false);
+  });
+
+  test("returns true when first item passes quickly", async () => {
+    const calls: number[] = [];
+
+    const result = await anyTrue([1, 2, 3], async (n) => {
+      calls.push(n);
+      if (n === 1) {
+        return true; // First item passes immediately
+      }
+      await Bun.sleep(100); // Others are slow
+      return false;
+    });
+
+    expect(result).toBe(true);
+    // First item should have been called
+    expect(calls).toContain(1);
+  });
+
+  test("returns true when last item passes", async () => {
+    const result = await anyTrue([1, 2, 3], async (n) => {
+      return n === 3; // Only last item passes
+    });
+
+    expect(result).toBe(true);
+  });
+
+  test("returns false when all items fail", async () => {
+    const result = await anyTrue([1, 2, 3], async () => false);
+    expect(result).toBe(false);
+  });
+
+  test("treats errors as false", async () => {
+    const result = await anyTrue([1, 2, 3], async (n) => {
+      if (n === 1) {
+        throw new Error("test error");
+      }
+      return n === 2; // Second item passes
+    });
+
+    expect(result).toBe(true);
+  });
+
+  test("returns false when all predicates error", async () => {
+    const result = await anyTrue([1, 2, 3], async () => {
+      throw new Error("test error");
+    });
+
+    expect(result).toBe(false);
+  });
+
+  test("starts all predicates concurrently", async () => {
+    const startTimes: number[] = [];
+    const startTime = Date.now();
+
+    await anyTrue([1, 2, 3], async (n) => {
+      startTimes.push(Date.now() - startTime);
+      await Bun.sleep(50);
+      return n === 3;
+    });
+
+    // All should start within ~10ms of each other (concurrent)
+    // If sequential, they'd be ~50ms apart
+    const maxDiff = Math.max(...startTimes) - Math.min(...startTimes);
+    expect(maxDiff).toBeLessThan(20);
+  });
+
+  test("resolves only once even with multiple true values", async () => {
+    let resolveCount = 0;
+
+    const promise = anyTrue([1, 2, 3], async () => {
+      await Bun.sleep(10);
+      return true; // All pass
+    });
+
+    // Wrap to count resolutions
+    const result = await promise.then((r) => {
+      resolveCount += 1;
+      return r;
+    });
+
+    expect(result).toBe(true);
+    expect(resolveCount).toBe(1);
+  });
+
+  test("works with complex async predicates", async () => {
+    const files = ["exists.txt", "missing.txt", "also-missing.txt"];
+
+    const result = await anyTrue(files, async (filename) => {
+      // Simulate async file check
+      await Bun.sleep(5);
+      return filename === "exists.txt";
+    });
+
+    expect(result).toBe(true);
+  });
+
+  test("does not wait for slow false predicates after finding true", async () => {
+    const startTime = Date.now();
+
+    const result = await anyTrue([1, 2, 3], async (n) => {
+      if (n === 1) {
+        return true; // Fast true
+      }
+      await Bun.sleep(500); // Slow false
+      return false;
+    });
+
+    const elapsed = Date.now() - startTime;
+
+    expect(result).toBe(true);
+    // Should resolve well under 500ms since we found true immediately
+    expect(elapsed).toBeLessThan(100);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a generic `anyTrue<T>()` helper that runs async predicates in parallel and resolves as soon as any returns true, without waiting for remaining operations.

- **New file**: `src/lib/promises.ts` with `anyTrue<T>()` function
- **Tests**: 12 test cases in `test/lib/promises.test.ts`
- **Refactor**: `anyExists()` and `anyGlobMatches()` in `project-root.ts` now use the helper

## Motivation

We had a recurring pattern where we needed to:
1. Start multiple async operations in parallel
2. Resolve as soon as any one succeeds
3. Not wait for remaining operations

This was duplicated in `anyExists()` (~27 lines) and `anyGlobMatches()` (~29 lines). The new helper reduces both to ~3-9 lines each.

## API

```typescript
const exists = await anyTrue(filenames, (f) => Bun.file(f).exists());
```

Unlike `Promise.race()`, waits for a truthy result. Unlike `Promise.any()`, doesn't require rejection for falsy values.

Closes #167

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>4f112d5</u></sup><!-- /BUGBOT_STATUS -->