### PR TITLE
fix(telemetry): fix commands importing buildCommand directly from @stricli/core

### DIFF
--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -5,9 +5,9 @@
  * Similar to 'gh api' for GitHub.
  */
 
-import { buildCommand } from "@stricli/core";
 import type { SentryContext } from "../context.js";
 import { rawApiRequest } from "../lib/api-client.js";
+import { buildCommand } from "../lib/command.js";
 import type { Writer } from "../types/index.js";
 
 type HttpMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";

--- a/src/commands/log/view.ts
+++ b/src/commands/log/view.ts
@@ -4,7 +4,6 @@
  * View detailed information about a Sentry log entry.
  */
 
-import { buildCommand } from "@stricli/core";
 import type { SentryContext } from "../../context.js";
 import { getLog } from "../../lib/api-client.js";
 import {
@@ -12,6 +11,7 @@ import {
   parseSlashSeparatedArg,
 } from "../../lib/arg-parsing.js";
 import { openInBrowser } from "../../lib/browser.js";
+import { buildCommand } from "../../lib/command.js";
 import { ContextError, ValidationError } from "../../lib/errors.js";
 import { formatLogDetails, writeJson } from "../../lib/formatters/index.js";
 import {

--- a/src/commands/trace/list.ts
+++ b/src/commands/trace/list.ts
@@ -4,10 +4,10 @@
  * List recent traces from Sentry projects.
  */
 
-import { buildCommand } from "@stricli/core";
 import type { SentryContext } from "../../context.js";
 import { listTransactions } from "../../lib/api-client.js";
 import { validateLimit } from "../../lib/arg-parsing.js";
+import { buildCommand } from "../../lib/command.js";
 import {
   formatTraceRow,
   formatTracesHeader,

--- a/src/commands/trace/view.ts
+++ b/src/commands/trace/view.ts
@@ -4,7 +4,6 @@
  * View detailed information about a distributed trace.
  */
 
-import { buildCommand } from "@stricli/core";
 import type { SentryContext } from "../../context.js";
 import { getDetailedTrace } from "../../lib/api-client.js";
 import {
@@ -13,6 +12,7 @@ import {
   spansFlag,
 } from "../../lib/arg-parsing.js";
 import { openInBrowser } from "../../lib/browser.js";
+import { buildCommand } from "../../lib/command.js";
 import { ContextError, ValidationError } from "../../lib/errors.js";
 import {
   computeTraceSummary,

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -2,7 +2,15 @@
  * Command Builder with Telemetry
  *
  * Wraps Stricli's buildCommand to automatically capture flag usage for telemetry.
- * Commands should import buildCommand from this module instead of @stricli/core.
+ *
+ * ALL commands MUST import `buildCommand` from this module, NOT from `@stricli/core`.
+ * Importing directly from `@stricli/core` silently bypasses flag/arg telemetry capture.
+ *
+ * Correct:   import { buildCommand } from "../../lib/command.js";
+ * Incorrect: import { buildCommand } from "@stricli/core";  // skips telemetry!
+ *
+ * Exception: `help.ts` may import from `@stricli/core` because it also needs `run`,
+ * and the help command has no meaningful flags to capture.
  */
 
 import {


### PR DESCRIPTION
## Summary

`trace/list`, `trace/view`, `log/view`, and `api.ts` were importing `buildCommand` directly from `@stricli/core`, silently bypassing the telemetry wrapper in `src/lib/command.ts` that captures flag and arg context as Sentry tags.

## Changes

- Switch all four commands to import from `../../lib/command.js` (or `../lib/command.js`)
- Add a prominent JSDoc comment in `command.ts` documenting the requirement and the exception for `help.ts`

## Not changed

`help.ts` is intentionally left on `@stricli/core` — it also imports `run` from there, and the help command has no meaningful flags to capture for telemetry.

## Notes

A Biome `noRestrictedImports` lint rule to enforce this statically was investigated but the rule is not available in the version of Biome used here. The JSDoc comment in `command.ts` serves as the documented convention instead.