### PR TITLE
fix(formatters): pad priority labels for consistent TRIAGE column alignment

### DIFF
--- a/src/lib/formatters/human.ts
+++ b/src/lib/formatters/human.ts
@@ -760,9 +760,9 @@ function formatPriorityLabel(priority?: string | null): string {
     case "high":
       return colorTag("red", "High");
     case "medium":
-      return colorTag("yellow", "Med");
+      return colorTag("yellow", "Med ");
     case "low":
-      return colorTag("muted", "Low");
+      return colorTag("muted", "Low ");
     default:
       return priority;
   }


### PR DESCRIPTION
## Summary

- Pads `Med` and `Low` priority labels to 4 characters (matching `High`) in the TRIAGE column of `issue list` output, so the fixability percentages align consistently across rows.

## Before
```
TRIAGE
High 82%
Med 65%
Low 40%
```

## After
```
TRIAGE
High 82%
Med  65%
Low  40%
```

The padding is applied inside the `colorTag()` call in `formatPriorityLabel()`, so `string-width` correctly counts the visible width for column sizing. `Critical` (8 chars) is left as-is since it's visually distinct.