### PR TITLE
fix(telemetry): set sentry.org tag in issue explain and plan commands

### DIFF
--- a/src/commands/issue/explain.ts
+++ b/src/commands/issue/explain.ts
@@ -74,7 +74,7 @@ export const explainCommand = buildCommand({
   },
   async *func(this: SentryContext, flags: ExplainFlags, issueArg: string) {
     applyFreshFlag(flags);
-    const { cwd } = this;
+    const { cwd, setContext } = this;
 
     // Declare org outside try block so it's accessible in catch for error messages
     let resolvedOrg: string | undefined;
@@ -87,6 +87,9 @@ export const explainCommand = buildCommand({
         command: "explain",
       });
       resolvedOrg = org;
+
+      // Set telemetry context so SeerError events carry the org tag
+      setContext([org], []);
 
       // Ensure root cause analysis exists (triggers if needed)
       const state = await ensureRootCauseAnalysis({

--- a/src/commands/issue/plan.ts
+++ b/src/commands/issue/plan.ts
@@ -193,7 +193,7 @@ export const planCommand = buildCommand({
   },
   async *func(this: SentryContext, flags: PlanFlags, issueArg: string) {
     applyFreshFlag(flags);
-    const { cwd } = this;
+    const { cwd, setContext } = this;
 
     // Declare org outside try block so it's accessible in catch for error messages
     let resolvedOrg: string | undefined;
@@ -206,6 +206,9 @@ export const planCommand = buildCommand({
         command: "plan",
       });
       resolvedOrg = org;
+
+      // Set telemetry context so SeerError events carry the org tag
+      setContext([org], []);
 
       // Ensure root cause analysis exists (runs explain if needed)
       const state = await ensureRootCauseAnalysis({


### PR DESCRIPTION
The `issue explain` and `issue plan` commands never called
`setOrgProjectContext()` after resolving the org slug, so `SeerError` events
captured to Sentry were missing the `sentry.org` tag. This made it impossible
to filter or group Seer paywall errors by customer org in dashboards.

### Changes

Add `setContext([org], [])` in both commands right after
`resolveOrgAndIssueId()` returns — before the Seer API call that may throw.
This follows the same pattern used in `issue view` and `issue list`.

### Context

This fixes the data gap for the **Seer Upsell Leads** dashboard
(https://sentry.sentry.io/dashboard/531980/) which tracks users hitting Seer
paywalls (`error.type:SeerError`). The `sentry.org` column was always empty
because the tag was never set. Going forward, new events will carry the org
slug.