### PR TITLE
fix(nightly): push to GHCR from artifacts dir so layer titles are bare filenames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,13 +269,18 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push to GHCR
+        # Push from inside the artifacts directory so ORAS records bare
+        # filenames (e.g. "sentry-linux-x64.gz") as layer titles, not
+        # "artifacts/sentry-linux-x64.gz". The CLI matches layers by
+        # filename in findLayerByFilename().
+        working-directory: artifacts
         run: |
           VERSION="${{ needs.changes.outputs.nightly-version }}"
           oras push ghcr.io/getsentry/cli:nightly \
             --artifact-type application/vnd.sentry.cli.nightly \
             --annotation "org.opencontainers.image.source=https://github.com/getsentry/cli" \
             --annotation "version=${VERSION}" \
-            artifacts/*.gz
+            *.gz
 
   test-e2e:
     name: E2E Tests


### PR DESCRIPTION
## Summary

- Fixes `Error: No nightly build found for sentry-linux-x64.gz` when running `sentry cli upgrade nightly`
- Root cause: ORAS records file paths as OCI layer title annotations verbatim. Pushing `artifacts/*.gz` stored titles as `artifacts/sentry-linux-x64.gz`, but `findLayerByFilename()` in `src/lib/ghcr.ts` searches for `sentry-linux-x64.gz` (no directory prefix).
- Fix: add `working-directory: artifacts` to the Push to GHCR step so the glob `*.gz` expands to bare filenames.

**Before** (from the live GHCR manifest):
```json
{"title": "artifacts/sentry-linux-x64.gz"}
```

**After**:
```json
{"title": "sentry-linux-x64.gz"}
```