### PR TITLE
fix(init): align multiselect hint lines with clack's visual frame

### DIFF
--- a/src/lib/init/interactive.ts
+++ b/src/lib/init/interactive.ts
@@ -107,12 +107,14 @@ async function handleMultiSelect(
   }
 
   const hints: string[] = [];
+  // Use clack's vertical bar character so hint lines align with the option lines below
+  const bar = chalk.gray("\u2502");
   if (hasRequired) {
     hints.push(
-      chalk.dim(`  ${featureLabel(REQUIRED_FEATURE)} is always included`)
+      `${bar}  ${chalk.dim(`${featureLabel(REQUIRED_FEATURE)} is always included`)}`
     );
   }
-  hints.push(chalk.dim("  space=toggle, a=all, enter=confirm"));
+  hints.push(`${bar}  ${chalk.dim("space=toggle, a=all, enter=confirm")}`);
 
   const selected = await multiselect({
     message: `${payload.prompt}\n${hints.join("\n")}`,


### PR DESCRIPTION
## Summary

- Fix misaligned hint lines in the `sentry init` feature multiselect prompt by prefixing them with clack's `│` bar character

## Problem

The multiselect hint lines ("Error Monitoring is always included" and "space=toggle, a=all, enter=confirm") were rendered without clack's `│` bar prefix, causing visual misalignment with the option lines below them.

**Before:**
```
◆  Select features to enable
  Error Monitoring is always included
  space=toggle, a=all, enter=confirm
│  ◻ Session Replay
│  ◼ Performance Monitoring
└
```

**After:**
```
◆  Select features to enable
│  Error Monitoring is always included
│  space=toggle, a=all, enter=confirm
│  ◻ Session Replay
│  ◼ Performance Monitoring
└
```

## Root Cause

Clack's `multiselect` renderer does not split multi-line `message` strings and prefix continuation lines with the `│` bar (unlike `log.message()` which does). The hint lines were embedded in the message with only manual `  ` padding, missing the `│  ` prefix that clack applies to option lines.

## Fix

Prefix hint lines with `chalk.gray("│")` (U+2502) to match clack's visual frame, keeping the bar gray (matching clack's coloring) and the hint text dim.