### PR TITLE
feat(init): show feedback hint after successful setup

### DIFF
--- a/src/lib/init/formatters.ts
+++ b/src/lib/init/formatters.ts
@@ -76,7 +76,7 @@ export function formatResult(result: WorkflowRunResult): void {
 
   log.info("Please review the changes above before committing.");
   log.info(
-    "You're one of the first to try the new setup wizard! Run `sentry feedback` to let us know how it went."
+    "You're one of the first to try the new setup wizard! Run `sentry cli feedback` to let us know how it went."
   );
 
   outro("Sentry SDK installed successfully!");


### PR DESCRIPTION
## Summary

After a successful `sentry init`, shows a hint reminding users they can run `sentry feedback` to share their experience. Since we're early, the message leans into that: "You're one of the first to try the new setup wizard!"

Closes #429