### PR TITLE
fix: preserve ApiError type in Seer handler + suggest trial start command (CLI-N, CLI-1D/BW/98)

### DIFF
--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -404,11 +404,14 @@ export class SeerError extends CliError {
   }
 
   override format(): string {
-    // Soften trial hint — we can't check availability synchronously,
-    // so use "check" language rather than "start" to avoid misleading
-    // users whose trial is already expired
-    const trialHint =
-      "\n\nYou may be eligible for a free trial:\n  sentry trial list";
+    // When org slug is known, suggest the direct trial start command.
+    // The interactive trial prompt in bin.ts handles TTY users; this
+    // message is the fallback for non-interactive contexts (AI agents, CI)
+    // where the prompt can't fire — hence the direct command suggestion
+    // (CLI-1D/BW/98, 237 users combined).
+    const trialHint = this.orgSlug
+      ? `\n\nStart a free trial:\n  sentry trial start seer ${this.orgSlug}`
+      : "\n\nYou may be eligible for a free trial:\n  sentry trial list";
 
     // When org slug is known, provide direct URLs to settings
     if (this.orgSlug) {

--- a/src/lib/formatters/seer.ts
+++ b/src/lib/formatters/seer.ts
@@ -10,7 +10,7 @@ import type {
   RootCause,
   SolutionArtifact,
 } from "../../types/seer.js";
-import { SeerError } from "../errors.js";
+import { ApiError, SeerError } from "../errors.js";
 import { cyan } from "./colors.js";
 import { escapeMarkdownInline, renderMarkdown } from "./markdown.js";
 
@@ -195,12 +195,17 @@ export function createSeerError(
 }
 
 /**
- * Convert an API error to a Seer-specific error or a generic error.
+ * Convert an API error to a Seer-specific error or an ApiError.
+ *
+ * Returns a SeerError for known Seer issues (402/403 with specific detail),
+ * or preserves the error as an ApiError for other failures. Previously
+ * returned a plain Error which lost the status code and endpoint — causing
+ * CLI-N (84 users) where unrecognized 403s became untyped errors.
  *
  * @param status - HTTP status code
  * @param detail - Error detail from API
  * @param orgSlug - Organization slug for constructing settings URLs
- * @returns SeerError for Seer-specific errors, or a generic Error for other API errors
+ * @returns SeerError for Seer-specific errors, or ApiError for other API errors
  */
 export function handleSeerApiError(
   status: number,
@@ -211,7 +216,7 @@ export function handleSeerApiError(
   if (seerError) {
     return seerError;
   }
-  return new Error(formatAutofixError(status, detail));
+  return new ApiError(formatAutofixError(status, detail), status, detail);
 }
 
 /**


### PR DESCRIPTION
## Two fixes for the highest-impact error classes

### 1. CLI-N (84 users): `handleSeerApiError` creates plain `Error` for non-Seer failures

**Root cause**: When the Seer endpoint returns a 403 that doesn't match known Seer patterns ("not enabled", "AI features"), or a 500 Internal Server Error, `handleSeerApiError` wraps it in a plain `Error`:
```typescript
// Before:
return new Error(formatAutofixError(status, detail));  // loses ApiError type!
```

This strips the status code, endpoint, and error type — making it appear as a generic `Error: Internal Error` or `Error: You do not have permission` in telemetry.

**Fix**: Return an `ApiError` to preserve type information:
```typescript
// After:
return new ApiError(formatAutofixError(status, detail), status, detail);
```

### 2. CLI-1D + CLI-BW + CLI-98 (237 users): Seer trial prompt can't fire for AI agents

**Root cause**: The trial prompt middleware in `bin.ts` requires `isatty(0)` (interactive terminal). Most Seer errors come from AI coding agents calling `sentry issue explain` — where stdin isn't a TTY, so the prompt never fires and the `SeerError` propagates.

The error message already includes guidance, but suggests the passive `sentry trial list` which only lists trials. For non-interactive users who can't use the prompt, the direct start command is more actionable.

**Fix**: When org slug is known, suggest `sentry trial start seer <org>` instead of `sentry trial list`:
```
Seer requires a paid plan.

To use Seer features, upgrade your plan:
  https://sentry.io/settings/my-org/billing/

Start a free trial:
  sentry trial start seer my-org
```