### PR TITLE
fix: enrich event 404 errors with retention and format suggestions (CLI-6F)

### DIFF
--- a/src/commands/event/view.ts
+++ b/src/commands/event/view.ts
@@ -348,11 +348,11 @@ async function fetchLatestEventData(
  * @returns The event data
  */
 async function fetchEventWithContext(
-  prefetchedEvent: import("../../types/index.js").SentryEvent | null,
+  prefetchedEvent: SentryEvent | null,
   org: string,
   project: string,
   eventId: string
-): Promise<import("../../types/index.js").SentryEvent> {
+): Promise<SentryEvent> {
   if (prefetchedEvent) {
     return prefetchedEvent;
   }
@@ -363,11 +363,11 @@ async function fetchEventWithContext(
       throw new ResolutionError(
         `Event '${eventId}'`,
         `not found in ${org}/${project}`,
-        `sentry event view ${org}/${project} <event-id>`,
+        `sentry event view ${org}/${project} ${eventId}`,
         [
           "The event may have been deleted due to data retention policies",
           "Verify the event ID is a 32-character hex string (e.g., a1b2c3d4...)",
-          `Check if the event belongs to a different project: sentry event view ${org}/ <event-id>`,
+          `Check if the event belongs to a different project: sentry event view ${org}/ ${eventId}`,
         ]
       );
     }


### PR DESCRIPTION
## Problem

When `sentry event view` gets a 404 Not Found, the error shows:

```
ApiError: Failed to get event: 404 Not Found
```

This doesn't help users diagnose whether the event ID is wrong, the event was deleted due to data retention, or it belongs to a different project. Affects **54 users** ([CLI-6F](https://sentry.sentry.io/issues/7272966997/)).

## Fix

Extracted event fetching into a `fetchEventWithContext()` helper that catches 404 errors and throws a `ResolutionError` with actionable suggestions:

```
Event 'abc123def456...' not found in my-org/my-project.

Try:
  sentry event view my-org/my-project <event-id>

Or:
  - The event may have been deleted due to data retention policies
  - Verify the event ID is a 32-character hex string (e.g., a1b2c3d4...)
  - Check if the event belongs to a different project: sentry event view my-org/ <event-id>
```

## Design Decisions

- Extracted into a separate function to avoid exceeding biome's cognitive complexity limit on `func()`
- Only catches 404 errors — other API errors (403, 500) propagate unchanged
- Reuses the existing `ResolutionError` pattern consistent with other commands
- The trailing-slash suggestion (`sentry event view my-org/ <event-id>`) hints at org-wide search