### PR TITLE
fix: add 400 suggestions to org-all issue list path (CLI-BY)

### DIFF
--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -826,15 +826,34 @@ async function handleOrgAllIssues(
 
   setContext([org], []);
 
-  const { issues, nextCursor } = await withProgress(
-    { message: `Fetching issues (up to ${flags.limit})...`, json: flags.json },
-    (setMessage) =>
-      fetchOrgAllIssues(org, flags, cursor, (fetched, limit) =>
-        setMessage(
-          `Fetching issues, ${fetched} and counting (up to ${limit})...`
+  let issuesResult: IssuesPage;
+  try {
+    issuesResult = await withProgress(
+      {
+        message: `Fetching issues (up to ${flags.limit})...`,
+        json: flags.json,
+      },
+      (setMessage) =>
+        fetchOrgAllIssues(org, flags, cursor, (fetched, limit) =>
+          setMessage(
+            `Fetching issues, ${fetched} and counting (up to ${limit})...`
+          )
         )
-      )
-  );
+    );
+  } catch (error) {
+    // Enrich 400 errors with the same suggestions as handleResolvedTargets
+    // (CLI-BY, 23 users). The org-all path was missing these hints.
+    if (error instanceof ApiError && error.status === 400) {
+      throw new ApiError(
+        error.message,
+        error.status,
+        build400Detail(error.detail, flags),
+        error.endpoint
+      );
+    }
+    throw error;
+  }
+  const { issues, nextCursor } = issuesResult;
 
   if (nextCursor) {
     setPaginationCursor(PAGINATION_KEY, contextKey, nextCursor);


### PR DESCRIPTION
## Problem

The org-all code path (`sentry issue list org/`) was missing the 400 Bad Request suggestions added in PR #489. When the API returns 400, users see a bare error without guidance. Affects **23 users** ([CLI-BY](https://sentry.sentry.io/issues/7316799779/)).

## Fix

Wrapped the `fetchOrgAllIssues` call in `handleOrgAllIssues` with a try-catch that enriches 400 errors using the existing `build400Detail()` helper — the same one used by `handleResolvedTargets`. Users now see suggestions about query syntax, period, and project access in both code paths.