### PR TITLE
fix: lowercase project slug in URL-parsed issue short IDs (CLI-C8 follow-up)

### DIFF
--- a/src/lib/arg-parsing.ts
+++ b/src/lib/arg-parsing.ts
@@ -400,7 +400,13 @@ function issueArgFromUrl(parsed: ParsedSentryUrl): ParsedIssueArg | null {
     const project = issueId.slice(0, dashIdx);
     const suffix = issueId.slice(dashIdx + 1).toUpperCase();
     if (project && suffix) {
-      return { type: "explicit", org: parsed.org, project, suffix };
+      // Lowercase project slug — Sentry slugs are always lowercase.
+      return {
+        type: "explicit",
+        org: parsed.org,
+        project: project.toLowerCase(),
+        suffix,
+      };
     }
   }
 

--- a/test/lib/arg-parsing.test.ts
+++ b/test/lib/arg-parsing.test.ts
@@ -345,18 +345,18 @@ describe("parseIssueArg", () => {
       });
     });
 
-    test("issue URL with short ID returns explicit", () => {
+    test("issue URL with short ID returns explicit with lowercase project", () => {
       expect(
         parseIssueArg("https://sentry.io/organizations/my-org/issues/CLI-G/")
       ).toEqual({
         type: "explicit",
         org: "my-org",
-        project: "CLI",
+        project: "cli",
         suffix: "G",
       });
     });
 
-    test("issue URL with multi-part short ID returns explicit", () => {
+    test("issue URL with multi-part short ID returns explicit with lowercase project", () => {
       expect(
         parseIssueArg(
           "https://sentry.io/organizations/my-org/issues/SPOTLIGHT-ELECTRON-4Y/"
@@ -364,7 +364,7 @@ describe("parseIssueArg", () => {
       ).toEqual({
         type: "explicit",
         org: "my-org",
-        project: "SPOTLIGHT-ELECTRON",
+        project: "spotlight-electron",
         suffix: "4Y",
       });
     });


### PR DESCRIPTION
## Follow-up to PR #496

Addresses unresolved [Bugbot review comment](https://github.com/getsentry/cli/pull/496#discussion_r2964724516) (High severity) that was missed before merging #496.

## Problem

`issueArgFromUrl` returned the project slug without `.toLowerCase()` when parsing Sentry issue URLs like:
```
https://sentry.io/organizations/my-org/issues/CLI-G/
```

This produced `project: "CLI"` (uppercase) which fails API lookups since Sentry slugs are always lowercase. The other three parsing paths (`parseWithDash`, `parseAfterSlash`, `parseMultiSlashIssueArg`) were already fixed in PR #496.

## Fix

Added `.toLowerCase()` to the project slug in `issueArgFromUrl` and updated two test expectations to match.