### PR TITLE
fix(docs): remove double borders and fix column alignment on landing page tables

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -8,6 +8,9 @@ const base = process.env.DOCS_BASE_PATH || "/";
 export default defineConfig({
   site: "https://cli.sentry.dev",
   base,
+  markdown: {
+    smartypants: false,
+  },
   integrations: [
     sentry({
       project: "cli-website",

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -913,7 +913,7 @@ starlight-tabs [role="tabpanel"] {
    Code Blocks
    ========================================================================== */
 
-pre:not(.pm-pre) {
+pre:not(.pm-pre):not(.table-box) {
   background: rgba(20, 20, 25, 0.9) !important;
   border: 1px solid rgba(255, 255, 255, 0.08) !important;
   border-radius: 12px !important;
@@ -927,6 +927,32 @@ pre.pm-pre,
   border-radius: 0 !important;
   margin: 0 !important;
   padding: 0 !important;
+}
+
+/* ASCII art tables inside terminals - no chrome, consistent monospace */
+pre.table-box {
+  background: transparent !important;
+  border: none !important;
+  border-radius: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+pre.table-box,
+pre.table-box * {
+  font-family: ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace !important;
+  font-size: inherit !important;
+  font-weight: 400 !important;
+  font-style: normal !important;
+  font-variant: normal !important;
+  font-variant-ligatures: none !important;
+  font-feature-settings: normal !important;
+  font-stretch: normal !important;
+  letter-spacing: 0 !important;
+  word-spacing: 0 !important;
+  text-decoration: none !important;
+  text-transform: none !important;
+  -webkit-text-size-adjust: none !important;
 }
 
 code {
@@ -1089,7 +1115,7 @@ code {
 }
 
 /* Standalone pre */
-.sl-markdown-content pre:not(.expressive-code pre):not(.pm-pre) {
+.sl-markdown-content pre:not(.expressive-code pre):not(.pm-pre):not(.table-box) {
   background: #0a0a0f !important;
   border: 1px solid rgba(255, 255, 255, 0.1) !important;
   border-radius: 12px !important;


### PR DESCRIPTION
## Summary

Fixes the ASCII art tables on the landing page that had double borders (CSS border on top of box-drawing characters) and misaligned column headers. The root cause was twofold: global `pre` styling rules adding unwanted borders/padding, and Astro's smartypants converting `'` → `'` and `...` → `…` inside `<pre>` blocks which broke monospace alignment.

## Changes

- Excluded `.table-box` from two global `pre` border rules in `custom.css`
- Added a dedicated `pre.table-box` reset that strips background, border, padding, and margin
- Forced system monospace fonts with normalized glyph metrics on all table-box children to guarantee consistent column alignment across browsers
- Disabled `markdown.smartypants` in `astro.config.mjs` to prevent character substitution that breaks monospace column widths

## Test plan

- [ ] Check the landing page (`/`) — both Terminal and FeatureTerminal tables should have no CSS border, only ASCII box-drawing borders
- [ ] Verify column headers align with data rows and separator lines
- [ ] Check on mobile viewport (~375px) — same alignment checks
- [ ] Verify code blocks on other pages (e.g. `/getting-started/`) still have their border styling