### PR TITLE
Minify JSON on read and pretty-print on write in init local ops

### DIFF
--- a/src/lib/init/local-ops.ts
+++ b/src/lib/init/local-ops.ts
@@ -574,18 +574,16 @@ function applyPatchsetDryRun(payload: ApplyPatchsetPayload): LocalOpResult {
  */
 function resolvePatchContent(
   absPath: string,
-  filePath: string,
-  rawContent: string,
-  action: string
+  patch: ApplyPatchsetPayload["params"]["patches"][number]
 ): string {
-  if (!filePath.endsWith(".json")) {
-    return rawContent;
+  if (!patch.path.endsWith(".json")) {
+    return patch.patch;
   }
-  if (action === "modify") {
+  if (patch.action === "modify") {
     const existing = fs.readFileSync(absPath, "utf-8");
-    return prettyPrintJson(rawContent, detectJsonIndent(existing));
+    return prettyPrintJson(patch.patch, detectJsonIndent(existing));
   }
-  return prettyPrintJson(rawContent, DEFAULT_JSON_INDENT);
+  return prettyPrintJson(patch.patch, DEFAULT_JSON_INDENT);
 }
 
 function applyPatchset(
@@ -619,12 +617,7 @@ function applyPatchset(
       case "create": {
         const dir = path.dirname(absPath);
         fs.mkdirSync(dir, { recursive: true });
-        const content = resolvePatchContent(
-          absPath,
-          patch.path,
-          patch.patch,
-          patch.action
-        );
+        const content = resolvePatchContent(absPath, patch);
         fs.writeFileSync(absPath, content, "utf-8");
         applied.push({ path: patch.path, action: "create" });
         break;
@@ -637,12 +630,7 @@ function applyPatchset(
             data: { applied },
           };
         }
-        const content = resolvePatchContent(
-          absPath,
-          patch.path,
-          patch.patch,
-          patch.action
-        );
+        const content = resolvePatchContent(absPath, patch);
         fs.writeFileSync(absPath, content, "utf-8");
         applied.push({ path: patch.path, action: "modify" });
         break;


### PR DESCRIPTION
## Summary

- **read-files**: Minifies `.json` file contents via `JSON.stringify()` to strip unnecessary whitespace before sending to the remote wizard workflow. Falls back to raw content if parsing fails (truncated files, JSONC, etc.).
- **apply-patchset**: Pretty-prints `.json` files when writing back to disk, restoring readable indentation that was lost during minification. For `modify` actions, the existing file's indentation style (tabs vs spaces, indent width) is detected and preserved. For `create` actions, a default of 2-space indentation is used.

### Implementation details

- `Indenter` constant with `SPACE` and `TAB` whitespace characters
- `JsonIndent` type with `replacer` and `length` fields for structured indent description
- `detectJsonIndent()` inspects the first indented line of existing file content to determine the indent style
- `prettyPrintJson()` re-serializes JSON with the detected (or default) indentation, with safe fallback if parsing fails
- `resolvePatchContent()` extracted from `applyPatchset` to keep complexity under the lint threshold