### PR TITLE
ci(coverage): use informational-patch input instead of sed hack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,15 +179,12 @@ jobs:
         run: bun run test:isolated --coverage --coverage-reporter=lcov --coverage-dir=coverage-isolated
       - name: Merge Coverage Reports
         run: bun run script/merge-lcov.ts coverage/lcov.info coverage-isolated/lcov.info > coverage/merged.lcov
-      - name: Make coverage checks informational on release branches
-        if: github.event_name == 'push'
-        run: |
-          sed -i 's/informational: false/informational: true/' codecov.yml
       - name: Coverage Report
         uses: getsentry/codecov-action@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: ./coverage/merged.lcov
+          informational-patch: ${{ github.event_name == 'push' }}
 
   build-binary:
     name: Build Binary (${{ matrix.target }})

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,6 +6,3 @@ coverage:
     project:
       default:
         informational: true
-    patch:
-      default:
-        informational: false


### PR DESCRIPTION
Follow-up to #541. Replaces the `sed`-based `codecov.yml` patching with the new `informational-patch` action input from getsentry/codecov-action (merged in getsentry/codecov-action#54).

### Changes

- **`ci.yml`**: Remove the `sed` step, add `informational-patch: ${{ github.event_name == 'push' }}` to the codecov action
- **`codecov.yml`**: Remove the `patch.default.informational` section (no longer needed)

### Behavior (unchanged)

| Context | `codecov/project` | `codecov/patch` |
|---------|-------------------|-----------------|
| PR | informational | **blocking** |
| `main` / `release/**` push | informational | informational |