### PR TITLE
ci: correct nightly artifact path in publish-nightly job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,7 @@ jobs:
 
           # Upload the new .gz binaries and the version manifest
           gh release upload nightly \
-            artifacts/dist-bin/*.gz \
+            artifacts/*.gz \
             version.json
 
   ci-status:


### PR DESCRIPTION
## Summary

- Fix `publish-nightly` job failing with `no matches found for artifacts/dist-bin/*.gz`
- `upload-artifact` with `path: dist-bin/sentry-*` strips the `dist-bin/` prefix — artifacts are stored as `sentry-linux-x64.gz`, not `dist-bin/sentry-linux-x64.gz`
- With `download-artifact`'s `merge-multiple: true`, files end up at `artifacts/*.gz`, not `artifacts/dist-bin/*.gz`

Fixes https://github.com/getsentry/cli/actions/runs/22420624136/job/64917462673