### PR TITLE
fix(setup): use correct auth command in install welcome message

### DIFF
--- a/src/commands/cli/setup.ts
+++ b/src/commands/cli/setup.ts
@@ -171,7 +171,7 @@ function printWelcomeMessage(
   log(`Installed sentry v${version} to ${binaryPath}`);
   log("");
   log("Get started:");
-  log("  sentry login       Authenticate with Sentry");
+  log("  sentry auth login  Authenticate with Sentry");
   log("  sentry --help      See all available commands");
   log("");
   log("https://cli.sentry.dev");

--- a/test/commands/cli/setup.test.ts
+++ b/test/commands/cli/setup.test.ts
@@ -378,7 +378,7 @@ describe("sentry cli setup", () => {
       // Should show welcome message, not "Setup complete!"
       expect(combined).toContain("Installed sentry v");
       expect(combined).toContain("Get started:");
-      expect(combined).toContain("sentry login");
+      expect(combined).toContain("sentry auth login");
       expect(combined).toContain("sentry --help");
       expect(combined).toContain("cli.sentry.dev");
       expect(combined).not.toContain("Setup complete!");


### PR DESCRIPTION
## Summary

The post-install welcome message showed `sentry login` but the actual command is `sentry auth login`. Users following the printed instructions would get an error.

## Changes

Fixed the command in `printWelcomeMessage` and updated the corresponding test assertion.

## Test Plan

`bun test test/commands/cli/setup.test.ts` — all 18 tests pass.

---
Closes #239