### PR TITLE
feat(init): enforce canonical feature display order

### DIFF
--- a/src/lib/init/clack-utils.ts
+++ b/src/lib/init/clack-utils.ts
@@ -17,7 +17,7 @@ export class WizardCancelledError extends Error {
 export function abortIfCancelled<T>(value: T | symbol): T {
   if (isCancel(value)) {
     cancel(
-      `Setup cancelled. You can visit ${SENTRY_DOCS_URL} to set up manually.`,
+      `Setup cancelled. You can visit ${SENTRY_DOCS_URL} to set up manually.`
     );
     throw new WizardCancelledError();
   }
@@ -72,7 +72,10 @@ export function sortFeatures(features: string[]): string[] {
   return features.slice().sort((a, b) => {
     const ai = FEATURE_DISPLAY_ORDER.indexOf(a);
     const bi = FEATURE_DISPLAY_ORDER.indexOf(b);
-    return (ai === -1 ? Number.MAX_SAFE_INTEGER : ai) - (bi === -1 ? Number.MAX_SAFE_INTEGER : bi);
+    return (
+      (ai === -1 ? Number.MAX_SAFE_INTEGER : ai) -
+      (bi === -1 ? Number.MAX_SAFE_INTEGER : bi)
+    );
   });
 }
 

--- a/src/lib/init/interactive.ts
+++ b/src/lib/init/interactive.ts
@@ -95,7 +95,9 @@ async function handleMultiSelect(
     return { features: available };
   }
 
-  const optional = sortFeatures(available.filter((f) => f !== REQUIRED_FEATURE));
+  const optional = sortFeatures(
+    available.filter((f) => f !== REQUIRED_FEATURE)
+  );
 
   if (optional.length === 0) {
     if (hasRequired) {

--- a/test/lib/init/clack-utils.test.ts
+++ b/test/lib/init/clack-utils.test.ts
@@ -58,9 +58,7 @@ describe("featureLabel", () => {
 
 describe("featureHint", () => {
   test("returns hint for known feature", () => {
-    expect(featureHint("errorMonitoring")).toBe(
-      "Error and crash reporting"
-    );
+    expect(featureHint("errorMonitoring")).toBe("Error and crash reporting");
     expect(featureHint("sessionReplay")).toBe("Visual replay of user sessions");
   });
 


### PR DESCRIPTION
## Summary

Sorts the feature multi-select prompt into a fixed display order instead of relying on whatever the server sends. Also tweaks a couple of feature labels/hints for clarity.

**Display order**: Errors → Replay → Tracing → Logs → Metrics → Profiling → Source Maps

## Changes

- Add `FEATURE_DISPLAY_ORDER` constant and `sortFeatures()` helper in `clack-utils.ts`
- Apply sorting in `handleMultiSelect()` before rendering the prompt
- Minor copy tweaks: "Performance Monitoring" → "Performance Monitoring (Tracing)", drop "Automatic" from error monitoring hint

## Test plan

- `bun run typecheck` passes
- `bun test` passes (no regressions)
- Manual: run `bun run dev` against staging API, confirm multi-select shows features in the expected order