### PR TITLE
feat(install): add Sentry error telemetry to install script

### DIFF
--- a/install
+++ b/install
@@ -39,15 +39,19 @@ report_error() {
     local timestamp
     timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
 
-    # Escape message for JSON (backslashes, quotes, newlines)
-    local json_msg
-    json_msg=$(printf '%s' "$msg" | sed 's/\\/\\\\/g;s/"/\\"/g' | tr '\n' ' ')
+    # Escape a value for safe JSON string interpolation
+    _esc() { printf '%s' "$1" | sed 's/\\/\\\\/g;s/"/\\"/g' | tr '\n' ' '; }
+
+    local json_msg; json_msg=$(_esc "$msg")
+    local json_step; json_step=$(_esc "$step")
+    local json_channel; json_channel=$(_esc "${requested_version:-stable}")
+    local json_version; json_version=$(_esc "${version:-unknown}")
 
     local envelope
     envelope=$(printf '%s\n%s\n%s' \
       "{\"event_id\":\"${event_id}\",\"dsn\":\"https://${SENTRY_DSN_KEY}@o1.ingest.us.sentry.io/${SENTRY_PROJECT_ID}\"}" \
       '{"type":"event"}' \
-      "{\"event_id\":\"${event_id}\",\"timestamp\":\"${timestamp}\",\"platform\":\"other\",\"level\":\"error\",\"logger\":\"install\",\"server_name\":\"install-script\",\"message\":{\"formatted\":\"${json_msg}\"},\"tags\":{\"os\":\"${os:-unknown}\",\"arch\":\"${arch:-unknown}\",\"channel\":\"${requested_version:-stable}\",\"step\":\"${step}\",\"install.version\":\"${version:-unknown}\"},\"contexts\":{\"runtime\":{\"name\":\"bash\",\"version\":\"${BASH_VERSION:-unknown}\"}}}")
+      "{\"event_id\":\"${event_id}\",\"timestamp\":\"${timestamp}\",\"platform\":\"other\",\"level\":\"error\",\"logger\":\"install\",\"server_name\":\"install-script\",\"message\":{\"formatted\":\"${json_msg}\"},\"tags\":{\"os\":\"${os:-unknown}\",\"arch\":\"${arch:-unknown}\",\"channel\":\"${json_channel}\",\"step\":\"${json_step}\",\"install.version\":\"${json_version}\"},\"contexts\":{\"runtime\":{\"name\":\"bash\",\"version\":\"${BASH_VERSION:-unknown}\"}}}")
 
     curl -sf --max-time 2 \
       -H "Content-Type: application/x-sentry-envelope" \


### PR DESCRIPTION
## Summary

Add fire-and-forget error reporting to the install script via Sentry's
envelope API. Uses the CLI's existing public write-only DSN — no new
secrets or projects needed. This would have caught the macOS digest
extraction bug (#331) automatically.

## Changes

- `report_error()` — builds a minimal Sentry envelope and sends it via
  background `curl` (2s timeout, never blocks installation)
- `die()` — replaces all 11 `echo + exit 1` patterns with error
  reporting + exit
- `ERR` trap — catches unexpected `set -e` / `pipefail` exits like the
  gunzip pipeline failure that triggered #331
- UUID generation with fallback chain: `/proc` → `uuidgen` → `awk`
- Opt-out via `SENTRY_CLI_NO_TELEMETRY=1` (same as the CLI binary)

Each error event is tagged with `os`, `arch`, `channel`, `step`,
`install.version`, and bash version for quick triage.