### PR TITLE
fix(deps): move runtime dependencies to devDependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
         run: bun install --frozen-lockfile
       - run: bun run lint
       - run: bun run typecheck
+      - run: bun run check:deps
 
   test-unit:
     name: Unit Tests

--- a/bun.lock
+++ b/bun.lock
@@ -4,11 +4,6 @@
   "workspaces": {
     "": {
       "name": "sentry",
-      "dependencies": {
-        "ignore": "^7.0.5",
-        "p-limit": "^7.2.0",
-        "pretty-ms": "^9.3.0",
-      },
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
         "@sentry/bun": "10.38.0",
@@ -23,7 +18,10 @@
         "chalk": "^5.6.2",
         "esbuild": "^0.25.0",
         "fast-check": "^4.5.3",
+        "ignore": "^7.0.5",
         "ky": "^1.14.2",
+        "p-limit": "^7.2.0",
+        "pretty-ms": "^9.3.0",
         "qrcode-terminal": "^0.12.0",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:isolated": "bun test test/isolated",
     "test:e2e": "bun test test/e2e",
     "generate:skill": "bun run script/generate-skill.ts",
-    "check:skill": "bun run script/check-skill.ts"
+    "check:skill": "bun run script/check-skill.ts",
+    "check:deps": "bun run script/check-no-deps.ts"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
@@ -38,7 +39,10 @@
     "chalk": "^5.6.2",
     "esbuild": "^0.25.0",
     "fast-check": "^4.5.3",
+    "ignore": "^7.0.5",
     "ky": "^1.14.2",
+    "p-limit": "^7.2.0",
+    "pretty-ms": "^9.3.0",
     "qrcode-terminal": "^0.12.0",
     "semver": "^7.7.3",
     "tinyglobby": "^0.2.15",
@@ -59,10 +63,5 @@
   "patchedDependencies": {
     "@stricli/core@1.2.5": "patches/@stricli%2Fcore@1.2.5.patch",
     "@sentry/core@10.38.0": "patches/@sentry%2Fcore@10.38.0.patch"
-  },
-  "dependencies": {
-    "ignore": "^7.0.5",
-    "p-limit": "^7.2.0",
-    "pretty-ms": "^9.3.0"
   }
 }

--- a/script/check-no-deps.ts
+++ b/script/check-no-deps.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env bun
+/**
+ * Check for Runtime Dependencies
+ *
+ * Ensures package.json has no `dependencies` field. All packages must be
+ * listed under `devDependencies` and bundled at build time via esbuild
+ * (npm bundle) or Bun.build (standalone binary). This keeps the published
+ * package at zero install-time dependencies.
+ *
+ * Usage:
+ *   bun run script/check-no-deps.ts
+ *
+ * Exit codes:
+ *   0 - No runtime dependencies found
+ *   1 - Runtime dependencies detected
+ */
+
+const pkg: { dependencies?: Record<string, string> } =
+  await Bun.file("package.json").json();
+
+const deps = Object.keys(pkg.dependencies ?? {});
+export {};
+
+if (deps.length === 0) {
+  console.log("✓ No runtime dependencies in package.json");
+  process.exit(0);
+}
+
+console.error("✗ Found runtime dependencies in package.json:");
+console.error("");
+for (const dep of deps) {
+  console.error(`  - ${dep}: ${pkg.dependencies?.[dep]}`);
+}
+console.error("");
+console.error(
+  "All packages must be in devDependencies and bundled at build time."
+);
+console.error(
+  "Move these to devDependencies: bun remove <pkg> && bun add -d <pkg>"
+);
+
+process.exit(1);

--- a/test/package.test.ts
+++ b/test/package.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+
+describe("package.json", () => {
+  test("has no runtime dependencies", async () => {
+    const pkg: { dependencies?: Record<string, string> } =
+      await Bun.file("package.json").json();
+
+    expect(pkg.dependencies ?? {}).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

All packages are bundled at build time via esbuild (npm) and `Bun.build` (standalone binaries), so the `dependencies` field should always be empty. Three packages (`ignore`, `p-limit`, `pretty-ms`) were accidentally listed there.

- Move `ignore`, `p-limit`, `pretty-ms` from `dependencies` to `devDependencies`
- Remove the now-empty `dependencies` field
- Add `script/check-no-deps.ts` CI check that fails if `dependencies` exists in `package.json`
- Wire `check:deps` into the CI lint job alongside `bun run lint` and `bun run typecheck`
- Add `test/package.test.ts` unit test for local regression catching

## Verification

- `bun run typecheck` — passes
- `bun run lint` — passes
- `bun run check:deps` — passes
- `bun run bundle` — produces working `dist/bin.cjs`
- `node dist/bin.cjs --help` — works
- `bun test test/package.test.ts` — passes