### PR TITLE
fix: detect issue short IDs passed to issue list (CLI-C3)

### DIFF
--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -399,10 +399,7 @@ async function resolveTargetsFromParsedArg(
           `'${parsed.projectSlug}'`,
           "looks like an issue short ID, not a project slug",
           `sentry issue view ${parsed.projectSlug}`,
-          [
-            `To view this issue: sentry issue view ${parsed.projectSlug}`,
-            "To list issues in a project: sentry issue list <org>/<project>",
-          ]
+          ["To list issues in a project: sentry issue list <org>/<project>"]
         );
       }
 


### PR DESCRIPTION
## Problem

When users run `sentry issue list CONVERSATION-SVC-F` or similar commands with an issue short ID, the CLI interprets it as a project slug to search for. Since project slugs are always lowercase and short IDs are uppercase, no project is found and the user sees:

```
ResolutionError: Project 'CONVERSATION-SVC-F' not found.
```

This affects **24 users** ([CLI-C3](https://sentry.sentry.io/issues/7319435132/)).

## Fix

Added a pre-flight check in the `project-search` handler of `issue list` that uses the existing `looksLikeIssueShortId()` utility to detect when the input looks like an issue short ID (all-uppercase, dash-separated with alphanumeric suffix). When detected, throws a helpful `ResolutionError` that suggests using `sentry issue view` instead:

```
'CONVERSATION-SVC-F' looks like an issue short ID, not a project slug.

Try:
  sentry issue view CONVERSATION-SVC-F

Or:
  - To view this issue: sentry issue view CONVERSATION-SVC-F
  - To list issues in a project: sentry issue list <org>/<project>
```

## Key Design Decisions

- Uses the existing `looksLikeIssueShortId()` pattern which requires all-uppercase with dash separators — this avoids false positives on legitimate lowercase project slugs
- Check runs before the API call to `findProjectsBySlug`, saving a round trip
- Uses `ResolutionError` (not `ContextError`) because the user provided a value that couldn't be matched