### PR TITLE
feat(build): add gzip-compressed binary downloads

### DIFF
--- a/install
+++ b/install
@@ -104,7 +104,16 @@ tmp_binary="${tmpdir}/sentry-install-$$${suffix}"
 trap 'rm -f "$tmp_binary"' EXIT
 
 echo -e "${MUTED}Downloading sentry v${version}...${NC}"
-curl -fsSL --progress-bar "$url" -o "$tmp_binary"
+
+# Try gzip-compressed download first (~60% smaller, ~37 MB vs ~99 MB).
+# gunzip is POSIX and available on all Unix systems.
+# Falls back to raw binary if the .gz asset doesn't exist yet.
+if curl -fsSL "${url}.gz" 2>/dev/null | gunzip > "$tmp_binary" 2>/dev/null; then
+  : # Compressed download succeeded
+else
+  curl -fsSL --progress-bar "$url" -o "$tmp_binary"
+fi
+
 chmod +x "$tmp_binary"
 
 # Delegate installation and configuration to the binary itself.


### PR DESCRIPTION
## Summary

- Reduce binary download size from ~99 MB to ~37 MB (~60% reduction) for both fresh installs and CLI self-upgrades
- Gzip level 6 via `node:zlib` in the build script (CI only), uploading `.gz` alongside raw binaries for backward compatibility
- Upgrade path tries `{url}.gz` first with streaming `DecompressionStream` decompression, falls back to raw binary on failure
- Install script tries `curl | gunzip` first (gunzip is POSIX-universal), falls back to raw `curl` download
- Works around `Bun.write` streaming bug ([oven-sh/bun#13237](https://github.com/oven-sh/bun/issues/13237)) using manual `for await` writer loop

## Changes

| File | What |
|------|------|
| `script/build.ts` | Async gzip compression after each binary build (CI only) |
| `src/lib/upgrade.ts` | `.gz`-first download with streaming decompression + fallback |
| `install` | `curl \| gunzip` with fallback to raw download |
| `test/lib/upgrade.test.ts` | Tests for gzip download, fallback paths, and error cases |

No CI or Craft config changes needed — existing artifact globs already match `.gz` files.