### PR TITLE
refactor(profile): replace --org/--project flags with positional args

### DIFF
--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -410,13 +410,11 @@ List transactions with profiling data
 - `-n, --limit <value> - Maximum number of transactions to return - (default: "20")`
 - `--json - Output as JSON`
 
-#### `sentry profile view <transaction>`
+#### `sentry profile view <args...>`
 
 View CPU profiling analysis for a transaction
 
 **Flags:**
-- `--org <value> - Organization slug`
-- `--project <value> - Project slug`
 - `--period <value> - Stats period: 1h, 24h, 7d, 14d, 30d - (default: "7d")`
 - `-n, --limit <value> - Number of hot paths to show (max 20) - (default: "10")`
 - `--allFrames - Include library/system frames (default: user code only)`

--- a/test/commands/profile/view.test.ts
+++ b/test/commands/profile/view.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Profile View Command Tests
+ *
+ * Tests for positional argument parsing in src/commands/profile/view.ts
+ */
+
+import { describe, expect, test } from "bun:test";
+import { parsePositionalArgs } from "../../../src/commands/profile/view.js";
+import { ContextError } from "../../../src/lib/errors.js";
+
+describe("parsePositionalArgs", () => {
+  describe("single argument (transaction only)", () => {
+    test("parses single arg as transaction name", () => {
+      const result = parsePositionalArgs(["/api/users"]);
+      expect(result.transactionRef).toBe("/api/users");
+      expect(result.targetArg).toBeUndefined();
+    });
+
+    test("parses transaction index", () => {
+      const result = parsePositionalArgs(["1"]);
+      expect(result.transactionRef).toBe("1");
+      expect(result.targetArg).toBeUndefined();
+    });
+
+    test("parses transaction alias", () => {
+      const result = parsePositionalArgs(["a"]);
+      expect(result.transactionRef).toBe("a");
+      expect(result.targetArg).toBeUndefined();
+    });
+
+    test("parses complex transaction name", () => {
+      const result = parsePositionalArgs(["POST /api/v2/users/:id/settings"]);
+      expect(result.transactionRef).toBe("POST /api/v2/users/:id/settings");
+      expect(result.targetArg).toBeUndefined();
+    });
+  });
+
+  describe("two arguments (target + transaction)", () => {
+    test("parses org/project target and transaction name", () => {
+      const result = parsePositionalArgs(["my-org/backend", "/api/users"]);
+      expect(result.targetArg).toBe("my-org/backend");
+      expect(result.transactionRef).toBe("/api/users");
+    });
+
+    test("parses project-only target and transaction", () => {
+      const result = parsePositionalArgs(["backend", "/api/users"]);
+      expect(result.targetArg).toBe("backend");
+      expect(result.transactionRef).toBe("/api/users");
+    });
+
+    test("parses org/ target (all projects) and transaction", () => {
+      const result = parsePositionalArgs(["my-org/", "/api/users"]);
+      expect(result.targetArg).toBe("my-org/");
+      expect(result.transactionRef).toBe("/api/users");
+    });
+
+    test("parses target and transaction index", () => {
+      const result = parsePositionalArgs(["my-org/backend", "1"]);
+      expect(result.targetArg).toBe("my-org/backend");
+      expect(result.transactionRef).toBe("1");
+    });
+
+    test("parses target and transaction alias", () => {
+      const result = parsePositionalArgs(["my-org/backend", "a"]);
+      expect(result.targetArg).toBe("my-org/backend");
+      expect(result.transactionRef).toBe("a");
+    });
+  });
+
+  describe("error cases", () => {
+    test("throws ContextError for empty args", () => {
+      expect(() => parsePositionalArgs([])).toThrow(ContextError);
+    });
+
+    test("throws ContextError with usage hint", () => {
+      try {
+        parsePositionalArgs([]);
+        expect.unreachable("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(ContextError);
+        expect((error as ContextError).message).toContain("Transaction");
+      }
+    });
+  });
+
+  describe("edge cases", () => {
+    test("handles more than two args (ignores extras)", () => {
+      const result = parsePositionalArgs([
+        "my-org/backend",
+        "/api/users",
+        "extra-arg",
+      ]);
+      expect(result.targetArg).toBe("my-org/backend");
+      expect(result.transactionRef).toBe("/api/users");
+    });
+
+    test("handles empty string transaction in two-arg case", () => {
+      const result = parsePositionalArgs(["my-org/backend", ""]);
+      expect(result.targetArg).toBe("my-org/backend");
+      expect(result.transactionRef).toBe("");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Migrate `profile view` command from `--org`/`--project` flags to `<org>/<project>` positional argument syntax
- Add unit tests for positional arg parsing

## Motivation

Ensures consistency with other commands. The `<org>/<project>` syntax is more concise and follows `gh` CLI conventions.

## Changes

**Command updated:**
- `sentry profile view [<org>/<project>] <transaction>` - now takes optional positional target

## Related

- PR #205 has the same changes for `event view` command (targeting main)

## Testing

- All tests pass
- Typecheck passes
- Lint passes