### PR TITLE
fix: add trace ID validation to trace view + UUID dash-stripping

### DIFF
--- a/src/commands/trace/view.ts
+++ b/src/commands/trace/view.ts
@@ -34,6 +34,7 @@ import {
   resolveProjectBySlug,
 } from "../../lib/resolve-target.js";
 import { buildTraceUrl } from "../../lib/sentry-urls.js";
+import { validateTraceId } from "../../lib/trace-id.js";
 import type { Writer } from "../../types/index.js";
 
 type ViewFlags = {
@@ -47,17 +48,50 @@ type ViewFlags = {
 const USAGE_HINT = "sentry trace view <org>/<project> <trace-id>";
 
 /**
+ * Validate a trace ID and detect UUID auto-correction.
+ *
+ * Returns the validated trace ID and an optional warning when dashes were
+ * stripped from a UUID-format input (e.g., `ed29abc8-71c4-475b-...`).
+ */
+function validateAndWarn(raw: string): {
+  traceId: string;
+  uuidWarning?: string;
+} {
+  const traceId = validateTraceId(raw);
+  const trimmedRaw = raw.trim().toLowerCase();
+  const uuidWarning =
+    trimmedRaw.includes("-") && trimmedRaw !== traceId
+      ? `Auto-corrected trace ID: stripped dashes → ${traceId}`
+      : undefined;
+  return { traceId, uuidWarning };
+}
+
+/**
+ * Merge multiple optional warning strings into a single warning, or undefined.
+ */
+function mergeWarnings(
+  ...warnings: (string | undefined)[]
+): string | undefined {
+  const filtered = warnings.filter(Boolean);
+  return filtered.length > 0 ? filtered.join("\n") : undefined;
+}
+
+/**
  * Parse positional arguments for trace view.
  * Handles: `<trace-id>` or `<target> <trace-id>`
+ *
+ * Validates the trace ID format (32-character hex) and auto-corrects
+ * UUID-format inputs by stripping dashes.
  *
  * @param args - Positional arguments from CLI
  * @returns Parsed trace ID and optional target arg
  * @throws {ContextError} If no arguments provided
+ * @throws {ValidationError} If the trace ID format is invalid
  */
 export function parsePositionalArgs(args: string[]): {
   traceId: string;
   targetArg: string | undefined;
-  /** Warning message if arguments appear to be in the wrong order */
+  /** Warning message if arguments appear to be in the wrong order or UUID was auto-corrected */
   warning?: string;
   /** Suggestion when first arg looks like an issue short ID */
   suggestion?: string;
@@ -72,23 +106,38 @@ export function parsePositionalArgs(args: string[]): {
   }
 
   if (args.length === 1) {
-    const { id: traceId, targetArg } = parseSlashSeparatedArg(
+    const { id, targetArg } = parseSlashSeparatedArg(
       first,
       "Trace ID",
       USAGE_HINT
     );
-    return { traceId, targetArg };
+    const validated = validateAndWarn(id);
+    return {
+      traceId: validated.traceId,
+      targetArg,
+      warning: validated.uuidWarning,
+    };
   }
 
   const second = args[1];
   if (second === undefined) {
-    return { traceId: first, targetArg: undefined };
+    const validated = validateAndWarn(first);
+    return {
+      traceId: validated.traceId,
+      targetArg: undefined,
+      warning: validated.uuidWarning,
+    };
   }
 
   // Detect swapped args: user put ID first and target second
   const swapWarning = detectSwappedViewArgs(first, second);
   if (swapWarning) {
-    return { traceId: first, targetArg: second, warning: swapWarning };
+    const validated = validateAndWarn(first);
+    return {
+      traceId: validated.traceId,
+      targetArg: second,
+      warning: mergeWarnings(swapWarning, validated.uuidWarning),
+    };
   }
 
   // Detect issue short ID passed as first arg (e.g., "CAM-82X some-trace-id")
@@ -97,7 +146,13 @@ export function parsePositionalArgs(args: string[]): {
     : undefined;
 
   // Two or more args - first is target, second is trace ID
-  return { traceId: second, targetArg: first, suggestion };
+  const validated = validateAndWarn(second);
+  return {
+    traceId: validated.traceId,
+    targetArg: first,
+    warning: validated.uuidWarning,
+    suggestion,
+  };
 }
 
 /**

--- a/src/lib/hex-id.ts
+++ b/src/lib/hex-id.ts
@@ -10,12 +10,24 @@ import { ValidationError } from "./errors.js";
 /** Regex for a valid 32-character hexadecimal ID */
 export const HEX_ID_RE = /^[0-9a-f]{32}$/i;
 
+/**
+ * Regex for UUID format with dashes: 8-4-4-4-12 hex groups.
+ * Users often copy trace/log IDs from tools that display them in UUID format.
+ * Stripping the dashes yields a valid 32-character hex ID.
+ */
+export const UUID_DASH_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 /** Max display length for invalid IDs in error messages before truncation */
 const MAX_DISPLAY_LENGTH = 40;
 
 /**
  * Validate that a string is a 32-character hexadecimal ID.
  * Trims whitespace and normalizes to lowercase before validation.
+ *
+ * When the input matches UUID format (8-4-4-4-12 hex with dashes), the dashes
+ * are automatically stripped. This is a common copy-paste mistake — the
+ * underlying hex content is valid, just formatted differently.
  *
  * Normalization to lowercase ensures consistent comparison with API responses,
  * which return lowercase hex IDs regardless of input casing.
@@ -29,7 +41,12 @@ const MAX_DISPLAY_LENGTH = 40;
  * @throws {ValidationError} If the format is invalid
  */
 export function validateHexId(value: string, label: string): string {
-  const trimmed = value.trim().toLowerCase();
+  let trimmed = value.trim().toLowerCase();
+
+  // Auto-correct UUID format: strip dashes (8-4-4-4-12 → 32 hex chars)
+  if (UUID_DASH_RE.test(trimmed)) {
+    trimmed = trimmed.replace(/-/g, "");
+  }
 
   if (!HEX_ID_RE.test(trimmed)) {
     const display =

--- a/test/commands/trace/view.func.test.ts
+++ b/test/commands/trace/view.func.test.ts
@@ -197,7 +197,7 @@ describe("viewCommand.func", () => {
         context,
         { json: false, web: false, spans: 100 },
         "test-org/test-project",
-        "0000000000000000"
+        "00000000000000000000000000000000"
       )
     ).rejects.toThrow(ValidationError);
   });
@@ -213,12 +213,14 @@ describe("viewCommand.func", () => {
         context,
         { json: false, web: false, spans: 100 },
         "test-org/test-project",
-        "deadbeef12345678"
+        "deadbeef12345678deadbeef12345678"
       );
       expect.unreachable("Should have thrown");
     } catch (error) {
       expect(error).toBeInstanceOf(ValidationError);
-      expect((error as ValidationError).message).toContain("deadbeef12345678");
+      expect((error as ValidationError).message).toContain(
+        "deadbeef12345678deadbeef12345678"
+      );
     }
   });
 

--- a/test/commands/trace/view.property.test.ts
+++ b/test/commands/trace/view.property.test.ts
@@ -9,14 +9,13 @@ import { describe, expect, test } from "bun:test";
 import {
   array,
   assert as fcAssert,
-  pre,
   property,
   string,
   stringMatching,
   tuple,
 } from "fast-check";
 import { parsePositionalArgs } from "../../../src/commands/trace/view.js";
-import { ContextError } from "../../../src/lib/errors.js";
+import { ContextError, ValidationError } from "../../../src/lib/errors.js";
 import { DEFAULT_NUM_RUNS } from "../../model-based/helpers.js";
 
 /** Valid trace IDs (32-char hex) */
@@ -28,16 +27,21 @@ const slugArb = stringMatching(/^[a-z][a-z0-9-]{1,20}[a-z0-9]$/);
 /** Non-empty strings for general args */
 const nonEmptyStringArb = string({ minLength: 1, maxLength: 50 });
 
-/** Non-empty strings without slashes (valid plain IDs) */
-const plainIdArb = nonEmptyStringArb.filter((s) => !s.includes("/"));
+/**
+ * Insert dashes at UUID positions (8-4-4-4-12) into a 32-char hex string.
+ */
+function toUuidFormat(hex: string): string {
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
 
 describe("parsePositionalArgs properties", () => {
-  test("single arg without slashes: returns it as traceId with undefined targetArg", async () => {
+  test("single valid trace ID: returns it as traceId with undefined targetArg", async () => {
     await fcAssert(
-      property(plainIdArb, (input) => {
+      property(traceIdArb, (input) => {
         const result = parsePositionalArgs([input]);
         expect(result.traceId).toBe(input);
         expect(result.targetArg).toBeUndefined();
+        expect(result.warning).toBeUndefined();
       }),
       { numRuns: DEFAULT_NUM_RUNS }
     );
@@ -69,18 +73,13 @@ describe("parsePositionalArgs properties", () => {
     );
   });
 
-  test("two args: first is always targetArg, second is always traceId", async () => {
+  test("two args with valid trace ID: first is targetArg, second is traceId", async () => {
     await fcAssert(
-      property(
-        tuple(nonEmptyStringArb, nonEmptyStringArb),
-        ([first, second]) => {
-          // Skip swap-detection cases (second has / but first doesn't)
-          pre(first.includes("/") || !second.includes("/"));
-          const result = parsePositionalArgs([first, second]);
-          expect(result.targetArg).toBe(first);
-          expect(result.traceId).toBe(second);
-        }
-      ),
+      property(tuple(nonEmptyStringArb, traceIdArb), ([first, traceId]) => {
+        const result = parsePositionalArgs([first, traceId]);
+        expect(result.targetArg).toBe(first);
+        expect(result.traceId).toBe(traceId);
+      }),
       { numRuns: DEFAULT_NUM_RUNS }
     );
   });
@@ -106,17 +105,15 @@ describe("parsePositionalArgs properties", () => {
       property(
         tuple(
           nonEmptyStringArb,
-          nonEmptyStringArb,
+          traceIdArb,
           array(nonEmptyStringArb, { minLength: 1, maxLength: 5 })
         ),
-        ([first, second, extras]) => {
-          // Skip swap-detection cases (second has / but first doesn't)
-          pre(first.includes("/") || !second.includes("/"));
-          const args = [first, second, ...extras];
+        ([first, traceId, extras]) => {
+          const args = [first, traceId, ...extras];
           const result = parsePositionalArgs(args);
 
           expect(result.targetArg).toBe(first);
-          expect(result.traceId).toBe(second);
+          expect(result.traceId).toBe(traceId);
         }
       ),
       { numRuns: DEFAULT_NUM_RUNS }
@@ -125,17 +122,12 @@ describe("parsePositionalArgs properties", () => {
 
   test("parsing is deterministic: same input always produces same output", async () => {
     await fcAssert(
-      property(
-        array(nonEmptyStringArb, { minLength: 1, maxLength: 3 }),
-        (args) => {
-          // Skip single-arg with slashes — those throw ContextError (tested separately)
-          pre(args.length > 1 || !args[0]?.includes("/"));
-
-          const result1 = parsePositionalArgs(args);
-          const result2 = parsePositionalArgs(args);
-          expect(result1).toEqual(result2);
-        }
-      ),
+      property(tuple(slugArb, traceIdArb), ([target, traceId]) => {
+        const args = [target, traceId];
+        const result1 = parsePositionalArgs(args);
+        const result2 = parsePositionalArgs(args);
+        expect(result1).toEqual(result2);
+      }),
       { numRuns: DEFAULT_NUM_RUNS }
     );
   });
@@ -144,19 +136,48 @@ describe("parsePositionalArgs properties", () => {
     expect(() => parsePositionalArgs([])).toThrow(ContextError);
   });
 
-  test("result always has traceId property defined", async () => {
+  test("result always has traceId property defined (valid inputs)", async () => {
     await fcAssert(
-      property(
-        array(nonEmptyStringArb, { minLength: 1, maxLength: 3 }),
-        (args) => {
-          // Skip single-arg with slashes — those throw ContextError (tested separately)
-          pre(args.length > 1 || !args[0]?.includes("/"));
+      property(traceIdArb, (traceId) => {
+        const result = parsePositionalArgs([traceId]);
+        expect(result.traceId).toBeDefined();
+        expect(typeof result.traceId).toBe("string");
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
 
-          const result = parsePositionalArgs(args);
-          expect(result.traceId).toBeDefined();
-          expect(typeof result.traceId).toBe("string");
-        }
-      ),
+  test("UUID-format trace IDs are accepted and produce 32-char hex", async () => {
+    await fcAssert(
+      property(traceIdArb, (hex) => {
+        const uuid = toUuidFormat(hex);
+        const result = parsePositionalArgs([uuid]);
+        expect(result.traceId).toBe(hex);
+        expect(result.warning).toContain("Auto-corrected");
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("UUID-format trace IDs work in two-arg case", async () => {
+    await fcAssert(
+      property(tuple(slugArb, traceIdArb), ([target, hex]) => {
+        const uuid = toUuidFormat(hex);
+        const result = parsePositionalArgs([target, uuid]);
+        expect(result.traceId).toBe(hex);
+        expect(result.targetArg).toBe(target);
+        expect(result.warning).toContain("Auto-corrected");
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("invalid trace IDs always throw ValidationError", async () => {
+    const invalidIdArb = stringMatching(/^[g-z]{10,20}$/);
+    await fcAssert(
+      property(invalidIdArb, (badId) => {
+        expect(() => parsePositionalArgs([badId])).toThrow(ValidationError);
+      }),
       { numRuns: DEFAULT_NUM_RUNS }
     );
   });

--- a/test/commands/trace/view.test.ts
+++ b/test/commands/trace/view.test.ts
@@ -17,32 +17,42 @@ import {
 } from "../../../src/lib/errors.js";
 import { resolveProjectBySlug } from "../../../src/lib/resolve-target.js";
 
+const VALID_TRACE_ID = "aaaa1111bbbb2222cccc3333dddd4444";
+const VALID_TRACE_ID_2 = "deadbeef12345678deadbeef12345678";
+const VALID_UUID = "ed29abc8-71c4-475b-9675-4655ef1a02d0";
+const VALID_UUID_STRIPPED = "ed29abc871c4475b96754655ef1a02d0";
+
 describe("parsePositionalArgs", () => {
   describe("single argument (trace ID only)", () => {
     test("parses single arg as trace ID", () => {
-      const result = parsePositionalArgs(["abc123def456"]);
-      expect(result.traceId).toBe("abc123def456");
+      const result = parsePositionalArgs([VALID_TRACE_ID]);
+      expect(result.traceId).toBe(VALID_TRACE_ID);
       expect(result.targetArg).toBeUndefined();
     });
 
     test("parses 32-char hex trace ID", () => {
-      const result = parsePositionalArgs(["aaaa1111bbbb2222cccc3333dddd4444"]);
-      expect(result.traceId).toBe("aaaa1111bbbb2222cccc3333dddd4444");
+      const result = parsePositionalArgs([VALID_TRACE_ID]);
+      expect(result.traceId).toBe(VALID_TRACE_ID);
       expect(result.targetArg).toBeUndefined();
+    });
+
+    test("normalizes uppercase trace ID to lowercase", () => {
+      const result = parsePositionalArgs(["AAAA1111BBBB2222CCCC3333DDDD4444"]);
+      expect(result.traceId).toBe(VALID_TRACE_ID);
     });
   });
 
   describe("two arguments (target + trace ID)", () => {
     test("parses org/project target and trace ID", () => {
-      const result = parsePositionalArgs(["my-org/frontend", "abc123def456"]);
+      const result = parsePositionalArgs(["my-org/frontend", VALID_TRACE_ID]);
       expect(result.targetArg).toBe("my-org/frontend");
-      expect(result.traceId).toBe("abc123def456");
+      expect(result.traceId).toBe(VALID_TRACE_ID);
     });
 
     test("parses project-only target and trace ID", () => {
-      const result = parsePositionalArgs(["frontend", "abc123def456"]);
+      const result = parsePositionalArgs(["frontend", VALID_TRACE_ID]);
       expect(result.targetArg).toBe("frontend");
-      expect(result.traceId).toBe("abc123def456");
+      expect(result.traceId).toBe(VALID_TRACE_ID);
     });
   });
 
@@ -60,23 +70,37 @@ describe("parsePositionalArgs", () => {
         expect((error as ContextError).message).toContain("Trace ID");
       }
     });
+
+    test("throws ValidationError for invalid trace ID", () => {
+      expect(() => parsePositionalArgs(["not-a-valid-trace-id"])).toThrow(
+        ValidationError
+      );
+    });
+
+    test("throws ValidationError for short hex", () => {
+      expect(() => parsePositionalArgs(["abc123"])).toThrow(ValidationError);
+    });
+
+    test("throws ValidationError for empty trace ID in two-arg case", () => {
+      expect(() => parsePositionalArgs(["my-org/frontend", ""])).toThrow(
+        ValidationError
+      );
+    });
   });
 
   describe("slash-separated org/project/traceId (single arg)", () => {
     test("parses org/project/traceId as target + trace ID", () => {
-      const result = parsePositionalArgs([
-        "sentry/cli/aaaa1111bbbb2222cccc3333dddd4444",
-      ]);
+      const result = parsePositionalArgs([`sentry/cli/${VALID_TRACE_ID}`]);
       expect(result.targetArg).toBe("sentry/cli");
-      expect(result.traceId).toBe("aaaa1111bbbb2222cccc3333dddd4444");
+      expect(result.traceId).toBe(VALID_TRACE_ID);
     });
 
     test("handles hyphenated org and project slugs", () => {
       const result = parsePositionalArgs([
-        "my-org/my-project/deadbeef12345678",
+        `my-org/my-project/${VALID_TRACE_ID_2}`,
       ]);
       expect(result.targetArg).toBe("my-org/my-project");
-      expect(result.traceId).toBe("deadbeef12345678");
+      expect(result.traceId).toBe(VALID_TRACE_ID_2);
     });
 
     test("one slash (org/project, missing trace ID) throws ContextError", () => {
@@ -102,17 +126,52 @@ describe("parsePositionalArgs", () => {
     test("handles more than two args (ignores extras)", () => {
       const result = parsePositionalArgs([
         "my-org/frontend",
-        "abc123",
+        VALID_TRACE_ID,
         "extra-arg",
       ]);
       expect(result.targetArg).toBe("my-org/frontend");
-      expect(result.traceId).toBe("abc123");
+      expect(result.traceId).toBe(VALID_TRACE_ID);
+    });
+  });
+
+  describe("UUID auto-correction", () => {
+    test("strips dashes from UUID trace ID (single arg)", () => {
+      const result = parsePositionalArgs([VALID_UUID]);
+      expect(result.traceId).toBe(VALID_UUID_STRIPPED);
+      expect(result.targetArg).toBeUndefined();
     });
 
-    test("handles empty string trace ID in two-arg case", () => {
-      const result = parsePositionalArgs(["my-org/frontend", ""]);
+    test("returns warning when UUID dashes are stripped", () => {
+      const result = parsePositionalArgs([VALID_UUID]);
+      expect(result.warning).toBeDefined();
+      expect(result.warning).toContain("Auto-corrected");
+      expect(result.warning).toContain(VALID_UUID_STRIPPED);
+    });
+
+    test("no warning for plain 32-char hex", () => {
+      const result = parsePositionalArgs([VALID_TRACE_ID]);
+      expect(result.warning).toBeUndefined();
+    });
+
+    test("strips dashes from UUID trace ID (two-arg case)", () => {
+      const result = parsePositionalArgs(["my-org/frontend", VALID_UUID]);
+      expect(result.traceId).toBe(VALID_UUID_STRIPPED);
       expect(result.targetArg).toBe("my-org/frontend");
-      expect(result.traceId).toBe("");
+      expect(result.warning).toContain("Auto-corrected");
+    });
+
+    test("strips dashes from UUID in slash-separated form", () => {
+      const result = parsePositionalArgs([`sentry/cli/${VALID_UUID}`]);
+      expect(result.traceId).toBe(VALID_UUID_STRIPPED);
+      expect(result.targetArg).toBe("sentry/cli");
+      expect(result.warning).toContain("Auto-corrected");
+    });
+
+    test("handles real user input from CLI-7Z", () => {
+      const result = parsePositionalArgs([
+        "ed29abc8-71c4-475b-9675-4655ef1a02d0",
+      ]);
+      expect(result.traceId).toBe("ed29abc871c4475b96754655ef1a02d0");
     });
   });
 });

--- a/test/lib/hex-id.test.ts
+++ b/test/lib/hex-id.test.ts
@@ -8,7 +8,11 @@
 import { describe, expect, test } from "bun:test";
 import { array, constantFrom, assert as fcAssert, property } from "fast-check";
 import { ValidationError } from "../../src/lib/errors.js";
-import { HEX_ID_RE, validateHexId } from "../../src/lib/hex-id.js";
+import {
+  HEX_ID_RE,
+  UUID_DASH_RE,
+  validateHexId,
+} from "../../src/lib/hex-id.js";
 import { DEFAULT_NUM_RUNS } from "../model-based/helpers.js";
 
 const HEX_CHARS = "0123456789abcdefABCDEF".split("");
@@ -56,6 +60,58 @@ describe("HEX_ID_RE", () => {
 
   test("rejects strings with newlines", () => {
     expect(HEX_ID_RE.test("aaaa1111bbbb2222cccc3333dddd4444\n")).toBe(false);
+  });
+});
+
+describe("UUID_DASH_RE", () => {
+  test("matches a valid UUID with dashes (lowercase)", () => {
+    expect(UUID_DASH_RE.test("aaaa1111-bbbb-2222-cccc-3333dddd4444")).toBe(
+      true
+    );
+  });
+
+  test("matches a valid UUID with dashes (uppercase)", () => {
+    expect(UUID_DASH_RE.test("AAAA1111-BBBB-2222-CCCC-3333DDDD4444")).toBe(
+      true
+    );
+  });
+
+  test("matches mixed-case UUID", () => {
+    expect(UUID_DASH_RE.test("AaAa1111-BbBb-2222-CcCc-3333DdDd4444")).toBe(
+      true
+    );
+  });
+
+  test("rejects plain 32-char hex (no dashes)", () => {
+    expect(UUID_DASH_RE.test("aaaa1111bbbb2222cccc3333dddd4444")).toBe(false);
+  });
+
+  test("rejects dashes in wrong positions", () => {
+    expect(UUID_DASH_RE.test("aaaa-1111bbbb-2222cccc-3333dddd-444444444")).toBe(
+      false
+    );
+  });
+
+  test("rejects too few hex chars between dashes", () => {
+    expect(UUID_DASH_RE.test("aaa-1111-bbbb-2222-cccc3333dddd4444")).toBe(
+      false
+    );
+  });
+
+  test("rejects empty string", () => {
+    expect(UUID_DASH_RE.test("")).toBe(false);
+  });
+
+  test("rejects non-hex chars in UUID format", () => {
+    expect(UUID_DASH_RE.test("gggg1111-bbbb-2222-cccc-3333dddd4444")).toBe(
+      false
+    );
+  });
+
+  test("matches real user input from CLI-7Z", () => {
+    expect(UUID_DASH_RE.test("ed29abc8-71c4-475b-9675-4655ef1a02d0")).toBe(
+      true
+    );
   });
 });
 
@@ -149,6 +205,49 @@ describe("validateHexId", () => {
     const multiLine = `${VALID_ID}\n${"bbbb1111cccc2222dddd3333eeee4444"}`;
     expect(() => validateHexId(multiLine, "test ID")).toThrow(ValidationError);
   });
+
+  test("strips dashes from UUID format and returns 32-char hex", () => {
+    expect(
+      validateHexId("aaaa1111-bbbb-2222-cccc-3333dddd4444", "test ID")
+    ).toBe(VALID_ID);
+  });
+
+  test("strips dashes from real user UUID (CLI-7Z)", () => {
+    expect(
+      validateHexId("ed29abc8-71c4-475b-9675-4655ef1a02d0", "test ID")
+    ).toBe("ed29abc871c4475b96754655ef1a02d0");
+  });
+
+  test("strips dashes from uppercase UUID and normalizes to lowercase", () => {
+    expect(
+      validateHexId("AAAA1111-BBBB-2222-CCCC-3333DDDD4444", "test ID")
+    ).toBe(VALID_ID);
+  });
+
+  test("strips dashes from UUID with whitespace padding", () => {
+    expect(
+      validateHexId("  aaaa1111-bbbb-2222-cccc-3333dddd4444  ", "test ID")
+    ).toBe(VALID_ID);
+  });
+
+  test("UUID validation is idempotent — validated UUID validates again unchanged", () => {
+    const first = validateHexId(
+      "aaaa1111-bbbb-2222-cccc-3333dddd4444",
+      "test ID"
+    );
+    const second = validateHexId(first, "test ID");
+    expect(second).toBe(first);
+  });
+
+  test("rejects non-UUID dash patterns (random dashes)", () => {
+    expect(() => validateHexId("abc-def", "test ID")).toThrow(ValidationError);
+  });
+
+  test("rejects dashes in wrong positions (not 8-4-4-4-12)", () => {
+    expect(() =>
+      validateHexId("aaaa-1111bbbb-2222cccc-3333dddd-4444", "test ID")
+    ).toThrow(ValidationError);
+  });
 });
 
 describe("property: validateHexId", () => {
@@ -195,6 +294,35 @@ describe("property: validateHexId", () => {
     fcAssert(
       property(wrongLengthHexArb, (id) => {
         expect(() => validateHexId(id, "test ID")).toThrow(ValidationError);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  /**
+   * Insert dashes at UUID positions (8-4-4-4-12) into a 32-char hex string.
+   */
+  function toUuidFormat(hex: string): string {
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+
+  test("UUID format with dashes produces same result as plain hex", () => {
+    fcAssert(
+      property(validIdArb, (id) => {
+        const expected = id.toLowerCase();
+        const uuid = toUuidFormat(id);
+        expect(validateHexId(uuid, "test ID")).toBe(expected);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("UUID validation round-trips: validateHexId(uuid) === validateHexId(plain)", () => {
+    fcAssert(
+      property(validIdArb, (id) => {
+        const fromPlain = validateHexId(id, "test ID");
+        const fromUuid = validateHexId(toUuidFormat(id), "test ID");
+        expect(fromUuid).toBe(fromPlain);
       }),
       { numRuns: DEFAULT_NUM_RUNS }
     );

--- a/test/lib/trace-id.test.ts
+++ b/test/lib/trace-id.test.ts
@@ -113,6 +113,18 @@ describe("validateTraceId", () => {
       expect(msg).not.toContain("sentry log list");
     }
   });
+
+  test("strips dashes from UUID-format trace ID (real user input from CLI-7Z)", () => {
+    expect(validateTraceId("ed29abc8-71c4-475b-9675-4655ef1a02d0")).toBe(
+      "ed29abc871c4475b96754655ef1a02d0"
+    );
+  });
+
+  test("strips dashes from uppercase UUID trace ID", () => {
+    expect(validateTraceId("AAAA1111-BBBB-2222-CCCC-3333DDDD4444")).toBe(
+      "aaaa1111bbbb2222cccc3333dddd4444"
+    );
+  });
 });
 
 describe("property: validateTraceId", () => {
@@ -166,6 +178,24 @@ describe("property: validateTraceId", () => {
     fcAssert(
       property(mixedCharsArb, (id) => {
         expect(() => validateTraceId(id)).toThrow(ValidationError);
+      }),
+      { numRuns: 100 }
+    );
+  });
+
+  /**
+   * Insert dashes at UUID positions (8-4-4-4-12) into a 32-char hex string.
+   */
+  function toUuidFormat(hex: string): string {
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+
+  test("UUID-format trace IDs produce valid 32-char hex", () => {
+    fcAssert(
+      property(validTraceIdArb, (id) => {
+        const uuid = toUuidFormat(id);
+        const result = validateTraceId(uuid);
+        expect(result).toBe(id.toLowerCase());
       }),
       { numRuns: 100 }
     );


### PR DESCRIPTION
Fix two related issues (CLI-7Z, CLI-4X) in `sentry trace view`:

1. **Missing trace ID validation** — `parsePositionalArgs()` never called
   `validateTraceId()`, so raw user input went directly to the API. Invalid
   formats produced confusing "No trace found" errors instead of clear
   validation messages. Now matches the pattern used by `trace logs`.

2. **UUID dash-stripping** — users often copy trace IDs in UUID format
   (e.g., `ed29abc8-71c4-475b-9675-4655ef1a02d0`). `validateHexId()` now
   auto-strips dashes when the input matches the 8-4-4-4-12 UUID pattern
   and logs a warning to stderr, following the project's auto-correct
   convention.

### Changes

- **`src/lib/hex-id.ts`**: Add `UUID_DASH_RE` regex and dash-stripping in
  `validateHexId()`
- **`src/commands/trace/view.ts`**: Add `validateTraceId()` at all 4 return
  paths in `parsePositionalArgs()` via `validateAndWarn()` helper
- **Tests**: Updated hex-id (unit + property), trace-id (unit + property),
  trace view (unit, property, func) — 123 tests pass

Fixes CLI-7Z
Fixes CLI-4X