### PR TITLE
feat(setup): install bash completions as fallback for unsupported shells

### DIFF
--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -266,3 +266,17 @@ export async function addToGitHubPath(
     return false;
   }
 }
+
+/**
+ * Check if bash is available on the system.
+ *
+ * Uses `Bun.which` to search PATH for a bash executable.
+ * Useful as a fallback for unsupported shells — many custom shells
+ * (xonsh, nushell, etc.) support bash completions.
+ *
+ * @param pathEnv - Override PATH for testing. Defaults to the process PATH.
+ */
+export function isBashAvailable(pathEnv?: string): boolean {
+  const opts = pathEnv !== undefined ? { PATH: pathEnv } : undefined;
+  return Bun.which("bash", opts) !== null;
+}

--- a/test/lib/shell.test.ts
+++ b/test/lib/shell.test.ts
@@ -7,13 +7,14 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
   addToGitHubPath,
   addToPath,
   detectShell,
   findExistingConfigFile,
   getConfigCandidates,
+  isBashAvailable,
 } from "../../src/lib/shell.js";
 
 describe("shell utilities", () => {
@@ -255,5 +256,25 @@ describe("shell utilities", () => {
 
       expect(result).toBe(false);
     });
+  });
+});
+
+describe("isBashAvailable", () => {
+  test("returns true when bash is in PATH", () => {
+    // Point PATH at the directory containing bash
+    const bashPath = Bun.which("bash");
+    if (!bashPath) {
+      // Skip if bash truly isn't on this system
+      return;
+    }
+    expect(isBashAvailable(dirname(bashPath))).toBe(true);
+  });
+
+  test("returns false when PATH has no bash", () => {
+    expect(isBashAvailable("/nonexistent")).toBe(false);
+  });
+
+  test("returns false when PATH is empty", () => {
+    expect(isBashAvailable("")).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

During `sentry setup`, if the user's shell isn't directly supported (e.g. xonsh, nushell, tcsh), completions are silently skipped or a \"not supported\" message is shown. Most systems have bash installed, and many custom shells can load bash completions as a compatibility layer.

## Solution

When `handleCompletions` encounters an unsupported shell (not bash/zsh/fish/sh/ash):
- If `bash` is found on `PATH` → install bash completions and inform the user
- If `bash` is not found → keep the existing \"Not supported\" message

Example output for an xonsh user:
```
Completions: Your shell (unknown) is not directly supported
      Installed bash completions as a fallback: ~/.local/share/bash-completion/completions/sentry
```

`sh`/`ash` continue to silently skip completions (no message), as they are minimal POSIX shells where completions aren't expected.

## Changes

- `src/lib/shell.ts` — `isBashAvailable()` using `Bun.which("bash")`
- `src/commands/cli/setup.ts` — `tryBashCompletionFallback()` helper; updated `handleCompletions()`
- Tests updated/added for the fallback path, the sh silent-skip, and `isBashAvailable`