### PR TITLE
refactor(init): remove dead determine-pm step label

### DIFF
--- a/src/lib/init/clack-utils.ts
+++ b/src/lib/init/clack-utils.ts
@@ -63,7 +63,6 @@ export const STEP_LABELS: Record<string, string> = {
   "detect-platform": "Detecting platform and framework",
   "ensure-sentry-project": "Setting up Sentry project",
   "select-features": "Selecting features",
-  "determine-pm": "Detecting package manager",
   "install-deps": "Installing dependencies",
   "plan-codemods": "Planning code modifications",
   "apply-codemods": "Applying code modifications",


### PR DESCRIPTION
## Summary

- Removes the `"determine-pm"` entry from `STEP_LABELS` in `clack-utils.ts` since this workflow step was merged into `detect-platform` in `cli-init-api`

## Test plan

- [ ] Verify the init wizard UI no longer references "Detecting package manager" as a separate step
- [ ] Confirm no other code references the `"determine-pm"` step ID

> Companion PR in `getsentry/cli-init-api`: https://github.com/getsentry/cli-init-api/pull/24

🤖 Generated with [Claude Code](https://claude.com/claude-code)