### PR TITLE
fix(issue): improve numeric issue ID resolution with org context and region routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ docs/.astro
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# OpenCode
+.opencode/


### PR DESCRIPTION
## Summary

- `sentry issue explain 99124558` (bare numeric ID) was failing with "Organization is required" even when the API fetch succeeded — the org was simply never extracted from the response
- `sentry issue view myorg/99124558` used an unscoped global API call despite having the org available, skipping region routing
- `parseSentryUrl` couldn't parse subdomain-style SaaS permalinks (`https://my-org.sentry.io/issues/99124558/`)

## Changes

**`parseSentryUrl`** — adds `matchSubdomainOrg()` to handle `{org}.sentry.io` URLs (filters out 2-char region subdomains like `us`/`de`)

**`getIssueInOrg(orgSlug, issueId)`** — new org-scoped API function using the SDK's `retrieveAnIssue` with `getOrgSdkConfig` region routing, same pattern as `getIssueByShortId`

**`resolveNumericIssue`** — extracted helper that:
1. Calls `resolveOrg({ cwd })` proactively (DSN / env vars / config defaults)
2. Uses `getIssueInOrg` when org is available, falls back to unscoped `getIssue` otherwise
3. Extracts org from `issue.permalink` as a final fallback

**`explicit-org-numeric` case** — now uses `getIssueInOrg` for proper region routing instead of the unscoped endpoint

## Result

| Before | After |
|--------|-------|
| `sentry issue explain 99124558` → "Organization is required" | Works — org extracted from permalink |
| `sentry issue view myorg/99124558` → unscoped call, wrong region possible | Org-scoped call with correct region |
| `sentry issue view 99124558` in project dir → no DSN fallback | Tries DSN/env/config first |