### PR TITLE
fix: include API endpoint in error messages for better diagnostics (CLI-BS)

### DIFF
--- a/src/lib/api/infrastructure.ts
+++ b/src/lib/api/infrastructure.ts
@@ -296,7 +296,8 @@ export async function apiRequestToRegion<T>(
     throw new ApiError(
       `API request failed: ${response.status} ${response.statusText}`,
       response.status,
-      detail
+      detail,
+      endpoint
     );
   }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -61,6 +61,9 @@ export class ApiError extends CliError {
 
   override format(): string {
     let msg = this.message;
+    if (this.endpoint) {
+      msg += `\n  Endpoint: ${this.endpoint}`;
+    }
     if (this.detail && this.detail !== this.message) {
       msg += `\n  ${this.detail}`;
     }


### PR DESCRIPTION
## Problem

The generic `API request failed: 404 Not Found` from `apiRequest()` doesn't identify which endpoint failed. This affects **24 users** ([CLI-BS](https://sentry.sentry.io/issues/7316293255/)) across issue view, whoami, and log list commands.

## Fix

Two changes:
1. **Pass endpoint to ApiError** in `apiRequest()` so it's captured in telemetry
2. **Show endpoint in `ApiError.format()`** so users see which API path failed:

```
API request failed: 404 Not Found
  Endpoint: /auth/
  {"detail": "Not found."}
```

This helps users identify:
- Self-hosted endpoints that don't exist (e.g., `/auth/` on older instances)
- Wrong org/project context causing resource-not-found
- Missing features (e.g., logs endpoint not enabled)