### PR TITLE
ci: rename CI workflow to Build and fix artifact filter

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -9,7 +9,7 @@ artifactProvider:
   name: github
   config:
     artifacts:
-      ci.yml:
+      Build:
         - 'sentry-*'
         - 'npm-package'
         - 'gh-pages'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build
 
 on:
   push:


### PR DESCRIPTION
## Summary

Publishing with craft fails because the artifact filter key in `.craft.yml` used the workflow **filename** (`ci.yml`) instead of the workflow **name** field. Craft's `GitHubArtifactProvider.filterWorkflowRuns()` matches config keys against `run.name`, so the filter `ci.yml` (regex `/^ci\.yml$/`) never matched `"CI"`, causing artifact retrieval to fail after 3 retries.

## Changes

- Rename the CI workflow from `CI` to `Build`
- Update `.craft.yml` artifact filter key from `ci.yml` to `Build`