### PR TITLE
fix(init): truncate uncommitted file list to first 5 entries

### DIFF
--- a/src/lib/init/git.ts
+++ b/src/lib/init/git.ts
@@ -7,6 +7,9 @@
 
 import { confirm, isCancel, log } from "@clack/prompts";
 
+/** Maximum number of uncommitted files to display before truncating. */
+const MAX_DISPLAYED_FILES = 5;
+
 export function isInsideGitWorkTree(opts: { cwd: string }): boolean {
   const result = Bun.spawnSync(["git", "rev-parse", "--is-inside-work-tree"], {
     stdout: "ignore",
@@ -64,7 +67,12 @@ export async function checkGitStatus(opts: {
 
   const uncommitted = getUncommittedOrUntrackedFiles({ cwd });
   if (uncommitted.length > 0) {
-    const fileList = uncommitted.join("\n");
+    const displayed = uncommitted.slice(0, MAX_DISPLAYED_FILES);
+    const remaining = uncommitted.length - displayed.length;
+    if (remaining > 0) {
+      displayed.push(`  + ${remaining} more uncommitted files`);
+    }
+    const fileList = displayed.join("\n");
     if (yes) {
       log.warn(
         `You have uncommitted or untracked files:\n${fileList}\nProceeding anyway (--yes).`


### PR DESCRIPTION
## Summary

- Truncates the uncommitted/untracked file list in the `init` git safety check to show only the first 5 files
- Appends a summary line (e.g. `+ 12 more uncommitted files`) when there are more than 5
- Prevents terminal flooding in repos with many dirty files while still communicating the situation clearly

## Changes

**`src/lib/init/git.ts`** — In `checkGitStatus`, instead of joining all files into the warning message, slice to `MAX_DISPLAYED_FILES` (5) and append a remainder count if truncated. Both the `--yes` auto-proceed and interactive prompt paths benefit from this.