### PR TITLE
fix(event): detect org/ISSUE-SHORT-ID in event view single-arg path (CLI-9K)

### DIFF
--- a/src/commands/event/view.ts
+++ b/src/commands/event/view.ts
@@ -120,9 +120,11 @@ function parseSingleArg(arg: string): ParsedPositionalArgs {
   if (slashIdx !== -1 && arg.indexOf("/", slashIdx + 1) === -1) {
     const afterSlash = arg.slice(slashIdx + 1);
     if (afterSlash && looksLikeIssueShortId(afterSlash)) {
+      // Use "org/" (trailing slash) to signal OrgAll mode so downstream
+      // parseOrgProjectArg interprets this as an org, not a project search.
       return {
         eventId: "latest",
-        targetArg: arg.slice(0, slashIdx),
+        targetArg: `${arg.slice(0, slashIdx)}/`,
         issueShortId: afterSlash,
       };
     }
@@ -511,14 +513,18 @@ async function resolveIssueShortcut(
   }
 
   // Issue short ID auto-redirect: user passed an issue short ID
-  // (e.g., "BRUNCHIE-APP-29") instead of a hex event ID. Resolve
-  // the issue and show its latest event.
+  // (e.g., "BRUNCHIE-APP-29" or "figma/FULLSCREEN-2RN") instead of a hex
+  // event ID. Resolve the issue and show its latest event.
   if (issueShortId) {
     log.warn(
       `'${issueShortId}' is an issue short ID, not an event ID. Showing the latest event.`
     );
 
-    const resolved = await resolveOrg({ cwd });
+    // Use the explicit org from the parsed target if available (e.g.,
+    // "figma/" → org-all with org "figma"), otherwise fall back to
+    // auto-detection via DSN/env/config.
+    const explicitOrg = parsed.type === "org-all" ? parsed.org : undefined;
+    const resolved = await resolveOrg({ org: explicitOrg, cwd });
     if (!resolved) {
       throw new ContextError(
         "Organization",

--- a/test/commands/event/view.test.ts
+++ b/test/commands/event/view.test.ts
@@ -85,14 +85,15 @@ describe("parsePositionalArgs", () => {
     test("detects org/ISSUE-SHORT-ID pattern (CLI-9K)", () => {
       const result = parsePositionalArgs(["figma/FULLSCREEN-2RN"]);
       expect(result.eventId).toBe("latest");
-      expect(result.targetArg).toBe("figma");
+      // Trailing slash signals OrgAll mode so downstream resolves org correctly
+      expect(result.targetArg).toBe("figma/");
       expect(result.issueShortId).toBe("FULLSCREEN-2RN");
     });
 
     test("detects org/CLI-G pattern", () => {
       const result = parsePositionalArgs(["sentry/CLI-G"]);
       expect(result.eventId).toBe("latest");
-      expect(result.targetArg).toBe("sentry");
+      expect(result.targetArg).toBe("sentry/");
       expect(result.issueShortId).toBe("CLI-G");
     });
 


### PR DESCRIPTION
## Summary

Extends the issue short ID detection in `event view` to handle the `org/ISSUE-SHORT-ID` pattern (e.g., `figma/FULLSCREEN-2RN`).

### Bug (CLI-9K — 13 events, 11 users)

When passing `figma/FULLSCREEN-2RN` to `sentry event view`, `parseSlashSeparatedArg` sees exactly one slash and interprets it as `org=figma` / `project=FULLSCREEN-2RN` with no event ID → throws `ContextError: Event ID is required.`

PR #524 added auto-redirect for **bare** issue short IDs like `BRUNCHIE-APP-29`, but the `org/SHORT-ID` pattern wasn't covered because `parseSlashSeparatedArg` throws before the detection code runs.

### Fix

Extract single-arg handling into `parseSingleArg()` which checks for the `org/ISSUE-SHORT-ID` pattern **before** calling `parseSlashSeparatedArg`:
1. If the arg has exactly one slash and the part after it matches `looksLikeIssueShortId()`, return it as an issue short ID auto-redirect (same as the bare case)
2. Otherwise, proceed with normal `parseSlashSeparatedArg` flow

This refactor also reduces `parsePositionalArgs` complexity from 16 to within the biome limit of 15.

### Tests added
- `figma/FULLSCREEN-2RN` → `{ eventId: "latest", targetArg: "figma", issueShortId: "FULLSCREEN-2RN" }`
- `sentry/CLI-G` → `{ eventId: "latest", targetArg: "sentry", issueShortId: "CLI-G" }`
- `my-org/my-project` → still throws ContextError (not a short ID)