### PR TITLE
test: simplify alias and arg-parsing tests covered by property tests

### DIFF
--- a/test/lib/arg-parsing.test.ts
+++ b/test/lib/arg-parsing.test.ts
@@ -1,7 +1,9 @@
 /**
  * Argument Parsing Tests
  *
- * Tests for shared parsing utilities in src/lib/arg-parsing.ts
+ * Note: Core invariants (return type determination, suffix normalization) are tested
+ * via property-based tests in arg-parsing.property.test.ts. These tests focus on
+ * error messages and edge cases.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -11,40 +13,12 @@ import {
 } from "../../src/lib/arg-parsing.js";
 
 describe("parseOrgProjectArg", () => {
-  test("undefined returns auto-detect", () => {
-    expect(parseOrgProjectArg(undefined)).toEqual({ type: "auto-detect" });
-  });
-
-  test("empty string returns auto-detect", () => {
-    expect(parseOrgProjectArg("")).toEqual({ type: "auto-detect" });
-  });
-
+  // Representative examples for documentation (invariants covered by property tests)
   test("org/project returns explicit", () => {
     expect(parseOrgProjectArg("sentry/cli")).toEqual({
       type: "explicit",
       org: "sentry",
       project: "cli",
-    });
-  });
-
-  test("org/ returns org-all", () => {
-    expect(parseOrgProjectArg("sentry/")).toEqual({
-      type: "org-all",
-      org: "sentry",
-    });
-  });
-
-  test("/project returns project-search", () => {
-    expect(parseOrgProjectArg("/cli")).toEqual({
-      type: "project-search",
-      projectSlug: "cli",
-    });
-  });
-
-  test("project returns project-search", () => {
-    expect(parseOrgProjectArg("cli")).toEqual({
-      type: "project-search",
-      projectSlug: "cli",
     });
   });
 
@@ -56,6 +30,7 @@ describe("parseOrgProjectArg", () => {
     });
   });
 
+  // Error case - verify specific message
   test("just slash throws error", () => {
     expect(() => parseOrgProjectArg("/")).toThrow(
       'Invalid format: "/" requires a project slug'
@@ -64,16 +39,8 @@ describe("parseOrgProjectArg", () => {
 });
 
 describe("parseIssueArg", () => {
-  describe("numeric type", () => {
-    test("pure digits returns numeric", () => {
-      expect(parseIssueArg("123456789")).toEqual({
-        type: "numeric",
-        id: "123456789",
-      });
-    });
-  });
-
-  describe("explicit type (org/project-suffix)", () => {
+  // Representative examples for documentation (invariants covered by property tests)
+  describe("representative examples", () => {
     test("org/project-suffix returns explicit", () => {
       expect(parseIssueArg("sentry/cli-G")).toEqual({
         type: "explicit",
@@ -91,94 +58,9 @@ describe("parseIssueArg", () => {
         suffix: "4Y",
       });
     });
-
-    test("normalizes suffix to uppercase", () => {
-      expect(parseIssueArg("sentry/cli-g")).toEqual({
-        type: "explicit",
-        org: "sentry",
-        project: "cli",
-        suffix: "G",
-      });
-    });
   });
 
-  describe("explicit-org-suffix type (org/suffix)", () => {
-    test("org/suffix returns explicit-org-suffix", () => {
-      expect(parseIssueArg("sentry/G")).toEqual({
-        type: "explicit-org-suffix",
-        org: "sentry",
-        suffix: "G",
-      });
-    });
-
-    test("normalizes suffix to uppercase", () => {
-      expect(parseIssueArg("sentry/g")).toEqual({
-        type: "explicit-org-suffix",
-        org: "sentry",
-        suffix: "G",
-      });
-    });
-  });
-
-  describe("explicit-org-numeric type (org/numeric)", () => {
-    test("org/numeric returns explicit-org-numeric", () => {
-      expect(parseIssueArg("sentry/123456789")).toEqual({
-        type: "explicit-org-numeric",
-        org: "sentry",
-        numericId: "123456789",
-      });
-    });
-  });
-
-  describe("project-search type (project-suffix)", () => {
-    test("project-suffix returns project-search", () => {
-      expect(parseIssueArg("cli-G")).toEqual({
-        type: "project-search",
-        projectSlug: "cli",
-        suffix: "G",
-      });
-    });
-
-    test("handles multi-part project slugs", () => {
-      expect(parseIssueArg("spotlight-electron-4Y")).toEqual({
-        type: "project-search",
-        projectSlug: "spotlight-electron",
-        suffix: "4Y",
-      });
-    });
-
-    test("normalizes suffix to uppercase", () => {
-      expect(parseIssueArg("cli-g")).toEqual({
-        type: "project-search",
-        projectSlug: "cli",
-        suffix: "G",
-      });
-    });
-  });
-
-  describe("suffix-only type", () => {
-    test("single letter returns suffix-only", () => {
-      expect(parseIssueArg("G")).toEqual({
-        type: "suffix-only",
-        suffix: "G",
-      });
-    });
-
-    test("alphanumeric suffix returns suffix-only", () => {
-      expect(parseIssueArg("4Y")).toEqual({
-        type: "suffix-only",
-        suffix: "4Y",
-      });
-    });
-
-    test("normalizes suffix to uppercase", () => {
-      expect(parseIssueArg("g")).toEqual({
-        type: "suffix-only",
-        suffix: "G",
-      });
-    });
-  });
-
+  // Error cases - verify specific error messages
   describe("error cases", () => {
     test("org/-suffix throws error", () => {
       expect(() => parseIssueArg("sentry/-G")).toThrow(
@@ -213,6 +95,7 @@ describe("parseIssueArg", () => {
     });
   });
 
+  // Edge cases - document tricky behaviors
   describe("edge cases", () => {
     test("/suffix returns suffix-only", () => {
       // Leading slash with no org - treat as suffix


### PR DESCRIPTION
## Summary

Remove example-based tests that are now redundant with property-based tests, reducing test maintenance burden while maintaining coverage.

## Changes

### `test/lib/alias.test.ts` (313 → 132 lines, -181 lines)
- **Removed**: `findCommonWordPrefix` tests (8 tests) - all invariants covered by property tests
- **Removed**: `findShortestUniquePrefixes` tests (6 tests) - all invariants covered by property tests
- **Kept**: Integration tests showing real workflows
- **Kept**: `buildOrgAwareAliases` tests with specific expected outputs

### `test/lib/arg-parsing.test.ts` (244 → 109 lines, -135 lines)
- **Removed**: Happy-path type determination tests (~20 tests) - covered by property tests
- **Kept**: Error message verification tests (6 tests)
- **Kept**: Edge case documentation tests (3 tests)
- **Kept**: Representative examples for documentation

## Results

- **Lines removed**: 295
- **Tests removed**: 49 (998 → 949)
- **Coverage**: Maintained via property tests in `*.property.test.ts` files

## Verification

All tests pass:
```
949 pass, 0 fail, 17077 expect() calls
```