### PR TITLE
fix: detect subcommand names passed as positional target patterns

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,6 +5,7 @@ import {
   buildApplication,
   buildRouteMap,
   text_en,
+  UnexpectedPositionalError,
 } from "@stricli/core";
 import { apiCommand } from "./commands/api.js";
 import { authRoute } from "./commands/auth/index.js";
@@ -33,7 +34,21 @@ import {
   getExitCode,
   stringifyUnknown,
 } from "./lib/errors.js";
-import { error as errorColor } from "./lib/formatters/colors.js";
+import { error as errorColor, warning } from "./lib/formatters/colors.js";
+
+/**
+ * Plural alias → singular route name mapping.
+ * Used to suggest the correct command when users type e.g. `sentry projects view cli`.
+ */
+const PLURAL_TO_SINGULAR: Record<string, string> = {
+  issues: "issue",
+  orgs: "org",
+  projects: "project",
+  repos: "repo",
+  teams: "team",
+  logs: "log",
+  traces: "trace",
+};
 
 /** Top-level route map containing all CLI commands */
 export const routes = buildRouteMap({
@@ -77,6 +92,27 @@ export const routes = buildRouteMap({
  */
 const customText: ApplicationText = {
   ...text_en,
+  exceptionWhileParsingArguments: (
+    exc: unknown,
+    ansiColor: boolean
+  ): string => {
+    // When a plural alias receives extra positional args (e.g. `sentry projects view cli`),
+    // Stricli throws UnexpectedPositionalError because the list command only accepts 1 arg.
+    // Detect this and suggest the singular form.
+    if (exc instanceof UnexpectedPositionalError) {
+      const args = process.argv.slice(2);
+      const firstArg = args[0];
+      if (firstArg && firstArg in PLURAL_TO_SINGULAR) {
+        const singular = PLURAL_TO_SINGULAR[firstArg];
+        const rest = args.slice(1).join(" ");
+        const hint = ansiColor
+          ? warning(`\nDid you mean: sentry ${singular} ${rest}\n`)
+          : `\nDid you mean: sentry ${singular} ${rest}\n`;
+        return `${text_en.exceptionWhileParsingArguments(exc, ansiColor)}${hint}`;
+      }
+    }
+    return text_en.exceptionWhileParsingArguments(exc, ansiColor);
+  },
   exceptionWhileRunningCommand: (exc: unknown, ansiColor: boolean): string => {
     // Re-throw AuthError("not_authenticated") for auto-login flow in bin.ts
     // Don't capture to Sentry - it's an expected state (user not logged in), not an error

--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -16,7 +16,6 @@ import {
   listProjects,
 } from "../../lib/api-client.js";
 import { parseOrgProjectArg } from "../../lib/arg-parsing.js";
-import { buildCommand } from "../../lib/command.js";
 import {
   clearPaginationCursor,
   escapeContextKeyValue,
@@ -43,6 +42,7 @@ import {
   writeJson,
 } from "../../lib/formatters/index.js";
 import {
+  buildListCommand,
   buildListLimitFlag,
   LIST_BASE_ALIASES,
   LIST_JSON_FLAG,
@@ -700,7 +700,7 @@ const issueListMeta: ListCommandMeta = {
   commandPrefix: "sentry issue list",
 };
 
-export const listCommand = buildCommand({
+export const listCommand = buildListCommand("issue", {
   docs: {
     brief: "List issues in a project",
     fullDescription:

--- a/src/commands/log/list.ts
+++ b/src/commands/log/list.ts
@@ -10,7 +10,6 @@ import * as Sentry from "@sentry/bun";
 import type { SentryContext } from "../../context.js";
 import { listLogs } from "../../lib/api-client.js";
 import { validateLimit } from "../../lib/arg-parsing.js";
-import { buildCommand } from "../../lib/command.js";
 import { AuthError, stringifyUnknown } from "../../lib/errors.js";
 import {
   formatLogRow,
@@ -18,7 +17,10 @@ import {
   writeFooter,
   writeJson,
 } from "../../lib/formatters/index.js";
-import { TARGET_PATTERN_NOTE } from "../../lib/list-command.js";
+import {
+  buildListCommand,
+  TARGET_PATTERN_NOTE,
+} from "../../lib/list-command.js";
 import { resolveOrgProjectFromArg } from "../../lib/resolve-target.js";
 import { getUpdateNotification } from "../../lib/version-check.js";
 import type { SentryLog, Writer } from "../../types/index.js";
@@ -228,7 +230,7 @@ async function executeFollowMode(options: FollowModeOptions): Promise<void> {
   }
 }
 
-export const listCommand = buildCommand({
+export const listCommand = buildListCommand("log", {
   docs: {
     brief: "List logs from a project",
     fullDescription:

--- a/src/commands/project/list.ts
+++ b/src/commands/project/list.ts
@@ -23,7 +23,6 @@ import {
   type ParsedOrgProject,
   parseOrgProjectArg,
 } from "../../lib/arg-parsing.js";
-import { buildCommand } from "../../lib/command.js";
 import { getDefaultOrganization } from "../../lib/db/defaults.js";
 import {
   clearPaginationCursor,
@@ -39,6 +38,7 @@ import {
   writeJson,
 } from "../../lib/formatters/index.js";
 import {
+  buildListCommand,
   buildListLimitFlag,
   LIST_BASE_ALIASES,
   LIST_CURSOR_FLAG,
@@ -603,7 +603,7 @@ const projectListMeta: ListCommandMeta = {
   commandPrefix: "sentry project list",
 };
 
-export const listCommand = buildCommand({
+export const listCommand = buildListCommand("project", {
   docs: {
     brief: "List projects",
     fullDescription:

--- a/src/commands/repo/list.ts
+++ b/src/commands/repo/list.ts
@@ -68,4 +68,4 @@ const docs: OrgListCommandDocs = {
     "  sentry repo list --json",
 };
 
-export const listCommand = buildOrgListCommand(repoListConfig, docs);
+export const listCommand = buildOrgListCommand(repoListConfig, docs, "repo");

--- a/src/commands/team/list.ts
+++ b/src/commands/team/list.ts
@@ -74,4 +74,4 @@ const docs: OrgListCommandDocs = {
     "  sentry team list --json",
 };
 
-export const listCommand = buildOrgListCommand(teamListConfig, docs);
+export const listCommand = buildOrgListCommand(teamListConfig, docs, "team");

--- a/src/commands/trace/list.ts
+++ b/src/commands/trace/list.ts
@@ -7,14 +7,16 @@
 import type { SentryContext } from "../../context.js";
 import { listTransactions } from "../../lib/api-client.js";
 import { validateLimit } from "../../lib/arg-parsing.js";
-import { buildCommand } from "../../lib/command.js";
 import {
   formatTraceRow,
   formatTracesHeader,
   writeFooter,
   writeJson,
 } from "../../lib/formatters/index.js";
-import { TARGET_PATTERN_NOTE } from "../../lib/list-command.js";
+import {
+  buildListCommand,
+  TARGET_PATTERN_NOTE,
+} from "../../lib/list-command.js";
 import { resolveOrgProjectFromArg } from "../../lib/resolve-target.js";
 
 type ListFlags = {
@@ -63,7 +65,7 @@ export function parseSort(value: string): SortValue {
   return value as SortValue;
 }
 
-export const listCommand = buildCommand({
+export const listCommand = buildListCommand("trace", {
   docs: {
     brief: "List recent traces in a project",
     fullDescription:

--- a/test/lib/route-subcommands.test.ts
+++ b/test/lib/route-subcommands.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for interceptSubcommand in list-command.ts.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { interceptSubcommand } from "../../src/lib/list-command.js";
+
+function makeStderr(): { write(s: string): void; output: string } {
+  let output = "";
+  return {
+    write(s: string) {
+      output += s;
+    },
+    get output() {
+      return output;
+    },
+  };
+}
+
+describe("interceptSubcommand", () => {
+  test("returns undefined and writes hint for known subcommand", () => {
+    const stderr = makeStderr();
+    const result = interceptSubcommand("list", stderr, "project");
+    expect(result).toBeUndefined();
+    expect(stderr.output).toContain("Tip:");
+    expect(stderr.output).toContain("sentry project list");
+  });
+
+  test("returns target unchanged for normal project names", () => {
+    const stderr = makeStderr();
+    const result = interceptSubcommand("my-project", stderr, "project");
+    expect(result).toBe("my-project");
+    expect(stderr.output).toBe("");
+  });
+
+  test("returns target unchanged for org/project patterns", () => {
+    const stderr = makeStderr();
+    const result = interceptSubcommand("sentry/cli", stderr, "issue");
+    expect(result).toBe("sentry/cli");
+    expect(stderr.output).toBe("");
+  });
+
+  test("returns undefined/empty unchanged (no hint)", () => {
+    const stderr = makeStderr();
+    expect(interceptSubcommand(undefined, stderr, "project")).toBeUndefined();
+    expect(stderr.output).toBe("");
+
+    expect(interceptSubcommand("", stderr, "project")).toBe("");
+    expect(stderr.output).toBe("");
+  });
+
+  test("hint includes the route name and subcommand", () => {
+    const stderr = makeStderr();
+    interceptSubcommand("view", stderr, "issue");
+    expect(stderr.output).toContain("sentry issue view");
+  });
+
+  test("handles 'explain' and 'plan' subcommands for issue route", () => {
+    const stderr1 = makeStderr();
+    expect(interceptSubcommand("explain", stderr1, "issue")).toBeUndefined();
+    expect(stderr1.output).toContain("sentry issue explain");
+
+    const stderr2 = makeStderr();
+    expect(interceptSubcommand("plan", stderr2, "issue")).toBeUndefined();
+    expect(stderr2.output).toContain("sentry issue plan");
+  });
+
+  test("does not intercept subcommands from unrelated routes", () => {
+    const stderr = makeStderr();
+    // "explain" is a subcommand of "issue" but not "project"
+    const result = interceptSubcommand("explain", stderr, "project");
+    expect(result).toBe("explain");
+    expect(stderr.output).toBe("");
+  });
+
+  test("only intercepts subcommands of the specified route", () => {
+    const stderr = makeStderr();
+    // "login" is a subcommand of "auth", not "project"
+    const result = interceptSubcommand("login", stderr, "project");
+    expect(result).toBe("login");
+    expect(stderr.output).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- Detects when subcommand names (`list`, `view`, `explain`, `plan`) are passed as positional target patterns and throws a clear `ValidationError` suggesting the singular form

## Motivation

**CLI-7G** (4 events, 3 users): Users typing `sentry projects list` get `"No project 'list' found"` because the `projects` plural alias maps directly to `projectListCommand`, and Stricli passes `list` as the positional arg (interpreted as a project slug). Same issue affects all plural aliases (`sentry issues list`, `sentry orgs list`, etc.).

## Changes

### `src/lib/arg-parsing.ts`
- Added `KNOWN_SUBCOMMANDS` set (`list`, `view`, `explain`, `plan`)
- `parseOrgProjectArg()` now checks if the trimmed arg matches a known subcommand name
- Throws `ValidationError` with message: `"list" is a subcommand, not a target pattern. Use the singular form (e.g. sentry project list, sentry issue view).`

### `test/lib/arg-parsing.test.ts`
- 5 new tests: each subcommand name throws `ValidationError`, non-subcommand names (`my-project`, `listing`) pass through normally

Fixes CLI-7G