### PR TITLE
perf: HTTP latency optimizations — diagnostics, cache warming, concurrency limits

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -1,6 +1,10 @@
 import { isatty } from "node:tty";
 import type { SentryContext } from "../../context.js";
-import { getCurrentUser, getUserRegions } from "../../lib/api-client.js";
+import {
+  getCurrentUser,
+  getUserRegions,
+  listOrganizationsUncached,
+} from "../../lib/api-client.js";
 import { buildCommand, numberParser } from "../../lib/command.js";
 import {
   clearAuth,
@@ -185,6 +189,9 @@ export const loginCommand = buildCommand({
         // Non-fatal: user info is supplementary. Token remains stored and valid.
       }
 
+      // Warm the org + region cache so the first real command is fast.
+      // Fire-and-forget — login already succeeded, caching is best-effort.
+      warmOrgCache();
       return yield new CommandOutput(result);
     }
 
@@ -194,6 +201,9 @@ export const loginCommand = buildCommand({
     });
 
     if (result) {
+      // Warm the org + region cache so the first real command is fast.
+      // Fire-and-forget — login already succeeded, caching is best-effort.
+      warmOrgCache();
       yield new CommandOutput(result);
     } else {
       // Error already displayed by runInteractiveLogin
@@ -201,3 +211,19 @@ export const loginCommand = buildCommand({
     }
   },
 });
+
+/**
+ * Pre-populate the org + region SQLite cache in the background.
+ *
+ * Called after successful authentication so that the first real command
+ * doesn't pay the cold-start cost of `getUserRegions()` + fan-out to
+ * each region's org list endpoint (~800ms on a typical SaaS account).
+ *
+ * Failures are silently ignored — the cache will be populated lazily
+ * on the next command that needs it.
+ */
+function warmOrgCache(): void {
+  listOrganizationsUncached().catch(() => {
+    // Best-effort: cache warming failure doesn't affect the login result
+  });
+}

--- a/src/commands/issue/utils.ts
+++ b/src/commands/issue/utils.ts
@@ -4,6 +4,7 @@
  * Common functionality used by explain, plan, view, and other issue commands.
  */
 
+import pLimit from "p-limit";
 import {
   findProjectsBySlug,
   getAutofixState,
@@ -13,6 +14,7 @@ import {
   type IssueSort,
   listIssuesPaginated,
   listOrganizations,
+  ORG_FANOUT_CONCURRENCY,
   triggerRootCauseAnalysis,
   tryGetIssueByShortId,
 } from "../../lib/api-client.js";
@@ -238,12 +240,16 @@ async function resolveProjectSearch(
   // 3. Fast path: try resolving the short ID directly across all orgs.
   //    The shortid endpoint validates both project existence and issue existence
   //    in a single call, eliminating the separate getProject() round-trip.
+  //    Concurrency-limited to avoid overwhelming the API for enterprise users.
   const fullShortId = expandToFullShortId(suffix, projectSlug);
   const orgs = await listOrganizations();
 
+  const limit = pLimit(ORG_FANOUT_CONCURRENCY);
   const results = await Promise.all(
     orgs.map((org) =>
-      withAuthGuard(() => tryGetIssueByShortId(org.slug, fullShortId))
+      limit(() =>
+        withAuthGuard(() => tryGetIssueByShortId(org.slug, fullShortId))
+      )
     )
   );
 

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -37,6 +37,7 @@ export {
   apiRequest,
   apiRequestToRegion,
   buildSearchParams,
+  ORG_FANOUT_CONCURRENCY,
   type PaginatedResponse,
   parseLinkHeader,
   rawApiRequest,

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -9,12 +9,17 @@ import {
   retrieveAnIssueEvent,
   resolveAnEventId as sdkResolveAnEventId,
 } from "@sentry/api";
+import pLimit from "p-limit";
 
 import type { SentryEvent } from "../../types/index.js";
 
 import { ApiError, AuthError } from "../errors.js";
 
-import { getOrgSdkConfig, unwrapResult } from "./infrastructure.js";
+import {
+  getOrgSdkConfig,
+  ORG_FANOUT_CONCURRENCY,
+  unwrapResult,
+} from "./infrastructure.js";
 import { listOrganizations } from "./organizations.js";
 
 /**
@@ -124,8 +129,9 @@ export async function findEventAcrossOrgs(
 ): Promise<ResolvedEvent | null> {
   const orgs = await listOrganizations();
 
+  const limit = pLimit(ORG_FANOUT_CONCURRENCY);
   const results = await Promise.allSettled(
-    orgs.map((org) => resolveEventInOrg(org.slug, eventId))
+    orgs.map((org) => limit(() => resolveEventInOrg(org.slug, eventId)))
   );
 
   // First pass: return the first successful match

--- a/src/lib/api/infrastructure.ts
+++ b/src/lib/api/infrastructure.ts
@@ -195,6 +195,15 @@ export const MAX_PAGINATION_PAGES = Math.max(
 export const API_MAX_PER_PAGE = 100;
 
 /**
+ * Maximum concurrent API requests when fanning out across organizations or regions.
+ *
+ * Limits parallel calls (e.g., `getProject()` per org, `resolveEventInOrg()` per org,
+ * DSN key search per region) to prevent overwhelming the API for enterprise users
+ * with many organizations. For typical users with 1-5 orgs this has no effect.
+ */
+export const ORG_FANOUT_CONCURRENCY = 5;
+
+/**
  * Paginated API response with cursor metadata.
  * More pages exist when `nextCursor` is defined.
  */

--- a/src/lib/api/projects.ts
+++ b/src/lib/api/projects.ts
@@ -12,6 +12,8 @@ import {
   retrieveAProject,
 } from "@sentry/api";
 
+import pLimit from "p-limit";
+
 import type {
   ProjectKey,
   Region,
@@ -29,6 +31,7 @@ import {
   apiRequestToRegion,
   getOrgSdkConfig,
   MAX_PAGINATION_PAGES,
+  ORG_FANOUT_CONCURRENCY,
   type PaginatedResponse,
   unwrapPaginatedResult,
   unwrapResult,
@@ -207,23 +210,28 @@ export async function findProjectsBySlug(
   // the expensive getUserRegions() + listOrganizationsInRegion() fan-out.
   const orgs = await listOrganizations();
 
-  // Direct lookup in parallel — one API call per org instead of paginating all projects
+  // Direct lookup with concurrency limit — one API call per org instead of
+  // paginating all projects. p-limit prevents overwhelming the API for users
+  // with many organizations.
+  const limit = pLimit(ORG_FANOUT_CONCURRENCY);
   const searchResults = await Promise.all(
     orgs.map((org) =>
-      withAuthGuard(async () => {
-        const project = await getProject(org.slug, projectSlug);
-        // The API accepts project_id_or_slug, so a numeric input could
-        // resolve by ID instead of slug. When the input is all digits,
-        // accept the match (the user passed a numeric project ID).
-        // For non-numeric inputs, verify the slug actually matches to
-        // avoid false positives from coincidental ID collisions.
-        // Note: Sentry enforces that project slugs must start with a letter,
-        // so an all-digits input can only ever be a numeric ID, never a slug.
-        if (!isNumericId && project.slug !== projectSlug) {
-          return null;
-        }
-        return { ...project, orgSlug: org.slug };
-      })
+      limit(() =>
+        withAuthGuard(async () => {
+          const project = await getProject(org.slug, projectSlug);
+          // The API accepts project_id_or_slug, so a numeric input could
+          // resolve by ID instead of slug. When the input is all digits,
+          // accept the match (the user passed a numeric project ID).
+          // For non-numeric inputs, verify the slug actually matches to
+          // avoid false positives from coincidental ID collisions.
+          // Note: Sentry enforces that project slugs must start with a letter,
+          // so an all-digits input can only ever be a numeric ID, never a slug.
+          if (!isNumericId && project.slug !== projectSlug) {
+            return null;
+          }
+          return { ...project, orgSlug: org.slug };
+        })
+      )
     )
   );
 
@@ -285,14 +293,17 @@ export async function findProjectsByPattern(
 ): Promise<ProjectWithOrg[]> {
   const orgs = await listOrganizations();
 
+  const limit = pLimit(ORG_FANOUT_CONCURRENCY);
   const searchResults = await Promise.all(
     orgs.map((org) =>
-      withAuthGuard(async () => {
-        const projects = await listProjects(org.slug);
-        return projects
-          .filter((p) => matchesWordBoundary(pattern, p.slug))
-          .map((p) => ({ ...p, orgSlug: org.slug }));
-      })
+      limit(() =>
+        withAuthGuard(async () => {
+          const projects = await listProjects(org.slug);
+          return projects
+            .filter((p) => matchesWordBoundary(pattern, p.slug))
+            .map((p) => ({ ...p, orgSlug: org.slug }));
+        })
+      )
     )
   );
 
@@ -328,19 +339,22 @@ export async function findProjectByDsnKey(
     return projects[0] ?? null;
   }
 
+  const limit = pLimit(ORG_FANOUT_CONCURRENCY);
   const results = await Promise.all(
-    regions.map(async (region) => {
-      try {
-        const { data } = await apiRequestToRegion<SentryProject[]>(
-          region.url,
-          "/projects/",
-          { params: { query: `dsn:${publicKey}` } }
-        );
-        return data;
-      } catch {
-        return [];
-      }
-    })
+    regions.map((region) =>
+      limit(async () => {
+        try {
+          const { data } = await apiRequestToRegion<SentryProject[]>(
+            region.url,
+            "/projects/",
+            { params: { query: `dsn:${publicKey}` } }
+          );
+          return data;
+        } catch {
+          return [];
+        }
+      })
+    )
   );
 
   for (const projects of results) {

--- a/src/lib/region.ts
+++ b/src/lib/region.ts
@@ -145,12 +145,19 @@ async function resolveOrgFromCache(
  * When users or AI agents extract org identifiers from DSN hosts
  * (e.g., `o1081365` from `o1081365.ingest.us.sentry.io`), the `o`-prefixed
  * form isn't recognized by the Sentry API. This function resolves the
- * identifier using the locally cached org list:
+ * identifier using two strategies:
  *
- * 1. Check local cache (slug or DSN numeric ID) → return resolved slug
- * 2. If cache miss, refresh the org list from the API (one fan-out call)
- *    and retry the local cache lookup
- * 3. Fall back to returning the original slug for downstream error handling
+ * **Normal slugs** (e.g., `acme-corp`):
+ * 1. Check local cache → return slug
+ * 2. Try `resolveOrgRegion(orgSlug)` — single API call to fetch org details
+ *    and populate the region cache. If it succeeds, the slug is valid.
+ * 3. Fall back to the original slug for downstream error handling
+ *
+ * **DSN numeric IDs** (e.g., `o1081365`):
+ * 1. Check local cache for numeric ID → slug mapping
+ * 2. Refresh the full org list from the API (fan-out to all regions)
+ *    to populate the numeric-ID-to-slug mapping
+ * 3. Retry cache lookup, fall back to original slug
  *
  * @param orgSlug - Raw org identifier from user input
  * @returns The org slug to use for API calls (may be normalized)
@@ -162,10 +169,27 @@ export async function resolveEffectiveOrg(orgSlug: string): Promise<string> {
     return fromCache;
   }
 
-  // Cache is cold or identifier is unknown — refresh the org list from API.
+  // Check if the identifier is a DSN-style numeric ID (e.g., `o1081365`).
+  // These need the full org list fan-out because we must map numeric ID → slug.
+  const numericId = stripDsnOrgPrefix(orgSlug);
+  const isDsnNumericId = numericId !== orgSlug;
+
+  if (!isDsnNumericId) {
+    // Normal slug: try a single resolveOrgRegion() call (1 API request)
+    // instead of the heavy listOrganizationsUncached() fan-out (1+N requests).
+    // If it succeeds, the slug is valid and the region is now cached.
+    try {
+      await resolveOrgRegion(orgSlug);
+      return orgSlug;
+    } catch {
+      // Org not found or auth error — fall through to return the original
+      // slug. The downstream API call will produce a relevant error.
+      return orgSlug;
+    }
+  }
+
+  // DSN numeric ID: refresh the full org list to populate ID → slug mapping.
   // listOrganizationsUncached() populates org_regions with slug, region, org_id, and name.
-  // Any error (auth failure, network error, etc.) falls back to the original
-  // slug; the downstream API call will produce a relevant error if needed.
   try {
     const { listOrganizationsUncached } = await import("./api-client.js");
     await listOrganizationsUncached();

--- a/src/lib/sentry-client.ts
+++ b/src/lib/sentry-client.ts
@@ -15,8 +15,11 @@ import {
   getUserAgent,
 } from "./constants.js";
 import { getAuthToken, isEnvTokenActive, refreshToken } from "./db/auth.js";
+import { logger } from "./logger.js";
 import { getCachedResponse, storeCachedResponse } from "./response-cache.js";
 import { withHttpSpan } from "./telemetry.js";
+
+const log = logger.withTag("http");
 
 /** Request timeout in milliseconds */
 const REQUEST_TIMEOUT_MS = 30_000;
@@ -316,7 +319,11 @@ async function fetchWithRetry(
       throw result.error;
     }
 
-    await Bun.sleep(backoffDelay(attempt));
+    const delay = backoffDelay(attempt);
+    log.debug(
+      `${method} ${new URL(fullUrl).pathname} → retry ${attempt + 1}/${MAX_RETRIES} after ${delay}ms`
+    );
+    await Bun.sleep(delay);
   }
 
   // Unreachable: the last attempt always returns 'done' or 'throw'
@@ -356,6 +363,7 @@ function createAuthenticatedFetch(): (
 
     return withHttpSpan(method, urlPath, async () => {
       const fullUrl = extractFullUrl(input);
+      const startTime = performance.now();
 
       // Check cache before auth/retry for GET requests.
       // Uses current token (no refresh) so lookups are fast but Vary-correct.
@@ -365,10 +373,17 @@ function createAuthenticatedFetch(): (
         authHeaders(getAuthToken())
       );
       if (cached) {
+        log.debug(
+          `${method} ${urlPath} → ${cached.status} (cache hit, ${(performance.now() - startTime).toFixed(0)}ms)`
+        );
         return cached;
       }
 
-      return await fetchWithRetry(input, init, method, fullUrl);
+      const response = await fetchWithRetry(input, init, method, fullUrl);
+      log.debug(
+        `${method} ${urlPath} → ${response.status} (${(performance.now() - startTime).toFixed(0)}ms)`
+      );
+      return response;
     });
   };
 }


### PR DESCRIPTION
## Summary

Four targeted optimizations based on investigation showing Bun already uses HTTP/2 multiplexing and keep-alive (transport is not the bottleneck), but sequential resolution chains and unbounded fan-outs cause observable slowness.

## Changes

### 1. HTTP timing diagnostics (`sentry-client.ts`)
Debug-level logging in the authenticated fetch showing method, URL path, status, timing (ms), cache hits, and retry attempts. Visible with `SENTRY_LOG_LEVEL=debug` or `--verbose`.

### 2. Post-login cache warming (`auth/login.ts`)
After successful login, fire-and-forget `listOrganizationsUncached()` to pre-populate the org + region SQLite cache, eliminating the ~800ms cold-start on the first command.

### 3. Concurrency limits on org fan-outs
Add `p-limit(5)` to all unbounded `Promise.all()` patterns that fan out across organizations or regions:
- `findProjectsBySlug()`, `findProjectsByPattern()`, `findProjectByDsnKey()` in `api/projects.ts`
- `findEventAcrossOrgs()` in `api/events.ts`
- `resolveProjectSearch()` in `commands/issue/utils.ts`

### 4. Faster org resolution for normal slugs (`region.ts`)
`resolveEffectiveOrg()` now uses `resolveOrgRegion()` (1 API call) for normal slugs instead of `listOrganizationsUncached()` (1+N requests). The expensive fan-out is reserved for DSN numeric IDs (`oNNNNN`) that need ID→slug mapping.

## Test plan

- `bun run typecheck` — clean
- `bun run lint` — clean
- 293 tests across affected modules pass