### PR TITLE
feat(init-eval): add Cloudflare Workers platform to eval suite

### DIFF
--- a/test/init-eval/cloudflare-workers.eval.test.ts
+++ b/test/init-eval/cloudflare-workers.eval.test.ts
@@ -1,0 +1,3 @@
+import { createEvalSuite } from "./helpers/create-eval-suite";
+
+createEvalSuite("cloudflare-workers");

--- a/test/init-eval/feature-docs.json
+++ b/test/init-eval/feature-docs.json
@@ -141,5 +141,17 @@
     "profiling": [
       "https://docs.sentry.io/platforms/javascript/guides/react/profiling/"
     ]
+  },
+
+  "cloudflare-workers": {
+    "getting-started": [
+      "https://docs.sentry.io/platforms/javascript/guides/cloudflare/"
+    ],
+    "errors": [
+      "https://docs.sentry.io/platforms/javascript/guides/cloudflare/"
+    ],
+    "tracing": [
+      "https://docs.sentry.io/platforms/javascript/guides/cloudflare/tracing/"
+    ]
   }
 }

--- a/test/init-eval/helpers/platforms.ts
+++ b/test/init-eval/helpers/platforms.ts
@@ -134,6 +134,18 @@ export const PLATFORMS: Platform[] = [
     initPattern: /Sentry\.init/,
     timeout: 300_000,
   },
+  {
+    id: "cloudflare-workers",
+    name: "Cloudflare Workers",
+    templateDir: join(TEMPLATES_DIR, "cloudflare-workers-app"),
+    sdkPackage: "@sentry/cloudflare",
+    depFile: "package.json",
+    docs: getDocs("cloudflare-workers"),
+    installCmd: "npm install",
+    buildCmd: "npx tsc --noEmit",
+    initPattern: /Sentry\.withSentry/,
+    timeout: 300_000,
+  },
 ];
 
 export function getPlatform(id: string): Platform {

--- a/test/init-eval/templates/cloudflare-workers-app/.gitignore
+++ b/test/init-eval/templates/cloudflare-workers-app/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.wrangler/

--- a/test/init-eval/templates/cloudflare-workers-app/package.json
+++ b/test/init-eval/templates/cloudflare-workers-app/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cloudflare-workers-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4",
+    "typescript": "^5",
+    "wrangler": "^4"
+  }
+}

--- a/test/init-eval/templates/cloudflare-workers-app/src/index.ts
+++ b/test/init-eval/templates/cloudflare-workers-app/src/index.ts
@@ -1,0 +1,13 @@
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/") {
+      return new Response(JSON.stringify({ message: "Hello World" }), {
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response("Not Found", { status: 404 });
+  },
+} satisfies ExportedHandler<Env>;

--- a/test/init-eval/templates/cloudflare-workers-app/tsconfig.json
+++ b/test/init-eval/templates/cloudflare-workers-app/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/test/init-eval/templates/cloudflare-workers-app/wrangler.toml
+++ b/test/init-eval/templates/cloudflare-workers-app/wrangler.toml
@@ -1,0 +1,3 @@
+name = "cloudflare-workers-app"
+main = "src/index.ts"
+compatibility_date = "2024-12-01"


### PR DESCRIPTION
## Summary

- Adds Cloudflare Workers as a new platform in the init-eval test suite
- Uses `Sentry.withSentry` as the init pattern (instead of `Sentry.init`) since Cloudflare Workers use the `withSentry` wrapper pattern
- Includes a minimal Cloudflare Workers template app (wrangler + TypeScript) and feature docs for getting-started, errors, and tracing