### PR TITLE
fix(install): fix nightly digest extraction on macOS

### DIFF
--- a/install
+++ b/install
@@ -127,11 +127,18 @@ if [[ "$requested_version" == "nightly" ]]; then
 
   echo -e "${MUTED}Installing nightly sentry ${version}...${NC}"
 
-  # Step 4: Find the blob digest for this platform's .gz file
+  # Step 4: Find the blob digest for this platform's .gz file.
+  # Each OCI layer has "digest" before "org.opencontainers.image.title".
+  # Track the last-seen digest and print it when the target filename matches.
+  # This avoids sed newline replacement which differs between GNU and BSD.
   gz_filename="sentry-${os}-${arch}${suffix}.gz"
   digest=$(echo "$MANIFEST" \
-    | sed 's/},{/}\n{/g' \
-    | awk -F'"' "/\"${gz_filename//./\\.}"'/{for(i=1;i<=NF;i++) if($i=="digest"){print $(i+2);exit}}')
+    | awk -F'"' -v target="$gz_filename" '{
+        for(i=1;i<=NF;i++){
+          if($i=="digest") d=$(i+2)
+          if($i=="org.opencontainers.image.title"&&$(i+2)==target){print d;exit}
+        }
+      }')
   if [[ -z "$digest" ]]; then
     echo -e "${RED}No nightly build found for ${gz_filename}${NC}"
     exit 1


### PR DESCRIPTION
## Summary

The nightly install script fails on macOS with:
```
gunzip: (stdin): unexpected end of file
```

The OCI manifest digest extraction in Step 4 used `sed 's/},{/}\\n{/g'` to
split layers onto separate lines before awk extracted the digest. This had
two bugs:

1. **BSD sed (macOS)** treats `\\n` as literal characters, not a newline —
   the manifest stays on one line and awk always finds the config digest
   (`sha256:44136fa...`, a 2-byte empty `{}` blob) instead of the binary.
2. **First-layer edge case**: the first layer shares a line with the config
   block because the array starts with `[{`, not `},{`.

The result: downloading 2 bytes of `{}` instead of the ~23 MB compressed
binary.

## Changes

### Fix digest extraction (commit 1)

Replace the `sed` + `awk` pipeline with a single `awk` pass that tracks
the last-seen `"digest"` value and prints it when the target filename
matches in `"org.opencontainers.image.title"`. No `sed` needed, works
on both GNU and BSD awk.

### Add install error telemetry (commit 2)

Reports install failures to the CLI's existing Sentry project so we
catch issues like this automatically. Uses the same public write-only
DSN already baked into every CLI binary.

- `report_error()` — builds a Sentry envelope and fires a background
  `curl` (fire-and-forget, 2s timeout, never blocks installation)
- `die()` — replaces all `echo + exit 1` patterns with error reporting
- `ERR` trap — catches unexpected `set -e` / `pipefail` exits (e.g.,
  the gunzip failure that triggered this issue)
- Tags: `os`, `arch`, `channel`, `step`, `install.version`
- Opt-out: `SENTRY_CLI_NO_TELEMETRY=1` (same as the CLI binary)