### PR TITLE
ci: handle fork PRs in SKILL.md auto-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,15 @@ jobs:
     steps:
       - name: Get auth token
         id: token
+        # Fork PRs don't have access to secrets, so this step is skipped
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
         uses: actions/create-github-app-token@v2.2.1
         with:
           app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
-          token: ${{ steps.token.outputs.token }}
+          token: ${{ steps.token.outputs.token || github.token }}
           ref: ${{ github.head_ref || github.ref_name }}
       - uses: oven-sh/setup-bun@v2
       - uses: actions/cache@v4
@@ -69,14 +71,19 @@ jobs:
         id: check
         run: bun run check:skill
         continue-on-error: true
-      - name: Commit regenerated SKILL.md
-        if: steps.check.outcome == 'failure'
+      - name: Auto-commit regenerated SKILL.md
+        if: steps.check.outcome == 'failure' && steps.token.outcome == 'success'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add plugins/sentry-cli/skills/sentry-cli/SKILL.md
           git commit -m "chore: regenerate SKILL.md"
           git push
+      - name: Fail for fork PRs with stale SKILL.md
+        if: steps.check.outcome == 'failure' && steps.token.outcome != 'success'
+        run: |
+          echo "::error::SKILL.md is out of date. Run 'bun run generate:skill' locally and commit the result."
+          exit 1
 
   lint:
     name: Lint & Typecheck


### PR DESCRIPTION
## Summary

Fixes a bug introduced in #224 where the `check-skill` CI job would fail for fork PRs.

## Problem

The auto-commit flow for stale SKILL.md uses a GitHub App token (`SENTRY_RELEASE_BOT`) to push commits back to the branch. This fails for fork PRs because:

1. **Secrets are unavailable** — GitHub does not expose repo secrets to `pull_request` workflows triggered from forks (security policy)
2. **No push access** — Even if the token were available, the GitHub App is installed on `getsentry/cli`, not the contributor's fork

## Fix

- **Skip the token step** for fork PRs (conditional on `github.event.pull_request.head.repo.full_name == github.repository`)
- **Fall back to `github.token`** for checkout when the app token isn't available
- **Auto-commit** only when the app token was successfully obtained (same-repo PRs and push events)
- **Fail with an actionable error** for fork PRs, asking the contributor to run `bun run generate:skill` locally