### PR TITLE
test: add coverage for fetchLatestVersion and versionExists

### DIFF
--- a/test/lib/upgrade.test.ts
+++ b/test/lib/upgrade.test.ts
@@ -9,7 +9,9 @@ import { UpgradeError } from "../../src/lib/errors.js";
 import {
   fetchLatestFromGitHub,
   fetchLatestFromNpm,
+  fetchLatestVersion,
   parseInstallationMethod,
+  versionExists,
 } from "../../src/lib/upgrade.js";
 
 // Store original fetch for restoration
@@ -217,5 +219,146 @@ describe("UpgradeError", () => {
     const error = new UpgradeError("network_error", "Custom error message");
     expect(error.reason).toBe("network_error");
     expect(error.message).toBe("Custom error message");
+  });
+});
+
+describe("fetchLatestVersion", () => {
+  test("uses GitHub for curl method", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ tag_name: "v2.0.0" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    const version = await fetchLatestVersion("curl");
+    expect(version).toBe("2.0.0");
+  });
+
+  test("uses npm for npm method", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ version: "2.0.0" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    const version = await fetchLatestVersion("npm");
+    expect(version).toBe("2.0.0");
+  });
+
+  test("uses npm for pnpm method", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ version: "2.0.0" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    const version = await fetchLatestVersion("pnpm");
+    expect(version).toBe("2.0.0");
+  });
+
+  test("uses npm for bun method", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ version: "2.0.0" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    const version = await fetchLatestVersion("bun");
+    expect(version).toBe("2.0.0");
+  });
+
+  test("uses npm for yarn method", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ version: "2.0.0" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    const version = await fetchLatestVersion("yarn");
+    expect(version).toBe("2.0.0");
+  });
+
+  test("uses npm for unknown method", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ version: "2.0.0" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    const version = await fetchLatestVersion("unknown");
+    expect(version).toBe("2.0.0");
+  });
+});
+
+describe("versionExists", () => {
+  test("checks GitHub for curl method - version exists", async () => {
+    globalThis.fetch = async () => new Response(null, { status: 200 });
+
+    const exists = await versionExists("curl", "1.0.0");
+    expect(exists).toBe(true);
+  });
+
+  test("checks GitHub for curl method - version does not exist", async () => {
+    globalThis.fetch = async () => new Response(null, { status: 404 });
+
+    const exists = await versionExists("curl", "99.99.99");
+    expect(exists).toBe(false);
+  });
+
+  test("checks npm for npm method - version exists", async () => {
+    globalThis.fetch = async () => new Response(null, { status: 200 });
+
+    const exists = await versionExists("npm", "1.0.0");
+    expect(exists).toBe(true);
+  });
+
+  test("checks npm for npm method - version does not exist", async () => {
+    globalThis.fetch = async () => new Response(null, { status: 404 });
+
+    const exists = await versionExists("npm", "99.99.99");
+    expect(exists).toBe(false);
+  });
+
+  test("checks npm for pnpm method", async () => {
+    globalThis.fetch = async () => new Response(null, { status: 200 });
+
+    const exists = await versionExists("pnpm", "1.0.0");
+    expect(exists).toBe(true);
+  });
+
+  test("checks npm for bun method", async () => {
+    globalThis.fetch = async () => new Response(null, { status: 200 });
+
+    const exists = await versionExists("bun", "1.0.0");
+    expect(exists).toBe(true);
+  });
+
+  test("checks npm for yarn method", async () => {
+    globalThis.fetch = async () => new Response(null, { status: 200 });
+
+    const exists = await versionExists("yarn", "1.0.0");
+    expect(exists).toBe(true);
+  });
+
+  test("throws on network failure", async () => {
+    globalThis.fetch = async () => {
+      throw new TypeError("fetch failed");
+    };
+
+    await expect(versionExists("curl", "1.0.0")).rejects.toThrow(UpgradeError);
+    await expect(versionExists("curl", "1.0.0")).rejects.toThrow(
+      "Failed to connect to GitHub"
+    );
+  });
+
+  test("throws on network failure for npm", async () => {
+    globalThis.fetch = async () => {
+      throw new TypeError("fetch failed");
+    };
+
+    await expect(versionExists("npm", "1.0.0")).rejects.toThrow(UpgradeError);
+    await expect(versionExists("npm", "1.0.0")).rejects.toThrow(
+      "Failed to connect to npm registry"
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Add tests for `fetchLatestVersion()` - tests routing logic for all installation methods (curl, npm, pnpm, bun, yarn, unknown)
- Add tests for `versionExists()` - tests version existence checking for curl (GitHub) and package manager (npm) methods

## Changes

- **+143 lines** in `test/lib/upgrade.test.ts`
- **+15 tests** (from 18 to 33 total)

## Test Coverage

| Function | Tests Added |
|----------|-------------|
| `fetchLatestVersion` | 6 (one per installation method) |
| `versionExists` | 9 (exists/not-exists for curl and npm, plus pnpm/bun/yarn, plus network error handling) |

These tests improve coverage for `src/lib/upgrade.ts` which was at 40.23%.