### PR TITLE
fix(brew): handle root-owned config dir from sudo installs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Read the full guidelines in `.cursor/rules/bun-cli.mdc`.
 | Write file | `await Bun.write(path, content)` | `fs.writeFileSync()` |
 | Check file exists | `await Bun.file(path).exists()` | `fs.existsSync()` |
 | Spawn process | `Bun.spawn()` | `child_process.spawn()` |
-| Shell commands | `Bun.$\`command\`` | `child_process.exec()` |
+| Shell commands | `Bun.$\`command\`` ⚠️ | `child_process.exec()` |
 | Find executable | `Bun.which("git")` | `which` package |
 | Glob patterns | `new Bun.Glob()` | `glob` / `fast-glob` packages |
 | Sleep | `await Bun.sleep(ms)` | `setTimeout` with Promise |
@@ -87,6 +87,12 @@ Read the full guidelines in `.cursor/rules/bun-cli.mdc`.
 ```typescript
 import { mkdirSync } from "node:fs";
 mkdirSync(dir, { recursive: true, mode: 0o700 });
+```
+
+**Exception**: `Bun.$` (shell tagged template) has no shim in `script/node-polyfills.ts` and will crash on the npm/node distribution. Until a shim is added, use `execSync` from `node:child_process` for shell commands that must work in both runtimes:
+```typescript
+import { execSync } from "node:child_process";
+const result = execSync("id -u username", { encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] });
 ```
 
 ## Architecture

--- a/src/commands/cli/fix.ts
+++ b/src/commands/cli/fix.ts
@@ -1,10 +1,11 @@
 /**
  * sentry cli fix
  *
- * Diagnose and repair CLI database issues (schema and permissions).
+ * Diagnose and repair CLI database issues (schema, permissions, and ownership).
  */
 
-import { chmod, stat } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { chmod, chown, stat } from "node:fs/promises";
 import type { SentryContext } from "../../context.js";
 import { buildCommand } from "../../lib/command.js";
 import { getConfigDir, getDbPath, getRawDatabase } from "../../lib/db/index.js";
@@ -14,6 +15,7 @@ import {
   repairSchema,
   type SchemaIssue,
 } from "../../lib/db/schema.js";
+import { getRealUsername } from "../../lib/utils.js";
 
 type FixFlags = {
   readonly "dry-run": boolean;
@@ -41,6 +43,17 @@ type PermissionIssue = {
   kind: "directory" | "database" | "journal";
   currentMode: number;
   expectedMode: number;
+};
+
+/**
+ * A file or directory that is owned by a different user (typically root),
+ * preventing the current process from writing to it.
+ */
+type OwnershipIssue = {
+  path: string;
+  kind: "directory" | "database" | "journal";
+  /** UID of the file's current owner */
+  ownerUid: number;
 };
 
 /**
@@ -130,6 +143,241 @@ async function checkPermissions(dbPath: string): Promise<PermissionIssue[]> {
   );
 
   return results.filter((r): r is PermissionIssue => r !== null);
+}
+
+/**
+ * Check whether any config dir files or the DB are owned by a different user
+ * (typically root after a `sudo` install).
+ *
+ * We only check the config directory and the DB file — those are the gating
+ * items. If they are owned by root, chmod will fail and is pointless to attempt.
+ *
+ * @param dbPath - Absolute path to the database file
+ * @param comparisonUid - The UID to compare against file owners. When running as
+ *   root via `sudo`, pass the real user's UID (not 0) so root-owned files are detected.
+ * @returns List of paths owned by a different user (empty = all owned by us)
+ */
+async function checkOwnership(
+  dbPath: string,
+  comparisonUid: number
+): Promise<OwnershipIssue[]> {
+  const configDir = getConfigDir();
+
+  const checks: Array<{ path: string; kind: OwnershipIssue["kind"] }> = [
+    { path: configDir, kind: "directory" },
+    { path: dbPath, kind: "database" },
+    { path: `${dbPath}-wal`, kind: "journal" },
+    { path: `${dbPath}-shm`, kind: "journal" },
+  ];
+
+  const settled = await Promise.allSettled(checks.map((c) => stat(c.path)));
+  const issues: OwnershipIssue[] = [];
+
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i] as PromiseSettledResult<
+      Awaited<ReturnType<typeof stat>>
+    >;
+    const check = checks[i] as (typeof checks)[number];
+
+    if (result.status === "fulfilled") {
+      const ownerUid = Number(result.value.uid);
+      if (ownerUid !== comparisonUid) {
+        issues.push({ path: check.path, kind: check.kind, ownerUid });
+      }
+      continue;
+    }
+
+    // Missing files are fine (WAL/SHM created on demand).
+    // EACCES on a child file means the directory already blocks access — the
+    // directory check above will surface the real issue.
+    const code =
+      result.reason instanceof Error
+        ? (result.reason as NodeJS.ErrnoException).code
+        : undefined;
+    if (code !== "ENOENT" && code !== "EACCES") {
+      throw result.reason;
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * Resolve the numeric UID for a username by running `id -u -- <username>`.
+ * Returns null if the lookup fails or returns a non-numeric result.
+ *
+ * Uses `execFileSync` (not `execSync`) so the username is passed as a
+ * separate argument — the shell never interpolates it, preventing injection.
+ */
+function resolveUid(username: string): number | null {
+  try {
+    const result = execFileSync("id", ["-u", "--", username], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+    const uid = Number(result.trim());
+    return Number.isNaN(uid) ? null : uid;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Perform chown on the given ownership issues, transferring files to
+ * `username`. Called only when the current process is already root.
+ *
+ * @returns Object with lists of human-readable success and failure messages
+ */
+async function repairOwnership(
+  issues: OwnershipIssue[],
+  username: string,
+  targetUid: number
+): Promise<{ fixed: string[]; failed: string[] }> {
+  const fixed: string[] = [];
+  const failed: string[] = [];
+
+  const results = await Promise.allSettled(
+    issues.map((issue) => chown(issue.path, targetUid, -1))
+  );
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i] as PromiseSettledResult<void>;
+    const issue = issues[i] as OwnershipIssue;
+    if (result.status === "fulfilled") {
+      fixed.push(`${issue.kind} ${issue.path}: transferred to ${username}`);
+    } else {
+      const reason =
+        result.reason instanceof Error
+          ? result.reason.message
+          : "unknown error";
+      failed.push(`${issue.kind} ${issue.path}: ${reason}`);
+    }
+  }
+
+  return { fixed, failed };
+}
+
+/**
+ * Diagnose ownership issues and optionally repair them.
+ *
+ * When the running process is root (`currentUid === 0`), we can perform chown
+ * to transfer ownership back to the real user. The real username is inferred
+ * from `SUDO_USER` / `USER` / `USERNAME` env vars (set by sudo).
+ *
+ * When not root, we print the exact `sudo chown` command the user must run.
+ *
+ * @param dbPath - Absolute path to the database file
+ * @param currentUid - UID of the running process
+ * @param dryRun - If true, report issues without repairing
+ * @param output - Streams for user-facing output
+ * @returns Count of issues found and whether any repairs failed
+ */
+async function handleOwnershipIssues(
+  dbPath: string,
+  currentUid: number,
+  dryRun: boolean,
+  { stdout, stderr }: Output
+): Promise<DiagnoseResult> {
+  const configDir = getConfigDir();
+  const username = getRealUsername();
+
+  // When running as root (e.g. `sudo sentry cli fix`), files from
+  // `sudo brew install` are uid 0 — same as the process uid. Compare against
+  // the real user's UID instead. If we can't resolve a non-root UID, bail
+  // early: using 0 would make root-owned files look correct, and chowning to
+  // 0 would permanently worsen things.
+  let comparisonUid = currentUid;
+  let resolvedTargetUid: number | null = null;
+  if (currentUid === 0) {
+    const uid = resolveUid(username);
+    if (uid === null || uid === 0) {
+      stderr.write(
+        `Warning: Could not determine a non-root UID for user "${username}".\n` +
+          "Run the following command manually:\n" +
+          `  chown -R ${username} "${configDir}"\n\n`
+      );
+      return { found: 0, repairFailed: true };
+    }
+    resolvedTargetUid = uid;
+    comparisonUid = uid;
+  }
+
+  const issues = await checkOwnership(dbPath, comparisonUid);
+  if (issues.length === 0) {
+    return { found: 0, repairFailed: false };
+  }
+
+  stdout.write(`Found ${issues.length} ownership issue(s):\n`);
+  for (const issue of issues) {
+    stdout.write(
+      `  - ${issue.kind} ${issue.path}: owned by uid ${issue.ownerUid}\n`
+    );
+  }
+  stdout.write("\n");
+
+  if (dryRun) {
+    stdout.write(
+      printOwnershipInstructions(currentUid, username, configDir, true)
+    );
+    return { found: issues.length, repairFailed: false };
+  }
+
+  if (currentUid !== 0) {
+    // Not root — can't chown, print instructions.
+    stderr.write(
+      printOwnershipInstructions(currentUid, username, configDir, false)
+    );
+    return { found: issues.length, repairFailed: true };
+  }
+
+  // Running as root — perform chown. resolvedTargetUid is guaranteed non-null
+  // and non-zero here (we bailed out above if it couldn't be resolved).
+  const resolvedUid = resolvedTargetUid as number;
+  stdout.write(
+    `Transferring ownership to ${username} (uid ${resolvedUid})...\n`
+  );
+  const { fixed, failed } = await repairOwnership(
+    issues,
+    username,
+    resolvedUid
+  );
+  for (const fix of fixed) {
+    stdout.write(`  + ${fix}\n`);
+  }
+  if (failed.length > 0) {
+    stderr.write("\nSome ownership repairs failed:\n");
+    for (const fail of failed) {
+      stderr.write(`  ! ${fail}\n`);
+    }
+    return { found: issues.length, repairFailed: true };
+  }
+  stdout.write("\n");
+  return { found: issues.length, repairFailed: false };
+}
+
+/**
+ * Return the ownership fix instructions string.
+ *
+ * @param currentUid - UID of the running process
+ * @param username - The real user's login name
+ * @param configDir - The config directory path
+ * @param dryRun - Whether this is a dry-run preview
+ */
+function printOwnershipInstructions(
+  currentUid: number,
+  username: string,
+  configDir: string,
+  dryRun: boolean
+): string {
+  if (dryRun && currentUid === 0) {
+    return `Would transfer ownership of "${configDir}" to ${username}.\n`;
+  }
+  return (
+    "To fix ownership, run one of:\n\n" +
+    `  sudo chown -R ${username} "${configDir}"\n\n` +
+    "Or let sentry fix it automatically:\n\n" +
+    "  sudo sentry cli fix\n\n"
+  );
 }
 
 /**
@@ -315,18 +563,53 @@ function handleSchemaIssues(
   return { found: issues.length, repairFailed: failed.length > 0 };
 }
 
+/**
+ * Run schema diagnostics, guarding against DB open failures.
+ *
+ * The schema check opens the database, which can throw if the DB or config
+ * directory is inaccessible. This wrapper catches those errors so `--dry-run`
+ * can finish all diagnostics even when the filesystem is broken.
+ *
+ * @param priorIssuesFound - Total ownership+permission issues already found.
+ *   If non-zero, a schema open failure is expected and we stay quiet about it.
+ */
+function safeHandleSchemaIssues(
+  dbPath: string,
+  dryRun: boolean,
+  out: Output,
+  priorIssuesFound: number
+): DiagnoseResult {
+  try {
+    return handleSchemaIssues(dbPath, dryRun, out);
+  } catch {
+    if (priorIssuesFound === 0) {
+      out.stderr.write("Could not open database to check schema.\n");
+      out.stderr.write(
+        `Try deleting the database and restarting: rm "${dbPath}"\n`
+      );
+    }
+    return { found: 0, repairFailed: true };
+  }
+}
+
 export const fixCommand = buildCommand({
   docs: {
     brief: "Diagnose and repair CLI database issues",
     fullDescription:
-      "Check the CLI's local SQLite database for schema and permission issues and repair them.\n\n" +
+      "Check the CLI's local SQLite database for schema, permission, and ownership\n" +
+      "issues and repair them.\n\n" +
       "This is useful when upgrading from older CLI versions, if the database\n" +
       "becomes inconsistent due to interrupted operations, or if file permissions\n" +
       "prevent the CLI from writing to its local database.\n\n" +
       "The command performs non-destructive repairs only - it adds missing tables\n" +
-      "and columns, and fixes file permissions, but never deletes data.\n\n" +
+      "and columns, fixes file permissions, and transfers ownership — but never\n" +
+      "deletes data.\n\n" +
+      "If files are owned by root (e.g. after `sudo brew install`), run with sudo\n" +
+      "to transfer ownership back to the current user:\n\n" +
+      "  sudo sentry cli fix\n\n" +
       "Examples:\n" +
       "  sentry cli fix              # Fix database issues\n" +
+      "  sudo sentry cli fix         # Fix root-owned files\n" +
       "  sentry cli fix --dry-run    # Show what would be fixed without making changes",
   },
   parameters: {
@@ -344,32 +627,38 @@ export const fixCommand = buildCommand({
     const dryRun = flags["dry-run"];
     const out = { stdout, stderr: this.stderr };
 
+    // process.getuid() is undefined on Windows
+    const currentUid =
+      typeof process.getuid === "function" ? process.getuid() : -1;
+
     stdout.write(`Database: ${dbPath}\n`);
     stdout.write(`Expected schema version: ${CURRENT_SCHEMA_VERSION}\n\n`);
 
-    const perm = await handlePermissionIssues(dbPath, dryRun, out);
+    // 1. Check ownership first — if files are root-owned, chmod will fail anyway.
+    //    On Windows (currentUid === -1), skip the ownership check entirely.
+    const ownership: DiagnoseResult =
+      currentUid >= 0
+        ? await handleOwnershipIssues(dbPath, currentUid, dryRun, out)
+        : { found: 0, repairFailed: false };
 
-    // Schema check opens the database, which can throw if the DB or config
-    // directory is readonly. Guard with try/catch so --dry-run can finish
-    // diagnostics even when the filesystem is broken.
-    let schema: DiagnoseResult;
-    try {
-      schema = handleSchemaIssues(dbPath, dryRun, out);
-    } catch {
-      // If we already found permission issues, the schema check failure is
-      // expected — don't obscure the permission report with an unrelated crash.
-      // If no permission issues were found, this is unexpected so re-report it.
-      if (perm.found === 0) {
-        out.stderr.write("Could not open database to check schema.\n");
-        out.stderr.write(
-          `Try deleting the database and restarting: rm "${dbPath}"\n`
-        );
-      }
-      schema = { found: 0, repairFailed: true };
-    }
+    // 2. Check permissions (skip if ownership issues already reported failures —
+    //    chmod will fail on root-owned files so the output would be misleading).
+    const skipPerm = !dryRun && ownership.repairFailed;
+    const perm: DiagnoseResult = skipPerm
+      ? { found: 0, repairFailed: false }
+      : await handlePermissionIssues(dbPath, dryRun, out);
 
-    const totalFound = perm.found + schema.found;
-    const anyFailed = perm.repairFailed || schema.repairFailed;
+    // 3. Schema check — guarded so filesystem errors don't hide earlier reports.
+    const schema = safeHandleSchemaIssues(
+      dbPath,
+      dryRun,
+      out,
+      ownership.found + perm.found
+    );
+
+    const totalFound = ownership.found + perm.found + schema.found;
+    const anyFailed =
+      ownership.repairFailed || perm.repairFailed || schema.repairFailed;
 
     if (totalFound === 0 && !anyFailed) {
       stdout.write(

--- a/src/commands/cli/setup.ts
+++ b/src/commands/cli/setup.ts
@@ -229,6 +229,107 @@ function printWelcomeMessage(
   log("https://cli.sentry.dev");
 }
 
+type WarnLogger = (step: string, error: unknown) => void;
+
+/**
+ * Run a best-effort setup step, logging a warning on failure instead of aborting.
+ *
+ * Post-install configuration steps (recording install info, shell completions,
+ * agent skills) are non-essential. Permission errors are common when Homebrew
+ * runs post-install (e.g. root-owned ~/.sentry from a previous `sudo brew install`,
+ * restricted ~/.local/share). The binary is already installed — these are
+ * nice-to-have side effects that should never crash setup.
+ */
+async function bestEffort(
+  stepName: string,
+  fn: () => void | Promise<void>,
+  warn: WarnLogger
+): Promise<void> {
+  try {
+    await fn();
+  } catch (error) {
+    warn(stepName, error);
+  }
+}
+
+/** Options for configuration steps, grouped to stay within parameter limits */
+type ConfigStepOptions = {
+  readonly flags: SetupFlags;
+  readonly binaryPath: string;
+  readonly binaryDir: string;
+  readonly homeDir: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly log: Logger;
+  readonly warn: WarnLogger;
+};
+
+/**
+ * Run all best-effort configuration steps after binary installation.
+ *
+ * Each step is independently guarded so a failure in one (e.g. DB permission
+ * error) doesn't prevent the others from running.
+ */
+async function runConfigurationSteps(opts: ConfigStepOptions): Promise<void> {
+  const { flags, binaryPath, binaryDir, homeDir, env, log, warn } = opts;
+  const shell = detectShell(env.SHELL, homeDir, env.XDG_CONFIG_HOME);
+
+  // 1. Record installation info
+  const method = flags.method;
+  if (method) {
+    await bestEffort(
+      "Recording installation info",
+      () => {
+        setInstallInfo({
+          method,
+          path: binaryPath,
+          version: CLI_VERSION,
+        });
+        if (!flags.install) {
+          log(`Recorded installation method: ${method}`);
+        }
+      },
+      warn
+    );
+  }
+
+  // 2. Handle PATH modification
+  if (!flags["no-modify-path"]) {
+    await bestEffort(
+      "PATH modification",
+      () => handlePathModification(binaryDir, shell, env, log),
+      warn
+    );
+  }
+
+  // 3. Install shell completions
+  if (!flags["no-completions"]) {
+    await bestEffort(
+      "Shell completions",
+      async () => {
+        const completionLines = await handleCompletions(
+          shell,
+          homeDir,
+          env.XDG_DATA_HOME,
+          env.PATH
+        );
+        for (const line of completionLines) {
+          log(line);
+        }
+      },
+      warn
+    );
+  }
+
+  // 4. Install agent skills (auto-detected, silent when no agent found)
+  if (!flags["no-agent-skills"]) {
+    await bestEffort(
+      "Agent skills",
+      () => handleAgentSkills(homeDir, log),
+      warn
+    );
+  }
+}
+
 export const setupCommand = buildCommand({
   docs: {
     brief: "Configure shell integration",
@@ -288,12 +389,18 @@ export const setupCommand = buildCommand({
   },
   async func(this: SentryContext, flags: SetupFlags): Promise<void> {
     const { process, homeDir } = this;
-    const { stdout } = process;
+    const { stdout, stderr } = process;
 
     const log: Logger = (msg: string) => {
       if (!flags.quiet) {
         stdout.write(`${msg}\n`);
       }
+    };
+
+    const warn: WarnLogger = (step, error) => {
+      const msg =
+        error instanceof Error ? error.message : "Unknown error occurred";
+      stderr.write(`Warning: ${step} failed: ${msg}\n`);
     };
 
     let binaryPath = process.execPath;
@@ -311,46 +418,16 @@ export const setupCommand = buildCommand({
       binaryDir = result.binaryDir;
     }
 
-    const shell = detectShell(
-      process.env.SHELL,
+    // 1–4. Run best-effort configuration steps
+    await runConfigurationSteps({
+      flags,
+      binaryPath,
+      binaryDir,
       homeDir,
-      process.env.XDG_CONFIG_HOME
-    );
-
-    // 1. Record installation info
-    if (flags.method) {
-      setInstallInfo({
-        method: flags.method,
-        path: binaryPath,
-        version: CLI_VERSION,
-      });
-      if (!flags.install) {
-        log(`Recorded installation method: ${flags.method}`);
-      }
-    }
-
-    // 2. Handle PATH modification
-    if (!flags["no-modify-path"]) {
-      await handlePathModification(binaryDir, shell, process.env, log);
-    }
-
-    // 3. Install shell completions
-    if (!flags["no-completions"]) {
-      const completionLines = await handleCompletions(
-        shell,
-        homeDir,
-        process.env.XDG_DATA_HOME,
-        process.env.PATH
-      );
-      for (const line of completionLines) {
-        log(line);
-      }
-    }
-
-    // 4. Install agent skills (auto-detected, silent when no agent found)
-    if (!flags["no-agent-skills"]) {
-      await handleAgentSkills(homeDir, log);
-    }
+      env: process.env,
+      log,
+      warn,
+    });
 
     // 5. Print welcome message (fresh install) or completion message
     if (!flags.quiet) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,6 +2,8 @@
  * General utility functions
  */
 
+import { userInfo } from "node:os";
+
 const ALL_DIGITS_PATTERN = /^\d+$/;
 
 /**
@@ -16,4 +18,28 @@ const ALL_DIGITS_PATTERN = /^\d+$/;
  */
 export function isAllDigits(str: string): boolean {
   return ALL_DIGITS_PATTERN.test(str);
+}
+
+/**
+ * Determine the real (non-root) username of the invoking user.
+ *
+ * When running under `sudo`, `SUDO_USER` holds the original user's login name.
+ * Falls back to `USER` / `USERNAME` env vars, then `os.userInfo()`.
+ * Used for building `chown` instructions and messages.
+ */
+export function getRealUsername(): string {
+  // userInfo() can throw on systems with missing or corrupted passwd entries.
+  let osUsername = "";
+  try {
+    osUsername = userInfo().username;
+  } catch {
+    // Fall through to the "$(whoami)" literal below.
+  }
+  return (
+    process.env.SUDO_USER ||
+    process.env.USER ||
+    process.env.USERNAME ||
+    osUsername ||
+    "$(whoami)"
+  );
 }


### PR DESCRIPTION
## Problem

Two errors were reported during Homebrew post-install of v0.12.0:

1. `SQLiteError: unable to open database file` (SQLITE_CANTOPEN) — setup aborts
2. `Warning: read-only database` + `EPERM` on zsh completions — setup aborts

Root cause: `sudo brew install` creates root-owned `~/.sentry/` and `~/.local/share/zsh/` files. The setup command had no error handling, so any failure aborted the entire post-install script and Homebrew showed a scary error even though the binary installed fine.

The same root cause explains the recurring "attempt to write a readonly database" Sentry telemetry issues (8 issues, 19 events, 100% macOS). Moving the config directory would not help — the same permission problems would occur at any path if created by root. macOS TCC does not restrict `~/.sentry/`.

## Changes

### Non-fatal setup steps (`setup.ts`)
Added a `bestEffort()` wrapper around each post-install configuration step. Permission failures now log a warning instead of aborting. The binary is already installed — these steps are nice-to-have side effects.

### Root-owned file detection in `tryRepairReadonly` (`telemetry.ts`)
Before attempting `chmod` (which fails silently on root-owned files), now checks `stat().uid`. If the file is owned by root, emits a targeted actionable message with the actual username:
```
Warning: Sentry CLI config directory is owned by root.
  Path:  /Users/am/.sentry
  Fix:   sudo chown -R am "/Users/am/.sentry"
  Or:    sudo sentry cli fix
```
Username is inferred from `SUDO_USER` → `USER` → `USERNAME` → `os.userInfo()`.

### Ownership repair in `sentry cli fix` (`fix.ts`)
- Ownership check runs **before** permissions (chmod fails on root-owned files anyway)
- **Not root**: prints `sudo chown -R <user> <configDir>` and `sudo sentry cli fix` instructions, exits with code 1
- **Running as root** (`sudo sentry cli fix`): resolves the real user's UID via `id -u <username>`, then performs `chown` to transfer ownership back

Fixes CLI-7Q, CLI-7K, CLI-6N, CLI-6D, CLI-4Z, CLI-51, CLI-4E, CLI-2E