### PR TITLE
fix(telemetry): reduce noise from version-check JSON parse errors

### DIFF
--- a/test/lib/version-check.test.ts
+++ b/test/lib/version-check.test.ts
@@ -39,6 +39,15 @@ describe("shouldSuppressNotification", () => {
     expect(shouldSuppressNotification(["cli", "feedback"])).toBe(false);
   });
 
+  test("does not suppress when setup/fix appear as non-cli args", () => {
+    expect(
+      shouldSuppressNotification(["issue", "list", "--project", "setup"])
+    ).toBe(false);
+    expect(
+      shouldSuppressNotification(["issue", "list", "--query", "fix"])
+    ).toBe(false);
+  });
+
   test("suppresses for --version flag", () => {
     expect(shouldSuppressNotification(["--version"])).toBe(true);
     expect(shouldSuppressNotification(["-V"])).toBe(true);


### PR DESCRIPTION
## Summary

Background version check errors (`SyntaxError: Unexpected end of JSON input`) from GitHub API calls were being reported via `captureException`, creating noise in the Issues feed (CLI-K: 10 events, CLI-5J: 1 event). These are transient infrastructure issues (rate limits, CDN errors, truncated responses), not CLI bugs.

- Replace `captureException` with span attributes (`version_check.error`, `version_check.error_type`) so errors remain queryable in Discover without creating Issues
- Suppress background version check for `sentry cli setup` and `sentry cli fix` — CLI management commands where update notifications are irrelevant

Fixes CLI-K, CLI-5J