### PR TITLE
docs(commands): add alias info to subcommand help output

### DIFF
--- a/src/commands/issue/index.ts
+++ b/src/commands/issue/index.ts
@@ -26,7 +26,8 @@ export const issueRoute = buildRouteMap({
       "Examples:\n" +
       "  sentry issue view @latest\n" +
       "  sentry issue explain @most_frequent\n" +
-      "  sentry issue plan my-org/@latest",
+      "  sentry issue plan my-org/@latest\n\n" +
+      "Alias: `sentry issues` → `sentry issue list`",
     hideRoute: {},
   },
 });

--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -1265,7 +1265,8 @@ export const listCommand = buildListCommand("issue", {
       "Projects with fewer issues than their share give their surplus to others. " +
       "Use --cursor / -c last to paginate through larger result sets.\n\n" +
       "By default, only issues with activity in the last 90 days are shown. " +
-      "Use --period to adjust (e.g. --period 24h, --period 14d).",
+      "Use --period to adjust (e.g. --period 24h, --period 14d).\n\n" +
+      "Alias: `sentry issues` → `sentry issue list`",
   },
   output: issueListOutput,
   parameters: {

--- a/src/commands/log/index.ts
+++ b/src/commands/log/index.ts
@@ -19,7 +19,8 @@ export const logRoute = buildRouteMap({
       "View and stream logs from your Sentry projects.\n\n" +
       "Commands:\n" +
       "  list     List or stream logs from a project\n" +
-      "  view     View details of a specific log entry",
+      "  view     View details of a specific log entry\n\n" +
+      "Alias: `sentry logs` → `sentry log list`",
     hideRoute: {},
   },
 });

--- a/src/commands/log/list.ts
+++ b/src/commands/log/list.ts
@@ -553,7 +553,8 @@ export const listCommand = buildListCommand("log", {
       "  sentry log list -f 5               # Stream logs (5s poll interval)\n" +
       "  sentry log list --limit 50         # Show last 50 logs\n" +
       "  sentry log list -q 'level:error'   # Filter to errors only\n" +
-      "  sentry log list --trace abc123def456abc123def456abc123de  # Filter by trace",
+      "  sentry log list --trace abc123def456abc123def456abc123de  # Filter by trace\n\n" +
+      "Alias: `sentry logs` → `sentry log list`",
   },
   output: {
     human: createLogRenderer,

--- a/src/commands/org/index.ts
+++ b/src/commands/org/index.ts
@@ -9,7 +9,9 @@ export const orgRoute = buildRouteMap({
   },
   docs: {
     brief: "Work with Sentry organizations",
-    fullDescription: "List and manage Sentry organizations you have access to.",
+    fullDescription:
+      "List and manage Sentry organizations you have access to.\n\n" +
+      "Alias: `sentry orgs` → `sentry org list`",
     hideRoute: {},
   },
 });

--- a/src/commands/org/list.ts
+++ b/src/commands/org/list.ts
@@ -115,7 +115,8 @@ export const listCommand = buildCommand({
       "Examples:\n" +
       "  sentry org list\n" +
       "  sentry org list --limit 10\n" +
-      "  sentry org list --json",
+      "  sentry org list --json\n\n" +
+      "Alias: `sentry orgs` → `sentry org list`",
   },
   output: { human: formatOrgListHuman },
   parameters: {

--- a/src/commands/project/index.ts
+++ b/src/commands/project/index.ts
@@ -11,7 +11,9 @@ export const projectRoute = buildRouteMap({
   },
   docs: {
     brief: "Work with Sentry projects",
-    fullDescription: "List and manage Sentry projects in your organizations.",
+    fullDescription:
+      "List and manage Sentry projects in your organizations.\n\n" +
+      "Alias: `sentry projects` → `sentry project list`",
     hideRoute: {},
   },
 });

--- a/src/commands/project/list.ts
+++ b/src/commands/project/list.ts
@@ -561,7 +561,8 @@ export const listCommand = buildListCommand("project", {
       "Filtering and output:\n" +
       "  sentry project list --platform javascript  # filter by platform\n" +
       "  sentry project list --limit 50              # show more results\n" +
-      "  sentry project list --json                  # output as JSON",
+      "  sentry project list --json                  # output as JSON\n\n" +
+      "Alias: `sentry projects` → `sentry project list`",
   },
   output: {
     human: (result: ListResult<ProjectWithOrg>) => {

--- a/src/commands/repo/index.ts
+++ b/src/commands/repo/index.ts
@@ -8,7 +8,8 @@ export const repoRoute = buildRouteMap({
   docs: {
     brief: "Work with Sentry repositories",
     fullDescription:
-      "List and manage repositories connected to your Sentry organizations.",
+      "List and manage repositories connected to your Sentry organizations.\n\n" +
+      "Alias: `sentry repos` → `sentry repo list`",
     hideRoute: {},
   },
 });

--- a/src/commands/repo/list.ts
+++ b/src/commands/repo/list.ts
@@ -66,7 +66,8 @@ const docs: OrgListCommandDocs = {
     "  sentry repo list              # auto-detect or list all\n" +
     "  sentry repo list my-org/      # list repositories in my-org (paginated)\n" +
     "  sentry repo list --limit 10\n" +
-    "  sentry repo list --json",
+    "  sentry repo list --json\n\n" +
+    "Alias: `sentry repos` → `sentry repo list`",
 };
 
 export const listCommand = buildOrgListCommand(repoListConfig, docs, "repo");

--- a/src/commands/span/index.ts
+++ b/src/commands/span/index.ts
@@ -19,6 +19,7 @@ export const spanRoute = buildRouteMap({
       "View and explore individual spans within distributed traces.\n\n" +
       "Commands:\n" +
       "  list     List spans in a trace\n" +
-      "  view     View details of specific spans",
+      "  view     View details of specific spans\n\n" +
+      "Alias: `sentry spans` → `sentry span list`",
   },
 });

--- a/src/commands/span/list.ts
+++ b/src/commands/span/list.ts
@@ -182,7 +182,8 @@ export const listCommand = buildCommand({
       "  sentry span list <trace-id> --limit 50            # Show more spans\n" +
       '  sentry span list <trace-id> -q "op:db"            # Filter by operation\n' +
       "  sentry span list <trace-id> --sort duration       # Sort by slowest first\n" +
-      '  sentry span list <trace-id> -q "duration:>100ms"  # Spans slower than 100ms',
+      '  sentry span list <trace-id> -q "duration:>100ms"  # Spans slower than 100ms\n\n' +
+      "Alias: `sentry spans` → `sentry span list`",
   },
   output: {
     human: formatSpanListHuman,

--- a/src/commands/team/index.ts
+++ b/src/commands/team/index.ts
@@ -7,7 +7,9 @@ export const teamRoute = buildRouteMap({
   },
   docs: {
     brief: "Work with Sentry teams",
-    fullDescription: "List and manage teams in your Sentry organizations.",
+    fullDescription:
+      "List and manage teams in your Sentry organizations.\n\n" +
+      "Alias: `sentry teams` → `sentry team list`",
     hideRoute: {},
   },
 });

--- a/src/commands/team/list.ts
+++ b/src/commands/team/list.ts
@@ -70,7 +70,8 @@ const docs: OrgListCommandDocs = {
     "  sentry team list              # auto-detect or list all\n" +
     "  sentry team list my-org/      # list teams in my-org (paginated)\n" +
     "  sentry team list --limit 10\n" +
-    "  sentry team list --json",
+    "  sentry team list --json\n\n" +
+    "Alias: `sentry teams` → `sentry team list`",
 };
 
 export const listCommand = buildOrgListCommand(teamListConfig, docs, "team");

--- a/src/commands/trace/index.ts
+++ b/src/commands/trace/index.ts
@@ -22,7 +22,8 @@ export const traceRoute = buildRouteMap({
       "Commands:\n" +
       "  list     List recent traces in a project\n" +
       "  view     View details of a specific trace\n" +
-      "  logs     View logs associated with a trace",
+      "  logs     View logs associated with a trace\n\n" +
+      "Alias: `sentry traces` → `sentry trace list`",
     hideRoute: {},
   },
 });

--- a/src/commands/trace/list.ts
+++ b/src/commands/trace/list.ts
@@ -177,7 +177,8 @@ export const listCommand = buildListCommand("trace", {
       "  sentry trace list                     # List last 10 traces\n" +
       "  sentry trace list --limit 50          # Show more traces\n" +
       "  sentry trace list --sort duration     # Sort by slowest first\n" +
-      '  sentry trace list -q "transaction:GET /api/users"  # Filter by transaction',
+      '  sentry trace list -q "transaction:GET /api/users"  # Filter by transaction\n\n' +
+      "Alias: `sentry traces` → `sentry trace list`",
   },
   output: {
     human: formatTraceListHuman,

--- a/src/commands/trial/index.ts
+++ b/src/commands/trial/index.ts
@@ -9,7 +9,9 @@ export const trialRoute = buildRouteMap({
   },
   docs: {
     brief: "Manage product trials",
-    fullDescription: "List and start product trials for your organization.",
+    fullDescription:
+      "List and start product trials for your organization.\n\n" +
+      "Alias: `sentry trials` → `sentry trial list`",
     hideRoute: {},
   },
 });

--- a/src/commands/trial/list.ts
+++ b/src/commands/trial/list.ts
@@ -200,7 +200,8 @@ export const listCommand = buildCommand({
       "Examples:\n" +
       "  sentry trial list\n" +
       "  sentry trial list my-org\n" +
-      "  sentry trial list --json",
+      "  sentry trial list --json\n\n" +
+      "Alias: `sentry trials` → `sentry trial list`",
   },
   output: {
     human: formatTrialListHuman,


### PR DESCRIPTION
## Summary

Each command group now shows its plural shortcut in the help text. For example, `sentry issue` now mentions that `sentry issues` is an alias for `sentry issue list`.

Follows up on #441 which hid the aliases from the top-level help.

## Test plan

- `sentry issue` — shows "Alias: \`sentry issues\` → \`sentry issue list\`"
- Same for org, project, repo, team, log, span, trace, trial