### PR TITLE
fix(init): remove implementation detail from help text

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -22,8 +22,7 @@ export const initCommand = buildCommand<InitFlags, [string?], SentryContext>({
     brief: "Initialize Sentry in your project",
     fullDescription:
       "Runs the Sentry setup wizard to detect your project's framework, " +
-      "install the SDK, and configure error monitoring. Uses a remote " +
-      "workflow that coordinates local file operations through the CLI.",
+      "install the SDK, and configure Sentry.",
   },
   parameters: {
     positional: {


### PR DESCRIPTION
## Summary

Cleans up the `sentry init` help text per @BYK's review feedback:
- Removes the sentence about remote workflow coordination (implementation detail, not useful to users)
- Broadens "configure error monitoring" to "configure Sentry" since the wizard sets up tracing, replays, crons, etc. — not just errors

## Test Plan

- `bun run typecheck` passes
- `bun test test/commands/init.test.ts` passes (7/7)