### PR TITLE
fix(dashboard): add missing datasets to agent guidance

### DIFF
--- a/docs/src/content/docs/agent-guidance.md
+++ b/docs/src/content/docs/agent-guidance.md
@@ -127,7 +127,7 @@ Display types with default sizes:
 
 Use **common** types for general dashboards. Use **specialized** only when specifically requested. Avoid **internal** types unless the user explicitly asks.
 
-Available datasets: `spans` (default, covers most use cases), `discover`, `issue`, `error-events`, `transaction-like`, `metrics`, `logs`.
+Available datasets: `spans` (default, covers most use cases), `discover`, `issue`, `error-events`, `transaction-like`, `metrics`, `logs`, `tracemetrics`, `preprod-app-size`.
 
 Run `sentry dashboard widget --help` for the full list including aggregate functions.
 

--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -137,7 +137,7 @@ Display types with default sizes:
 
 Use **common** types for general dashboards. Use **specialized** only when specifically requested. Avoid **internal** types unless the user explicitly asks.
 
-Available datasets: `spans` (default, covers most use cases), `discover`, `issue`, `error-events`, `transaction-like`, `metrics`, `logs`.
+Available datasets: `spans` (default, covers most use cases), `discover`, `issue`, `error-events`, `transaction-like`, `metrics`, `logs`, `tracemetrics`, `preprod-app-size`.
 
 Run `sentry dashboard widget --help` for the full list including aggregate functions.
 


### PR DESCRIPTION
## Summary

Adds `tracemetrics` and `preprod-app-size` to the datasets list in the Dashboard Layout section of agent-guidance.md. These were already listed in `sentry dashboard widget --help` but were missing from the agent guidance doc.

## Test plan

- [ ] `bun run check:skill` — skill files up to date


🤖 Generated with [Claude Code](https://claude.com/claude-code)