### PR TITLE
test: add comprehensive tests for DSN errors and resolver

### DIFF
--- a/test/lib/dsn/errors.test.ts
+++ b/test/lib/dsn/errors.test.ts
@@ -1,0 +1,376 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  formatConflictError,
+  formatMultipleProjectsFooter,
+  formatNoDsnError,
+  formatResolutionError,
+} from "../../../src/lib/dsn/errors.js";
+import type {
+  DetectedDsn,
+  DsnDetectionResult,
+} from "../../../src/lib/dsn/types.js";
+
+// Mock api-client to prevent real API calls from getAccessibleProjects
+const mockListOrganizations = mock(() => Promise.resolve([]));
+const mockListProjects = mock(() => Promise.resolve([]));
+
+mock.module("../../../src/lib/api-client.js", () => ({
+  listOrganizations: mockListOrganizations,
+  listProjects: mockListProjects,
+  findProjectByDsnKey: mock(() => Promise.resolve(null)),
+}));
+
+describe("formatConflictError", () => {
+  test("formats error with two conflicting DSNs", () => {
+    const result: DsnDetectionResult = {
+      primary: null,
+      all: [
+        {
+          raw: "https://abc123@o123.ingest.sentry.io/456",
+          protocol: "https",
+          publicKey: "abc123",
+          host: "o123.ingest.sentry.io",
+          projectId: "456",
+          orgId: "123",
+          source: "env_file",
+          sourcePath: ".env",
+        },
+        {
+          raw: "https://def456@o789.ingest.sentry.io/101112",
+          protocol: "https",
+          publicKey: "def456",
+          host: "o789.ingest.sentry.io",
+          projectId: "101112",
+          orgId: "789",
+          source: "code",
+          sourcePath: "src/sentry.ts",
+        },
+      ],
+      hasMultiple: true,
+      fingerprint: "",
+    };
+
+    const error = formatConflictError(result);
+
+    expect(error).toContain("Error: Multiple Sentry DSNs detected");
+    expect(error).toContain("DSN 1:");
+    expect(error).toContain("abc123@o123.ingest.sentry.io/456");
+    expect(error).toContain("DSN 2:");
+    expect(error).toContain("def456@o789.ingest.sentry.io/101112");
+    expect(error).toContain("Project ID: 456");
+    expect(error).toContain("Project ID: 101112");
+    expect(error).toContain(
+      "sentry issue list --org <org> --project <project>"
+    );
+    expect(error).toContain("sentry config set defaults.org");
+  });
+
+  test("formats error with DSN without projectId", () => {
+    const result: DsnDetectionResult = {
+      primary: null,
+      all: [
+        {
+          raw: "https://abc123@sentry.io/456",
+          protocol: "https",
+          publicKey: "abc123",
+          host: "sentry.io",
+          projectId: "456",
+          source: "env",
+        },
+        {
+          raw: "https://xyz789@sentry.io/789",
+          protocol: "https",
+          publicKey: "xyz789",
+          host: "sentry.io",
+          // No projectId on this one intentionally
+          source: "code",
+          sourcePath: "app.js",
+        } as DetectedDsn,
+      ],
+      hasMultiple: true,
+      fingerprint: "",
+    };
+
+    const error = formatConflictError(result);
+
+    expect(error).toContain("DSN 1:");
+    expect(error).toContain("DSN 2:");
+    // First one has projectId, second doesn't
+    expect(error).toContain("Project ID: 456");
+  });
+
+  test("formats error with single DSN (edge case)", () => {
+    const result: DsnDetectionResult = {
+      primary: null,
+      all: [
+        {
+          raw: "https://single@o1.ingest.sentry.io/1",
+          protocol: "https",
+          publicKey: "single",
+          host: "o1.ingest.sentry.io",
+          projectId: "1",
+          orgId: "1",
+          source: "env",
+        },
+      ],
+      hasMultiple: false,
+      fingerprint: "",
+    };
+
+    const error = formatConflictError(result);
+
+    expect(error).toContain("DSN 1:");
+    expect(error).not.toContain("DSN 2:");
+  });
+
+  test("includes source description for each DSN", () => {
+    const result: DsnDetectionResult = {
+      primary: null,
+      all: [
+        {
+          raw: "https://a@o1.ingest.sentry.io/1",
+          protocol: "https",
+          publicKey: "a",
+          host: "o1.ingest.sentry.io",
+          projectId: "1",
+          orgId: "1",
+          source: "env",
+        },
+        {
+          raw: "https://b@o2.ingest.sentry.io/2",
+          protocol: "https",
+          publicKey: "b",
+          host: "o2.ingest.sentry.io",
+          projectId: "2",
+          orgId: "2",
+          source: "env_file",
+          sourcePath: ".env.local",
+        },
+        {
+          raw: "https://c@o3.ingest.sentry.io/3",
+          protocol: "https",
+          publicKey: "c",
+          host: "o3.ingest.sentry.io",
+          projectId: "3",
+          orgId: "3",
+          source: "code",
+          sourcePath: "config/sentry.js",
+        },
+      ],
+      hasMultiple: true,
+      fingerprint: "",
+    };
+
+    const error = formatConflictError(result);
+
+    expect(error).toContain("Source:");
+    // env source
+    expect(error).toMatch(/Source:.*SENTRY_DSN/i);
+  });
+});
+
+describe("formatNoDsnError", () => {
+  beforeEach(() => {
+    mockListOrganizations.mockReset();
+    mockListProjects.mockReset();
+  });
+
+  test("formats basic error message with search locations", async () => {
+    mockListOrganizations.mockResolvedValue([]);
+
+    const error = await formatNoDsnError("/path/to/project", false);
+
+    expect(error).toContain("No Sentry DSN detected in /path/to/project");
+    expect(error).toContain("SENTRY_DSN environment variable");
+    expect(error).toContain(".env files");
+    expect(error).toContain("JavaScript/TypeScript source code");
+    expect(error).toContain("export SENTRY_DSN=");
+    expect(error).toContain("sentry issue list --org");
+    expect(error).toContain("sentry config set defaults.org");
+  });
+
+  test("includes accessible projects when showProjects is true", async () => {
+    mockListOrganizations.mockResolvedValue([
+      { id: "1", slug: "my-org", name: "My Organization" },
+    ]);
+    mockListProjects.mockResolvedValue([
+      { id: "10", slug: "frontend", name: "Frontend App" },
+      { id: "11", slug: "backend", name: "Backend API" },
+    ]);
+
+    const error = await formatNoDsnError("/path/to/project", true);
+
+    expect(error).toContain("Your accessible projects:");
+    expect(error).toContain("my-org/frontend");
+    expect(error).toContain("my-org/backend");
+  });
+
+  test("skips projects section when API fails", async () => {
+    mockListOrganizations.mockRejectedValue(new Error("Not authenticated"));
+
+    const error = await formatNoDsnError("/path/to/project", true);
+
+    expect(error).not.toContain("Your accessible projects:");
+    expect(error).toContain("No Sentry DSN detected");
+  });
+
+  test("skips projects section when no projects returned", async () => {
+    mockListOrganizations.mockResolvedValue([
+      { id: "1", slug: "empty-org", name: "Empty Org" },
+    ]);
+    mockListProjects.mockResolvedValue([]);
+
+    const error = await formatNoDsnError("/path/to/project", true);
+
+    expect(error).not.toContain("Your accessible projects:");
+    expect(error).toContain("No Sentry DSN detected");
+  });
+
+  test("does not call API when showProjects is false", async () => {
+    const error = await formatNoDsnError("/path/to/project", false);
+
+    expect(mockListOrganizations).not.toHaveBeenCalled();
+    expect(error).toContain("No Sentry DSN detected");
+  });
+});
+
+describe("formatResolutionError", () => {
+  test("formats error with DSN and error message", () => {
+    const error = new Error("Connection timeout");
+    const dsn = "https://abc123@o123.ingest.sentry.io/456";
+
+    const formatted = formatResolutionError(error, dsn);
+
+    expect(formatted).toContain("Error: Could not resolve project from DSN");
+    expect(formatted).toContain(`DSN: ${dsn}`);
+    expect(formatted).toContain("Error: Connection timeout");
+    expect(formatted).toContain("You don't have access to this project");
+    expect(formatted).toContain("self-hosted Sentry instance");
+    expect(formatted).toContain("invalid or expired");
+    expect(formatted).toContain(
+      "sentry issue list --org <org> --project <project>"
+    );
+  });
+
+  test("formats error with access denied message", () => {
+    const error = new Error("403 Forbidden");
+    const dsn = "https://secret@o999.ingest.sentry.io/123";
+
+    const formatted = formatResolutionError(error, dsn);
+
+    expect(formatted).toContain("Error: 403 Forbidden");
+    expect(formatted).toContain(`DSN: ${dsn}`);
+  });
+});
+
+describe("formatMultipleProjectsFooter", () => {
+  test("returns empty string for single project", () => {
+    const projects = [
+      {
+        orgDisplay: "my-org",
+        projectDisplay: "frontend",
+        detectedFrom: ".env",
+      },
+    ];
+
+    const footer = formatMultipleProjectsFooter(projects);
+
+    expect(footer).toBe("");
+  });
+
+  test("returns empty string for empty array", () => {
+    const footer = formatMultipleProjectsFooter([]);
+
+    expect(footer).toBe("");
+  });
+
+  test("formats footer with two projects", () => {
+    const projects = [
+      {
+        orgDisplay: "my-org",
+        projectDisplay: "frontend",
+        detectedFrom: "packages/frontend/.env",
+      },
+      {
+        orgDisplay: "my-org",
+        projectDisplay: "backend",
+        detectedFrom: "src/sentry.ts",
+      },
+    ];
+
+    const footer = formatMultipleProjectsFooter(projects);
+
+    expect(footer).toContain("Found 2 Sentry projects:");
+    expect(footer).toContain(
+      "• my-org / frontend (from packages/frontend/.env)"
+    );
+    expect(footer).toContain("• my-org / backend (from src/sentry.ts)");
+    expect(footer).toContain(
+      "Use --org and --project to target a specific project"
+    );
+  });
+
+  test("formats footer with projects without detectedFrom", () => {
+    const projects = [
+      {
+        orgDisplay: "org-a",
+        projectDisplay: "project-1",
+      },
+      {
+        orgDisplay: "org-b",
+        projectDisplay: "project-2",
+      },
+    ];
+
+    const footer = formatMultipleProjectsFooter(projects);
+
+    expect(footer).toContain("Found 2 Sentry projects:");
+    expect(footer).toContain("• org-a / project-1");
+    expect(footer).toContain("• org-b / project-2");
+    expect(footer).not.toContain("(from");
+  });
+
+  test("formats footer with mixed detectedFrom presence", () => {
+    const projects = [
+      {
+        orgDisplay: "my-org",
+        projectDisplay: "frontend",
+        detectedFrom: ".env.local",
+      },
+      {
+        orgDisplay: "my-org",
+        projectDisplay: "backend",
+        // No detectedFrom
+      },
+      {
+        orgDisplay: "other-org",
+        projectDisplay: "shared",
+        detectedFrom: "libs/shared/sentry.config.js",
+      },
+    ];
+
+    const footer = formatMultipleProjectsFooter(projects);
+
+    expect(footer).toContain("Found 3 Sentry projects:");
+    expect(footer).toContain("• my-org / frontend (from .env.local)");
+    expect(footer).toContain("• my-org / backend");
+    expect(footer).not.toContain("• my-org / backend (from");
+    expect(footer).toContain(
+      "• other-org / shared (from libs/shared/sentry.config.js)"
+    );
+  });
+
+  test("handles many projects", () => {
+    const projects = Array.from({ length: 10 }, (_, i) => ({
+      orgDisplay: `org-${i}`,
+      projectDisplay: `project-${i}`,
+      detectedFrom: `path/to/project-${i}/.env`,
+    }));
+
+    const footer = formatMultipleProjectsFooter(projects);
+
+    expect(footer).toContain("Found 10 Sentry projects:");
+    expect(footer).toContain("• org-0 / project-0");
+    expect(footer).toContain("• org-9 / project-9");
+  });
+});

--- a/test/lib/dsn/resolver.test.ts
+++ b/test/lib/dsn/resolver.test.ts
@@ -1,0 +1,341 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createIsolatedDbContext } from "../../model-based/helpers.js";
+
+// Mock api-client module to avoid real API calls
+const mockListOrganizations = mock(() => Promise.resolve([]));
+const mockListProjects = mock(() => Promise.resolve([]));
+const mockFindProjectByDsnKey = mock(() => Promise.resolve(null));
+
+mock.module("../../../src/lib/api-client.js", () => ({
+  listOrganizations: mockListOrganizations,
+  listProjects: mockListProjects,
+  findProjectByDsnKey: mockFindProjectByDsnKey,
+}));
+
+// Now import the resolver after mocking
+import {
+  getAccessibleProjects,
+  resolveProject,
+} from "../../../src/lib/dsn/resolver.js";
+import type { DetectedDsn } from "../../../src/lib/dsn/types.js";
+
+describe("resolveProject", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    cleanup = createIsolatedDbContext();
+    mockListOrganizations.mockClear();
+    mockListProjects.mockClear();
+    mockFindProjectByDsnKey.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("returns resolved info if DSN already has resolved field", async () => {
+    const dsn: DetectedDsn = {
+      raw: "https://abc123@o123.ingest.sentry.io/456",
+      protocol: "https",
+      publicKey: "abc123",
+      host: "o123.ingest.sentry.io",
+      projectId: "456",
+      orgId: "123",
+      source: "env",
+      resolved: {
+        orgSlug: "my-org",
+        orgName: "My Organization",
+        projectSlug: "frontend",
+        projectName: "Frontend App",
+      },
+    };
+
+    const result = await resolveProject("/some/path", dsn);
+
+    expect(result.orgSlug).toBe("my-org");
+    expect(result.orgName).toBe("My Organization");
+    expect(result.projectSlug).toBe("frontend");
+    expect(result.projectName).toBe("Frontend App");
+    expect(result.dsn).toBe(dsn);
+    expect(result.sourceDescription).toContain("SENTRY_DSN");
+    // Should not call API
+    expect(mockListOrganizations).not.toHaveBeenCalled();
+    expect(mockFindProjectByDsnKey).not.toHaveBeenCalled();
+  });
+
+  test("resolves DSN without orgId using findProjectByDsnKey", async () => {
+    const dsn: DetectedDsn = {
+      raw: "https://abc123@sentry.io/456",
+      protocol: "https",
+      publicKey: "abc123",
+      host: "sentry.io",
+      projectId: "456",
+      // No orgId - self-hosted or legacy DSN
+      source: "env_file",
+      sourcePath: ".env",
+    };
+
+    mockFindProjectByDsnKey.mockResolvedValue({
+      id: "456",
+      slug: "my-project",
+      name: "My Project",
+      organization: {
+        id: "123",
+        slug: "my-org",
+        name: "My Organization",
+      },
+    });
+
+    const result = await resolveProject("/test/path", dsn);
+
+    expect(result.orgSlug).toBe("my-org");
+    expect(result.orgName).toBe("My Organization");
+    expect(result.projectSlug).toBe("my-project");
+    expect(result.projectName).toBe("My Project");
+    expect(mockFindProjectByDsnKey).toHaveBeenCalledWith("abc123");
+  });
+
+  test("throws when DSN without orgId cannot be resolved", async () => {
+    const dsn: DetectedDsn = {
+      raw: "https://unknown@sentry.io/999",
+      protocol: "https",
+      publicKey: "unknown",
+      host: "sentry.io",
+      projectId: "999",
+      source: "code",
+      sourcePath: "app.js",
+    };
+
+    mockFindProjectByDsnKey.mockResolvedValue(null);
+
+    await expect(resolveProject("/test/path", dsn)).rejects.toThrow(
+      /Cannot resolve project.*DSN could not be matched/
+    );
+  });
+
+  test("throws when project has no organization", async () => {
+    const dsn: DetectedDsn = {
+      raw: "https://abc123@sentry.io/456",
+      protocol: "https",
+      publicKey: "abc123",
+      host: "sentry.io",
+      projectId: "456",
+      source: "env",
+    };
+
+    mockFindProjectByDsnKey.mockResolvedValue({
+      id: "456",
+      slug: "orphan-project",
+      name: "Orphan Project",
+      // No organization
+    });
+
+    await expect(resolveProject("/test/path", dsn)).rejects.toThrow(
+      /Cannot resolve project/
+    );
+  });
+
+  test("resolves DSN with orgId using listOrganizations and listProjects", async () => {
+    const dsn: DetectedDsn = {
+      raw: "https://abc123@o123.ingest.sentry.io/456",
+      protocol: "https",
+      publicKey: "abc123",
+      host: "o123.ingest.sentry.io",
+      projectId: "456",
+      orgId: "123",
+      source: "code",
+      sourcePath: "src/sentry.ts",
+    };
+
+    mockListOrganizations.mockResolvedValue([
+      { id: "999", slug: "other-org", name: "Other Org" },
+      { id: "123", slug: "my-org", name: "My Organization" },
+    ]);
+
+    mockListProjects.mockResolvedValue([
+      { id: "789", slug: "other-project", name: "Other Project" },
+      { id: "456", slug: "frontend", name: "Frontend App" },
+    ]);
+
+    const result = await resolveProject("/test/path", dsn);
+
+    expect(result.orgSlug).toBe("my-org");
+    expect(result.orgName).toBe("My Organization");
+    expect(result.projectSlug).toBe("frontend");
+    expect(result.projectName).toBe("Frontend App");
+    expect(mockListOrganizations).toHaveBeenCalled();
+    expect(mockListProjects).toHaveBeenCalledWith("my-org");
+  });
+
+  test("throws when organization not found by orgId", async () => {
+    const dsn: DetectedDsn = {
+      raw: "https://abc123@o999.ingest.sentry.io/456",
+      protocol: "https",
+      publicKey: "abc123",
+      host: "o999.ingest.sentry.io",
+      projectId: "456",
+      orgId: "999",
+      source: "env",
+    };
+
+    mockListOrganizations.mockResolvedValue([
+      { id: "123", slug: "my-org", name: "My Org" },
+    ]);
+
+    await expect(resolveProject("/test/path", dsn)).rejects.toThrow(
+      /Could not find organization with ID 999/
+    );
+  });
+
+  test("throws when project not found by projectId", async () => {
+    const dsn: DetectedDsn = {
+      raw: "https://abc123@o123.ingest.sentry.io/999",
+      protocol: "https",
+      publicKey: "abc123",
+      host: "o123.ingest.sentry.io",
+      projectId: "999",
+      orgId: "123",
+      source: "env",
+    };
+
+    mockListOrganizations.mockResolvedValue([
+      { id: "123", slug: "my-org", name: "My Org" },
+    ]);
+
+    mockListProjects.mockResolvedValue([
+      { id: "456", slug: "existing-project", name: "Existing" },
+    ]);
+
+    await expect(resolveProject("/test/path", dsn)).rejects.toThrow(
+      /Could not find project with ID 999 in organization my-org/
+    );
+  });
+
+  test("handles org ID as string vs number comparison", async () => {
+    const dsn: DetectedDsn = {
+      raw: "https://key@o42.ingest.sentry.io/100",
+      protocol: "https",
+      publicKey: "key",
+      host: "o42.ingest.sentry.io",
+      projectId: "100",
+      orgId: "42",
+      source: "env",
+    };
+
+    // API returns id as number, but DSN has it as string
+    mockListOrganizations.mockResolvedValue([
+      { id: 42, slug: "number-org", name: "Number Org" },
+    ]);
+
+    mockListProjects.mockResolvedValue([
+      { id: 100, slug: "number-project", name: "Number Project" },
+    ]);
+
+    const result = await resolveProject("/test/path", dsn);
+
+    expect(result.orgSlug).toBe("number-org");
+    expect(result.projectSlug).toBe("number-project");
+  });
+});
+
+describe("getAccessibleProjects", () => {
+  beforeEach(() => {
+    mockListOrganizations.mockReset();
+    mockListProjects.mockReset();
+  });
+
+  test("returns empty array when not authenticated", async () => {
+    mockListOrganizations.mockRejectedValue(new Error("Not authenticated"));
+
+    const projects = await getAccessibleProjects();
+
+    expect(projects).toEqual([]);
+  });
+
+  test("returns projects from all accessible organizations", async () => {
+    mockListOrganizations.mockResolvedValue([
+      { id: "1", slug: "org-a", name: "Organization A" },
+      { id: "2", slug: "org-b", name: "Organization B" },
+    ]);
+
+    // First call for org-a
+    mockListProjects.mockResolvedValueOnce([
+      { id: "10", slug: "frontend", name: "Frontend" },
+      { id: "11", slug: "backend", name: "Backend" },
+    ]);
+
+    // Second call for org-b
+    mockListProjects.mockResolvedValueOnce([
+      { id: "20", slug: "api", name: "API Service" },
+    ]);
+
+    const projects = await getAccessibleProjects();
+
+    expect(projects).toHaveLength(3);
+    expect(projects).toContainEqual({
+      org: "org-a",
+      project: "frontend",
+      orgName: "Organization A",
+      projectName: "Frontend",
+    });
+    expect(projects).toContainEqual({
+      org: "org-a",
+      project: "backend",
+      orgName: "Organization A",
+      projectName: "Backend",
+    });
+    expect(projects).toContainEqual({
+      org: "org-b",
+      project: "api",
+      orgName: "Organization B",
+      projectName: "API Service",
+    });
+  });
+
+  test("skips organizations that fail to list projects", async () => {
+    mockListOrganizations.mockResolvedValue([
+      { id: "1", slug: "accessible", name: "Accessible Org" },
+      { id: "2", slug: "forbidden", name: "Forbidden Org" },
+    ]);
+
+    mockListProjects.mockResolvedValueOnce([
+      { id: "10", slug: "my-project", name: "My Project" },
+    ]);
+
+    mockListProjects.mockRejectedValueOnce(new Error("403 Forbidden"));
+
+    const projects = await getAccessibleProjects();
+
+    expect(projects).toHaveLength(1);
+    expect(projects[0]).toEqual({
+      org: "accessible",
+      project: "my-project",
+      orgName: "Accessible Org",
+      projectName: "My Project",
+    });
+  });
+
+  test("returns empty array when no projects exist", async () => {
+    mockListOrganizations.mockResolvedValue([
+      { id: "1", slug: "empty-org", name: "Empty Organization" },
+    ]);
+
+    mockListProjects.mockResolvedValue([]);
+
+    const projects = await getAccessibleProjects();
+
+    expect(projects).toEqual([]);
+  });
+
+  test("handles organization with no access to projects", async () => {
+    mockListOrganizations.mockResolvedValue([
+      { id: "1", slug: "org-1", name: "Org 1" },
+    ]);
+
+    mockListProjects.mockRejectedValue(new Error("Access denied"));
+
+    const projects = await getAccessibleProjects();
+
+    expect(projects).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds 30 tests covering previously untested DSN error formatting and project resolution functions.

## Coverage Impact

| File | Before | After | Change |
|------|--------|-------|--------|
| `src/lib/dsn/errors.ts` | 5.94% | **100%** | +94.06% |
| `src/lib/dsn/resolver.ts` | 3.23% | **94.57%** | +91.34% |

## Test Coverage

### errors.ts
- `formatConflictError`: Multiple DSN conflict formatting with various DSN configurations
- `formatNoDsnError`: No DSN found with project suggestions, API error handling
- `formatResolutionError`: Resolution failure formatting with error details
- `formatMultipleProjectsFooter`: Monorepo footer formatting for multiple projects

### resolver.ts
- `resolveProject`: DSN to org/project resolution with caching, handles:
  - Pre-resolved DSNs
  - DSNs without orgId (legacy/self-hosted)
  - DSNs with orgId (SaaS)
  - Error cases (org not found, project not found, API errors)
- `getAccessibleProjects`: Fetching all accessible projects across organizations

Both test files mock `api-client` to avoid real API calls during tests.