### PR TITLE
fix(craft): use regex pattern for binary artifact matching

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -10,7 +10,7 @@ artifactProvider:
   config:
     artifacts:
       Build:
-        - 'sentry-*'
+        - '/^sentry-.*$/'
         - 'npm-package'
         - 'gh-pages'
 targets:


### PR DESCRIPTION
## Summary

Fixes the broken `curl` install (`curl https://cli.sentry.dev/install | bash`) which 404s because 0.9.0 shipped without platform binaries.

## Root Cause

Craft's `patternToRegexp()` treats plain strings as **exact matches**, escaping `*` to `\*`. The pattern `'sentry-*'` in `.craft.yml` became `/^sentry\-\*$/` — matching only the literal string `"sentry-*"`, not actual artifact names like `sentry-linux-x64`.

Only `gh-pages` and `npm-package` (exact name matches) were downloaded and uploaded to the GitHub release. All 5 platform binaries were silently skipped.

## Fix

Use Craft's regex syntax (`'/^sentry-.*$/'` with enclosing slashes) so the pattern is parsed as an actual regex.

This was introduced in #215 when migrating from `requireNames` (which used proper regex `/^sentry-.+$/`) to the new `artifactProvider` config.