### PR TITLE
fix: event 404 hint should suggest different project, not repeat failing command

### DIFF
--- a/src/commands/event/view.ts
+++ b/src/commands/event/view.ts
@@ -363,11 +363,11 @@ async function fetchEventWithContext(
       throw new ResolutionError(
         `Event '${eventId}'`,
         `not found in ${org}/${project}`,
-        `sentry event view ${org}/${project} ${eventId}`,
+        `sentry event view ${org}/<project> ${eventId}`,
         [
           "The event may have been deleted due to data retention policies",
           "Verify the event ID is a 32-character hex string (e.g., a1b2c3d4...)",
-          `Check if the event belongs to a different project: sentry event view ${org}/ ${eventId}`,
+          `Search across all projects in the org: sentry event view ${org}/ ${eventId}`,
         ]
       );
     }


### PR DESCRIPTION
## Follow-up to PR #491

Addresses unresolved [Bugbot review comment](https://github.com/getsentry/cli/pull/491#discussion_r2963456854) that I missed before merging #491.

## Problem

The `Try:` hint in `fetchEventWithContext` repeated the exact command that just produced the 404:

```
Event 'abc123' not found in my-org/my-project.

Try:
  sentry event view my-org/my-project abc123   ← same failing command!
```

## Fix

Changed the hint to use a `<project>` placeholder to suggest trying a different project, and updated the `Or:` suggestion to explicitly mention org-wide search:

```
Event 'abc123' not found in my-org/my-project.

Try:
  sentry event view my-org/<project> abc123     ← try a different project

Or:
  - The event may have been deleted due to data retention policies
  - Verify the event ID is a 32-character hex string (e.g., a1b2c3d4...)
  - Search across all projects in the org: sentry event view my-org/ abc123
```