### PR TITLE
fix(npm): add Node.js >= 22 version guard to npm bundle

### DIFF
--- a/script/bundle.ts
+++ b/script/bundle.ts
@@ -96,7 +96,7 @@ const result = await build({
   banner: {
     // Check Node.js version (>= 22 required for node:sqlite) and suppress warnings
     js: `#!/usr/bin/env node
-if(parseInt(process.versions.node)<22){console.error("Error: sentry requires Node.js 22 or later (found "+process.version+").\n\nEither upgrade Node.js, or install the standalone binary instead:\n  curl -fsSL https://cli.sentry.dev/install | bash\n");process.exit(1)}
+if(parseInt(process.versions.node)<22){console.error("Error: sentry requires Node.js 22 or later (found "+process.version+").\\n\\nEither upgrade Node.js, or install the standalone binary instead:\\n  curl -fsSL https://cli.sentry.dev/install | bash\\n");process.exit(1)}
 {let e=process.emit;process.emit=function(n,...a){return n==="warning"?!1:e.apply(this,[n,...a])}}`,
   },
   sourcemap: true,


### PR DESCRIPTION
## Problem

Users installing via pnpm (or npm/yarn without strict engine enforcement) on Node.js < 22 get a cryptic crash at startup:

```
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
Node.js v20.18.0
```

The `bun:sqlite` polyfill in the npm bundle depends on `node:sqlite`, which only exists in Node.js 22+. Since the polyfill is injected at the very top of `dist/bin.cjs` via esbuild's `inject` option, the `require('node:sqlite')` happens during module loading — before any error handler can catch it. `package.json` already declares `"engines": { "node": ">=22" }`, but pnpm doesn't enforce engine constraints by default.

## Fix

Add a version check to the esbuild bundle banner in `script/bundle.ts`. The banner runs before the injected polyfill code, so it catches the incompatibility before `node:sqlite` is ever required.

Users on Node < 22 now see:

```
Error: sentry requires Node.js 22 or later (found v20.18.0).

Either upgrade Node.js, or install the standalone binary instead:
  curl -fsSL https://cli.sentry.dev/install | bash
```