### PR TITLE
chore(lint): enforce command output conventions via Biome plugins

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,6 +1,10 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "extends": ["ultracite/core"],
+  "plugins": [
+    "./lint-rules/no-stdout-write-in-commands.grit",
+    "./lint-rules/no-process-stdout-in-commands.grit"
+  ],
   "files": {
     "includes": ["!docs", "!test/init-eval/templates"]
   },
@@ -74,6 +78,31 @@
         "rules": {
           "style": {
             "noRestrictedImports": "off"
+          }
+        }
+      }
+    },
+    {
+      // Commands must use colorTag() from markdown.ts — not raw chalk.
+      // Raw chalk bypasses the plain-output pipeline (NO_COLOR, SENTRY_PLAIN_OUTPUT).
+      "includes": ["src/commands/**/*.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "@stricli/core": {
+                    "importNames": ["buildCommand"],
+                    "message": "Import buildCommand from '../lib/command.js' instead. The wrapper injects telemetry, --log-level, and --verbose."
+                  },
+                  "chalk": {
+                    "message": "Use colorTag() from formatters/markdown.js for colored output. Raw chalk bypasses the plain-output pipeline (NO_COLOR, SENTRY_PLAIN_OUTPUT)."
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/lint-rules/no-process-stdout-in-commands.grit
+++ b/lint-rules/no-process-stdout-in-commands.grit
@@ -1,0 +1,5 @@
+file($name, $body) where {
+  $name <: r".*src/commands/.*",
+  $body <: contains `process.stdout` as $access,
+  register_diagnostic(span=$access, message="Don't use process.stdout in commands. Yield CommandOutput and let the buildCommand wrapper handle output.")
+}

--- a/lint-rules/no-stdout-write-in-commands.grit
+++ b/lint-rules/no-stdout-write-in-commands.grit
@@ -1,0 +1,5 @@
+file($name, $body) where {
+  $name <: r".*src/commands/.*",
+  $body <: contains `stdout.write($args)` as $call,
+  register_diagnostic(span=$call, message="Don't call stdout.write() in commands. Yield CommandOutput instead and let the buildCommand wrapper handle output rendering.")
+}

--- a/src/commands/issue/view.ts
+++ b/src/commands/issue/view.ts
@@ -12,6 +12,7 @@ import { buildCommand } from "../../lib/command.js";
 import {
   formatEventDetails,
   formatIssueDetails,
+  isPlainOutput,
   muted,
 } from "../../lib/formatters/index.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
@@ -159,11 +160,11 @@ export const viewCommand = buildCommand({
     if (spanTreeResult) {
       spanTreeLines = spanTreeResult.lines;
     } else if (!orgSlug) {
-      spanTreeLines = [
-        muted("\nOrganization context required to fetch span tree."),
-      ];
+      const msg = "\nOrganization context required to fetch span tree.";
+      spanTreeLines = [isPlainOutput() ? msg : muted(msg)];
     } else if (!event) {
-      spanTreeLines = [muted("\nCould not fetch event to display span tree.")];
+      const msg = "\nCould not fetch event to display span tree.";
+      spanTreeLines = [isPlainOutput() ? msg : muted(msg)];
     }
 
     const trace = spanTreeResult?.success


### PR DESCRIPTION
Enforce PR #433 `buildCommand` conventions via lint rules that run as part of `bun run lint`:

## GritQL Plugins (new)

Two Biome GritQL plugins in `lint-rules/` ban anti-patterns in `src/commands/`:

- **`no-stdout-write-in-commands`** — commands should yield `CommandOutput`, not call `stdout.write()` directly
- **`no-process-stdout-in-commands`** — commands should not access `process.stdout`

Both use `file($name, $body)` scoping so they only fire on command files and produce inline editor diagnostics.

> **Note on Biome GritQL:** bare `$filename` / `$program` metavariables don't work in Biome 2.3.8 plugins (they cause "didn't specify a valid span" errors). The `file($name, $body)` pattern is the correct approach — `$name` contains the full absolute path so regex needs `.*` anchors.

## noRestrictedImports (new)

Biome override bans `chalk` imports in `src/commands/**/*.ts`, directing developers to `colorTag()` from the markdown rendering pipeline which respects `NO_COLOR` / `SENTRY_PLAIN_OUTPUT`.

## Bug fix

Fix `muted()` usage in `src/commands/issue/view.ts` to use the `isPlainOutput()` pattern, so span-tree fallback messages don't leak ANSI codes in plain-output mode.