### PR TITLE
feat(init): add experimental warning before wizard runs

### DIFF
--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -7,12 +7,16 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { cancel, intro, log, spinner } from "@clack/prompts";
+import { cancel, confirm, intro, log, spinner } from "@clack/prompts";
 import { MastraClient } from "@mastra/client-js";
 import { formatBanner } from "../banner.js";
 import { CLI_VERSION } from "../constants.js";
 import { getAuthToken } from "../db/auth.js";
-import { STEP_LABELS, WizardCancelledError } from "./clack-utils.js";
+import {
+  abortIfCancelled,
+  STEP_LABELS,
+  WizardCancelledError,
+} from "./clack-utils.js";
 import {
   API_TIMEOUT_MS,
   MASTRA_API_URL,
@@ -170,22 +174,54 @@ function withTimeout<T>(
   });
 }
 
-export async function runWizard(options: WizardOptions): Promise<void> {
-  const { directory, yes, dryRun, features } = options;
+/** Returns `true` if the user confirmed, `false` if they declined. */
+async function confirmExperimental(yes: boolean): Promise<boolean> {
+  if (yes) {
+    return true;
+  }
+  const proceed = await confirm({
+    message:
+      "EXPERIMENTAL: This feature is experimental and may modify your code. Continue?",
+  });
+  abortIfCancelled(proceed);
+  return !!proceed;
+}
 
+/**
+ * Pre-flight checks: TTY guard, banner, intro, and experimental warning.
+ * Returns `true` when the wizard should continue, `false` to abort.
+ */
+async function preamble(yes: boolean, dryRun: boolean): Promise<boolean> {
   if (!(yes || process.stdin.isTTY)) {
     process.stderr.write(
       "Error: Interactive mode requires a terminal. Use --yes for non-interactive mode.\n"
     );
     process.exitCode = 1;
-    return;
+    return false;
   }
 
   process.stderr.write(`\n${formatBanner()}\n\n`);
   intro("sentry init");
 
+  const confirmed = await confirmExperimental(yes);
+  if (!confirmed) {
+    cancel("Setup cancelled.");
+    process.exitCode = 0;
+    return false;
+  }
+
   if (dryRun) {
     log.warn("Dry-run mode: no files will be modified.");
+  }
+
+  return true;
+}
+
+export async function runWizard(options: WizardOptions): Promise<void> {
+  const { directory, yes, dryRun, features } = options;
+
+  if (!(await preamble(yes, dryRun))) {
+    return;
   }
 
   log.info(

--- a/test/lib/init/wizard-runner.test.ts
+++ b/test/lib/init/wizard-runner.test.ts
@@ -54,6 +54,7 @@ function makeOptions(overrides?: Partial<WizardOptions>): WizardOptions {
 
 // clack
 let introSpy: ReturnType<typeof spyOn>;
+let confirmSpy: ReturnType<typeof spyOn>;
 let logInfoSpy: ReturnType<typeof spyOn>;
 let logWarnSpy: ReturnType<typeof spyOn>;
 let logErrorSpy: ReturnType<typeof spyOn>;
@@ -124,6 +125,7 @@ beforeEach(() => {
 
   // clack spies
   introSpy = spyOn(clack, "intro").mockImplementation(noop);
+  confirmSpy = spyOn(clack, "confirm").mockResolvedValue(true);
   logInfoSpy = spyOn(clack.log, "info").mockImplementation(noop);
   logWarnSpy = spyOn(clack.log, "warn").mockImplementation(noop);
   logErrorSpy = spyOn(clack.log, "error").mockImplementation(noop);
@@ -162,6 +164,7 @@ beforeEach(() => {
 
 afterEach(() => {
   introSpy.mockRestore();
+  confirmSpy.mockRestore();
   logInfoSpy.mockRestore();
   logWarnSpy.mockRestore();
   logErrorSpy.mockRestore();
@@ -218,6 +221,62 @@ describe("runWizard", () => {
     });
   });
 
+  describe("experimental warning", () => {
+    test("shows experimental warning and proceeds on confirm", async () => {
+      const origIsTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: true,
+        configurable: true,
+      });
+
+      mockStartResult = { status: "success" };
+
+      await runWizard(makeOptions({ yes: false }));
+
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: origIsTTY,
+        configurable: true,
+      });
+
+      expect(confirmSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("EXPERIMENTAL"),
+        })
+      );
+      expect(formatResultSpy).toHaveBeenCalled();
+    });
+
+    test("skips experimental warning with --yes", async () => {
+      mockStartResult = { status: "success" };
+
+      await runWizard(makeOptions({ yes: true }));
+
+      expect(confirmSpy).not.toHaveBeenCalled();
+      expect(formatResultSpy).toHaveBeenCalled();
+    });
+
+    test("exits cleanly when user declines experimental warning", async () => {
+      const origIsTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: true,
+        configurable: true,
+      });
+
+      confirmSpy.mockResolvedValue(false);
+
+      await runWizard(makeOptions({ yes: false }));
+
+      Object.defineProperty(process.stdin, "isTTY", {
+        value: origIsTTY,
+        configurable: true,
+      });
+
+      expect(cancelSpy).toHaveBeenCalledWith("Setup cancelled.");
+      expect(process.exitCode).toBe(0);
+      expect(formatResultSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe("connection error", () => {
     test("times out if startAsync hangs", async () => {
       jest.useFakeTimers();
@@ -243,8 +302,10 @@ describe("runWizard", () => {
       const promise = runWizard(makeOptions());
 
       // Flush microtasks so runWizard reaches the withTimeout setTimeout
-      await Promise.resolve();
-      await Promise.resolve();
+      // (extra ticks needed for async preamble + confirmExperimental)
+      for (let i = 0; i < 8; i++) {
+        await Promise.resolve();
+      }
 
       // Advance past the timeout
       jest.advanceTimersByTime(API_TIMEOUT_MS);


### PR DESCRIPTION
## Summary

Shows a confirm prompt when running `sentry init` warning that the feature is experimental and may modify code. Users must explicitly agree before the wizard proceeds. The prompt is skipped when `--yes` is passed (non-interactive mode).

## Changes

<img width="1172" height="688" alt="Screenshot 2026-03-10 at 11 35 02" src="https://github.com/user-attachments/assets/213e9f1c-74de-4635-bb90-42b76a9e5f55" />

Adds a `confirmExperimental()` helper that gates on the `--yes` flag, and extracts a `preamble()` function from `runWizard` to bundle the TTY check, banner, intro, experimental warning, and dry-run notice. This also resolves the cognitive complexity lint violation that would have been introduced by inlining the new branch.

Three new tests cover the confirm/skip/decline paths.

## Test Plan

- `bun test test/lib/init/wizard-runner.test.ts` — 22 tests pass
- `bun run lint` — clean
- Manual: `bun run cli/src/bin.ts init` shows the experimental confirm prompt
- Manual: `bun run cli/src/bin.ts init --yes` skips it