### PR TITLE
chore(ci): auto-commit SKILL.md when stale

### DIFF
--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -100,7 +100,7 @@ Work with Sentry organizations
 
 #### `sentry org list`
 
-List organizations (test auto-commit)
+List organizations
 
 **Flags:**
 - `--limit <value> - Maximum number of organizations to list - (default: "30")`
@@ -518,11 +518,11 @@ List issues in a project
 
 ### Orgs
 
-List organizations (test auto-commit)
+List organizations
 
 #### `sentry orgs`
 
-List organizations (test auto-commit)
+List organizations
 
 **Flags:**
 - `--limit <value> - Maximum number of organizations to list - (default: "30")`


### PR DESCRIPTION
## Summary

When `check-skill` detects SKILL.md is out of date, auto-commit the regenerated file instead of failing CI with instructions.

`check-skill.ts` already runs `generate-skill.ts` internally and leaves the updated file on disk — so we just need to `git add`, `commit`, and `push` when the check fails.

## Changes

Replaced the "Output regeneration instructions" step (which printed manual fix commands and failed the build) with a step that commits and pushes the regenerated SKILL.md using the `github-actions[bot]` identity.