### PR TITLE
refactor(init): remove add-example-trigger step

### DIFF
--- a/src/lib/init/clack-utils.ts
+++ b/src/lib/init/clack-utils.ts
@@ -68,6 +68,5 @@ export const STEP_LABELS: Record<string, string> = {
   "plan-codemods": "Planning code modifications",
   "apply-codemods": "Applying code modifications",
   "verify-changes": "Verifying changes",
-  "add-example-trigger": "Example error trigger",
   "open-sentry-ui": "Finishing up",
 };

--- a/src/lib/init/interactive.ts
+++ b/src/lib/init/interactive.ts
@@ -130,14 +130,7 @@ async function handleConfirm(
   payload: ConfirmPayload,
   options: WizardOptions
 ): Promise<Record<string, unknown>> {
-  const isExample =
-    payload.purpose === "add-example" || payload.prompt.includes("example");
-
   if (options.yes) {
-    if (isExample) {
-      log.info("Auto-confirmed: adding example trigger");
-      return { addExample: true };
-    }
     log.info("Auto-confirmed: continuing");
     return { action: "continue" };
   }
@@ -148,9 +141,5 @@ async function handleConfirm(
   });
 
   const value = abortIfCancelled(confirmed);
-
-  if (isExample) {
-    return { addExample: value };
-  }
   return { action: value ? "continue" : "stop" };
 }

--- a/src/lib/init/types.ts
+++ b/src/lib/init/types.ts
@@ -134,7 +134,6 @@ export type ConfirmPayload = {
   type: "interactive";
   kind: "confirm";
   prompt: string;
-  purpose?: string;
 };
 
 // Combined suspend payload — either a local-op or an interactive prompt

--- a/test/lib/init/interactive.test.ts
+++ b/test/lib/init/interactive.test.ts
@@ -293,19 +293,6 @@ describe("handleMultiSelect", () => {
 });
 
 describe("handleConfirm", () => {
-  test("auto-confirms with addExample when prompt contains 'example' and --yes", async () => {
-    const result = await handleInteractive(
-      {
-        type: "interactive",
-        prompt: "Add an example error trigger?",
-        kind: "confirm",
-      },
-      makeOptions({ yes: true })
-    );
-
-    expect(result).toEqual({ addExample: true });
-  });
-
   test("auto-confirms with action: continue for non-example prompts with --yes", async () => {
     const result = await handleInteractive(
       {
@@ -317,21 +304,6 @@ describe("handleConfirm", () => {
     );
 
     expect(result).toEqual({ action: "continue" });
-  });
-
-  test("returns addExample based on user choice for example prompts", async () => {
-    confirmSpy.mockImplementation(() => Promise.resolve(false) as any);
-
-    const result = await handleInteractive(
-      {
-        type: "interactive",
-        prompt: "Add an example error trigger?",
-        kind: "confirm",
-      },
-      makeOptions({ yes: false })
-    );
-
-    expect(result).toEqual({ addExample: false });
   });
 
   test("throws WizardCancelledError when user cancels confirm", async () => {
@@ -349,49 +321,6 @@ describe("handleConfirm", () => {
         makeOptions({ yes: false })
       )
     ).rejects.toThrow("Setup cancelled");
-  });
-
-  test("returns addExample: true via purpose field with --yes", async () => {
-    const result = await handleInteractive(
-      {
-        type: "interactive",
-        prompt: "Would you like to add a trigger?",
-        kind: "confirm",
-        purpose: "add-example",
-      },
-      makeOptions({ yes: true })
-    );
-
-    expect(result).toEqual({ addExample: true });
-  });
-
-  test("returns addExample via purpose field in interactive mode", async () => {
-    confirmSpy.mockImplementation(() => Promise.resolve(false) as any);
-
-    const result = await handleInteractive(
-      {
-        type: "interactive",
-        prompt: "Would you like to add a trigger?",
-        kind: "confirm",
-        purpose: "add-example",
-      },
-      makeOptions({ yes: false })
-    );
-
-    expect(result).toEqual({ addExample: false });
-  });
-
-  test("falls back to prompt string match when no purpose field", async () => {
-    const result = await handleInteractive(
-      {
-        type: "interactive",
-        prompt: "Add an example error trigger?",
-        kind: "confirm",
-      },
-      makeOptions({ yes: true })
-    );
-
-    expect(result).toEqual({ addExample: true });
   });
 
   test("returns action: stop when user declines non-example prompt", async () => {


### PR DESCRIPTION
## Summary

Removes `add-example-trigger` references from the CLI to match the API repo, where this step was already removed. Cleans up the step label, confirm handler logic, `purpose` field on `ConfirmPayload`, and 5 related test cases.

## Changes

- Removed `"add-example-trigger"` from `STEP_LABELS` in `clack-utils.ts`
- Removed `addExample` / `isExample` logic from `handleConfirm` in `interactive.ts`
- Removed optional `purpose` field from `ConfirmPayload` in `types.ts`
- Removed 5 test cases covering example-trigger confirm behavior

## Test plan

- `bun run lint` passes
- `bun test test/lib/init/interactive.test.ts` — remaining confirm tests pass
- `git grep "addExample\|add-example-trigger\|add-example" -- src/ test/` returns 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)