### PR TITLE
fix(setup): suppress agent skills and welcome messages on upgrade

### DIFF
--- a/src/commands/cli/setup.ts
+++ b/src/commands/cli/setup.ts
@@ -6,11 +6,15 @@
  * and the upgrade command for curl-based installs).
  */
 
-import { unlinkSync } from "node:fs";
-import { dirname } from "node:path";
+import { existsSync, unlinkSync } from "node:fs";
+import { dirname, join } from "node:path";
 import type { SentryContext } from "../../context.js";
 import { installAgentSkills } from "../../lib/agent-skills.js";
-import { determineInstallDir, installBinary } from "../../lib/binary.js";
+import {
+  determineInstallDir,
+  getBinaryFilename,
+  installBinary,
+} from "../../lib/binary.js";
 import { buildCommand } from "../../lib/command.js";
 import {
   type CompletionLocation,
@@ -60,15 +64,19 @@ type Logger = (msg: string) => void;
  * On Windows, the temp binary cannot be deleted while running. It will
  * be cleaned up by the OS when the temp directory is purged.
  *
- * @returns The absolute path of the installed binary and its directory
+ * @returns The installed binary path, its directory, and whether this
+ *   was a fresh install (`created`) or an upgrade of an existing binary
  */
 async function handleInstall(
   execPath: string,
   homeDir: string,
   env: NodeJS.ProcessEnv,
   log: Logger
-): Promise<{ binaryPath: string; binaryDir: string }> {
+): Promise<{ binaryPath: string; binaryDir: string; created: boolean }> {
   const installDir = determineInstallDir(homeDir, env);
+  const targetPath = join(installDir, getBinaryFilename());
+  const alreadyExists = existsSync(targetPath);
+
   const binaryPath = await installBinary(execPath, installDir);
   const binaryDir = dirname(binaryPath);
 
@@ -83,7 +91,7 @@ async function handleInstall(
     }
   }
 
-  return { binaryPath, binaryDir };
+  return { binaryPath, binaryDir, created: !alreadyExists };
 }
 
 /**
@@ -220,13 +228,15 @@ async function handleCompletions(
  *
  * Detects supported agents (currently Claude Code) and installs the
  * version-pinned skill file. Silent when no agent is detected.
+ *
+ * Only produces output when the skill file is freshly created. Subsequent
+ * runs (e.g. after upgrade) silently update without printing.
  */
 async function handleAgentSkills(homeDir: string, log: Logger): Promise<void> {
   const location = await installAgentSkills(homeDir, CLI_VERSION);
 
-  if (location) {
-    const action = location.created ? "Installed to" : "Updated";
-    log(`Agent skills: ${action} ${location.path}`);
+  if (location?.created) {
+    log(`Agent skills: Installed to ${location.path}`);
   }
 }
 
@@ -446,6 +456,7 @@ export const setupCommand = buildCommand({
 
     let binaryPath = process.execPath;
     let binaryDir = dirname(binaryPath);
+    let freshInstall = false;
 
     // 0. Install binary from temp location (when --install is set)
     if (flags.install) {
@@ -457,6 +468,7 @@ export const setupCommand = buildCommand({
       );
       binaryPath = result.binaryPath;
       binaryDir = result.binaryDir;
+      freshInstall = result.created;
     }
 
     // 1–4. Run best-effort configuration steps
@@ -470,13 +482,10 @@ export const setupCommand = buildCommand({
       warn,
     });
 
-    // 5. Print welcome message (fresh install) or completion message
-    if (!flags.quiet) {
-      if (flags.install) {
-        printWelcomeMessage(log, CLI_VERSION, binaryPath);
-      } else {
-        stdout.write("\nSetup complete!\n");
-      }
+    // 5. Print welcome message only on fresh install — upgrades are silent
+    // since the upgrade command itself prints a success message.
+    if (!flags.quiet && freshInstall) {
+      printWelcomeMessage(log, CLI_VERSION, binaryPath);
     }
   },
 });

--- a/test/commands/cli/setup.test.ts
+++ b/test/commands/cli/setup.test.ts
@@ -124,7 +124,9 @@ describe("sentry cli setup", () => {
     expect(output.join("")).toBe("");
   });
 
-  test("outputs 'Setup complete!' without --quiet", async () => {
+  test("produces no welcome or completion output without --install", async () => {
+    // Without --install, setup is being called for an upgrade or manual re-run.
+    // Output is suppressed — the upgrade command itself prints success.
     const { context, output } = createMockContext({ homeDir: testDir });
 
     await run(
@@ -140,7 +142,7 @@ describe("sentry cli setup", () => {
     );
 
     const combined = output.join("");
-    expect(combined).toContain("Setup complete!");
+    expect(combined).toBe("");
   });
 
   test("records install method when --method is provided", async () => {
@@ -515,6 +517,53 @@ describe("sentry cli setup", () => {
       expect(combined).not.toContain("Recorded installation method");
     });
 
+    test("--install suppresses welcome when binary already exists (upgrade)", async () => {
+      const installDir = join(testDir, "install-dir");
+      mkdirSync(installDir, { recursive: true });
+      // Pre-existing binary — this is an upgrade, not a fresh install
+      writeFileSync(join(installDir, "sentry"), "old-binary");
+
+      const sourceDir = join(testDir, "tmp");
+      mkdirSync(sourceDir, { recursive: true });
+      const sourcePath = join(sourceDir, "sentry-download");
+      writeFileSync(sourcePath, "new-binary");
+      const { chmodSync } = await import("node:fs");
+      chmodSync(sourcePath, 0o755);
+
+      const { context, output } = createMockContext({
+        homeDir: testDir,
+        execPath: sourcePath,
+        env: {
+          PATH: "/usr/bin:/bin",
+          SHELL: "/bin/bash",
+          SENTRY_INSTALL_DIR: installDir,
+        },
+      });
+
+      await run(
+        app,
+        [
+          "cli",
+          "setup",
+          "--install",
+          "--method",
+          "curl",
+          "--no-modify-path",
+          "--no-completions",
+          "--no-agent-skills",
+        ],
+        context
+      );
+
+      const combined = output.join("");
+
+      // Binary placement is still logged
+      expect(combined).toContain("Binary: Installed to");
+      // But welcome/getting-started is suppressed for upgrades
+      expect(combined).not.toContain("Get started:");
+      expect(combined).not.toContain("sentry auth login");
+    });
+
     test("--install with --quiet suppresses all output", async () => {
       const sourceDir = join(testDir, "tmp");
       mkdirSync(sourceDir, { recursive: true });
@@ -620,6 +669,40 @@ describe("sentry cli setup", () => {
       expect(combined).not.toContain("Agent skills:");
     });
 
+    test("suppresses agent skills message on subsequent runs (upgrade scenario)", async () => {
+      mkdirSync(join(testDir, ".claude"), { recursive: true });
+
+      const { context, output } = createMockContext({
+        homeDir: testDir,
+        execPath: join(testDir, "bin", "sentry"),
+        env: {
+          PATH: `/usr/bin:${join(testDir, "bin")}:/bin`,
+          SHELL: "/bin/bash",
+        },
+      });
+
+      // First run — should show "Installed to"
+      await run(
+        app,
+        ["cli", "setup", "--no-modify-path", "--no-completions"],
+        context
+      );
+
+      const firstRun = output.join("");
+      expect(firstRun).toContain("Agent skills: Installed to");
+
+      // Second run — skill file already exists, should be silent
+      output.length = 0;
+      await run(
+        app,
+        ["cli", "setup", "--no-modify-path", "--no-completions"],
+        context
+      );
+
+      const secondRun = output.join("");
+      expect(secondRun).not.toContain("Agent skills:");
+    });
+
     test("skips when --no-agent-skills is set", async () => {
       mkdirSync(join(testDir, ".claude"), { recursive: true });
 
@@ -670,10 +753,10 @@ describe("sentry cli setup", () => {
         context
       );
 
-      // Setup should still complete successfully
+      // Setup should still complete without errors (no output without --install)
       const combined = output.join("");
-      expect(combined).toContain("Setup complete!");
       expect(combined).not.toContain("Agent skills:");
+      expect(combined).not.toContain("Warning:");
     });
 
     test("bestEffort catches errors from steps and setup still completes", async () => {
@@ -704,8 +787,10 @@ describe("sentry cli setup", () => {
       );
 
       const combined = output.join("");
-      // Setup must complete even though the completions step threw
-      expect(combined).toContain("Setup complete!");
+      // Setup must complete even though the completions step threw —
+      // the warning goes to stderr but no crash
+      expect(combined).toContain("Warning:");
+      expect(combined).toContain("Shell completions failed");
 
       chmod(zshDir, 0o755);
     });


### PR DESCRIPTION
## Summary

Suppresses noisy output during upgrades that is only relevant for fresh installs. Follows up on #326 which did the same for shell completions.

### What's suppressed on upgrade

| Message | When suppressed |
|---------|----------------|
| `Agent skills: Updated <path>` | Subsequent runs (file already exists) |
| `Get started:` welcome block | `--install` when binary already exists |
| `Setup complete!` | Always (upgrade command prints its own message) |

### How it works

- **Agent skills**: Same `created` pattern as completions — only print on first creation, silently update on subsequent runs
- **Welcome message**: `handleInstall()` now checks if the binary already exists before installation. Returns `created: boolean` to distinguish fresh install from upgrade
- **Setup complete**: Removed entirely — the upgrade command already prints `Successfully upgraded to <version>`

### Behavior table

| Scenario | Output |
|----------|--------|
| Fresh install (`--install`, no existing binary) | Binary path + welcome + getting started |
| Curl upgrade (`--install`, binary exists) | Binary path only |
| npm/pnpm upgrade (no `--install`) | Silent |
| Any + `--quiet` | Silent |

### Tests

- Updated 3 existing tests for new behavior
- Added 2 new tests: upgrade suppression for agent skills and `--install` with pre-existing binary