### PR TITLE
fix(formatters): expand streaming table to fill terminal width

### DIFF
--- a/src/lib/formatters/text-table.ts
+++ b/src/lib/formatters/text-table.ts
@@ -626,8 +626,8 @@ export class StreamingTable {
     const totalFitted = this.columnWidths.reduce((s, w) => s + w, 0);
     const lastIdx = this.columnWidths.length - 1;
     if (totalFitted < maxContentWidth && lastIdx >= 0) {
-      this.columnWidths[lastIdx] = (this.columnWidths[lastIdx] ?? 0) +
-        (maxContentWidth - totalFitted);
+      this.columnWidths[lastIdx] =
+        (this.columnWidths[lastIdx] ?? 0) + (maxContentWidth - totalFitted);
     }
   }
 


### PR DESCRIPTION
PRE:
<img width="1470" height="318" alt="Screenshot 2026-03-02 at 13 34 16" src="https://github.com/user-attachments/assets/77b85bf2-eb59-471d-8ca4-2c9bdf039834" />


POST:
<img width="1487" height="416" alt="Screenshot 2026-03-02 at 13 34 35" src="https://github.com/user-attachments/assets/52695289-92ea-48f6-8349-0f67869998d1" />



## Summary

The `sentry logs --follow` streaming table rendered ~72 columns wide even on wide terminals. The Message column wrapped unnecessarily despite ample space.

`fitColumns` only shrinks columns — when hint rows (short placeholder data) produce intrinsic widths below the terminal width, it returns them as-is with no expansion. After `fitColumns`, the `StreamingTable` constructor now expands the last column to absorb remaining space. `renderTextTable` is unaffected since it uses real data.

## Test plan

- [x] `bun test test/lib/formatters/text-table.test.ts` — 32 tests pass
- [x] `bun test test/lib/formatters/log.test.ts` — 34 tests pass
- [ ] Manual: `sentry logs --follow` fills terminal width
- [ ] Manual: `sentry issue list` table unaffected