### PR TITLE
fix: add actionable suggestions for 400 Bad Request on issue list (CLI-BM, CLI-7B)

### DIFF
--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -911,10 +911,10 @@ function build400Detail(
   originalDetail: string | undefined,
   flags: Pick<ListFlags, "query" | "period">
 ): string {
-  const parts: string[] = [];
+  const lines: string[] = [];
 
   if (originalDetail) {
-    parts.push(originalDetail);
+    lines.push(originalDetail);
   }
 
   const suggestions: string[] = [];
@@ -933,15 +933,18 @@ function build400Detail(
     "Verify you have access to the target project: sentry project list <org>/"
   );
 
-  if (suggestions.length > 0) {
-    parts.push("");
-    parts.push("Suggestions:");
-    for (const s of suggestions) {
-      parts.push(`  • ${s}`);
-    }
+  // Only add the separator when there's a detail line preceding the suggestions
+  if (lines.length > 0) {
+    lines.push("");
+  }
+  lines.push("Suggestions:");
+  for (const s of suggestions) {
+    lines.push(`  • ${s}`);
   }
 
-  return parts.join("\n");
+  // ApiError.format() prepends "\n  " only before the first line of detail.
+  // Indent continuation lines to maintain alignment with the first line.
+  return lines.join("\n  ");
 }
 
 /**


### PR DESCRIPTION
## Problem

When `sentry issue list` gets a 400 Bad Request from the API, the error shows the raw API detail but doesn't guide users on what to fix. This is the most common API error class, affecting **93 users** across [CLI-BM](https://sentry.sentry.io/issues/7315010148/) (55 users) and [CLI-7B](https://sentry.sentry.io/issues/7277810245/) (38 users).

Common causes include:
- Invalid Sentry search query syntax (e.g., unparenthesized OR operators)
- Default `--period 90d` exceeding plan data retention
- Project access issues

## Fix

Added a `build400Detail()` helper that enriches the 400 error detail with context-aware suggestions based on the current command flags:

**When `--query` is provided:**
```
Failed to fetch issues from 1 project(s): Failed to list issues: 400 Bad Request
  Invalid search query: ...

  Suggestions:
    • Check your --query syntax (Sentry search reference: https://docs.sentry.io/concepts/search/)
    • Try a shorter time range: --period 14d or --period 24h
    • Verify you have access to the target project: sentry project list <org>/
```

**When using default period (no --query):**
```
Failed to fetch issues from 1 project(s): Failed to list issues: 400 Bad Request
  ...

  Suggestions:
    • Try a shorter time range: --period 14d or --period 24h
    • Verify you have access to the target project: sentry project list <org>/
```

## Design Decisions

- Suggestions are **appended after** the original API detail so the specific error reason is shown first
- The query syntax suggestion only appears when `--query` is actually used
- The period suggestion only appears when using the default 90d (users who explicitly set a period likely don't need this hint)
- The `build400Detail` function is intentionally narrow-scoped to 400 errors to avoid cluttering other error types