### PR TITLE
fix: avoid double-prefixing in buildCommandHint for slashed args (CLI-8C)

### DIFF
--- a/src/commands/issue/utils.ts
+++ b/src/commands/issue/utils.ts
@@ -63,6 +63,7 @@ export const issueIdPositional = {
  * Build a command hint string for error messages.
  *
  * Returns context-aware hints based on the issue ID format:
+ * - Already contains `/` (e.g., "saber-ut/103103195") → show as-is (already has context)
  * - Numeric ID (e.g., "123456789") → suggest `<org>/123456789`
  * - Suffix only (e.g., "G") → suggest `<project>-G`
  * - Has dash (e.g., "cli-G") → suggest `<org>/cli-G`
@@ -74,6 +75,10 @@ export function buildCommandHint(command: string, issueId: string): string {
   // Selectors already include the @ prefix and are self-contained
   if (issueId.startsWith("@")) {
     return `sentry issue ${command} <org>/${issueId}`;
+  }
+  // Input already contains org/project context — show as-is to avoid double-prefixing
+  if (issueId.includes("/")) {
+    return `sentry issue ${command} ${issueId}`;
   }
   // Numeric IDs always need org context - can't be combined with project
   if (isAllDigits(issueId)) {

--- a/test/commands/issue/utils.test.ts
+++ b/test/commands/issue/utils.test.ts
@@ -56,6 +56,21 @@ describe("buildCommandHint", () => {
       "sentry issue explain <org>/@most_frequent"
     );
   });
+
+  test("shows as-is when input already contains a slash (CLI-8C)", () => {
+    // org/numeric — don't add another <org>/ prefix
+    expect(buildCommandHint("view", "saber-ut/103103195")).toBe(
+      "sentry issue view saber-ut/103103195"
+    );
+    // org/project-suffix — already has full context
+    expect(buildCommandHint("view", "sentry/cli-G")).toBe(
+      "sentry issue view sentry/cli-G"
+    );
+    // org/project/suffix — three-level path, show as-is
+    expect(buildCommandHint("explain", "sentry/cli/CLI-A1")).toBe(
+      "sentry issue explain sentry/cli/CLI-A1"
+    );
+  });
 });
 
 const getConfigDir = useTestConfigDir("test-issue-utils-", {


### PR DESCRIPTION
## Summary

Fixes `buildCommandHint()` producing nonsensical error hints when the user-provided issue arg already contains a slash.

### Bug (CLI-8C — 50 events, 8 users)

When a user passes `saber-ut/103103195` to `sentry issue view`, the error path calls `buildCommandHint("view", "saber-ut/103103195")`. Since the input contains a dash, it fell through to the final branch and produced:

```
sentry issue view <org>/saber-ut/103103195
```

This is wrong — the user already provided the org prefix `saber-ut`.

### Fix

Add an early check: if the input already contains a `/`, it has org context embedded — show it as-is without adding another `<org>/` prefix.

### Test cases added
- `saber-ut/103103195` → `sentry issue view saber-ut/103103195`
- `sentry/cli-G` → `sentry issue view sentry/cli-G`
- `sentry/cli/CLI-A1` → `sentry issue explain sentry/cli/CLI-A1`