### PR TITLE
fix: enrich short ID 404 with org context and suggestions (CLI-A1)

### DIFF
--- a/src/lib/api/issues.ts
+++ b/src/lib/api/issues.ts
@@ -237,7 +237,27 @@ export async function getIssueByShortId(
     },
   });
 
-  const data = unwrapResult(result, "Failed to resolve short ID");
+  let data: ReturnType<typeof unwrapResult>;
+  try {
+    data = unwrapResult(result, "Failed to resolve short ID");
+  } catch (error) {
+    // Enrich 404 errors with actionable context. The generic
+    // "Failed to resolve short ID: 404 Not Found" is the most common
+    // issue view error (CLI-A1, 27 users). Callers like
+    // tryGetIssueByShortId still catch ApiError by status code.
+    if (error instanceof ApiError && error.status === 404) {
+      throw new ApiError(
+        `Short ID '${normalizedShortId}' not found in organization '${orgSlug}'`,
+        404,
+        [
+          "The issue may have been deleted or merged",
+          `Verify the short ID and org: sentry issue view ${orgSlug}/${normalizedShortId}`,
+          `List issues in this org: sentry issue list ${orgSlug}/`,
+        ].join("\n  ")
+      );
+    }
+    throw error;
+  }
 
   // resolveAShortId returns a ShortIdLookupResponse with a group (issue)
   const resolved = data as unknown as { group?: SentryIssue };


### PR DESCRIPTION
## Problem

When resolving an issue by short ID (e.g., `sentry issue view CLI-BM`) fails with 404, the error shows:

```
ApiError: Failed to resolve short ID: 404 Not Found
```

This doesn't tell the user what short ID was searched, which organization was searched, or what to do next. Affects **27 users** ([CLI-A1](https://sentry.sentry.io/issues/7297901204/)).

## Fix

Enhanced the 404 error in `getIssueByShortId` to include context and suggestions:

```
Short ID 'CLI-BM' not found in organization 'sentry'.
  The issue may have been deleted or merged
  Verify the short ID and org: sentry issue view sentry/CLI-BM
  List issues in this org: sentry issue list sentry/
```

## Design Decisions

- **Keeps ApiError type**: The enhanced error still has `status=404`, so `tryGetIssueByShortId` (used for parallel fan-out across orgs) continues to work unchanged — it catches `ApiError` by status code
- **Inline detail**: Suggestions are formatted as the ApiError `detail` field, which `ApiError.format()` renders on indented lines below the main message
- **Context-aware**: Includes the actual short ID and org slug so users can verify both