### PR TITLE
feat(telemetry): track TTY vs non-TTY invocations via metric

### DIFF
--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -249,6 +249,9 @@ const EXCLUDED_INTEGRATIONS = new Set([
 /** Current beforeExit handler, tracked so it can be replaced on re-init */
 let currentBeforeExitHandler: (() => void) | null = null;
 
+/** Whether the cli.invocation metric has already been emitted this process */
+let invocationCounted = false;
+
 /** Match all SaaS regional URLs (us.sentry.io, de.sentry.io, o1234.ingest.us.sentry.io, etc.) */
 const SENTRY_SAAS_SUBDOMAIN_RE = /^https:\/\/[^/]*\.sentry\.io(\/|$)/;
 
@@ -342,10 +345,14 @@ export function initSentry(enabled: boolean): Sentry.BunClient | undefined {
     // Tag whether targeting self-hosted Sentry (not SaaS)
     Sentry.setTag("is_self_hosted", !isSentrySaasUrl(getSentryBaseUrl()));
 
-    // Track TTY vs non-TTY invocations to measure agent/CI usage percentage
-    Sentry.metrics.count("cli.invocation", 1, {
-      attributes: { is_tty: !!process.stdout.isTTY },
-    });
+    // Track TTY vs non-TTY invocations to measure agent/CI usage percentage.
+    // Guarded because initSentry is called again on auto-login retry.
+    if (!invocationCounted) {
+      invocationCounted = true;
+      Sentry.metrics.count("cli.invocation", 1, {
+        attributes: { is_tty: !!process.stdout.isTTY },
+      });
+    }
 
     // Wire up consola → Sentry log forwarding now that the client is active
     attachSentryReporter();


### PR DESCRIPTION
## Summary

Adds a `cli.invocation` counter metric with an `is_tty` attribute so we can measure what percentage of CLI usage comes from agents/CI vs interactive terminals in the Sentry Metrics dashboard.

## Changes

One-liner in `initSentry()` — emits `Sentry.metrics.count("cli.invocation", 1, { attributes: { is_tty } })` on every CLI call, right next to the existing `cli.runtime` and `is_self_hosted` tags.

## Test Plan

- `bun run typecheck` passes
- `bun test test/lib/telemetry.test.ts` — all 96 tests pass
- Run `sentry issue list` in a terminal (TTY=true) and via `echo | sentry issue list` (TTY=false), confirm metric appears in Sentry Metrics