### PR TITLE
fix: handle EIO stream errors gracefully in bin.ts

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -6,17 +6,21 @@
  * the full CLI with telemetry, middleware, and error recovery.
  */
 
-// Exit cleanly on non-recoverable stream I/O errors.
+// Handle non-recoverable stream I/O errors gracefully instead of crashing.
 // - EPIPE (errno -32): downstream pipe consumer closed (e.g., `sentry issue list | head`).
-//   Normal Unix behavior — not an error. Node.js/Bun ignore SIGPIPE at the process level,
-//   so pipe write failures surface as async 'error' events on the stream.
+//   Normal Unix behavior — not an error. Exit 0 because the CLI succeeded; the consumer
+//   just stopped reading.
 // - EIO (errno -5): low-level I/O failure on the stream fd (e.g., terminal device driver
 //   error, broken PTY, disk I/O failure on redirected output). Non-recoverable — the
-//   stream is unusable. Seen in CLI-H2 on self-hosted macOS with virtualized storage.
+//   stream is unusable and output may be incomplete. Exit 1 so callers (scripts, CI) know
+//   the output was lost. Seen in CLI-H2 on self-hosted macOS with virtualized storage.
 // Without this handler these errors become uncaught exceptions.
 function handleStreamError(err: NodeJS.ErrnoException): void {
-  if (err.code === "EPIPE" || err.code === "EIO") {
+  if (err.code === "EPIPE") {
     process.exit(0);
+  }
+  if (err.code === "EIO") {
+    process.exit(1);
   }
   throw err;
 }


### PR DESCRIPTION
Fixes [CLI-H2](https://sentry.sentry.io/issues/7347407245/) — an unhandled `EIO: i/o error, read` that crashed the CLI during `sentry auth login` on a self-hosted macOS instance.

## Root Cause

The `handleStreamError` function in `bin.ts` only special-cased `EPIPE` (broken pipe) and re-threw all other errors. When `stdout`/`stderr` emits an `EIO` error event (non-recoverable I/O failure on the stream fd), the `throw` inside the synchronous event handler becomes an uncaught exception — matching the `auto.node.onuncaughtexception` mechanism seen in the issue.

## Fix

Add `EIO` to the stream error handler allowlist alongside `EPIPE`. Both are non-recoverable stream errors where the fd is unusable, so the CLI should exit cleanly rather than crash with a fatal unhandled exception.

`EIO` (errno -5) occurs from low-level I/O failures: terminal device driver errors, broken PTYs, disk I/O failures on redirected output, or virtualized storage glitches — common on self-hosted instances.