### PR TITLE
fix: handle full short IDs and numeric IDs in multi-slash issue args (CLI-KC, CLI-B6)

### DIFF
--- a/src/lib/arg-parsing.ts
+++ b/src/lib/arg-parsing.ts
@@ -607,6 +607,11 @@ export type ParsedIssueArg =
  *
  * Splits `rest` on its first `/` to extract the project slug and a remainder
  * that is treated as the issue reference (suffix, numeric ID, or short ID).
+ *
+ * Handles three remainder formats:
+ * - Pure digits → numeric issue ID (project context is redundant)
+ * - Full short ID whose prefix matches the project → extract just the suffix
+ * - Anything else → treat entire remainder as the suffix
  */
 function parseMultiSlashIssueArg(
   arg: string,
@@ -626,22 +631,44 @@ function parseMultiSlashIssueArg(
   // Lowercase project slug — Sentry slugs are always lowercase.
   const normalizedProject = project.toLowerCase();
 
-  // Remainder with dash: "org/project/PROJ-G" — split remainder on last dash
+  // Pure numeric remainder: "org/project/123456789" → org + numeric ID.
+  // Project context is redundant for numeric IDs — Sentry resolves them globally.
+  if (isAllDigits(remainder)) {
+    return { type: "explicit-org-numeric", org, numericId: remainder };
+  }
+
+  // Remainder with dash: could be a full short ID like "CLI-A1" or "SPOTLIGHT-ELECTRON-4Y"
   if (remainder.includes("-")) {
     const lastDash = remainder.lastIndexOf("-");
-    const subProject = remainder.slice(0, lastDash);
+    const prefix = remainder.slice(0, lastDash);
     const suffix = remainder.slice(lastDash + 1).toUpperCase();
-    if (subProject && suffix) {
+
+    if (prefix && suffix) {
+      // Check if the prefix matches the project slug (case-insensitive).
+      // If so, the remainder is already a full short ID — use only the suffix.
+      // e.g., "sentry/cli/CLI-A1" → prefix "CLI" matches project "cli" → suffix "A1"
+      // e.g., "org/spotlight-electron/SPOTLIGHT-ELECTRON-4Y" → prefix matches → suffix "4Y"
+      if (prefix.toLowerCase() === normalizedProject) {
+        return {
+          type: "explicit",
+          org,
+          project: normalizedProject,
+          suffix,
+        };
+      }
+
+      // Prefix doesn't match project — treat entire remainder as the suffix.
+      // e.g., "org/project/SUBPROJ-G" where SUBPROJ ≠ project
       return {
         type: "explicit",
         org,
         project: normalizedProject,
-        suffix: `${subProject}-${suffix}`.toUpperCase(),
+        suffix: `${prefix}-${suffix}`.toUpperCase(),
       };
     }
   }
 
-  // "org/project/101149101" or "org/project/G" — treat remainder as suffix
+  // No dash: "org/project/G" — treat remainder as suffix
   return {
     type: "explicit",
     org,

--- a/test/lib/arg-parsing.test.ts
+++ b/test/lib/arg-parsing.test.ts
@@ -464,30 +464,74 @@ describe("parseIssueArg", () => {
 
   // Multi-slash issue args (org/project/suffix)
   describe("multi-slash issue args", () => {
-    test("org/project/suffix returns explicit with project and suffix", () => {
+    test("org/project/numeric returns explicit-org-numeric", () => {
       expect(parseIssueArg("org/project/101149101")).toEqual({
-        type: "explicit",
+        type: "explicit-org-numeric",
         org: "org",
-        project: "project",
-        suffix: "101149101",
+        numericId: "101149101",
       });
     });
 
-    test("org/project/numeric returns explicit with numeric suffix", () => {
+    test("org/project/short-numeric returns explicit-org-numeric", () => {
       expect(parseIssueArg("org/project/123456")).toEqual({
-        type: "explicit",
+        type: "explicit-org-numeric",
         org: "org",
-        project: "project",
-        suffix: "123456",
+        numericId: "123456",
       });
     });
 
-    test("org/project/PROJ-G returns explicit with combined suffix", () => {
+    test("org/project/PROJ-G where PROJ ≠ project returns explicit with combined suffix", () => {
       expect(parseIssueArg("org/project/PROJ-G")).toEqual({
         type: "explicit",
         org: "org",
         project: "project",
         suffix: "PROJ-G",
+      });
+    });
+
+    test("org/project/PROJECT-G where prefix matches project strips prefix (CLI-KC)", () => {
+      expect(parseIssueArg("sentry/cli/CLI-A1")).toEqual({
+        type: "explicit",
+        org: "sentry",
+        project: "cli",
+        suffix: "A1",
+      });
+    });
+
+    test("org/project/PROJECT-suffix is case-insensitive on prefix match", () => {
+      expect(parseIssueArg("sentry/cli/cli-b6")).toEqual({
+        type: "explicit",
+        org: "sentry",
+        project: "cli",
+        suffix: "B6",
+      });
+    });
+
+    test("compound project slug with matching full short ID (CLI-KC)", () => {
+      expect(
+        parseIssueArg("org/spotlight-electron/SPOTLIGHT-ELECTRON-4Y")
+      ).toEqual({
+        type: "explicit",
+        org: "org",
+        project: "spotlight-electron",
+        suffix: "4Y",
+      });
+    });
+
+    test("org/project/numeric-id returns explicit-org-numeric (CLI-B6)", () => {
+      expect(parseIssueArg("fever/cashless/6918259357")).toEqual({
+        type: "explicit-org-numeric",
+        org: "fever",
+        numericId: "6918259357",
+      });
+    });
+
+    test("org/project/G returns explicit with suffix", () => {
+      expect(parseIssueArg("org/project/G")).toEqual({
+        type: "explicit",
+        org: "org",
+        project: "project",
+        suffix: "G",
       });
     });
 


### PR DESCRIPTION
## Summary

Fixes two bugs in `parseMultiSlashIssueArg()` that affected users passing `org/project/issue-id` format:

### Bug 1: Double-prefix (CLI-KC — 33 events, escalating)

When passing `sentry/cli/CLI-A1`, the function split `CLI-A1` on its last dash and recombined as suffix `CLI-A1`. Later, `expandToFullShortId("CLI-A1", "cli")` produced `CLI-CLI-A1` — a double-prefixed ID that doesn't exist.

**Fix**: Detect when the prefix before the last dash matches the project slug (case-insensitive) and extract just the suffix part.

### Bug 2: Numeric ID as suffix (CLI-B6 — 3 events, 2 users)

When passing `fever/cashless/6918259357`, the numeric remainder was treated as a suffix, producing `CASHLESS-6918259357` as a short ID.

**Fix**: Detect pure numeric remainders and return `explicit-org-numeric` type instead.

### Test cases added
- `sentry/cli/CLI-A1` → suffix `A1` (not `CLI-A1`)
- `sentry/cli/cli-b6` → suffix `B6` (case-insensitive)
- `org/spotlight-electron/SPOTLIGHT-ELECTRON-4Y` → suffix `4Y` (compound project slug)
- `fever/cashless/6918259357` → `explicit-org-numeric` (not suffix)
- `org/project/PROJ-G` where PROJ ≠ project → suffix `PROJ-G` (unchanged behavior)