### PR TITLE
fix(upgrade): remove v prefix from release URLs and work around Bun.write streaming bug

### DIFF
--- a/src/lib/binary.ts
+++ b/src/lib/binary.ts
@@ -39,7 +39,7 @@ export function getBinaryDownloadUrl(version: string): string {
   const arch = process.arch === "arm64" ? "arm64" : "x64";
   const suffix = process.platform === "win32" ? ".exe" : "";
 
-  return `https://github.com/getsentry/cli/releases/download/v${version}/sentry-${os}-${arch}${suffix}`;
+  return `https://github.com/getsentry/cli/releases/download/${version}/sentry-${os}-${arch}${suffix}`;
 }
 
 /**

--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -316,7 +316,7 @@ export async function versionExists(
 ): Promise<boolean> {
   if (method === "curl") {
     const response = await fetchWithUpgradeError(
-      `${GITHUB_RELEASES_URL}/tags/v${version}`,
+      `${GITHUB_RELEASES_URL}/tags/${version}`,
       { method: "HEAD", headers: getGitHubHeaders() },
       "GitHub"
     );
@@ -388,8 +388,12 @@ export async function downloadBinaryToTemp(
       );
     }
 
-    // Write to temp file
-    await Bun.write(tempPath, response);
+    // Fully consume the response body before writing to disk.
+    // Bun.write(path, Response) with a large streaming body can exit the
+    // process before the download completes (Bun event-loop bug).
+    // Materialising the body first ensures the await keeps the process alive.
+    const body = await response.arrayBuffer();
+    await Bun.write(tempPath, body);
 
     // Set executable permission (Unix only)
     if (process.platform !== "win32") {

--- a/test/commands/cli/upgrade.test.ts
+++ b/test/commands/cli/upgrade.test.ts
@@ -101,17 +101,17 @@ function mockGitHubVersion(version: string): void {
 
     // GitHub latest release endpoint — returns JSON with tag_name
     if (urlStr.includes("releases/latest")) {
-      return new Response(JSON.stringify({ tag_name: `v${version}` }), {
+      return new Response(JSON.stringify({ tag_name: version }), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
     }
 
-    // GitHub tag check (for versionExists)
-    if (urlStr.includes("/releases/tag/")) {
-      const requested = urlStr.split("/releases/tag/v")[1];
+    // GitHub tag check (for versionExists) — this repo uses un-prefixed tags
+    if (urlStr.includes("/releases/tags/")) {
+      const requested = urlStr.split("/releases/tags/")[1];
       if (requested === version) {
-        return new Response(JSON.stringify({ tag_name: `v${version}` }), {
+        return new Response(JSON.stringify({ tag_name: version }), {
           status: 200,
           headers: { "content-type": "application/json" },
         });

--- a/test/lib/binary.test.ts
+++ b/test/lib/binary.test.ts
@@ -31,9 +31,9 @@ describe("getBinaryDownloadUrl", () => {
   test("builds correct URL for current platform", () => {
     const url = getBinaryDownloadUrl("1.0.0");
 
-    expect(url).toContain("/v1.0.0/");
+    expect(url).toContain("/1.0.0/");
     expect(url).toStartWith(
-      "https://github.com/getsentry/cli/releases/download/v"
+      "https://github.com/getsentry/cli/releases/download/"
     );
     expect(url).toContain("sentry-");
 

--- a/test/lib/upgrade.test.ts
+++ b/test/lib/upgrade.test.ts
@@ -437,10 +437,10 @@ describe("getBinaryDownloadUrl", () => {
   test("builds correct URL for current platform", () => {
     const url = getBinaryDownloadUrl("1.0.0");
 
-    // URL should contain the version with 'v' prefix (GitHub tag format)
-    expect(url).toContain("/v1.0.0/");
+    // URL should contain the version without 'v' prefix (this repo's tag format)
+    expect(url).toContain("/1.0.0/");
     expect(url).toStartWith(
-      "https://github.com/getsentry/cli/releases/download/v"
+      "https://github.com/getsentry/cli/releases/download/"
     );
     expect(url).toContain("sentry-");
 


### PR DESCRIPTION
## Summary

Fixes two bugs that prevent `sentry cli upgrade` from working for curl-installed users (CLI-5F):

1. **`v` prefix on release URLs** — `getBinaryDownloadUrl()` and `versionExists()` constructed GitHub release URLs with a `v` prefix (e.g., `/download/v0.10.1/...`), but this repo's tags are un-prefixed (`0.10.1`), causing HTTP 404 errors.

2. **`Bun.write(path, Response)` event-loop bug** — Even with correct URLs, `Bun.write(tempPath, response)` with a large streaming HTTP response body doesn't properly keep the Bun event loop alive. The process exits mid-download with code 0 and no error output. The workaround is to materialise the body first via `await response.arrayBuffer()`, then write the buffer.

## Changes

**`src/lib/binary.ts`**
- Remove `v` prefix from download URL template in `getBinaryDownloadUrl()`

**`src/lib/upgrade.ts`**
- Remove `v` prefix from version-exists tag check URL in `versionExists()`
- Replace `Bun.write(tempPath, response)` with `response.arrayBuffer()` + `Bun.write(tempPath, body)` to work around the Bun streaming bug

**Tests** — Updated URL assertions and mocks across 3 test files to match the un-prefixed tag format.

## How the Bun bug was diagnosed

`strace` showed the process actively receiving data from GitHub's CDN, then calling `exit_group(0)` mid-download. Adding debug logging confirmed `Bun.write(path, Response)` starts but its `await` never resolves — the event loop drains and the process exits cleanly. A standalone repro (`await Bun.write(path, await fetch(url))`) hangs indefinitely, but within the CLI's async call stack, the process exits. Materialising the body first with `arrayBuffer()` fixes both cases.