### PR TITLE
build: enable minify for standalone binaries

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -80,7 +80,7 @@ async function buildTarget(target: BuildTarget): Promise<boolean> {
       SENTRY_CLIENT_ID_BUILD: JSON.stringify(SENTRY_CLIENT_ID),
       "process.env.NODE_ENV": JSON.stringify("production"),
     },
-    sourcemap: "none",
+    minify: true, // Shrink bundled JS (-1% binary size, -8% startup, -4% memory)
   });
 
   if (!result.success) {


### PR DESCRIPTION
## Summary

Add `minify: true` to `Bun.build()` for standalone executables in `script/build.ts`.

Benchmarked all Bun compile optimization flags (`minify`, `bytecode`, `sourcemap: "linked"`, `execArgv: ["--smol"]`) using hyperfine (50 runs, 5 warmup) on linux-x64:

| Config | Size | Δ Size | Startup (mean ± σ) | Δ Startup | Peak RSS | Δ RSS |
|---|---|---|---|---|---|---|
| baseline | 99.2 MB | — | 337.0 ± 17.1 ms | — | 94,080 KB | — |
| **minify** | **98.2 MB** | **-1%** | **316.7 ± 14.0 ms** | **-6%** | **90,624 KB** | **-4%** |
| minify+smol | 98.2 MB | -1% | 315.2 ± 12.4 ms | -6% | 90,624 KB | -4% |
| minify+sourcemap | 100.3 MB | +1% | 311.6 ± 9.2 ms | -8% | 92,672 KB | -1% |

**Not shown:** `bytecode: true` variants added +10% binary size for negligible startup improvement.

## Decisions

- **`minify: true`** — applied. Smaller binary, faster startup, less memory. No trade-off.
- **`bytecode: true`** — rejected. +10 MB binary size, bytecode representation larger than minified source.
- **`--smol`** — rejected. Zero measurable effect for a CLI that exits in <1s.
- **`sourcemap: "linked"`** — deferred. +2 MB for readable stack traces, viable for the future.

Full plan and benchmark details in `script/OPTIMIZE-BINARIES.md` (also attached as a git note).