### PR TITLE
refactor: centralize slug normalization warning in parseOrgProjectArg

### DIFF
--- a/src/commands/event/view.ts
+++ b/src/commands/event/view.ts
@@ -344,9 +344,6 @@ export const viewCommand = buildCommand({
       log.warn(suggestion);
     }
     const parsed = parseOrgProjectArg(targetArg);
-    if (parsed.type !== "auto-detect" && parsed.normalized) {
-      log.warn("Normalized slug (Sentry slugs use dashes, not underscores)");
-    }
 
     const target = await resolveEventTarget({
       parsed,

--- a/src/commands/log/view.ts
+++ b/src/commands/log/view.ts
@@ -358,9 +358,6 @@ export const viewCommand = buildCommand({
       cmdLog.warn(suggestion);
     }
     const parsed = parseOrgProjectArg(targetArg);
-    if (parsed.type !== "auto-detect" && parsed.normalized) {
-      cmdLog.warn("Normalized slug (Sentry slugs use dashes, not underscores)");
-    }
 
     const target = await resolveTarget(parsed, logIds, cwd);
 

--- a/src/commands/span/list.ts
+++ b/src/commands/span/list.ts
@@ -35,7 +35,6 @@ import {
   FRESH_FLAG,
   LIST_CURSOR_FLAG,
 } from "../../lib/list-command.js";
-import { logger } from "../../lib/logger.js";
 import {
   resolveOrgAndProject,
   resolveProjectBySlug,
@@ -281,14 +280,10 @@ export const listCommand = buildCommand({
   async *func(this: SentryContext, flags: ListFlags, ...args: string[]) {
     applyFreshFlag(flags);
     const { cwd, setContext } = this;
-    const log = logger.withTag("span.list");
 
     // Parse positional args
     const { traceId, targetArg } = parsePositionalArgs(args);
     const parsed = parseOrgProjectArg(targetArg);
-    if (parsed.type !== "auto-detect" && parsed.normalized) {
-      log.warn("Normalized slug (Sentry slugs use dashes, not underscores)");
-    }
 
     // Resolve target
     let target: { org: string; project: string } | null = null;

--- a/src/commands/span/view.ts
+++ b/src/commands/span/view.ts
@@ -284,14 +284,10 @@ export const viewCommand = buildCommand({
   async *func(this: SentryContext, flags: ViewFlags, ...args: string[]) {
     applyFreshFlag(flags);
     const { cwd, setContext } = this;
-    const cmdLog = logger.withTag("span.view");
 
     // Parse positional args: first is trace ID (with optional target), rest are span IDs
     const { traceId, spanIds, targetArg } = parsePositionalArgs(args);
     const parsed = parseOrgProjectArg(targetArg);
-    if (parsed.type !== "auto-detect" && parsed.normalized) {
-      cmdLog.warn("Normalized slug (Sentry slugs use dashes, not underscores)");
-    }
 
     const target = await resolveTarget(parsed, traceId, cwd);
 

--- a/src/commands/trace/view.ts
+++ b/src/commands/trace/view.ts
@@ -202,9 +202,6 @@ export const viewCommand = buildCommand({
       log.warn(suggestion);
     }
     const parsed = parseOrgProjectArg(targetArg);
-    if (parsed.type !== "auto-detect" && parsed.normalized) {
-      log.warn("Normalized slug (Sentry slugs use dashes, not underscores)");
-    }
 
     let target: ResolvedTraceTarget | null = null;
 

--- a/src/lib/arg-parsing.ts
+++ b/src/lib/arg-parsing.ts
@@ -8,6 +8,7 @@
 
 import { ContextError, ValidationError } from "./errors.js";
 import { validateResourceId } from "./input-validation.js";
+import { logger } from "./logger.js";
 import type { ParsedSentryUrl } from "./sentry-url-parser.js";
 import { applySentryUrlContext, parseSentryUrl } from "./sentry-url-parser.js";
 import { isAllDigits } from "./utils.js";
@@ -38,6 +39,36 @@ export function normalizeSlug(slug: string): {
     return { slug: slug.replace(/_/g, "-"), normalized: true };
   }
   return { slug, normalized: false };
+}
+
+const log = logger.withTag("arg-parsing");
+
+/**
+ * Emit a warning when slug normalization replaced underscores with dashes.
+ * Called internally by {@link parseOrgProjectArg} — callers do not need to
+ * check `parsed.normalized` themselves.
+ */
+function warnNormalized(
+  parsed: Exclude<ParsedOrgProject, { type: "auto-detect" }>
+): void {
+  let slug: string;
+  switch (parsed.type) {
+    case "explicit":
+      slug = `${parsed.org}/${parsed.project}`;
+      break;
+    case "org-all":
+      slug = `${parsed.org}/`;
+      break;
+    case "project-search":
+      slug = parsed.projectSlug;
+      break;
+    default:
+      return;
+  }
+
+  log.warn(
+    `Normalized slug to '${slug}' (Sentry slugs use dashes, never underscores)`
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -420,18 +451,25 @@ export function parseOrgProjectArg(arg: string | undefined): ParsedOrgProject {
     return orgProjectFromUrl(urlParsed);
   }
 
+  let parsed: ParsedOrgProject;
   if (trimmed.includes("/")) {
-    return parseSlashOrgProject(trimmed);
+    parsed = parseSlashOrgProject(trimmed);
+  } else {
+    // No slash → search for project across all orgs
+    validateResourceId(trimmed, "project slug");
+    const np = normalizeSlug(trimmed);
+    parsed = {
+      type: "project-search",
+      projectSlug: np.slug,
+      ...(np.normalized && { normalized: true }),
+    };
   }
 
-  // No slash → search for project across all orgs
-  validateResourceId(trimmed, "project slug");
-  const np = normalizeSlug(trimmed);
-  return {
-    type: "project-search",
-    projectSlug: np.slug,
-    ...(np.normalized && { normalized: true }),
-  };
+  if (parsed.type !== "auto-detect" && parsed.normalized) {
+    warnNormalized(parsed);
+  }
+
+  return parsed;
 }
 
 /**

--- a/test/lib/arg-parsing.test.ts
+++ b/test/lib/arg-parsing.test.ts
@@ -6,7 +6,7 @@
  * error messages and edge cases.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import {
   detectSwappedTrialArgs,
   detectSwappedViewArgs,
@@ -175,6 +175,80 @@ describe("parseOrgProjectArg", () => {
         type: "org-all",
         org: "acme-corp",
       });
+    });
+  });
+
+  describe("slug normalization warning", () => {
+    let stderrSpy: ReturnType<typeof spyOn>;
+    let stderrOutput: string;
+
+    beforeEach(() => {
+      stderrOutput = "";
+      stderrSpy = spyOn(process.stderr, "write").mockImplementation(
+        (chunk: string | Uint8Array) => {
+          stderrOutput += typeof chunk === "string" ? chunk : "";
+          return true;
+        }
+      );
+    });
+
+    afterEach(() => {
+      stderrSpy.mockRestore();
+    });
+
+    test("emits warning for underscored project slug", () => {
+      const result = parseOrgProjectArg("my_project");
+      expect(result).toEqual({
+        type: "project-search",
+        projectSlug: "my-project",
+        normalized: true,
+      });
+      expect(stderrOutput).toContain("Normalized slug to 'my-project'");
+      expect(stderrOutput).toContain(
+        "Sentry slugs use dashes, never underscores"
+      );
+    });
+
+    test("emits warning for underscored org in explicit mode", () => {
+      const result = parseOrgProjectArg("my_org/cli");
+      expect(result).toEqual({
+        type: "explicit",
+        org: "my-org",
+        project: "cli",
+        normalized: true,
+      });
+      expect(stderrOutput).toContain("Normalized slug to 'my-org/cli'");
+    });
+
+    test("emits warning for underscored project in explicit mode", () => {
+      const result = parseOrgProjectArg("sentry/my_project");
+      expect(result).toEqual({
+        type: "explicit",
+        org: "sentry",
+        project: "my-project",
+        normalized: true,
+      });
+      expect(stderrOutput).toContain("Normalized slug to 'sentry/my-project'");
+    });
+
+    test("emits warning for underscored org in org-all mode", () => {
+      const result = parseOrgProjectArg("my_org/");
+      expect(result).toEqual({
+        type: "org-all",
+        org: "my-org",
+        normalized: true,
+      });
+      expect(stderrOutput).toContain("Normalized slug to 'my-org/'");
+    });
+
+    test("does not emit warning for auto-detect", () => {
+      parseOrgProjectArg(undefined);
+      expect(stderrOutput).not.toContain("Normalized slug");
+    });
+
+    test("does not emit warning when no underscores present", () => {
+      parseOrgProjectArg("sentry/cli");
+      expect(stderrOutput).not.toContain("Normalized slug");
     });
   });
 });


### PR DESCRIPTION
## Summary

Moves the slug normalization warning from 5 individual command files into `parseOrgProjectArg()` itself. Every caller now gets the warning automatically — no per-command boilerplate, and no risk of future commands forgetting it.

### Changes

**`src/lib/arg-parsing.ts`** — core change:
- Added private `warnNormalized()` helper that builds a display slug from the `ParsedOrgProject` variant
- Restructured `parseOrgProjectArg()` to emit the warning internally before returning
- Improved message now includes the actual normalized value:
  `Normalized slug to 'my-org/my-project' (Sentry slugs use dashes, never underscores)`

**5 command files** — removed duplicate 3-line if-blocks:
- `src/commands/event/view.ts`
- `src/commands/log/view.ts`
- `src/commands/trace/view.ts`
- `src/commands/span/list.ts` (also removed now-unused `logger.withTag()`)
- `src/commands/span/view.ts` (also removed now-unused `cmdLog` variable)

**`test/lib/arg-parsing.test.ts`** — 6 new tests:
- Warning emitted for each variant: `project-search`, `explicit` (org/project), `org-all`
- No warning for `auto-detect` or non-underscored slugs

### Before / After

**Before** — copy-pasted in every command:
```typescript
const parsed = parseOrgProjectArg(targetArg);
if (parsed.type !== "auto-detect" && parsed.normalized) {
  log.warn("Normalized slug (Sentry slugs use dashes, not underscores)");
}
```

**After** — callers just call the parser:
```typescript
const parsed = parseOrgProjectArg(targetArg);
// Warning emitted automatically inside parseOrgProjectArg
```

### Test Plan
- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes (0 errors)
- [x] `bun test test/lib/arg-parsing.test.ts` — 106 tests pass
- [x] `git grep 'Sentry slugs use dashes' -- 'src/'` — only matches `arg-parsing.ts`

Closes #431