### PR TITLE
test: add property tests for async utilities (Phase 4)

### DIFF
--- a/test/lib/polling.property.test.ts
+++ b/test/lib/polling.property.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Property-Based Tests for Polling Utility
+ *
+ * Uses fast-check to verify invariants of the poll() function
+ * that are difficult to exhaustively test with example-based tests.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  array,
+  asyncProperty,
+  assert as fcAssert,
+  integer,
+  nat,
+} from "fast-check";
+import { poll } from "../../src/lib/polling.js";
+import { DEFAULT_NUM_RUNS } from "../model-based/helpers.js";
+
+/** Mock stderr that captures output */
+function createMockStderr() {
+  const lines: string[] = [];
+  return {
+    write: (s: string) => {
+      lines.push(s);
+      return true;
+    },
+    getOutput: () => lines.join(""),
+  };
+}
+
+describe("poll properties", () => {
+  test("returns immediately when shouldStop is true on first fetch", async () => {
+    await fcAssert(
+      asyncProperty(nat(100), async (stateValue) => {
+        const stderr = createMockStderr();
+        let fetchCount = 0;
+
+        const result = await poll({
+          fetchState: async () => {
+            fetchCount += 1;
+            return { value: stateValue };
+          },
+          shouldStop: () => true, // Always stop
+          getProgressMessage: () => "Testing...",
+          stderr,
+          json: true, // Suppress output for cleaner tests
+          pollIntervalMs: 10,
+          timeoutMs: 1000,
+        });
+
+        expect(result.value).toBe(stateValue);
+        expect(fetchCount).toBe(1); // Only called once
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("returns state that satisfies shouldStop predicate", async () => {
+    await fcAssert(
+      asyncProperty(
+        integer({ min: 1, max: 5 }), // stopAfter: 1-5 fetches
+        nat(100), // stateValue
+        async (stopAfter, stateValue) => {
+          const stderr = createMockStderr();
+          let fetchCount = 0;
+
+          const result = await poll({
+            fetchState: async () => {
+              fetchCount += 1;
+              return { value: stateValue, count: fetchCount };
+            },
+            shouldStop: (state) => state.count >= stopAfter,
+            getProgressMessage: () => "Testing...",
+            stderr,
+            json: true,
+            pollIntervalMs: 5, // Fast polling for tests
+            timeoutMs: 5000,
+          });
+
+          // Result should satisfy the stop condition
+          expect(result.count).toBeGreaterThanOrEqual(stopAfter);
+          expect(result.value).toBe(stateValue);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("throws timeout error when shouldStop never returns true", async () => {
+    await fcAssert(
+      asyncProperty(nat(50), async (stateValue) => {
+        const stderr = createMockStderr();
+        const timeoutMs = 50; // Very short timeout for testing
+        const customMessage = `Custom timeout: ${stateValue}`;
+
+        await expect(
+          poll({
+            fetchState: async () => ({ value: stateValue }),
+            shouldStop: () => false, // Never stop
+            getProgressMessage: () => "Testing...",
+            stderr,
+            json: true,
+            pollIntervalMs: 10,
+            timeoutMs,
+            timeoutMessage: customMessage,
+          })
+        ).rejects.toThrow(customMessage);
+      }),
+      { numRuns: Math.min(DEFAULT_NUM_RUNS, 20) } // Fewer runs since timeout tests are slow
+    );
+  });
+
+  test("fetchState call count is bounded by timeout/interval", async () => {
+    await fcAssert(
+      asyncProperty(
+        integer({ min: 10, max: 50 }), // pollIntervalMs
+        integer({ min: 50, max: 200 }), // timeoutMs
+        async (pollIntervalMs, timeoutMs) => {
+          const stderr = createMockStderr();
+          let fetchCount = 0;
+
+          // Ensure timeout > interval
+          const actualTimeout = Math.max(timeoutMs, pollIntervalMs * 2);
+
+          try {
+            await poll({
+              fetchState: async () => {
+                fetchCount += 1;
+                return { count: fetchCount };
+              },
+              shouldStop: () => false, // Never stop
+              getProgressMessage: () => "Testing...",
+              stderr,
+              json: true,
+              pollIntervalMs,
+              timeoutMs: actualTimeout,
+            });
+          } catch {
+            // Expected timeout
+          }
+
+          // Fetch count should be bounded by timeout/interval + some tolerance
+          const maxExpectedCalls =
+            Math.ceil(actualTimeout / pollIntervalMs) + 2;
+          expect(fetchCount).toBeLessThanOrEqual(maxExpectedCalls);
+          expect(fetchCount).toBeGreaterThanOrEqual(1); // At least one call
+        }
+      ),
+      { numRuns: Math.min(DEFAULT_NUM_RUNS, 20) }
+    );
+  });
+
+  test("null fetchState results are skipped until valid state", async () => {
+    await fcAssert(
+      asyncProperty(
+        integer({ min: 1, max: 5 }), // nullCount: number of nulls before valid state
+        nat(100), // stateValue
+        async (nullCount, stateValue) => {
+          const stderr = createMockStderr();
+          let fetchCount = 0;
+
+          const result = await poll({
+            fetchState: async () => {
+              fetchCount += 1;
+              // Return null for first N calls, then valid state
+              if (fetchCount <= nullCount) {
+                return null;
+              }
+              return { value: stateValue };
+            },
+            shouldStop: () => true,
+            getProgressMessage: () => "Testing...",
+            stderr,
+            json: true,
+            pollIntervalMs: 5,
+            timeoutMs: 5000,
+          });
+
+          expect(result.value).toBe(stateValue);
+          expect(fetchCount).toBe(nullCount + 1);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("progress message is updated from state", async () => {
+    await fcAssert(
+      asyncProperty(
+        array(nat(100), { minLength: 1, maxLength: 5 }),
+        async (stateValues) => {
+          const stderr = createMockStderr();
+          let fetchIndex = 0;
+          const messages: string[] = [];
+
+          await poll({
+            fetchState: async () => {
+              const value = stateValues[fetchIndex];
+              fetchIndex = Math.min(fetchIndex + 1, stateValues.length - 1);
+              return { value };
+            },
+            shouldStop: (state) =>
+              state.value === stateValues.at(-1) &&
+              fetchIndex >= stateValues.length - 1,
+            getProgressMessage: (state) => {
+              const msg = `State: ${state.value}`;
+              messages.push(msg);
+              return msg;
+            },
+            stderr,
+            json: true, // Suppress animation
+            pollIntervalMs: 5,
+            timeoutMs: 5000,
+          });
+
+          // Messages should have been generated for each non-null state
+          expect(messages.length).toBeGreaterThanOrEqual(1);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});
+
+describe("poll edge cases", () => {
+  test("handles immediate timeout (timeoutMs = 0)", async () => {
+    const stderr = createMockStderr();
+
+    // With 0 timeout, should throw immediately or after first fetch
+    await expect(
+      poll({
+        fetchState: async () => ({ value: 1 }),
+        shouldStop: () => false,
+        getProgressMessage: () => "Testing...",
+        stderr,
+        json: true,
+        pollIntervalMs: 10,
+        timeoutMs: 0,
+      })
+    ).rejects.toThrow();
+  });
+
+  test("handles fetchState throwing errors", async () => {
+    const stderr = createMockStderr();
+
+    await expect(
+      poll({
+        fetchState: async () => {
+          throw new Error("Fetch failed");
+        },
+        shouldStop: () => true,
+        getProgressMessage: () => "Testing...",
+        stderr,
+        json: true,
+        pollIntervalMs: 10,
+        timeoutMs: 1000,
+      })
+    ).rejects.toThrow("Fetch failed");
+  });
+});

--- a/test/lib/promises.property.test.ts
+++ b/test/lib/promises.property.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Property-Based Tests for Promise Utilities
+ *
+ * Uses fast-check to verify invariants of anyTrue() that are difficult
+ * to exhaustively test with example-based tests.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  array,
+  asyncProperty,
+  boolean,
+  assert as fcAssert,
+  integer,
+  nat,
+} from "fast-check";
+import { anyTrue } from "../../src/lib/promises.js";
+import { DEFAULT_NUM_RUNS } from "../model-based/helpers.js";
+
+describe("anyTrue properties", () => {
+  test("returns true if and only if at least one predicate returns true", async () => {
+    await fcAssert(
+      asyncProperty(
+        array(boolean(), { minLength: 0, maxLength: 20 }),
+        async (results) => {
+          const items = results.map((_, i) => i);
+          const expectedResult = results.includes(true);
+
+          const actualResult = await anyTrue(items, async (i) => results[i]);
+
+          expect(actualResult).toBe(expectedResult);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("empty array always returns false regardless of predicate", async () => {
+    await fcAssert(
+      asyncProperty(boolean(), async (predicateResult) => {
+        const result = await anyTrue([], async () => predicateResult);
+        expect(result).toBe(false);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("single-element array result equals predicate result", async () => {
+    await fcAssert(
+      asyncProperty(boolean(), async (predicateResult) => {
+        const result = await anyTrue([1], async () => predicateResult);
+        expect(result).toBe(predicateResult);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("errors in predicates are treated as false", async () => {
+    await fcAssert(
+      asyncProperty(
+        integer({ min: 0, max: 10 }), // errorIndex
+        integer({ min: 0, max: 10 }), // trueIndex
+        integer({ min: 3, max: 15 }), // arrayLength
+        async (errorIndex, trueIndex, arrayLength) => {
+          const items = Array.from({ length: arrayLength }, (_, i) => i);
+
+          const result = await anyTrue(items, async (i) => {
+            if (i === errorIndex % arrayLength) {
+              throw new Error("Test error");
+            }
+            return i === trueIndex % arrayLength;
+          });
+
+          // Result should be true if trueIndex exists and isn't the error index
+          const expectedTrue =
+            trueIndex % arrayLength !== errorIndex % arrayLength;
+          expect(result).toBe(expectedTrue);
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("all predicates throwing returns false", async () => {
+    await fcAssert(
+      asyncProperty(integer({ min: 1, max: 10 }), async (arrayLength) => {
+        const items = Array.from({ length: arrayLength }, (_, i) => i);
+
+        const result = await anyTrue(items, async () => {
+          throw new Error("Test error");
+        });
+
+        expect(result).toBe(false);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("result does not depend on predicate completion order", async () => {
+    await fcAssert(
+      asyncProperty(
+        array(nat(50), { minLength: 2, maxLength: 10 }), // delays
+        integer({ min: 0, max: 9 }), // trueIndex
+        async (delays, trueIndex) => {
+          const items = delays.map((_, i) => i);
+          const actualTrueIndex = trueIndex % items.length;
+
+          // Run with different delays
+          const result = await anyTrue(items, async (i) => {
+            await Bun.sleep(delays[i] ?? 0);
+            return i === actualTrueIndex;
+          });
+
+          expect(result).toBe(true);
+        }
+      ),
+      { numRuns: Math.min(DEFAULT_NUM_RUNS, 20) } // Fewer runs since we use delays
+    );
+  });
+
+  test("all false predicates return false regardless of timing", async () => {
+    await fcAssert(
+      asyncProperty(
+        array(nat(20), { minLength: 1, maxLength: 5 }), // delays
+        async (delays) => {
+          const items = delays.map((_, i) => i);
+
+          const result = await anyTrue(items, async (i) => {
+            await Bun.sleep(delays[i] ?? 0);
+            return false; // All false
+          });
+
+          expect(result).toBe(false);
+        }
+      ),
+      { numRuns: Math.min(DEFAULT_NUM_RUNS, 20) }
+    );
+  });
+
+  test("predicate is called for each item at least once (when no early true)", async () => {
+    await fcAssert(
+      asyncProperty(integer({ min: 1, max: 10 }), async (arrayLength) => {
+        const items = Array.from({ length: arrayLength }, (_, i) => i);
+        const called = new Set<number>();
+
+        await anyTrue(items, async (i) => {
+          called.add(i);
+          return false; // All false, so all must be checked
+        });
+
+        // All items should have been checked
+        expect(called.size).toBe(arrayLength);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4 of our model-based/property-based testing initiative. Adds property tests for async utilities that handle polling and concurrent operations.

## Changes

### New Files

- **`test/lib/polling.property.test.ts`** - 8 property tests for `poll()` function
- **`test/lib/promises.property.test.ts`** - 8 property tests for `anyTrue()` function

## Test Coverage

### poll() properties:
| Property | Description |
|----------|-------------|
| Immediate return | Returns immediately when shouldStop is true on first fetch |
| Stop predicate | Returns state that satisfies shouldStop predicate |
| Timeout behavior | Throws timeout error when shouldStop never returns true |
| Bounded fetch count | Number of fetchState calls ≤ timeout/interval + tolerance |
| Null handling | Null fetchState results are skipped until valid state |
| Progress updates | Progress message is updated from state |
| Immediate timeout | Handles timeoutMs = 0 edge case |
| Error propagation | fetchState errors propagate correctly |

### anyTrue() properties:
| Property | Description |
|----------|-------------|
| Correctness | Returns true iff any predicate returns true |
| Empty array | Empty array always returns false |
| Single element | Single-element result equals predicate result |
| Error handling | Errors in predicates are treated as false |
| All errors | All predicates throwing returns false |
| Order independence | Result doesn't depend on predicate completion order |
| All false | All false predicates return false regardless of timing |
| Completeness | Predicate called for each item when no early true |

## Verification

```bash
bun test test/lib/polling.property.test.ts test/lib/promises.property.test.ts
# 16 pass, 0 fail, 752 expect() calls

bun test  # Full suite
# 1034 pass, 0 fail, 14905 expect() calls
```

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> is reviewing your changes for commit <u>1b782b1</u></sup><!-- /BUGBOT_STATUS -->