### PR TITLE
fix: address bugbot review comments on dsn-cache model-based tests

### DIFF
--- a/test/lib/db/dsn-cache.model-based.test.ts
+++ b/test/lib/db/dsn-cache.model-based.test.ts
@@ -122,7 +122,7 @@ const dsnArb = tuple(
 
 const sourceArb = constantFrom(
   "env" as CachedDsnEntry["source"],
-  "env-file" as CachedDsnEntry["source"],
+  "env_file" as CachedDsnEntry["source"],
   "code" as CachedDsnEntry["source"]
 );
 
@@ -322,7 +322,9 @@ class GetCachedProjectCommand implements AsyncCommand<CacheModel, RealCache> {
     if (modelEntry) {
       expect(realEntry).toBeDefined();
       expect(realEntry?.orgSlug).toBe(modelEntry.orgSlug);
+      expect(realEntry?.orgName).toBe(modelEntry.orgName);
       expect(realEntry?.projectSlug).toBe(modelEntry.projectSlug);
+      expect(realEntry?.projectName).toBe(modelEntry.projectName);
     } else {
       expect(realEntry).toBeUndefined();
     }
@@ -381,7 +383,9 @@ class GetCachedProjectByDsnKeyCommand
     if (modelEntry) {
       expect(realEntry).toBeDefined();
       expect(realEntry?.orgSlug).toBe(modelEntry.orgSlug);
+      expect(realEntry?.orgName).toBe(modelEntry.orgName);
       expect(realEntry?.projectSlug).toBe(modelEntry.projectSlug);
+      expect(realEntry?.projectName).toBe(modelEntry.projectName);
     } else {
       expect(realEntry).toBeUndefined();
     }


### PR DESCRIPTION
## Summary

Addresses the review comments from Cursor Bugbot on PR #171.

## Fixes

### 1. Invalid source value (Low Severity)
- Changed `"env-file"` (hyphen) to `"env_file"` (underscore) to match the actual `DsnSource` type definition

### 2. Incomplete field verification (Low Severity)
- Added `orgName` and `projectName` verification to `GetCachedProjectCommand`
- Added `orgName` and `projectName` verification to `GetCachedProjectByDsnKeyCommand`
- Now all 4 fields of the `ResolvedInfo` type are verified, matching the thoroughness of `GetCachedDsnCommand`

## Verification

```bash
bun test test/lib/db/dsn-cache.model-based.test.ts
# 4 pass, 0 fail, 2024 expect() calls (up from ~1659)
```

The increased assertion count (2024 vs previous) confirms the additional field verifications are being executed.

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>57767d3</u></sup><!-- /BUGBOT_STATUS -->