### PR TITLE
feat(auth): add token command and remove /users/me/ dependency

### DIFF
--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -90,6 +90,10 @@ View authentication status
 sentry auth status
 ```
 
+#### `sentry auth token`
+
+Print the stored authentication token
+
 ### Org
 
 Work with Sentry organizations

--- a/src/commands/auth/index.ts
+++ b/src/commands/auth/index.ts
@@ -3,6 +3,7 @@ import { loginCommand } from "./login.js";
 import { logoutCommand } from "./logout.js";
 import { refreshCommand } from "./refresh.js";
 import { statusCommand } from "./status.js";
+import { tokenCommand } from "./token.js";
 
 export const authRoute = buildRouteMap({
   routes: {
@@ -10,12 +11,14 @@ export const authRoute = buildRouteMap({
     logout: logoutCommand,
     refresh: refreshCommand,
     status: statusCommand,
+    token: tokenCommand,
   },
   docs: {
     brief: "Authenticate with Sentry",
     fullDescription:
       "Manage authentication with Sentry. Use 'sentry auth login' to authenticate, " +
       "'sentry auth logout' to remove credentials, 'sentry auth refresh' to manually refresh your token, " +
-      "and 'sentry auth status' to check your authentication status.",
+      "'sentry auth status' to check your authentication status, " +
+      "and 'sentry auth token' to print your token for use in scripts.",
   },
 });

--- a/src/commands/auth/token.ts
+++ b/src/commands/auth/token.ts
@@ -1,0 +1,36 @@
+/**
+ * sentry auth token
+ *
+ * Print the stored authentication token (unmasked).
+ * Useful for piping to other commands or scripts.
+ */
+
+import { buildCommand } from "@stricli/core";
+import type { SentryContext } from "../../context.js";
+import { getAuthToken } from "../../lib/db/auth.js";
+import { AuthError } from "../../lib/errors.js";
+
+export const tokenCommand = buildCommand({
+  docs: {
+    brief: "Print the stored authentication token",
+    fullDescription:
+      "Print the stored authentication token to stdout.\n\n" +
+      "This outputs the raw token without any formatting, making it suitable for " +
+      "piping to other commands or scripts. The token is printed without a trailing newline " +
+      "when stdout is not a TTY (e.g., when piped).",
+  },
+  parameters: {},
+  func(this: SentryContext): void {
+    const { stdout } = this;
+
+    const token = getAuthToken();
+    if (!token) {
+      throw new AuthError("not_authenticated");
+    }
+
+    // Add newline only if stdout is a TTY (interactive terminal)
+    // When piped, omit newline for cleaner output
+    const suffix = process.stdout.isTTY ? "\n" : "";
+    stdout.write(`${token}${suffix}`);
+  },
+});

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -991,6 +991,9 @@ export function triggerSolutionPlanning(
 /**
  * Get the currently authenticated user's information.
  * Used for setting user context in telemetry.
+ *
+ * Note: This endpoint may not work with OAuth App tokens, but works with
+ * manually created API tokens. Callers should handle failures gracefully.
  */
 export function getCurrentUser(): Promise<SentryUser> {
   return apiRequest<SentryUser>("/users/me/", {

--- a/src/lib/version-check.ts
+++ b/src/lib/version-check.ts
@@ -22,7 +22,13 @@ const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const JITTER_FACTOR = 0.2;
 
 /** Commands/flags that should not show update notifications */
-const SUPPRESSED_ARGS = new Set(["upgrade", "--version", "-V", "--json"]);
+const SUPPRESSED_ARGS = new Set([
+  "upgrade",
+  "--version",
+  "-V",
+  "--json",
+  "token",
+]);
 
 /** AbortController for pending version check fetch */
 let pendingAbortController: AbortController | null = null;


### PR DESCRIPTION
## Summary

- Adds `sentry auth token` command that prints the unmasked auth token for scripting/piping
- Uses `/users/me/regions/` for token validation (works with all token types including OAuth App tokens)
- Optionally fetches user info via `/users/me/` after validation (gracefully handles permission errors)

## Changes

- **New command**: `sentry auth token` - outputs raw token, no trailing newline when piped
- **Updated**: `auth login --token` validates using `getUserRegions()`, then tries `getCurrentUser()` for user info
- **Updated**: User info fetching wrapped in try-catch to handle tokens without user read permissions
- **Updated**: Suppresses upgrade notification for `auth token` command

## User Identity

- **OAuth login**: User identity comes from the token response (handled in `interactive-login.ts`)
- **Manual `--token` login**: Tries to fetch user info via `/users/me/` after validation succeeds. Failures are silently ignored (token may not have permission).