### PR TITLE
fix: use ASCII arrow for consistent terminal rendering

### DIFF
--- a/src/lib/formatters/human.ts
+++ b/src/lib/formatters/human.ts
@@ -529,7 +529,7 @@ export function formatIssueDetails(issue: SentryIssue): string[] {
         lines.push(`Release:    ${firstReleaseVersion}`);
       } else {
         lines.push(
-          `Releases:   ${firstReleaseVersion} → ${lastReleaseVersion}`
+          `Releases:   ${firstReleaseVersion} -> ${lastReleaseVersion}`
         );
       }
     } else if (lastReleaseVersion) {
@@ -703,11 +703,11 @@ function formatBreadcrumb(breadcrumb: Breadcrumb): string {
     const data = breadcrumb.data as Record<string, unknown>;
     if (data.url && data.method) {
       // HTTP request breadcrumb
-      const status = data.status_code ? ` → ${data.status_code}` : "";
+      const status = data.status_code ? ` -> ${data.status_code}` : "";
       message = `${data.method} ${data.url}${status}`;
     } else if (data.from && data.to) {
       // Navigation breadcrumb
-      message = `${data.from} → ${data.to}`;
+      message = `${data.from} -> ${data.to}`;
     } else if (data.arguments && Array.isArray(data.arguments)) {
       // Console breadcrumb
       message = String(data.arguments[0] || "").slice(0, 60);

--- a/src/lib/version-check.ts
+++ b/src/lib/version-check.ts
@@ -133,7 +133,7 @@ function getUpdateNotificationImpl(): string | null {
       return null;
     }
 
-    return `\n${muted("Update available:")} ${cyan(CLI_VERSION)} → ${cyan(latestVersion)}  Run ${cyan('"sentry cli upgrade"')} to update.\n`;
+    return `\n${muted("Update available:")} ${cyan(CLI_VERSION)} -> ${cyan(latestVersion)}  Run ${cyan('"sentry cli upgrade"')} to update.\n`;
   } catch (error) {
     // DB access failed - report to Sentry but don't crash CLI
     Sentry.captureException(error);


### PR DESCRIPTION
## Summary

Replace Unicode arrow `→` (U+2192) with ASCII `->` in user-facing output to fix rendering issues on certain terminals and fonts.

## Problem

The Unicode RIGHTWARDS ARROW has East Asian Width "Ambiguous", causing some terminals/fonts (e.g., Iosevka) to render it as 2 cells while advancing the cursor by only 1. This visually "eats" the following space character.

<img width="829" height="68" alt="image" src="https://github.com/user-attachments/assets/f9ce0cde-cb83-4e7d-8224-f2ea1a1a85da" />


**Before:** `Update available: 0.0.0-dev →0.6.0` (space missing after arrow)
**After:** `Update available: 0.0.0-dev -> 0.6.0`

## Changes

- `src/lib/version-check.ts` - Update notification
- `src/lib/formatters/human.ts` - Release range, HTTP breadcrumb, navigation breadcrumb