### PR TITLE
chore(ci): remove merge-artifacts job with Craft 2.21.1

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,13 +1,18 @@
-minVersion: '2.19.0'
+minVersion: '2.21.1'
 changelog:
   policy: auto
 versioning:
   policy: auto
 preReleaseCommand: node --experimental-strip-types script/bump-version.ts --pre
 postReleaseCommand: node --experimental-strip-types script/bump-version.ts --post
-requireNames:
-  - /^sentry-.+$/
-  - /^sentry-.*\.tgz$/
+artifactProvider:
+  name: github
+  config:
+    artifacts:
+      ci.yml:
+        - 'sentry-*'
+        - 'npm-package'
+        - 'gh-pages'
 targets:
   - name: npm
   - name: github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,31 +286,17 @@ jobs:
           name: gh-pages
           path: gh-pages.zip
 
-  merge-artifacts:
-    name: Merge Artifacts
-    needs: [build-binary, build-npm, build-docs, test-e2e]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v4
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.sha }}
-          path: |
-            sentry-*/
-            npm-package/*.tgz
-            gh-pages/gh-pages.zip
-
   ci-status:
     name: CI Status
     if: always()
-    needs: [changes, check-skill, merge-artifacts]
+    needs: [changes, check-skill, build-binary, build-npm, build-docs, test-e2e]
     runs-on: ubuntu-latest
     permissions: {}
     steps:
       - name: Check CI status
         run: |
-          # Check for explicit failures or cancellations
-          results="${{ needs.check-skill.result }} ${{ needs.merge-artifacts.result }}"
+          # Check for explicit failures or cancellations in all jobs
+          results="${{ needs.check-skill.result }} ${{ needs.build-binary.result }} ${{ needs.build-npm.result }} ${{ needs.build-docs.result }} ${{ needs.test-e2e.result }}"
           for result in $results; do
             if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
               echo "::error::CI failed"
@@ -320,8 +306,8 @@ jobs:
 
           # Detect upstream failures: if changes were detected but jobs were skipped,
           # it means an upstream job failed (skipped jobs cascade to dependents)
-          if [[ "${{ needs.changes.outputs.code }}" == "true" && "${{ needs.merge-artifacts.result }}" == "skipped" ]]; then
-            echo "::error::CI failed - upstream job failed causing merge-artifacts to be skipped"
+          if [[ "${{ needs.changes.outputs.code }}" == "true" && "${{ needs.test-e2e.result }}" == "skipped" ]]; then
+            echo "::error::CI failed - upstream job failed causing test-e2e to be skipped"
             exit 1
           fi
           if [[ "${{ needs.changes.outputs.skill }}" == "true" && "${{ needs.check-skill.result }}" == "skipped" ]]; then


### PR DESCRIPTION
## Summary

Upgrade to Craft 2.21.1 which supports workflow-specific artifact filtering, eliminating the need to merge all CI artifacts into a single SHA-named artifact.

## Changes

### `.craft.yml`
- Bump `minVersion` to `2.21.1`
- Replace `requireNames` with `artifactProvider.config.artifacts` for precise artifact filtering
- Artifacts collected from `ci.yml` workflow: `sentry-*`, `npm-package`, `gh-pages`

### `.github/workflows/ci.yml`
- Remove `merge-artifacts` job (previously downloaded all artifacts and re-uploaded as `${{ github.sha }}`)
- Update `ci-status` job dependencies and status checking logic

## Benefits
- **Faster CI** — eliminates redundant download/upload step
- **Cleaner config** — artifact filtering at provider level with explicit patterns
- **Better defaults** — leverages Craft 2.21.1 improvements

## References
- [Craft 2.21.1 Release](https://github.com/getsentry/craft/releases/tag/2.21.1)
- [PR #709: Configure GitHub artifact provider to filter by workflow and name](https://github.com/getsentry/craft/pull/709)