### PR TITLE
ref(output): Make human renderers explicit

### DIFF
--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -1053,7 +1053,7 @@ function logResponse(response: { status: number; headers: Headers }): void {
 }
 
 export const apiCommand = buildCommand({
-  output: { human: formatApiResponse },
+  output: { renderHuman: formatApiResponse },
   docs: {
     brief: "Make an authenticated API request",
     fullDescription:

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -129,7 +129,7 @@ export const loginCommand = buildCommand({
       },
     },
   },
-  output: { human: formatLoginResult },
+  output: { renderHuman: formatLoginResult },
   async *func(this: SentryContext, flags: LoginFlags) {
     // Check if already authenticated and handle re-authentication
     if (await isAuthenticated()) {

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -33,7 +33,7 @@ export const logoutCommand = buildCommand({
     fullDescription:
       "Remove stored authentication credentials from the local database.",
   },
-  output: { human: formatLogoutResult },
+  output: { renderHuman: formatLogoutResult },
   parameters: {
     flags: {},
   },

--- a/src/commands/auth/refresh.ts
+++ b/src/commands/auth/refresh.ts
@@ -59,7 +59,7 @@ Examples:
   {"success":true,"refreshed":true,"expiresIn":3600,"expiresAt":"..."}
     `.trim(),
   },
-  output: { human: formatRefreshResult },
+  output: { renderHuman: formatRefreshResult },
   parameters: {
     flags: {
       force: {

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -144,7 +144,7 @@ export const statusCommand = buildCommand({
       "Display information about your current authentication status, " +
       "including whether you're logged in and your default organization/project settings.",
   },
-  output: { human: formatAuthStatus },
+  output: { renderHuman: formatAuthStatus },
   parameters: {
     flags: {
       "show-token": {

--- a/src/commands/auth/token.ts
+++ b/src/commands/auth/token.ts
@@ -20,7 +20,7 @@ export const tokenCommand = buildCommand({
       "piping to other commands or scripts.",
   },
   parameters: {},
-  output: { human: (token: string) => token },
+  output: { renderHuman: (token: string) => token },
   // biome-ignore lint/suspicious/useAwait: sync body but async generator required by buildCommand
   async *func(this: SentryContext) {
     const token = getAuthToken();

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -35,7 +35,7 @@ export const whoamiCommand = buildCommand({
       "the current token. Works with all token types: OAuth, API tokens, and OAuth App tokens.",
   },
   output: {
-    human: formatUserIdentity,
+    renderHuman: formatUserIdentity,
   },
   parameters: {
     flags: {

--- a/src/commands/cli/feedback.ts
+++ b/src/commands/cli/feedback.ts
@@ -31,7 +31,7 @@ export const feedbackCommand = buildCommand({
       "Submit feedback about your experience with the Sentry CLI. " +
       "All text after 'feedback' is sent as your message.",
   },
-  output: { human: formatFeedbackResult },
+  output: { renderHuman: formatFeedbackResult },
   parameters: {
     flags: {},
     positional: {

--- a/src/commands/cli/fix.ts
+++ b/src/commands/cli/fix.ts
@@ -669,7 +669,7 @@ export const fixCommand = buildCommand({
       "  sudo sentry cli fix         # Fix root-owned files\n" +
       "  sentry cli fix --dry-run    # Show what would be fixed without making changes",
   },
-  output: { human: formatFixResult },
+  output: { renderHuman: formatFixResult },
   parameters: {
     flags: {
       "dry-run": {

--- a/src/commands/cli/setup.ts
+++ b/src/commands/cli/setup.ts
@@ -459,7 +459,7 @@ export const setupCommand = buildCommand({
       },
     },
   },
-  output: { human: formatSetupResult },
+  output: { renderHuman: formatSetupResult },
   async *func(this: SentryContext, flags: SetupFlags) {
     const { process, homeDir } = this;
 

--- a/src/commands/cli/upgrade.ts
+++ b/src/commands/cli/upgrade.ts
@@ -595,7 +595,7 @@ export const upgradeCommand = buildCommand({
       "  sentry cli upgrade --method npm # Force using npm to upgrade\n" +
       "  sentry cli upgrade --offline    # Upgrade from cached patches (no network)",
   },
-  output: { human: formatUpgradeResult },
+  output: { renderHuman: formatUpgradeResult },
   parameters: {
     positional: {
       kind: "tuple",

--- a/src/commands/dashboard/create.ts
+++ b/src/commands/dashboard/create.ts
@@ -141,7 +141,7 @@ export const createCommand = buildCommand({
       "  sentry dashboard create my-org/my-project 'My Dashboard'",
   },
   output: {
-    human: formatDashboardCreated,
+    renderHuman: formatDashboardCreated,
   },
   parameters: {
     positional: {

--- a/src/commands/dashboard/list.ts
+++ b/src/commands/dashboard/list.ts
@@ -91,7 +91,7 @@ export const listCommand = buildCommand({
       "  sentry dashboard list --web",
   },
   output: {
-    human: formatDashboardListHuman,
+    renderHuman: formatDashboardListHuman,
     jsonTransform: (result: DashboardListResult) => result.dashboards,
   },
   parameters: {

--- a/src/commands/dashboard/view.ts
+++ b/src/commands/dashboard/view.ts
@@ -47,7 +47,7 @@ export const viewCommand = buildCommand({
       "  sentry dashboard view 12345 --web",
   },
   output: {
-    human: formatDashboardView,
+    renderHuman: formatDashboardView,
   },
   parameters: {
     positional: {

--- a/src/commands/event/view.ts
+++ b/src/commands/event/view.ts
@@ -344,7 +344,7 @@ export const viewCommand = buildCommand({
       "  sentry event view <project> <event-id>    # find project across all orgs",
   },
   output: {
-    human: formatEventView,
+    renderHuman: formatEventView,
     jsonExclude: ["spanTreeLines"],
   },
   parameters: {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -28,7 +28,7 @@ export const helpCommand = buildCommand({
       "Use --json for machine-readable output suitable for AI agents.",
   },
   output: {
-    human: formatHelpHuman,
+    renderHuman: formatHelpHuman,
     jsonExclude: ["_banner"] as const,
   },
   parameters: {

--- a/src/commands/issue/explain.ts
+++ b/src/commands/issue/explain.ts
@@ -59,7 +59,7 @@ export const explainCommand = buildCommand({
       "  sentry issue explain 123456789 --json\n" +
       "  sentry issue explain 123456789 --force",
   },
-  output: { human: formatRootCauseList },
+  output: { renderHuman: formatRootCauseList },
   parameters: {
     positional: issueIdPositional,
     flags: {

--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -1240,7 +1240,7 @@ const jsonTransformIssueList = jsonTransformListResult;
 
 /** Output configuration for the issue list command. */
 const issueListOutput: OutputConfig<IssueListResult> = {
-  human: formatIssueListHuman,
+  renderHuman: formatIssueListHuman,
   jsonTransform: jsonTransformIssueList,
 };
 

--- a/src/commands/issue/plan.ts
+++ b/src/commands/issue/plan.ts
@@ -171,7 +171,7 @@ export const planCommand = buildCommand({
       "  sentry issue plan 123456789 --force",
   },
   output: {
-    human: formatPlanOutput,
+    renderHuman: formatPlanOutput,
   },
   parameters: {
     positional: issueIdPositional,

--- a/src/commands/issue/view.ts
+++ b/src/commands/issue/view.ts
@@ -103,7 +103,7 @@ export const viewCommand = buildCommand({
       "where 'f' is the project alias shown in the list).",
   },
   output: {
-    human: formatIssueView,
+    renderHuman: formatIssueView,
     jsonExclude: ["spanTreeLines"],
   },
   parameters: {

--- a/src/commands/log/list.ts
+++ b/src/commands/log/list.ts
@@ -651,7 +651,7 @@ export const listCommand = buildListCommand("log", {
       "Alias: `sentry logs` → `sentry log list`",
   },
   output: {
-    human: createLogRenderer,
+    createHumanRenderer: createLogRenderer,
     jsonTransform: jsonTransformLogOutput,
   },
   parameters: {

--- a/src/commands/log/view.ts
+++ b/src/commands/log/view.ts
@@ -319,7 +319,7 @@ export const viewCommand = buildCommand({
       "The log ID is the 32-character hexadecimal identifier shown in log listings.",
   },
   output: {
-    human: formatLogViewHuman,
+    renderHuman: formatLogViewHuman,
     // Preserve original JSON contract: bare array of log entries.
     // orgSlug exists only for the human formatter (trace URLs).
     jsonTransform: (data: LogViewData, fields) =>

--- a/src/commands/org/list.ts
+++ b/src/commands/org/list.ts
@@ -119,7 +119,7 @@ export const listCommand = buildCommand({
       "  sentry org list --json\n\n" +
       "Alias: `sentry orgs` → `sentry org list`",
   },
-  output: { human: formatOrgListHuman },
+  output: { renderHuman: formatOrgListHuman },
   parameters: {
     flags: {
       limit: buildListLimitFlag("organizations"),

--- a/src/commands/org/view.ts
+++ b/src/commands/org/view.ts
@@ -36,7 +36,7 @@ export const viewCommand = buildCommand({
       "  2. Config defaults\n" +
       "  3. SENTRY_DSN environment variable or source code detection",
   },
-  output: { human: formatOrgDetails },
+  output: { renderHuman: formatOrgDetails },
   parameters: {
     positional: {
       kind: "tuple",

--- a/src/commands/project/create.ts
+++ b/src/commands/project/create.ts
@@ -279,7 +279,7 @@ export const createCommand = buildCommand({
       "  sentry project create my-app go --json",
   },
   output: {
-    human: formatProjectCreated,
+    renderHuman: formatProjectCreated,
     jsonExclude: [
       "slugDiverged",
       "expectedSlug",

--- a/src/commands/project/delete.ts
+++ b/src/commands/project/delete.ts
@@ -178,7 +178,7 @@ export const deleteCommand = buildCommand({
       "  sentry project delete acme-corp/my-app --dry-run",
   },
   output: {
-    human: formatProjectDeleted,
+    renderHuman: formatProjectDeleted,
     jsonTransform: (result: ProjectDeleteResult) => {
       if (result.dryRun) {
         return {

--- a/src/commands/project/list.ts
+++ b/src/commands/project/list.ts
@@ -585,7 +585,7 @@ export const listCommand = buildListCommand("project", {
       "Alias: `sentry projects` → `sentry project list`",
   },
   output: {
-    human: (result: ListResult<ProjectWithOrg>) => {
+    renderHuman: (result: ListResult<ProjectWithOrg>) => {
       if (result.items.length === 0) {
         return result.hint ?? "No projects found.";
       }

--- a/src/commands/project/view.ts
+++ b/src/commands/project/view.ts
@@ -183,7 +183,7 @@ export const viewCommand = buildCommand({
       "In monorepos with multiple Sentry projects, shows details for all detected projects.",
   },
   output: {
-    human: formatProjectViewHuman,
+    renderHuman: formatProjectViewHuman,
     jsonExclude: ["detectedFrom"],
   },
   parameters: {

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -273,7 +273,7 @@ export const schemaCommand = buildCommand({
       "  sentry schema --search monitor      Search endpoints by keyword",
   },
   output: {
-    human: formatSchemaHuman,
+    renderHuman: formatSchemaHuman,
     jsonTransform: jsonTransformSchema,
   },
   parameters: {

--- a/src/commands/span/list.ts
+++ b/src/commands/span/list.ts
@@ -187,7 +187,7 @@ export const listCommand = buildCommand({
       "Alias: `sentry spans` → `sentry span list`",
   },
   output: {
-    human: formatSpanListHuman,
+    renderHuman: formatSpanListHuman,
     jsonTransform: jsonTransformSpanList,
   },
   parameters: {

--- a/src/commands/span/view.ts
+++ b/src/commands/span/view.ts
@@ -211,7 +211,7 @@ export const viewCommand = buildCommand({
       "  sentry span view sentry/my-project/<trace-id> a1b2c3d4e5f67890",
   },
   output: {
-    human: formatSpanViewHuman,
+    renderHuman: formatSpanViewHuman,
     jsonTransform: jsonTransformSpanView,
   },
   parameters: {

--- a/src/commands/trace/list.ts
+++ b/src/commands/trace/list.ts
@@ -182,7 +182,7 @@ export const listCommand = buildListCommand("trace", {
       "Alias: `sentry traces` → `sentry trace list`",
   },
   output: {
-    human: formatTraceListHuman,
+    renderHuman: formatTraceListHuman,
     jsonTransform: jsonTransformTraceList,
   },
   parameters: {

--- a/src/commands/trace/logs.ts
+++ b/src/commands/trace/logs.ts
@@ -105,7 +105,7 @@ export const logsCommand = buildCommand({
       "  sentry trace logs --json abc123def456abc123def456abc123de",
   },
   output: {
-    human: formatTraceLogsHuman,
+    renderHuman: formatTraceLogsHuman,
     jsonTransform: (data: TraceLogsData, fields?: string[]) => {
       const items =
         fields && fields.length > 0

--- a/src/commands/trace/view.ts
+++ b/src/commands/trace/view.ts
@@ -129,7 +129,7 @@ export const viewCommand = buildCommand({
       "The trace ID is the 32-character hexadecimal identifier.",
   },
   output: {
-    human: formatTraceView,
+    renderHuman: formatTraceView,
     jsonExclude: ["spanTreeLines"],
   },
   parameters: {

--- a/src/commands/trial/list.ts
+++ b/src/commands/trial/list.ts
@@ -205,7 +205,7 @@ export const listCommand = buildCommand({
       "Alias: `sentry trials` → `sentry trial list`",
   },
   output: {
-    human: formatTrialListHuman,
+    renderHuman: formatTrialListHuman,
     jsonExclude: ["displayName"],
   },
   parameters: {

--- a/src/commands/trial/start.ts
+++ b/src/commands/trial/start.ts
@@ -89,7 +89,7 @@ export const startCommand = buildCommand({
       "  sentry trial start plan\n" +
       "  sentry trial start --json seer",
   },
-  output: { human: formatStartResult },
+  output: { renderHuman: formatStartResult },
   parameters: {
     positional: {
       kind: "tuple" as const,

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -138,12 +138,12 @@ type LocalCommandBuilderArguments<
    * @example
    * ```ts
    * buildCommand({
-   *   output: { human: formatUser },
+   *   output: { renderHuman: formatUser },
    *   async *func() { yield new CommandOutput(user); },
    * })
    * ```
    */
-  // biome-ignore lint/suspicious/noExplicitAny: Variance erasure — OutputConfig<T>.human is contravariant in T, but the builder erases T because it doesn't know the output type. Using `any` allows commands to declare OutputConfig<SpecificType> while the wrapper handles it generically.
+  // biome-ignore lint/suspicious/noExplicitAny: Variance erasure — OutputConfig<T> contains function positions that are contravariant in T, but the builder erases T because it does not know the output type. Using `any` allows commands to declare OutputConfig<SpecificType> while the wrapper handles it generically.
   readonly output?: OutputConfig<any>;
 };
 
@@ -255,7 +255,7 @@ export function applyLoggingFlags(
  *
  * Similarly, when a command already defines its own `json` flag (e.g. for
  * custom brief text), the injected `JSON_FLAG` is skipped. `--fields` is
- * always injected when `output: { human: ... }` regardless.
+ * always injected when `output: { renderHuman: ... }` regardless.
  *
  * Flag keys use kebab-case because Stricli uses the literal object key as
  * the CLI flag name (e.g. `"log-level"` → `--log-level`).
@@ -331,7 +331,7 @@ export function buildCommand<
    * Strip injected flags from the raw Stricli-parsed flags object.
    * --log-level is always stripped. --verbose is stripped only when we
    * injected it (not when the command defines its own). --fields is
-   * pre-parsed from comma-string to string[] when output: { human: ... }.
+   * pre-parsed from comma-string to string[] when output: { renderHuman: ... }.
    */
   function cleanRawFlags(
     raw: Record<string, unknown>
@@ -401,7 +401,7 @@ export function buildCommand<
     // Resolve the human renderer once per invocation. Factory creates
     // fresh per-invocation state for streaming commands.
     const renderer = outputConfig
-      ? resolveRenderer(outputConfig.human)
+      ? resolveRenderer(outputConfig)
       : undefined;
 
     // OutputError handler: render data through the output system, then

--- a/src/lib/formatters/output.ts
+++ b/src/lib/formatters/output.ts
@@ -15,7 +15,7 @@
  *    `buildCommand`, then yield data from the generator:
  *    ```ts
  *    buildCommand({
- *      output: { human: formatUser },
+ *      output: { renderHuman: formatUser },
  *      async *func() { yield new CommandOutput(data); },
  *    })
  *    ```
@@ -86,57 +86,23 @@ export type HumanRenderer<T> = {
 };
 
 /**
- * Resolve the `human` field of an {@link OutputConfig} into a
- * {@link HumanRenderer}. Supports two forms:
+ * Resolve an {@link OutputConfig} into a per-invocation {@link HumanRenderer}.
  *
- * 1. **Plain function** — `(data: T) => string` — auto-wrapped into a
- *    stateless renderer (no `finalize`).
- * 2. **Factory** — `() => HumanRenderer<T>` — called once per invocation
- *    to produce a renderer with optional `finalize()`.
- *
- * Disambiguation: a function with `.length === 0` is treated as a factory.
+ * - `renderHuman` declares stateless formatting directly.
+ * - `createHumanRenderer` declares a stateful renderer factory explicitly.
  */
-export function resolveRenderer<T>(human: HumanOutput<T>): HumanRenderer<T> {
-  // Factory: zero-arg function that returns a renderer
-  if (human.length === 0) {
-    return (human as () => HumanRenderer<T>)();
+export function resolveRenderer<T>(config: OutputConfig<T>): HumanRenderer<T> {
+  if (config.createHumanRenderer) {
+    return config.createHumanRenderer();
   }
-  // Plain formatter: wrap in a stateless renderer
-  return { render: human as (data: T) => string };
+  return { render: config.renderHuman };
 }
 
-/**
- * Human rendering for an {@link OutputConfig}.
- *
- * Two forms:
- * - **Plain function** `(data: T) => string` — stateless, auto-wrapped.
- * - **Factory** `() => HumanRenderer<T>` — called per invocation for
- *   stateful renderers (e.g., streaming tables with `finalize()`).
- */
-export type HumanOutput<T> = ((data: T) => string) | (() => HumanRenderer<T>);
-
-/**
- * Output configuration declared on `buildCommand` for automatic rendering.
- *
- * When present, `--json` and `--fields` flags are injected and the wrapper
- * auto-renders yielded {@link CommandOutput} values.
- *
- * @typeParam T - Type of data the command yields (used by `human` formatter
- *   and serialized as-is to JSON)
- */
-export type OutputConfig<T> = {
-  /**
-   * Human-readable renderer.
-   *
-   * Pass a plain `(data: T) => string` for stateless formatting, or a
-   * zero-arg factory `() => HumanRenderer<T>` for stateful rendering
-   * with `finalize()` support.
-   */
-  human: HumanOutput<T>;
+type SharedOutputConfig<T> = {
   /**
    * Top-level keys to strip from JSON output.
    *
-   * Use this for fields that exist only for the human formatter
+   * Use this for fields that exist only for the human renderer
    * (e.g. pre-formatted terminal strings) and should not appear
    * in the JSON contract.
    *
@@ -161,6 +127,30 @@ export type OutputConfig<T> = {
 };
 
 /**
+ * Output configuration declared on `buildCommand` for automatic rendering.
+ *
+ * When present, `--json` and `--fields` flags are injected and the wrapper
+ * auto-renders yielded {@link CommandOutput} values.
+ *
+ * @typeParam T - Type of data the command yields and serializes as JSON
+ */
+export type OutputConfig<T> =
+  | (SharedOutputConfig<T> & {
+      /**
+       * Stateless human formatter for commands that render each chunk independently.
+       */
+      renderHuman: (data: T) => string;
+      createHumanRenderer?: never;
+    })
+  | (SharedOutputConfig<T> & {
+      /**
+       * Factory for commands that need per-invocation render state or `finalize()`.
+       */
+      createHumanRenderer: () => HumanRenderer<T>;
+      renderHuman?: never;
+    });
+
+/**
  * Yield type for commands with {@link OutputConfig}.
  *
  * Commands wrap each yielded value in this class so the `buildCommand`
@@ -173,7 +163,7 @@ export type OutputConfig<T> = {
  * @typeParam T - The data type (matches the `OutputConfig<T>` type parameter)
  */
 export class CommandOutput<T> {
-  /** The data to render (serialized as-is to JSON, passed to `human` formatter) */
+  /** The data to render (serialized as-is to JSON, passed to the resolved human renderer) */
   readonly data: T;
   constructor(data: T) {
     this.data = data;
@@ -273,7 +263,7 @@ function writeTransformedJson(stdout: Writer, transformed: unknown): void {
  * @param stdout - Writer to output to
  * @param data - The data yielded by the command
  * @param config - The output config declared on buildCommand
- * @param renderer - Per-invocation renderer (from `config.human()`)
+ * @param renderer - Per-invocation renderer (from the resolved output config)
  * @param ctx - Rendering context with flag values
  */
 // biome-ignore lint/nursery/useMaxParams: Framework function — config/renderer/ctx are all required for JSON vs human split.

--- a/src/lib/list-command.ts
+++ b/src/lib/list-command.ts
@@ -85,7 +85,7 @@ export function targetPatternExplanation(cursorNote?: string): string {
  * The `--json` flag shared by all list commands.
  * Outputs machine-readable JSON instead of a human-readable table.
  *
- * @deprecated Use `output: { human: ... }` on `buildCommand` instead, which
+ * @deprecated Use `output: { renderHuman: ... }` on `buildCommand` instead, which
  * injects `--json` and `--fields` automatically. This constant is kept
  * for commands that define `--json` with custom brief text.
  */
@@ -475,7 +475,7 @@ export function buildOrgListCommand<TEntity, TWithOrg>(
   return buildListCommand(routeName, {
     docs,
     output: {
-      human: (result: ListResult<TWithOrg>) => formatListHuman(result, config),
+      renderHuman: (result: ListResult<TWithOrg>) => formatListHuman(result, config),
       jsonTransform: (result: ListResult<TWithOrg>, fields?: string[]) =>
         jsonTransformListResult(result, fields),
     } satisfies OutputConfig<ListResult<TWithOrg>>,


### PR DESCRIPTION
Make the output renderer contract explicit

The output config currently decides between a stateless human formatter and a stateful renderer factory by checking function arity. That hides behavior at the call site and makes the shared output layer harder to reason about.

This changes the contract to use renderHuman for stateless formatting and createHumanRenderer for per-invocation renderer state. It updates the shared output helpers, the list-command wrapper, and the existing command definitions so the renderer shape is visible where each command declares its output.

Validated with bun run typecheck after generating the local API schema required by this checkout.