### PR TITLE
fix(setup): show actual shell name instead of "unknown" for unsupported shells

### DIFF
--- a/src/commands/cli/setup.ts
+++ b/src/commands/cli/setup.ts
@@ -188,12 +188,12 @@ async function handleCompletions(
 
   if (fallbackMsg) {
     return [
-      `Completions: Your shell (${shell.type}) is not directly supported`,
+      `Completions: Your shell (${shell.name}) is not directly supported`,
       fallbackMsg,
     ];
   }
 
-  return [`Completions: Not supported for ${shell.type} shell`];
+  return [`Completions: Not supported for ${shell.name} shell`];
 }
 
 /**

--- a/src/lib/shell.ts
+++ b/src/lib/shell.ts
@@ -15,6 +15,8 @@ export type ShellType = "bash" | "zsh" | "fish" | "sh" | "ash" | "unknown";
 export type ShellInfo = {
   /** Detected shell type */
   type: ShellType;
+  /** Display name for the shell (e.g. "xonsh", "bash"). Derived from $SHELL basename. */
+  name: string;
   /** Path to shell config file, if found */
   configFile: string | null;
   /** All candidate config files for this shell */
@@ -129,11 +131,13 @@ export function detectShell(
   xdgConfigHome?: string
 ): ShellInfo {
   const type = detectShellType(shellPath);
+  const name = shellPath ? basename(shellPath) : type;
   const configCandidates = getConfigCandidates(type, homeDir, xdgConfigHome);
   const configFile = findExistingConfigFile(configCandidates);
 
   return {
     type,
+    name,
     configFile,
     configCandidates,
   };

--- a/test/commands/cli/setup.test.ts
+++ b/test/commands/cli/setup.test.ts
@@ -323,7 +323,7 @@ describe("sentry cli setup", () => {
     );
 
     const combined = output.join("");
-    expect(combined).toContain("not directly supported");
+    expect(combined).toContain("Your shell (xonsh) is not directly supported");
     expect(combined).toContain("bash completions as a fallback");
     expect(combined).toContain("bash-completion");
   });
@@ -346,7 +346,7 @@ describe("sentry cli setup", () => {
     );
 
     const combined = output.join("");
-    expect(combined).toContain("Not supported for unknown shell");
+    expect(combined).toContain("Not supported for xonsh shell");
   });
 
   test("silently skips completions for sh shell", async () => {


### PR DESCRIPTION
## Problem

When an unsupported shell (e.g. xonsh) is detected during \`sentry setup\`, the completions message shows the literal string \`unknown\` — the internal \`ShellType\` value — rather than the actual shell binary name from \`\$SHELL\`:

```
Completions: Your shell (unknown) is not directly supported
```

## Solution

Add a \`name\` field to \`ShellInfo\` populated from \`basename(\$SHELL)\` at detection time, and use it in the user-facing message:

```
Completions: Your shell (xonsh) is not directly supported
      Installed bash completions as a fallback: ~/.local/share/bash-completion/completions/sentry
```

When \`\$SHELL\` is unset, \`name\` falls back to the type string.

## Changes

- `src/lib/shell.ts` — `name` field added to `ShellInfo`, populated in `detectShell()`
- `src/commands/cli/setup.ts` — use `shell.name` in unsupported/fallback messages
- `test/commands/cli/setup.test.ts` — assert on the real shell name