### PR TITLE
fix(errors): add ResolutionError for not-found/ambiguous resolution failures

### DIFF
--- a/src/commands/event/view.ts
+++ b/src/commands/event/view.ts
@@ -19,7 +19,7 @@ import {
 } from "../../lib/arg-parsing.js";
 import { openInBrowser } from "../../lib/browser.js";
 import { buildCommand } from "../../lib/command.js";
-import { ContextError } from "../../lib/errors.js";
+import { ContextError, ResolutionError } from "../../lib/errors.js";
 import { formatEventDetails, writeJson } from "../../lib/formatters/index.js";
 import {
   resolveOrgAndProject,
@@ -221,9 +221,10 @@ export async function resolveOrgAllTarget(
 ): Promise<ResolvedEventTarget> {
   const resolved = await resolveEventInOrg(org, eventId);
   if (!resolved) {
-    throw new ContextError(
+    throw new ResolutionError(
       `Event ${eventId} in organization "${org}"`,
-      `sentry event view ${org}/ ${eventId}`
+      "not found",
+      `sentry event view ${org}/<project> ${eventId}`
     );
   }
   return {

--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -31,6 +31,7 @@ import {
   ApiError,
   AuthError,
   ContextError,
+  ResolutionError,
   ValidationError,
 } from "../../lib/errors.js";
 import {
@@ -352,10 +353,11 @@ async function resolveTargetsFromParsedArg(
       const matches = await findProjectsBySlug(parsed.projectSlug);
 
       if (matches.length === 0) {
-        throw new ContextError(
-          "Project",
-          `No project '${parsed.projectSlug}' found in any accessible organization.\n\n` +
-            `Try: sentry issue list <org>/${parsed.projectSlug}`
+        throw new ResolutionError(
+          `Project '${parsed.projectSlug}'`,
+          "not found",
+          `sentry issue list <org>/${parsed.projectSlug}`,
+          ["No project with this slug found in any accessible organization"]
         );
       }
 

--- a/test/commands/log/view.test.ts
+++ b/test/commands/log/view.test.ts
@@ -10,7 +10,11 @@ import { parsePositionalArgs } from "../../../src/commands/log/view.js";
 import type { ProjectWithOrg } from "../../../src/lib/api-client.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as apiClient from "../../../src/lib/api-client.js";
-import { ContextError, ValidationError } from "../../../src/lib/errors.js";
+import {
+  ContextError,
+  ResolutionError,
+  ValidationError,
+} from "../../../src/lib/errors.js";
 import { resolveProjectBySlug } from "../../../src/lib/resolve-target.js";
 
 describe("parsePositionalArgs", () => {
@@ -138,11 +142,11 @@ describe("resolveProjectBySlug", () => {
   });
 
   describe("no projects found", () => {
-    test("throws ContextError when project not found", async () => {
+    test("throws ResolutionError when project not found", async () => {
       findProjectsBySlugSpy.mockResolvedValue([]);
 
       await expect(resolveProjectBySlug("my-project", HINT)).rejects.toThrow(
-        ContextError
+        ResolutionError
       );
     });
 
@@ -153,11 +157,15 @@ describe("resolveProjectBySlug", () => {
         await resolveProjectBySlug("frontend", HINT);
         expect.unreachable("Should have thrown");
       } catch (error) {
-        expect(error).toBeInstanceOf(ContextError);
-        expect((error as ContextError).message).toContain('Project "frontend"');
-        expect((error as ContextError).message).toContain(
+        expect(error).toBeInstanceOf(ResolutionError);
+        expect((error as ResolutionError).message).toContain(
+          'Project "frontend"'
+        );
+        expect((error as ResolutionError).message).toContain(
           "Check that you have access"
         );
+        // Message says "not found", not "is required"
+        expect((error as ResolutionError).message).toContain("not found");
       }
     });
   });

--- a/test/commands/trace/list.test.ts
+++ b/test/commands/trace/list.test.ts
@@ -22,7 +22,7 @@ import type { ProjectWithOrg } from "../../../src/lib/api-client.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as apiClient from "../../../src/lib/api-client.js";
 import { validateLimit } from "../../../src/lib/arg-parsing.js";
-import { ContextError } from "../../../src/lib/errors.js";
+import { ContextError, ResolutionError } from "../../../src/lib/errors.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as resolveTarget from "../../../src/lib/resolve-target.js";
 import type { TransactionListItem } from "../../../src/types/sentry.js";
@@ -150,7 +150,7 @@ describe("resolveOrgProjectFromArg", () => {
         "/tmp",
         "trace list"
       )
-    ).rejects.toThrow(ContextError);
+    ).rejects.toThrow(ResolutionError);
   });
 
   test("throws when multiple projects found", async () => {
@@ -167,8 +167,10 @@ describe("resolveOrgProjectFromArg", () => {
       );
       expect.unreachable("Should have thrown");
     } catch (error) {
-      expect(error).toBeInstanceOf(ContextError);
-      expect((error as ContextError).message).toContain("2 organizations");
+      expect(error).toBeInstanceOf(ResolutionError);
+      // Message says "is ambiguous", not "is required"
+      expect((error as ResolutionError).message).toContain("is ambiguous");
+      expect((error as ResolutionError).message).toContain("2 organizations");
     }
   });
 

--- a/test/commands/trace/view.test.ts
+++ b/test/commands/trace/view.test.ts
@@ -10,7 +10,11 @@ import { parsePositionalArgs } from "../../../src/commands/trace/view.js";
 import type { ProjectWithOrg } from "../../../src/lib/api-client.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as apiClient from "../../../src/lib/api-client.js";
-import { ContextError, ValidationError } from "../../../src/lib/errors.js";
+import {
+  ContextError,
+  ResolutionError,
+  ValidationError,
+} from "../../../src/lib/errors.js";
 import { resolveProjectBySlug } from "../../../src/lib/resolve-target.js";
 
 describe("parsePositionalArgs", () => {
@@ -126,11 +130,11 @@ describe("resolveProjectBySlug", () => {
   });
 
   describe("no projects found", () => {
-    test("throws ContextError when project not found", async () => {
+    test("throws ResolutionError when project not found", async () => {
       findProjectsBySlugSpy.mockResolvedValue([]);
 
       await expect(resolveProjectBySlug("my-project", HINT)).rejects.toThrow(
-        ContextError
+        ResolutionError
       );
     });
 
@@ -141,11 +145,15 @@ describe("resolveProjectBySlug", () => {
         await resolveProjectBySlug("frontend", HINT);
         expect.unreachable("Should have thrown");
       } catch (error) {
-        expect(error).toBeInstanceOf(ContextError);
-        expect((error as ContextError).message).toContain('Project "frontend"');
-        expect((error as ContextError).message).toContain(
+        expect(error).toBeInstanceOf(ResolutionError);
+        expect((error as ResolutionError).message).toContain(
+          'Project "frontend"'
+        );
+        expect((error as ResolutionError).message).toContain(
           "Check that you have access"
         );
+        // Message says "not found", not "is required"
+        expect((error as ResolutionError).message).toContain("not found");
       }
     });
   });

--- a/test/lib/resolve-target-listing.test.ts
+++ b/test/lib/resolve-target-listing.test.ts
@@ -11,7 +11,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import * as apiClient from "../../src/lib/api-client.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as defaults from "../../src/lib/db/defaults.js";
-import { ContextError } from "../../src/lib/errors.js";
+import { ContextError, ResolutionError } from "../../src/lib/errors.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as resolveTargetModule from "../../src/lib/resolve-target.js";
 import {
@@ -165,7 +165,7 @@ describe("resolveOrgProjectTarget", () => {
     expect(result).toEqual({ org: "found-org", project: "my-proj" });
   });
 
-  test("throws ContextError for project-search when no match", async () => {
+  test("throws ResolutionError for project-search when no match", async () => {
     findProjectsBySlugSpy.mockResolvedValue([]);
 
     const parsed = {
@@ -175,10 +175,10 @@ describe("resolveOrgProjectTarget", () => {
 
     await expect(
       resolveOrgProjectTarget(parsed, CWD, "trace list")
-    ).rejects.toThrow(ContextError);
+    ).rejects.toThrow(ResolutionError);
   });
 
-  test("throws ContextError for project-search when multiple matches", async () => {
+  test("throws ResolutionError for project-search when multiple matches", async () => {
     findProjectsBySlugSpy.mockResolvedValue([
       { orgSlug: "org-a", slug: "my-proj", name: "My Project" },
       { orgSlug: "org-b", slug: "my-proj", name: "My Project" },
@@ -188,7 +188,7 @@ describe("resolveOrgProjectTarget", () => {
 
     await expect(
       resolveOrgProjectTarget(parsed, CWD, "trace list")
-    ).rejects.toThrow(ContextError);
+    ).rejects.toThrow(ResolutionError);
   });
 
   test("resolves auto-detect when DSN detection succeeds", async () => {


### PR DESCRIPTION
## Summary

- Fixes confusing errors like `Issue 99124558 is required.` (Sentry issue CLI-8C) — these appeared when a numeric issue ID was looked up but not found, misusing `ContextError` which is meant for omitted required values
- Adds a new `ResolutionError` class for when the user *provided* a value that couldn't be resolved, with a structured format: `${resource} ${headline}.\n\nTry:\n  ${hint}\n\nOr:\n  - ${suggestions}`
- Migrates 12 callsites across `issue/utils.ts`, `resolve-target.ts`, `event/view.ts`, and `issue/list.ts` from `ContextError` to `ResolutionError` with appropriate headlines (`not found`, `is ambiguous`, `could not be resolved`)

## Before / After

**Before:**
```
Issue 99124558 is required.

Try:
  sentry issue view <org>/99124558
```

**After:**
```
Issue 99124558 not found.

Try:
  sentry issue view <org>/99124558

Or:
  - No issue with numeric ID 99124558 found — you may not have access or it belongs to a different org
  - If this is a short ID suffix, try: sentry issue view <project>-99124558
```