### PR TITLE
fix: handle invalid URLs gracefully in response cache (CLI-GC)

### DIFF
--- a/src/lib/response-cache.ts
+++ b/src/lib/response-cache.ts
@@ -123,6 +123,7 @@ export function buildCacheKey(method: string, url: string): string {
  * Normalize method + URL into a stable string for cache key derivation.
  * Sorts query params alphabetically for deterministic key generation.
  *
+ * @throws {TypeError} If the URL cannot be parsed
  * @internal Exported for testing
  */
 export function normalizeUrl(method: string, url: string): string {
@@ -367,7 +368,15 @@ export async function getCachedResponse(
     return;
   }
 
-  const key = buildCacheKey(method, url);
+  let key: string;
+  try {
+    key = buildCacheKey(method, url);
+  } catch {
+    // Malformed URL (e.g., self-hosted with bad base URL) — skip cache lookup.
+    // The request will proceed without caching; fetch() itself will surface
+    // the real error if the URL is truly broken.
+    return;
+  }
 
   return await withCacheSpan(
     url,
@@ -467,7 +476,13 @@ export async function storeCachedResponse(
     return;
   }
 
-  const key = buildCacheKey(method, url);
+  let key: string;
+  try {
+    key = buildCacheKey(method, url);
+  } catch {
+    // Malformed URL — skip caching this response
+    return;
+  }
 
   try {
     await withCacheSpan(

--- a/test/lib/response-cache.test.ts
+++ b/test/lib/response-cache.test.ts
@@ -12,6 +12,7 @@ import {
   buildCacheKey,
   clearResponseCache,
   getCachedResponse,
+  normalizeUrl,
   resetCacheState,
   storeCachedResponse,
 } from "../../src/lib/response-cache.js";
@@ -264,6 +265,37 @@ describe("cache bypass", () => {
 });
 
 // ---------------------------------------------------------------------------
+// normalizeUrl
+// ---------------------------------------------------------------------------
+
+describe("normalizeUrl", () => {
+  test("sorts query params alphabetically", () => {
+    const result = normalizeUrl(
+      "GET",
+      "https://sentry.io/api/0/issues/?b=2&a=1"
+    );
+    expect(result).toBe("GET|https://sentry.io/api/0/issues/?a=1&b=2");
+  });
+
+  test("uppercases the method", () => {
+    const result = normalizeUrl("get", "https://sentry.io/api/0/issues/");
+    expect(result).toMatch(/^GET\|/);
+  });
+
+  test("throws on invalid URLs", () => {
+    expect(() => normalizeUrl("GET", "not-a-valid-url")).toThrow();
+  });
+
+  test("handles self-hosted URLs with unusual schemes", () => {
+    const result = normalizeUrl(
+      "GET",
+      "https://sentry.mycompany.internal/api/0/issues/"
+    );
+    expect(result).toBe("GET|https://sentry.mycompany.internal/api/0/issues/");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // buildCacheKey
 // ---------------------------------------------------------------------------
 
@@ -283,6 +315,27 @@ describe("buildCacheKey", () => {
     const getKey = buildCacheKey("GET", TEST_URL);
     const postKey = buildCacheKey("POST", TEST_URL);
     expect(getKey).not.toBe(postKey);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid URL handling (CLI-GC)
+// ---------------------------------------------------------------------------
+
+describe("invalid URL handling", () => {
+  test("getCachedResponse skips cache for malformed URLs", async () => {
+    const result = await getCachedResponse("GET", "not-a-valid-url", {});
+    expect(result).toBeUndefined();
+  });
+
+  test("storeCachedResponse skips cache for malformed URLs", async () => {
+    // Should not throw — just silently skip
+    await storeCachedResponse(
+      "GET",
+      "not-a-valid-url",
+      {},
+      mockResponse({ ok: true })
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes a crash in the response cache layer when self-hosted Sentry instances have malformed base URLs.

### Bug (CLI-GC — 3 events, 1 user)

`getCachedResponse()` and `storeCachedResponse()` both call `buildCacheKey()` — which internally runs `new URL(url)` — **outside** their try-catch guards. On self-hosted instances with malformed base URLs, this throws `TypeError: Invalid URL`, crashing the entire command before the actual API request even fires.

### Fix

Guard the `buildCacheKey()` call in both functions. When the URL can't be parsed:
- **Cache lookup**: skip and return `undefined` (treat as cache miss)
- **Cache store**: skip silently (response was already returned to the caller)

The actual `fetch()` call will surface the real error if the URL is truly broken — the cache layer shouldn't be the one to crash.

`normalizeUrl()` itself **still throws** on invalid URLs (correct behavior for a low-level utility) — the callers handle the failure since caching is non-essential infrastructure.

### Tests added
- `normalizeUrl()` throws on invalid URL (verifies it doesn't silently swallow)
- `getCachedResponse()` returns undefined for malformed URLs (no crash)
- `storeCachedResponse()` completes without throwing for malformed URLs