### PR TITLE
ci(craft): add sentry-release-registry target

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -17,6 +17,17 @@ targets:
   - name: npm
   - name: github
   - name: gh-pages
+  - name: registry
+    apps:
+      'app:sentry':
+        name: 'Sentry CLI'
+        packageUrl: 'https://www.npmjs.com/package/sentry'
+        mainDocsUrl: 'https://cli.sentry.dev'
+        urlTemplate: 'https://github.com/getsentry/cli/releases/download/{{version}}/{{file}}'
+        includeNames: '/^sentry-.*\.gz$/'
+        checksums:
+          - algorithm: sha256
+            format: hex
   - name: brew
     tap: getsentry/tools
     formula: sentry


### PR DESCRIPTION
## Summary

Adds the missing `registry` target to `.craft.yml` so that each release publishes version metadata to [getsentry/sentry-release-registry](https://github.com/getsentry/sentry-release-registry).

## What this does

On release, Craft will create `apps/sentry/<version>.json` in the release registry with:
- Download URLs pointing at the GitHub release artifacts
- SHA-256 hex checksums for each compressed binary

The new entry uses the canonical name `app:sentry` (a clean break from `app:sentry-cli` which belongs to the old Rust CLI) and covers all five platform binaries matched by `/^sentry-.*\.gz$/`.

No GCS target or CI changes are needed — GitHub release URLs are used directly, consistent with the existing Brew formula.