### PR TITLE
fix(test): handle 0/-0 in getComparator anti-symmetry property test

### DIFF
--- a/test/commands/issue/list.property.test.ts
+++ b/test/commands/issue/list.property.test.ts
@@ -305,7 +305,9 @@ describe("property: getComparator", () => {
         const cmp = getComparator(sort);
         const ab = cmp(a, b);
         const ba = cmp(b, a);
-        expect(Math.sign(ab)).toBe(-Math.sign(ba));
+        // ab + ba === 0 is the anti-symmetry check that handles 0/-0 correctly
+        // (Object.is(0, -0) is false, but 0 + -0 === 0)
+        expect(ab + ba).toBe(0);
       }),
       { numRuns: DEFAULT_NUM_RUNS }
     );


### PR DESCRIPTION
## Summary

Fixes the unit test failure on main after merging #306: https://github.com/getsentry/cli/actions/runs/22508163174/job/65211393828

**Failing test:** `property: getComparator > comparator is anti-symmetric: sign(cmp(a,b)) === -sign(cmp(b,a))`

**Root cause:** Bun's `expect().toBe()` uses `Object.is()` which distinguishes `+0` from `-0`. When two generated issues have identical sort fields (e.g., same `lastSeen`, same `count`, same `userCount`), the comparator returns `0` for both `cmp(a,b)` and `cmp(b,a)`. However, `Math.sign(0)` is `+0` and `-Math.sign(0)` is `-0`, so `Object.is(0, -0)` fails.

**Fix:** Use `ab + ba === 0` instead of `Math.sign(ab) === -Math.sign(ba)` — this correctly handles the `0/-0` edge case since `0 + (-0) === 0`. Same fix was already applied to the `compareDates` anti-symmetry test in the same file but was missed for `getComparator`.