### PR TITLE
fix(ci): use github context for compressed artifact upload condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
             !dist-bin/*.gz
 
       - name: Upload compressed artifact
-        if: env.RELEASE_BUILD == '1'
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: sentry-${{ matrix.target }}-gz


### PR DESCRIPTION
## Summary

- Fix publish-nightly failure: `stat artifacts/*.gz: no such file or directory`
- Root cause: `env.RELEASE_BUILD` was set in the Build step's `env` block, scoping it to that step only. The "Upload compressed artifact" step's `if: env.RELEASE_BUILD == '1'` could never see it, so `.gz` artifacts were never uploaded.
- Fix: replace with `github.event_name != 'pull_request'` which is always available in step-level `if` expressions.

Fixes the nightly publish failure from https://github.com/getsentry/cli/actions/runs/22447281434/job/65006196655