### PR TITLE
refactor(db): DRY up database layer with shared helpers and lint enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,26 +368,34 @@ if (result.success) {
 
 ### SQL Utilities
 
-Use the `upsert()` helper from `src/lib/db/utils.ts` to reduce SQL boilerplate:
+Use helpers from `src/lib/db/utils.ts` to reduce SQL boilerplate:
 
 ```typescript
-import { upsert, runUpsert } from "../db/utils.js";
+import { upsert, runUpsert, getMetadata, setMetadata, clearMetadata, touchCacheEntry } from "../db/utils.js";
 
-// Generate UPSERT statement
-const { sql, values } = upsert("table", { id: 1, name: "foo" }, ["id"]);
-db.query(sql).run(...values);
-
-// Or use convenience wrapper
+// UPSERT (insert or update on conflict)
 runUpsert(db, "table", { id: 1, name: "foo" }, ["id"]);
 
-// Exclude columns from update
+// With excludeFromUpdate (columns only set on INSERT)
 const { sql, values } = upsert(
   "users",
   { id: 1, name: "Bob", created_at: now },
   ["id"],
   { excludeFromUpdate: ["created_at"] }
 );
+db.query(sql).run(...values);
+
+// METADATA table helpers (for key-value config in the metadata table)
+const m = getMetadata(db, [KEY_A, KEY_B]);              // SELECT ... WHERE key IN (...)
+setMetadata(db, { [KEY_A]: "val1", [KEY_B]: "val2" });  // Batch upsert in transaction
+clearMetadata(db, [KEY_A, KEY_B]);                       // DELETE ... WHERE key IN (...)
+
+// Cache entry touch (update last_accessed timestamp)
+touchCacheEntry("dsn_cache", "directory", directoryPath);
 ```
+
+**Enforced by lint:** GritQL rules ban raw metadata queries, inline `last_accessed` UPDATEs,
+and manual `BEGIN`/`COMMIT`/`ROLLBACK` transactions outside `utils.ts` and `migration.ts`.
 
 ### Error Handling
 
@@ -460,15 +468,22 @@ entity-aware suggestions (e.g., "This looks like a span ID").
 - `trace/view.ts` — issue short ID → issue's trace redirect
 - `hex-id.ts` — entity-aware error hints in `validateHexId`/`validateSpanId`
 
-### Async Config Functions
+### DB and Config Function Signatures
 
-All config operations are async. Always await:
+Database operations in `src/lib/db/` are **synchronous** (SQLite is synchronous in Bun).
+Functions that only do SQLite work return values directly — no `async`/`await` needed:
 
 ```typescript
-const token = await getAuthToken();
-const isAuth = await isAuthenticated();
-await setAuthToken(token, expiresIn);
+const org = getDefaultOrganization();  // returns string | undefined
+const info = getUserInfo();            // returns UserInfo | undefined
+setDefaults("my-org", "my-project");   // returns void
+const token = getAuthToken();          // returns string | undefined
 ```
+
+Exceptions that ARE async (they do file I/O or network calls):
+- `clearAuth()` — awaits cache directory cleanup
+- `getCachedDetection()`, `getCachedProjectRoot()`, `setCachedProjectRoot()` — await `stat()` for mtime validation
+- `refreshToken()`, `performTokenRefresh()` — await HTTP calls
 
 ### Imports
 
@@ -831,6 +846,30 @@ mock.module("./some-module", () => ({
 
 <!-- lore:019cb950-9b7b-731a-9832-b7f6cfb6a6a2 -->
 * **Self-hosted OAuth device flow requires Sentry 26.1.0+ and SENTRY\_CLIENT\_ID**: Self-hosted OAuth device flow requires Sentry 26.1.0+ and both \`SENTRY\_URL\` and \`SENTRY\_CLIENT\_ID\` env vars. Users must create a public OAuth app in Settings → Developer Settings. The client ID is NOT optional for self-hosted. Fallback for older instances: \`sentry auth login --token\`. \`getSentryUrl()\` and \`getClientId()\` in \`src/lib/oauth.ts\` read lazily (not at module load) so URL parsing from arguments can set \`SENTRY\_URL\` after import.
+
+<!-- lore:019ce2be-39f1-7ad9-a4c5-4506b62f689c -->
+* **api-client.ts split into domain modules under src/lib/api/**: The original monolithic \`src/lib/api-client.ts\` (1,977 lines) was split into 12 focused domain modules under \`src/lib/api/\`: infrastructure.ts (shared helpers, types, raw requests), organizations.ts, projects.ts, teams.ts, repositories.ts, issues.ts, events.ts, traces.ts, logs.ts, seer.ts, trials.ts, users.ts. The original \`api-client.ts\` was converted to a ~100-line barrel re-export file preserving all existing import paths. The \`biome.jsonc\` override for \`noBarrelFile\` already includes \`api-client.ts\`. When adding new API functions, place them in the appropriate domain module under \`src/lib/api/\`, not in the barrel file.
+
+<!-- lore:019d0b69-1430-74f0-8e9a-426a5c7b321d -->
+* **Bun compiled binary sourcemap options and size impact**: Binary build (\`script/build.ts\`) uses two steps: (1) \`Bun.build()\` produces \`dist-bin/bin.js\` + \`.map\` with \`sourcemap: "linked"\` and minification. (2) \`Bun.build()\` with \`compile: true\` produces native binary — no sourcemap embedded. Bun's compiled binaries use \`/$bunfs/root/bin.js\` as the virtual path in stack traces. Sourcemap upload must use \`--url-prefix '/$bunfs/root/'\` so Sentry can match frames. The upload runs \`sentry-cli sourcemaps inject dist-bin/\` first (adds debug IDs), then uploads both JS and map. Bun's compile step strips comments (including \`//# debugId=\`), but debug ID matching still works via the injected runtime snippet + URL prefix matching. Size: +0.04 MB gzipped vs +2.30 MB for inline sourcemaps. Without \`SENTRY\_AUTH\_TOKEN\`, upload is skipped gracefully.
+
+<!-- lore:019cb8ea-c6f0-75d8-bda7-e32b4e217f92 -->
+* **CLI telemetry DSN is public write-only — safe to embed in install script**: The CLI's Sentry DSN (\`SENTRY\_CLI\_DSN\` in \`src/lib/constants.ts\`) is a public write-only ingest key already baked into every binary. Safe to hardcode in install scripts. Opt-out: \`SENTRY\_CLI\_NO\_TELEMETRY=1\`.
+
+<!-- lore:019c978a-18b5-7a0d-a55f-b72f7789bdac -->
+* **cli.sentry.dev is served from gh-pages branch via GitHub Pages**: \`cli.sentry.dev\` is served from gh-pages branch via GitHub Pages. Craft's gh-pages target runs \`git rm -r -f .\` before extracting docs — persist extra files via \`postReleaseCommand\` in \`.craft.yml\`. Install script supports \`--channel nightly\`, downloading from the \`nightly\` release tag directly. version.json is only used by upgrade/version-check flow.
+
+<!-- lore:019cbe93-19b8-7776-9705-20bbde226599 -->
+* **Nightly delta upgrade buildNightlyPatchGraph fetches ALL patch tags — O(N) HTTP calls**: Delta upgrade in \`src/lib/delta-upgrade.ts\` supports stable (GitHub Releases) and nightly (GHCR) channels. \`filterAndSortChainTags\` filters \`patch-\*\` tags by version range using \`Bun.semver.order()\`. GHCR uses \`fetchWithRetry\` (10s timeout + 1 retry; blobs 30s) with optional \`signal?: AbortSignal\` combined via \`AbortSignal.any()\`. \`isExternalAbort(error, signal)\` skips retries for external aborts — critical for background prefetch. Patches cached to \`~/.sentry/patch-cache/\` (file-based, 7-day TTL). \`loadCachedChain\` stitches patches for multi-hop offline upgrades.
+
+<!-- lore:2c3eb7ab-1341-4392-89fd-d81095cfe9c4 -->
+* **npm bundle requires Node.js >= 22 due to node:sqlite polyfill**: The npm package (dist/bin.cjs) requires Node.js >= 22 because the bun:sqlite polyfill uses \`node:sqlite\`. A runtime version guard in the esbuild banner catches this early. When writing esbuild banner strings in TS template literals, double-escape: \`\\\\\\\n\` in TS → \`\\\n\` in output → newline at runtime. Single \`\\\n\` produces a literal newline inside a JS string, causing SyntaxError.
+
+<!-- lore:019c972c-9f0f-75cd-9e24-9bdbb1ac03d6 -->
+* **Numeric issue ID resolution returns org:undefined despite API success**: Numeric issue ID resolution in \`resolveNumericIssue()\`: (1) try DSN/env/config for org, (2) if found use \`getIssueInOrg(org, id)\` with region routing, (3) else fall back to unscoped \`getIssue(id)\`, (4) extract org from \`issue.permalink\` via \`parseSentryUrl\` as final fallback. \`parseSentryUrl\` handles path-based (\`/organizations/{org}/...\`) and subdomain-style URLs. \`matchSubdomainOrg()\` filters region subdomains by requiring slug length > 2. Self-hosted uses path-based only.
+
+<!-- lore:019ce0bb-f35d-7380-b661-8dc56f9938cf -->
+* **Seer trial prompt uses middleware layering in bin.ts error handling chain**: Error recovery middlewares in \`bin.ts\` are layered: \`main() → executeWithAutoAuth() → executeWithSeerTrialPrompt() → runCommand()\`. Seer trial prompts (for \`no\_budget\`/\`not\_enabled\`) caught by inner wrapper; auth errors bubble to outer. Auth retry goes through full chain. Trial API: \`GET /api/0/customers/{org}/\` → \`productTrials\[]\` (prefer \`seerUsers\`, fallback \`seerAutofix\`). Start: \`PUT /api/0/customers/{org}/product-trial/\`. SaaS-only; self-hosted 404s gracefully. \`ai\_disabled\` excluded. \`startSeerTrial\` accepts \`category\` from trial object — don't hardcode.
 
 <!-- lore:019d0b16-977c-7e49-b06d-523b7782692f -->
 * **Sentry CLI fuzzy matching coverage map across subsystems**: Fuzzy matching exists in: (1) Stricli built-in Damerau-Levenshtein for subcommand/flag typos within known route groups, (2) custom \`fuzzyMatch()\` in \`complete.ts\` for dynamic tab-completion using Levenshtein+prefix+contains scoring, (3) custom \`levenshtein()\` in \`platforms.ts\` for platform name suggestions, (4) plural alias detection in \`app.ts\`, (5) \`resolveCommandPath()\` in \`introspect.ts\` uses \`fuzzyMatch()\` from \`fuzzy.ts\` for top-level and subcommand typos — covering both \`sentry \<typo>\` and \`sentry help \<typo>\`. Static shell tab-completion uses shell-native prefix matching (compgen/\`\_describe\`/fish \`-a\`).

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -3,7 +3,10 @@
   "extends": ["ultracite/core"],
   "plugins": [
     "./lint-rules/no-stdout-write-in-commands.grit",
-    "./lint-rules/no-process-stdout-in-commands.grit"
+    "./lint-rules/no-process-stdout-in-commands.grit",
+    "./lint-rules/no-raw-metadata-queries.grit",
+    "./lint-rules/no-manual-transactions.grit",
+    "./lint-rules/no-inline-touch-cache.grit"
   ],
   "files": {
     "includes": ["!docs", "!test/init-eval/templates"]
@@ -48,8 +51,13 @@
       }
     },
     {
-      // SQLite operations are sync but we keep async signatures for API compatibility
-      "includes": ["src/lib/db/**/*.ts"],
+      // A few DB modules still have genuinely async functions (stat() for mtime validation,
+      // clearResponseCache for auth cleanup). The useAwait rule is off for these specific files.
+      "includes": [
+        "src/lib/db/dsn-cache.ts",
+        "src/lib/db/project-root-cache.ts",
+        "src/lib/db/auth.ts"
+      ],
       "linter": {
         "rules": {
           "suspicious": {

--- a/lint-rules/no-inline-touch-cache.grit
+++ b/lint-rules/no-inline-touch-cache.grit
@@ -1,0 +1,7 @@
+file($name, $body) where {
+  $name <: not r".*utils\.ts$",
+  $body <: contains `$db.query($sql).run($args)` as $match where {
+    $sql <: r".*UPDATE .* SET last_accessed.*"
+  },
+  register_diagnostic(span=$match, message="Use touchCacheEntry() from db/utils.js instead of inline last_accessed UPDATE.")
+}

--- a/lint-rules/no-manual-transactions.grit
+++ b/lint-rules/no-manual-transactions.grit
@@ -1,0 +1,12 @@
+file($name, $body) where {
+  $name <: not r".*migration\.ts$",
+  $name <: not r".*node-polyfills\.ts$",
+  $body <: contains `$db.exec($sql)` as $match where {
+    $sql <: or {
+      r".*BEGIN.*",
+      r".*COMMIT.*",
+      r".*ROLLBACK.*"
+    }
+  },
+  register_diagnostic(span=$match, message="Use db.transaction()() instead of manual BEGIN/COMMIT/ROLLBACK.")
+}

--- a/lint-rules/no-raw-metadata-queries.grit
+++ b/lint-rules/no-raw-metadata-queries.grit
@@ -1,0 +1,14 @@
+file($name, $body) where {
+  $name <: not r".*utils\.ts$",
+  $name <: not r".*migration\.ts$",
+  $body <: contains or {
+    `$db.query($sql)` as $match where {
+      $sql <: or {
+        r".*SELECT value FROM metadata.*",
+        r".*DELETE FROM metadata.*"
+      }
+    },
+    `runUpsert($db, "metadata", $data, $keys)` as $match
+  },
+  register_diagnostic(span=$match, message="Use getMetadata/setMetadata/clearMetadata from db/utils.js instead of raw metadata queries.")
+}

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -39,7 +39,7 @@ async function runCompletion(completionArgs: string[]): Promise<void> {
   // Disable telemetry so db/index.ts skips the @sentry/node-core lazy-require (~280ms)
   process.env.SENTRY_CLI_NO_TELEMETRY = "1";
   const { handleComplete } = await import("./lib/complete.js");
-  await handleComplete(completionArgs);
+  handleComplete(completionArgs);
 }
 
 /**

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -139,7 +139,7 @@ export const loginCommand = buildCommand({
   output: { human: formatLoginResult },
   async *func(this: SentryContext, flags: LoginFlags) {
     // Check if already authenticated and handle re-authentication
-    if (await isAuthenticated()) {
+    if (isAuthenticated()) {
       const shouldProceed = await handleExistingAuth(flags.force);
       if (!shouldProceed) {
         return;

--- a/src/commands/auth/logout.ts
+++ b/src/commands/auth/logout.ts
@@ -38,7 +38,7 @@ export const logoutCommand = buildCommand({
     flags: {},
   },
   async *func(this: SentryContext) {
-    if (!(await isAuthenticated())) {
+    if (!isAuthenticated()) {
       return yield new CommandOutput({
         loggedOut: false,
         message: "Not currently authenticated.",

--- a/src/commands/auth/status.ts
+++ b/src/commands/auth/status.ts
@@ -104,9 +104,9 @@ function collectTokenInfo(
 /**
  * Collect default org/project into the data structure.
  */
-async function collectDefaults(): Promise<AuthStatusData["defaults"]> {
-  const org = await getDefaultOrganization();
-  const project = await getDefaultProject();
+function collectDefaults(): AuthStatusData["defaults"] {
+  const org = getDefaultOrganization();
+  const project = getDefaultProject();
 
   if (!(org || project)) {
     return;
@@ -160,7 +160,7 @@ export const statusCommand = buildCommand({
     applyFreshFlag(flags);
 
     const auth = getAuthConfig();
-    const authenticated = await isAuthenticated();
+    const authenticated = isAuthenticated();
     const fromEnv = auth ? isEnvSource(auth.source) : false;
 
     if (!authenticated) {
@@ -186,7 +186,7 @@ export const statusCommand = buildCommand({
       configPath: fromEnv ? undefined : getDbPath(),
       user,
       token: collectTokenInfo(auth, flags["show-token"]),
-      defaults: await collectDefaults(),
+      defaults: collectDefaults(),
       verification: await verifyCredentials(),
     };
 

--- a/src/commands/auth/whoami.ts
+++ b/src/commands/auth/whoami.ts
@@ -46,7 +46,7 @@ export const whoamiCommand = buildCommand({
   async *func(this: SentryContext, flags: WhoamiFlags) {
     applyFreshFlag(flags);
 
-    if (!(await isAuthenticated())) {
+    if (!isAuthenticated()) {
       throw new AuthError("not_authenticated");
     }
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -43,12 +43,13 @@ export const helpCommand = buildCommand({
     },
   },
   // biome-ignore lint/complexity/noBannedTypes: Stricli requires empty object for commands with no flags
+  // biome-ignore lint/suspicious/useAwait: async generator required by Stricli buildCommand pattern
   async *func(this: SentryContext, _flags: {}, ...commandPath: string[]) {
     if (commandPath.length === 0) {
       // Yield the full command tree. Attach the branded banner for human display;
       // jsonExclude strips _banner from JSON output.
       const tree = introspectAllCommands();
-      const banner = await printCustomHelp();
+      const banner = printCustomHelp();
       return yield new CommandOutput({ ...tree, _banner: banner });
     }
 

--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -1280,9 +1280,9 @@ async function handleResolvedTargets(
 
   if (isMultiProject) {
     const fingerprint = createDsnFingerprint(detectedDsns ?? []);
-    await setProjectAliases(entries, fingerprint);
+    setProjectAliases(entries, fingerprint);
   } else {
-    await clearProjectAliases();
+    clearProjectAliases();
   }
 
   const allIssuesWithOptions = attachFormatOptions(

--- a/src/commands/issue/utils.ts
+++ b/src/commands/issue/utils.ts
@@ -131,7 +131,7 @@ async function tryResolveFromAlias(
   // Detect DSNs to get fingerprint for validation
   const detection = await detectAllDsns(cwd);
   const fingerprint = detection.fingerprint;
-  const projectEntry = await getProjectByAlias(alias, fingerprint);
+  const projectEntry = getProjectByAlias(alias, fingerprint);
   if (!projectEntry) {
     return null;
   }

--- a/src/commands/org/list.ts
+++ b/src/commands/org/list.ts
@@ -141,7 +141,7 @@ export const listCommand = buildCommand({
     const limitedOrgs = orgs.slice(0, flags.limit);
 
     // Check if user has orgs in multiple regions
-    const orgRegions = await getAllOrgRegions();
+    const orgRegions = getAllOrgRegions();
     const uniqueRegions = new Set(orgRegions.values());
     const showRegion = uniqueRegions.size > 1;
 

--- a/src/commands/project/delete.ts
+++ b/src/commands/project/delete.ts
@@ -104,7 +104,7 @@ async function buildPermissionError(
   // Try the org cache first (populated by listOrganizations), then fall back
   // to a fresh API call. The cache avoids an extra HTTP round-trip when the
   // org listing has already been fetched during this session.
-  let orgRole = await getCachedOrgRole(orgSlug);
+  let orgRole = getCachedOrgRole(orgSlug);
   if (!orgRole) {
     try {
       const org = await getOrganization(orgSlug);

--- a/src/commands/project/list.ts
+++ b/src/commands/project/list.ts
@@ -203,7 +203,7 @@ type OrgResolution = {
  */
 async function resolveOrgsForAutoDetect(cwd: string): Promise<OrgResolution> {
   // 1. Check config defaults
-  const defaultOrg = await getDefaultOrganization();
+  const defaultOrg = getDefaultOrganization();
   if (defaultOrg) {
     return { orgs: [defaultOrg] };
   }

--- a/src/lib/api/organizations.ts
+++ b/src/lib/api/organizations.ts
@@ -109,7 +109,7 @@ export async function listOrganizationsInRegion(
 export async function listOrganizations(): Promise<SentryOrganization[]> {
   const { getCachedOrganizations } = await import("../db/regions.js");
 
-  const cached = await getCachedOrganizations();
+  const cached = getCachedOrganizations();
   if (cached.length > 0) {
     return cached.map((org) => ({
       id: org.id,
@@ -145,7 +145,7 @@ export async function listOrganizationsUncached(): Promise<
     // Fall back to default API for self-hosted instances
     const orgs = await listOrganizationsInRegion(getApiBaseUrl());
     const baseUrl = getApiBaseUrl();
-    await setOrgRegions(
+    setOrgRegions(
       orgs.map((org) => ({
         slug: org.slug,
         regionUrl: baseUrl,
@@ -203,7 +203,7 @@ export async function listOrganizationsUncached(): Promise<
     orgName: r.org.name,
     orgRole: (r.org as Record<string, unknown>).orgRole as string | undefined,
   }));
-  await setOrgRegions(regionEntries);
+  setOrgRegions(regionEntries);
 
   return orgs;
 }

--- a/src/lib/api/projects.ts
+++ b/src/lib/api/projects.ts
@@ -86,7 +86,7 @@ export async function listProjects(orgSlug: string): Promise<SentryProject[]> {
   // Populate project cache for shell completions (best-effort).
   // Mirrors how listOrganizations() calls setOrgRegions().
   try {
-    const orgs = await getCachedOrganizations();
+    const orgs = getCachedOrganizations();
     const orgName = orgs.find((o) => o.slug === orgSlug)?.name ?? orgSlug;
     cacheProjectsForOrg(orgSlug, orgName, allResults);
   } catch {

--- a/src/lib/complete.ts
+++ b/src/lib/complete.ts
@@ -39,7 +39,7 @@ type Completion = {
  *
  * @param args - The words after `__complete` (COMP_WORDS[1:] from the shell)
  */
-export async function handleComplete(args: string[]): Promise<void> {
+export function handleComplete(args: string[]): void {
   const startMs = performance.now();
 
   // The last word is the partial being completed (may be empty)
@@ -50,7 +50,7 @@ export async function handleComplete(args: string[]): Promise<void> {
   let completions: Completion[];
 
   try {
-    completions = await getCompletions(precedingWords, partial);
+    completions = getCompletions(precedingWords, partial);
   } catch {
     // Graceful degradation — if DB fails, return no completions
     completions = [];
@@ -129,10 +129,10 @@ export const ORG_ONLY_COMMANDS = new Set([
  * @param precedingWords - Words before the partial (determines context)
  * @param partial - The current partial word being completed
  */
-export async function getCompletions(
+export function getCompletions(
   precedingWords: string[],
   partial: string
-): Promise<Completion[]> {
+): Completion[] {
   // Build the command path from preceding words (e.g., "issue list")
   const cmdPath =
     precedingWords.length >= 2
@@ -140,11 +140,11 @@ export async function getCompletions(
       : "";
 
   if (ORG_PROJECT_COMMANDS.has(cmdPath)) {
-    return await completeOrgSlashProject(partial);
+    return completeOrgSlashProject(partial);
   }
 
   if (ORG_ONLY_COMMANDS.has(cmdPath)) {
-    return await completeOrgSlugs(partial);
+    return completeOrgSlugs(partial);
   }
 
   // Not a known command path — no dynamic completions
@@ -161,11 +161,8 @@ export async function getCompletions(
  * @param suffix - Appended to each slug (e.g., "/" for org/project mode)
  * @returns Completions with org names as descriptions
  */
-export async function completeOrgSlugs(
-  partial: string,
-  suffix = ""
-): Promise<Completion[]> {
-  const orgs = await getCachedOrganizations();
+export function completeOrgSlugs(partial: string, suffix = ""): Completion[] {
+  const orgs = getCachedOrganizations();
   if (orgs.length === 0) {
     return [];
   }
@@ -191,17 +188,13 @@ export async function completeOrgSlugs(
  * @param partial - The partial input (e.g., "", "sen", "sentry/", "sentry/cl")
  * @returns Completions for org or org/project values
  */
-export async function completeOrgSlashProject(
-  partial: string
-): Promise<Completion[]> {
+export function completeOrgSlashProject(partial: string): Completion[] {
   const slashIdx = partial.indexOf("/");
 
   if (slashIdx === -1) {
     // No slash — suggest org slugs (with trailing slash) + aliases
-    const [orgCompletions, aliasCompletions] = await Promise.all([
-      completeOrgSlugsWithSlash(partial),
-      completeAliases(partial),
-    ]);
+    const orgCompletions = completeOrgSlugsWithSlash(partial);
+    const aliasCompletions = completeAliases(partial);
     return [...orgCompletions, ...aliasCompletions];
   }
 
@@ -215,7 +208,7 @@ export async function completeOrgSlashProject(
     return [];
   }
 
-  const resolvedOrg = await fuzzyResolveOrg(orgPart);
+  const resolvedOrg = fuzzyResolveOrg(orgPart);
   if (!resolvedOrg) {
     return [];
   }
@@ -229,7 +222,7 @@ export async function completeOrgSlashProject(
  * When the user types `sentry issue list sen<TAB>`, we want to suggest
  * `sentry/` so they can continue typing the project name.
  */
-function completeOrgSlugsWithSlash(partial: string): Promise<Completion[]> {
+function completeOrgSlugsWithSlash(partial: string): Completion[] {
   return completeOrgSlugs(partial, "/");
 }
 
@@ -244,11 +237,11 @@ function completeOrgSlugsWithSlash(partial: string): Promise<Completion[]> {
  * @param projectPartial - Partial project slug to match
  * @param orgSlug - The org to find projects for
  */
-export async function completeProjectSlugs(
+export function completeProjectSlugs(
   projectPartial: string,
   orgSlug: string
-): Promise<Completion[]> {
-  const projects = await getCachedProjectsForOrg(orgSlug);
+): Completion[] {
+  const projects = getCachedProjectsForOrg(orgSlug);
 
   if (projects.length === 0) {
     return [];
@@ -273,8 +266,8 @@ export async function completeProjectSlugs(
  * @param orgPart - The potentially misspelled org slug
  * @returns The resolved org slug, or undefined if no match
  */
-async function fuzzyResolveOrg(orgPart: string): Promise<string | undefined> {
-  const orgs = await getCachedOrganizations();
+function fuzzyResolveOrg(orgPart: string): string | undefined {
+  const orgs = getCachedOrganizations();
   if (orgs.length === 0) {
     return;
   }
@@ -290,8 +283,8 @@ async function fuzzyResolveOrg(orgPart: string): Promise<string | undefined> {
  * Aliases are short identifiers that resolve to org/project pairs.
  * They are shown alongside org slug completions.
  */
-export async function completeAliases(partial: string): Promise<Completion[]> {
-  const aliases = await getProjectAliases();
+export function completeAliases(partial: string): Completion[] {
+  const aliases = getProjectAliases();
   if (!aliases) {
     return [];
   }

--- a/src/lib/db/auth.ts
+++ b/src/lib/db/auth.ts
@@ -173,8 +173,8 @@ export async function clearAuth(): Promise<void> {
   }
 }
 
-export async function isAuthenticated(): Promise<boolean> {
-  const token = await getAuthToken();
+export function isAuthenticated(): boolean {
+  const token = getAuthToken();
   return !!token;
 }
 

--- a/src/lib/db/defaults.ts
+++ b/src/lib/db/defaults.ts
@@ -11,7 +11,7 @@ type DefaultsRow = {
   updated_at: number;
 };
 
-export async function getDefaultOrganization(): Promise<string | undefined> {
+export function getDefaultOrganization(): string | undefined {
   const db = getDatabase();
   const row = db
     .query("SELECT organization FROM defaults WHERE id = 1")
@@ -20,7 +20,7 @@ export async function getDefaultOrganization(): Promise<string | undefined> {
   return row?.organization ?? undefined;
 }
 
-export async function getDefaultProject(): Promise<string | undefined> {
+export function getDefaultProject(): string | undefined {
   const db = getDatabase();
   const row = db.query("SELECT project FROM defaults WHERE id = 1").get() as
     | Pick<DefaultsRow, "project">
@@ -35,10 +35,10 @@ export async function getDefaultProject(): Promise<string | undefined> {
  * @param organization - undefined = keep existing, null = clear, string = set new value
  * @param project - undefined = keep existing, null = clear, string = set new value
  */
-export async function setDefaults(
+export function setDefaults(
   organization?: string | null,
   project?: string | null
-): Promise<void> {
+): void {
   const db = getDatabase();
   const now = Date.now();
 

--- a/src/lib/db/dsn-cache.ts
+++ b/src/lib/db/dsn-cache.ts
@@ -14,7 +14,7 @@ import type {
   ResolvedProjectInfo,
 } from "../dsn/types.js";
 import { getDatabase, maybeCleanupCaches } from "./index.js";
-import { runUpsert } from "./utils.js";
+import { runUpsert, touchCacheEntry } from "./utils.js";
 
 /** Cache TTL in milliseconds (24 hours) */
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
@@ -129,17 +129,7 @@ function rowToCachedDsnEntry(row: DsnCacheRow): CachedDsnEntry {
   return entry;
 }
 
-function touchCacheEntry(directory: string): void {
-  const db = getDatabase();
-  db.query("UPDATE dsn_cache SET last_accessed = ? WHERE directory = ?").run(
-    Date.now(),
-    directory
-  );
-}
-
-export async function getCachedDsn(
-  directory: string
-): Promise<CachedDsnEntry | undefined> {
+export function getCachedDsn(directory: string): CachedDsnEntry | undefined {
   if (dsnCacheDisabled) {
     return;
   }
@@ -154,14 +144,14 @@ export async function getCachedDsn(
     return;
   }
 
-  touchCacheEntry(directory);
+  touchCacheEntry("dsn_cache", "directory", directory);
   return rowToCachedDsnEntry(row);
 }
 
-export async function setCachedDsn(
+export function setCachedDsn(
   directory: string,
   entry: Omit<CachedDsnEntry, "cachedAt">
-): Promise<void> {
+): void {
   const db = getDatabase();
   const now = Date.now();
 
@@ -193,10 +183,10 @@ export async function setCachedDsn(
 }
 
 /** Update resolved org/project info after API resolution. */
-export async function updateCachedResolution(
+export function updateCachedResolution(
   directory: string,
   resolved: ResolvedProjectInfo
-): Promise<void> {
+): void {
   const db = getDatabase();
 
   const exists = db
@@ -224,7 +214,7 @@ export async function updateCachedResolution(
   );
 }
 
-export async function clearDsnCache(directory?: string): Promise<void> {
+export function clearDsnCache(directory?: string): void {
   const db = getDatabase();
 
   if (directory) {
@@ -383,7 +373,7 @@ export async function getCachedDetection(
   }
 
   // Cache is valid - update last access time
-  touchCacheEntry(projectRoot);
+  touchCacheEntry("dsn_cache", "directory", projectRoot);
 
   // Parse and return cached detection
   const allDsns = JSON.parse(row.all_dsns_json) as DetectedDsn[];
@@ -407,10 +397,10 @@ export async function getCachedDetection(
  * @param projectRoot - Project root directory
  * @param entry - Detection result to cache
  */
-export async function setCachedDetection(
+export function setCachedDetection(
   projectRoot: string,
   entry: DetectionCacheEntry
-): Promise<void> {
+): void {
   const db = getDatabase();
   const now = Date.now();
 

--- a/src/lib/db/install-info.ts
+++ b/src/lib/db/install-info.ts
@@ -8,12 +8,14 @@
 
 import type { InstallationMethod } from "../upgrade.js";
 import { getDatabase } from "./index.js";
-import { runUpsert } from "./utils.js";
+import { clearMetadata, getMetadata, setMetadata } from "./utils.js";
 
 const KEY_METHOD = "install.method";
 const KEY_PATH = "install.path";
 const KEY_VERSION = "install.version";
 const KEY_RECORDED_AT = "install.recorded_at";
+
+const ALL_KEYS = [KEY_METHOD, KEY_PATH, KEY_VERSION, KEY_RECORDED_AT];
 
 export type StoredInstallInfo = {
   /** How the CLI was installed */
@@ -33,33 +35,18 @@ export type StoredInstallInfo = {
  */
 export function getInstallInfo(): StoredInstallInfo | null {
   const db = getDatabase();
+  const m = getMetadata(db, ALL_KEYS);
 
-  const methodRow = db
-    .query("SELECT value FROM metadata WHERE key = ?")
-    .get(KEY_METHOD) as { value: string } | undefined;
-
-  // If no method is stored, we have no install info
-  if (!methodRow) {
+  const method = m.get(KEY_METHOD);
+  if (!method) {
     return null;
   }
 
-  const pathRow = db
-    .query("SELECT value FROM metadata WHERE key = ?")
-    .get(KEY_PATH) as { value: string } | undefined;
-
-  const versionRow = db
-    .query("SELECT value FROM metadata WHERE key = ?")
-    .get(KEY_VERSION) as { value: string } | undefined;
-
-  const recordedAtRow = db
-    .query("SELECT value FROM metadata WHERE key = ?")
-    .get(KEY_RECORDED_AT) as { value: string } | undefined;
-
   return {
-    method: methodRow.value as InstallationMethod,
-    path: pathRow?.value ?? "",
-    version: versionRow?.value ?? "",
-    recordedAt: recordedAtRow ? Number(recordedAtRow.value) : 0,
+    method: method as InstallationMethod,
+    path: m.get(KEY_PATH) ?? "",
+    version: m.get(KEY_VERSION) ?? "",
+    recordedAt: m.has(KEY_RECORDED_AT) ? Number(m.get(KEY_RECORDED_AT)) : 0,
   };
 }
 
@@ -72,14 +59,12 @@ export function setInstallInfo(
   info: Omit<StoredInstallInfo, "recordedAt">
 ): void {
   const db = getDatabase();
-  const now = Date.now();
-
-  runUpsert(db, "metadata", { key: KEY_METHOD, value: info.method }, ["key"]);
-  runUpsert(db, "metadata", { key: KEY_PATH, value: info.path }, ["key"]);
-  runUpsert(db, "metadata", { key: KEY_VERSION, value: info.version }, ["key"]);
-  runUpsert(db, "metadata", { key: KEY_RECORDED_AT, value: String(now) }, [
-    "key",
-  ]);
+  setMetadata(db, {
+    [KEY_METHOD]: info.method,
+    [KEY_PATH]: info.path,
+    [KEY_VERSION]: info.version,
+    [KEY_RECORDED_AT]: String(Date.now()),
+  });
 }
 
 /**
@@ -88,9 +73,5 @@ export function setInstallInfo(
  */
 export function clearInstallInfo(): void {
   const db = getDatabase();
-
-  db.query("DELETE FROM metadata WHERE key = ?").run(KEY_METHOD);
-  db.query("DELETE FROM metadata WHERE key = ?").run(KEY_PATH);
-  db.query("DELETE FROM metadata WHERE key = ?").run(KEY_VERSION);
-  db.query("DELETE FROM metadata WHERE key = ?").run(KEY_RECORDED_AT);
+  clearMetadata(db, ALL_KEYS);
 }

--- a/src/lib/db/project-aliases.ts
+++ b/src/lib/db/project-aliases.ts
@@ -4,6 +4,7 @@
 
 import type { ProjectAliasEntry } from "../../types/index.js";
 import { getDatabase, maybeCleanupCaches } from "./index.js";
+import { touchCacheEntry } from "./utils.js";
 
 type ProjectAliasRow = {
   alias: string;
@@ -16,20 +17,19 @@ type ProjectAliasRow = {
 
 function touchAliasEntries(): void {
   const db = getDatabase();
+  // biome-ignore lint/plugin: global touch — updates ALL rows, not a single keyed entry
   db.query("UPDATE project_aliases SET last_accessed = ?").run(Date.now());
 }
 
 /** Set project aliases, replacing all existing ones. */
-export async function setProjectAliases(
+export function setProjectAliases(
   aliases: Record<string, ProjectAliasEntry>,
   dsnFingerprint?: string
-): Promise<void> {
+): void {
   const db = getDatabase();
   const now = Date.now();
 
-  db.exec("BEGIN TRANSACTION");
-
-  try {
+  db.transaction(() => {
     db.query("DELETE FROM project_aliases").run();
 
     const insertStmt = db.query(`
@@ -48,19 +48,14 @@ export async function setProjectAliases(
         now
       );
     }
-
-    db.exec("COMMIT");
-  } catch (error) {
-    db.exec("ROLLBACK");
-    throw error;
-  }
+  })();
 
   maybeCleanupCaches();
 }
 
-export async function getProjectAliases(): Promise<
-  Record<string, ProjectAliasEntry> | undefined
-> {
+export function getProjectAliases():
+  | Record<string, ProjectAliasEntry>
+  | undefined {
   const db = getDatabase();
 
   const rows = db
@@ -85,10 +80,10 @@ export async function getProjectAliases(): Promise<
 }
 
 /** Get project by alias. Validates DSN fingerprint if both current and cached are present. */
-export async function getProjectByAlias(
+export function getProjectByAlias(
   alias: string,
   currentFingerprint?: string
-): Promise<ProjectAliasEntry | undefined> {
+): ProjectAliasEntry | undefined {
   const db = getDatabase();
 
   const row = db
@@ -108,10 +103,7 @@ export async function getProjectByAlias(
     return;
   }
 
-  db.query("UPDATE project_aliases SET last_accessed = ? WHERE alias = ?").run(
-    Date.now(),
-    alias.toLowerCase()
-  );
+  touchCacheEntry("project_aliases", "alias", alias.toLowerCase());
 
   return {
     orgSlug: row.org_slug,
@@ -119,7 +111,7 @@ export async function getProjectByAlias(
   };
 }
 
-export async function clearProjectAliases(): Promise<void> {
+export function clearProjectAliases(): void {
   const db = getDatabase();
   db.query("DELETE FROM project_aliases").run();
 }

--- a/src/lib/db/project-cache.ts
+++ b/src/lib/db/project-cache.ts
@@ -4,7 +4,7 @@
 
 import type { CachedProject } from "../../types/index.js";
 import { getDatabase, maybeCleanupCaches } from "./index.js";
-import { runUpsert } from "./utils.js";
+import { runUpsert, touchCacheEntry } from "./utils.js";
 
 type ProjectCacheRow = {
   cache_key: string;
@@ -36,20 +36,9 @@ function rowToCachedProject(row: ProjectCacheRow): CachedProject {
   };
 }
 
-function touchCacheEntry(cacheKey: string): void {
+/** Shared get implementation — looks up by pre-computed cache key. */
+function getByKey(key: string): CachedProject | undefined {
   const db = getDatabase();
-  db.query(
-    "UPDATE project_cache SET last_accessed = ? WHERE cache_key = ?"
-  ).run(Date.now(), cacheKey);
-}
-
-export async function getCachedProject(
-  orgId: string,
-  projectId: string
-): Promise<CachedProject | undefined> {
-  const db = getDatabase();
-  const key = projectCacheKey(orgId, projectId);
-
   const row = db
     .query("SELECT * FROM project_cache WHERE cache_key = ?")
     .get(key) as ProjectCacheRow | undefined;
@@ -58,83 +47,62 @@ export async function getCachedProject(
     return;
   }
 
-  touchCacheEntry(key);
+  touchCacheEntry("project_cache", "cache_key", key);
   return rowToCachedProject(row);
 }
 
-export async function setCachedProject(
+/** Shared set implementation — writes by pre-computed cache key. */
+function setByKey(key: string, info: Omit<CachedProject, "cachedAt">): void {
+  const db = getDatabase();
+  const now = Date.now();
+
+  runUpsert(
+    db,
+    "project_cache",
+    {
+      cache_key: key,
+      org_slug: info.orgSlug,
+      org_name: info.orgName,
+      project_slug: info.projectSlug,
+      project_name: info.projectName,
+      project_id: info.projectId ?? null,
+      cached_at: now,
+      last_accessed: now,
+    },
+    ["cache_key"]
+  );
+
+  maybeCleanupCaches();
+}
+
+export function getCachedProject(
+  orgId: string,
+  projectId: string
+): CachedProject | undefined {
+  return getByKey(projectCacheKey(orgId, projectId));
+}
+
+export function setCachedProject(
   orgId: string,
   projectId: string,
   info: Omit<CachedProject, "cachedAt">
-): Promise<void> {
-  const db = getDatabase();
-  const key = projectCacheKey(orgId, projectId);
-  const now = Date.now();
-
-  runUpsert(
-    db,
-    "project_cache",
-    {
-      cache_key: key,
-      org_slug: info.orgSlug,
-      org_name: info.orgName,
-      project_slug: info.projectSlug,
-      project_name: info.projectName,
-      project_id: info.projectId ?? null,
-      cached_at: now,
-      last_accessed: now,
-    },
-    ["cache_key"]
-  );
-
-  maybeCleanupCaches();
+): void {
+  setByKey(projectCacheKey(orgId, projectId), info);
 }
 
 /** Get cached project by DSN public key (for self-hosted or SaaS DSNs without org ID). */
-export async function getCachedProjectByDsnKey(
+export function getCachedProjectByDsnKey(
   publicKey: string
-): Promise<CachedProject | undefined> {
-  const db = getDatabase();
-  const key = dsnCacheKey(publicKey);
-
-  const row = db
-    .query("SELECT * FROM project_cache WHERE cache_key = ?")
-    .get(key) as ProjectCacheRow | undefined;
-
-  if (!row) {
-    return;
-  }
-
-  touchCacheEntry(key);
-  return rowToCachedProject(row);
+): CachedProject | undefined {
+  return getByKey(dsnCacheKey(publicKey));
 }
 
 /** Cache project by DSN public key (for self-hosted or SaaS DSNs without org ID). */
-export async function setCachedProjectByDsnKey(
+export function setCachedProjectByDsnKey(
   publicKey: string,
   info: Omit<CachedProject, "cachedAt">
-): Promise<void> {
-  const db = getDatabase();
-  const key = dsnCacheKey(publicKey);
-  const now = Date.now();
-
-  runUpsert(
-    db,
-    "project_cache",
-    {
-      cache_key: key,
-      org_slug: info.orgSlug,
-      org_name: info.orgName,
-      project_slug: info.projectSlug,
-      project_name: info.projectName,
-      project_id: info.projectId ?? null,
-      cached_at: now,
-      last_accessed: now,
-    },
-    ["cache_key"]
-  );
-
-  maybeCleanupCaches();
+): void {
+  setByKey(dsnCacheKey(publicKey), info);
 }
 
 /**
@@ -145,9 +113,9 @@ export async function setCachedProjectByDsnKey(
  *
  * @param orgSlug - The organization slug to filter by
  */
-export async function getCachedProjectsForOrg(
+export function getCachedProjectsForOrg(
   orgSlug: string
-): Promise<{ projectSlug: string; projectName: string }[]> {
+): { projectSlug: string; projectName: string }[] {
   const db = getDatabase();
   // Use MAX(cached_at) to deterministically pick the most recently cached
   // project_name when the same project appears under different cache keys
@@ -212,7 +180,7 @@ export function cacheProjectsForOrg(
   maybeCleanupCaches();
 }
 
-export async function clearProjectCache(): Promise<void> {
+export function clearProjectCache(): void {
   const db = getDatabase();
   db.query("DELETE FROM project_cache").run();
 }

--- a/src/lib/db/regions.ts
+++ b/src/lib/db/regions.ts
@@ -53,9 +53,7 @@ export type OrgRegionEntry = {
  * @param orgSlug - The organization slug
  * @returns The region URL if cached, undefined otherwise
  */
-export async function getOrgRegion(
-  orgSlug: string
-): Promise<string | undefined> {
+export function getOrgRegion(orgSlug: string): string | undefined {
   const db = getDatabase();
   const row = db
     .query(`SELECT region_url FROM ${TABLE} WHERE org_slug = ?`)
@@ -73,9 +71,9 @@ export async function getOrgRegion(
  * @param numericId - The bare numeric org ID (without "o" prefix)
  * @returns The org slug and region URL if found, undefined otherwise
  */
-export async function getOrgByNumericId(
+export function getOrgByNumericId(
   numericId: string
-): Promise<{ slug: string; regionUrl: string } | undefined> {
+): { slug: string; regionUrl: string } | undefined {
   const db = getDatabase();
   const row = db
     .query(`SELECT org_slug, region_url FROM ${TABLE} WHERE org_id = ?`)
@@ -95,10 +93,7 @@ export async function getOrgByNumericId(
  * @param orgSlug - The organization slug
  * @param regionUrl - The region URL (e.g., https://us.sentry.io)
  */
-export async function setOrgRegion(
-  orgSlug: string,
-  regionUrl: string
-): Promise<void> {
+export function setOrgRegion(orgSlug: string, regionUrl: string): void {
   const db = getDatabase();
   const now = Date.now();
 
@@ -119,7 +114,7 @@ export async function setOrgRegion(
  *
  * @param entries - Array of org region entries
  */
-export async function setOrgRegions(entries: OrgRegionEntry[]): Promise<void> {
+export function setOrgRegions(entries: OrgRegionEntry[]): void {
   if (entries.length === 0) {
     return;
   }
@@ -152,7 +147,7 @@ export async function setOrgRegions(entries: OrgRegionEntry[]): Promise<void> {
  * Clear all cached organization regions.
  * Should be called when the user logs out.
  */
-export async function clearOrgRegions(): Promise<void> {
+export function clearOrgRegions(): void {
   const db = getDatabase();
   db.query(`DELETE FROM ${TABLE}`).run();
 }
@@ -163,7 +158,7 @@ export async function clearOrgRegions(): Promise<void> {
  *
  * @returns Map of org slug to region URL
  */
-export async function getAllOrgRegions(): Promise<Map<string, string>> {
+export function getAllOrgRegions(): Map<string, string> {
   const db = getDatabase();
   const rows = db
     .query(`SELECT org_slug, region_url FROM ${TABLE}`)
@@ -202,7 +197,7 @@ const ORG_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
  *
  * @returns Array of cached org entries, or empty if cache is cold/stale/disabled/incomplete
  */
-export async function getCachedOrganizations(): Promise<CachedOrg[]> {
+export function getCachedOrganizations(): CachedOrg[] {
   if (orgCacheDisabled) {
     return [];
   }
@@ -236,9 +231,7 @@ export async function getCachedOrganizations(): Promise<CachedOrg[]> {
  * @param orgSlug - The organization slug
  * @returns The user's role (e.g., "member", "admin", "owner"), or undefined if not cached
  */
-export async function getCachedOrgRole(
-  orgSlug: string
-): Promise<string | undefined> {
+export function getCachedOrgRole(orgSlug: string): string | undefined {
   const db = getDatabase();
   const cutoff = Date.now() - ORG_CACHE_TTL_MS;
   const row = db

--- a/src/lib/db/release-channel.ts
+++ b/src/lib/db/release-channel.ts
@@ -10,7 +10,7 @@
  */
 
 import { getDatabase } from "./index.js";
-import { runUpsert } from "./utils.js";
+import { getMetadata, setMetadata } from "./utils.js";
 import { clearVersionCheckCache } from "./version-check.js";
 
 const KEY = "release_channel";
@@ -25,11 +25,9 @@ export type ReleaseChannel = "stable" | "nightly";
  */
 export function getReleaseChannel(): ReleaseChannel {
   const db = getDatabase();
-  const row = db.query("SELECT value FROM metadata WHERE key = ?").get(KEY) as
-    | { value: string }
-    | undefined;
+  const m = getMetadata(db, [KEY]);
 
-  if (row?.value === "nightly") {
+  if (m.get(KEY) === "nightly") {
     return "nightly";
   }
   return "stable";
@@ -47,7 +45,7 @@ export function getReleaseChannel(): ReleaseChannel {
 export function setReleaseChannel(channel: ReleaseChannel): void {
   const db = getDatabase();
   const current = getReleaseChannel();
-  runUpsert(db, "metadata", { key: KEY, value: channel }, ["key"]);
+  setMetadata(db, { [KEY]: channel });
   if (channel !== current) {
     clearVersionCheckCache();
   }

--- a/src/lib/db/utils.ts
+++ b/src/lib/db/utils.ts
@@ -5,6 +5,8 @@
 
 import type { SQLQueryBindings } from "bun:sqlite";
 
+import { getDatabase } from "./index.js";
+
 /** Valid SQLite binding value (matches bun:sqlite's SQLQueryBindings) */
 export type SqlValue = SQLQueryBindings;
 
@@ -91,8 +93,14 @@ export function upsert<T extends Record<string, SqlValue>>(
   return { sql, values };
 }
 
-/** Minimal db interface needed for query execution */
-type QueryRunner = { query(sql: string): { run(...values: SqlValue[]): void } };
+/** Minimal db interface needed for query execution and metadata helpers */
+type QueryRunner = {
+  query(sql: string): {
+    run(...values: SqlValue[]): void;
+    all(...values: SqlValue[]): Record<string, SqlValue>[];
+  };
+  transaction<T>(fn: () => T): () => T;
+};
 
 /**
  * Execute an UPSERT statement directly on the database.
@@ -116,4 +124,102 @@ export function runUpsert<T extends Record<string, SqlValue>>(
 ): void {
   const { sql, values } = upsert(table, data, conflictColumns);
   db.query(sql).run(...values);
+}
+
+// ---------------------------------------------------------------------------
+// Metadata table helpers
+// ---------------------------------------------------------------------------
+
+type MetadataRow = { key: string; value: string };
+
+/**
+ * Read multiple values from the `metadata` key-value table in a single query.
+ *
+ * @param db - Database instance
+ * @param keys - The metadata keys to read
+ * @returns Map of key → value for keys that exist. Missing keys are omitted.
+ *
+ * @example
+ * const m = getMetadata(db, ["install.method", "install.path"]);
+ * const method = m.get("install.method"); // string | undefined
+ */
+export function getMetadata(
+  db: QueryRunner,
+  keys: string[]
+): Map<string, string> {
+  if (keys.length === 0) {
+    return new Map();
+  }
+  const placeholders = keys.map(() => "?").join(", ");
+  const rows = db
+    .query(`SELECT key, value FROM metadata WHERE key IN (${placeholders})`)
+    .all(...keys) as MetadataRow[];
+  return new Map(rows.map((r) => [r.key, r.value]));
+}
+
+/**
+ * Write multiple key-value pairs to the `metadata` table in a single transaction.
+ *
+ * @param db - Database instance
+ * @param entries - Object mapping metadata keys to string values
+ *
+ * @example
+ * setMetadata(db, { "install.method": "binary", "install.path": "/usr/bin/sentry" });
+ */
+export function setMetadata(
+  db: QueryRunner,
+  entries: Record<string, string>
+): void {
+  const pairs = Object.entries(entries);
+  if (pairs.length === 0) {
+    return;
+  }
+  db.transaction(() => {
+    for (const [key, value] of pairs) {
+      runUpsert(db, "metadata", { key, value }, ["key"]);
+    }
+  })();
+}
+
+/**
+ * Delete multiple keys from the `metadata` table in a single query.
+ *
+ * @param db - Database instance
+ * @param keys - The metadata keys to delete
+ *
+ * @example
+ * clearMetadata(db, ["install.method", "install.path", "install.version"]);
+ */
+export function clearMetadata(db: QueryRunner, keys: string[]): void {
+  if (keys.length === 0) {
+    return;
+  }
+  const placeholders = keys.map(() => "?").join(", ");
+  db.query(`DELETE FROM metadata WHERE key IN (${placeholders})`).run(...keys);
+}
+
+// ---------------------------------------------------------------------------
+// Cache entry helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Update the `last_accessed` timestamp for a cache entry.
+ *
+ * Shared helper to avoid duplicating the same UPDATE pattern in every
+ * cache module. Calls `getDatabase()` internally.
+ *
+ * @param table - Cache table name (e.g., "dsn_cache", "project_cache")
+ * @param keyColumn - Name of the primary key column (e.g., "directory", "cache_key")
+ * @param keyValue - The key value identifying the row to touch
+ */
+export function touchCacheEntry(
+  table: string,
+  keyColumn: string,
+  keyValue: string
+): void {
+  const db = getDatabase();
+  db.query(`UPDATE ${table} SET last_accessed = ? WHERE ${keyColumn} = ?`).run(
+    Date.now(),
+    keyValue
+  );
 }

--- a/src/lib/db/version-check.ts
+++ b/src/lib/db/version-check.ts
@@ -6,10 +6,12 @@
  */
 
 import { getDatabase } from "./index.js";
-import { runUpsert } from "./utils.js";
+import { clearMetadata, getMetadata, setMetadata } from "./utils.js";
 
 const KEY_LAST_CHECKED = "version_check.last_checked";
 const KEY_LATEST_VERSION = "version_check.latest_version";
+
+const ALL_KEYS = [KEY_LAST_CHECKED, KEY_LATEST_VERSION];
 
 export type VersionCheckInfo = {
   /** Unix timestamp (ms) of last check, or null if never checked */
@@ -23,18 +25,14 @@ export type VersionCheckInfo = {
  */
 export function getVersionCheckInfo(): VersionCheckInfo {
   const db = getDatabase();
+  const m = getMetadata(db, ALL_KEYS);
 
-  const lastCheckedRow = db
-    .query("SELECT value FROM metadata WHERE key = ?")
-    .get(KEY_LAST_CHECKED) as { value: string } | undefined;
-
-  const latestVersionRow = db
-    .query("SELECT value FROM metadata WHERE key = ?")
-    .get(KEY_LATEST_VERSION) as { value: string } | undefined;
+  const lastChecked = m.get(KEY_LAST_CHECKED);
+  const latestVersion = m.get(KEY_LATEST_VERSION);
 
   return {
-    lastChecked: lastCheckedRow ? Number(lastCheckedRow.value) : null,
-    latestVersion: latestVersionRow?.value ?? null,
+    lastChecked: lastChecked ? Number(lastChecked) : null,
+    latestVersion: latestVersion ?? null,
   };
 }
 
@@ -48,10 +46,7 @@ export function getVersionCheckInfo(): VersionCheckInfo {
  */
 export function clearVersionCheckCache(): void {
   const db = getDatabase();
-  db.query("DELETE FROM metadata WHERE key = ? OR key = ?").run(
-    KEY_LAST_CHECKED,
-    KEY_LATEST_VERSION
-  );
+  clearMetadata(db, ALL_KEYS);
 }
 
 /**
@@ -60,12 +55,8 @@ export function clearVersionCheckCache(): void {
  */
 export function setVersionCheckInfo(latestVersion: string): void {
   const db = getDatabase();
-  const now = Date.now();
-
-  runUpsert(db, "metadata", { key: KEY_LAST_CHECKED, value: String(now) }, [
-    "key",
-  ]);
-  runUpsert(db, "metadata", { key: KEY_LATEST_VERSION, value: latestVersion }, [
-    "key",
-  ]);
+  setMetadata(db, {
+    [KEY_LAST_CHECKED]: String(Date.now()),
+    [KEY_LATEST_VERSION]: latestVersion,
+  });
 }

--- a/src/lib/dsn/detector.ts
+++ b/src/lib/dsn/detector.ts
@@ -67,7 +67,7 @@ export async function detectDsn(cwd: string): Promise<DetectedDsn | null> {
   const { projectRoot } = await findProjectRoot(cwd);
 
   // 2. Check cache for project root (fast path)
-  const cached = await getCachedDsn(projectRoot);
+  const cached = getCachedDsn(projectRoot);
 
   if (cached) {
     const verified = await verifyCachedDsn(projectRoot, cached);
@@ -75,7 +75,7 @@ export async function detectDsn(cwd: string): Promise<DetectedDsn | null> {
       // Check if DSN changed
       if (verified.raw !== cached.dsn) {
         // DSN changed - update cache
-        await setCachedDsn(projectRoot, {
+        setCachedDsn(projectRoot, {
           dsn: verified.raw,
           projectId: verified.projectId,
           orgId: verified.orgId,
@@ -99,7 +99,7 @@ export async function detectDsn(cwd: string): Promise<DetectedDsn | null> {
 
   if (detected) {
     // Cache for next time (without resolved info yet)
-    await setCachedDsn(projectRoot, {
+    setCachedDsn(projectRoot, {
       dsn: detected.raw,
       projectId: detected.projectId,
       orgId: detected.orgId,
@@ -211,7 +211,7 @@ export async function detectAllDsns(cwd: string): Promise<DsnDetectionResult> {
   }
 
   // Store in cache
-  await setCachedDetection(projectRoot, {
+  setCachedDetection(projectRoot, {
     fingerprint,
     allDsns,
     sourceMtimes: allSourceMtimes,

--- a/src/lib/dsn/resolver.ts
+++ b/src/lib/dsn/resolver.ts
@@ -43,7 +43,7 @@ export async function resolveProject(
   }
 
   // Check cache for resolution
-  const cached = await getCachedDsn(cwd);
+  const cached = getCachedDsn(cwd);
   if (cached?.resolved && cached.dsn === dsn.raw) {
     return {
       ...cached.resolved,
@@ -70,7 +70,7 @@ export async function resolveProject(
       projectName: project.name,
     };
 
-    await updateCachedResolution(cwd, resolved);
+    updateCachedResolution(cwd, resolved);
 
     return {
       ...resolved,
@@ -82,7 +82,7 @@ export async function resolveProject(
   const resolved = await fetchProjectInfo(dsn.orgId, dsn.projectId);
 
   // Update cache with resolution
-  await updateCachedResolution(cwd, resolved);
+  updateCachedResolution(cwd, resolved);
 
   return {
     ...resolved,

--- a/src/lib/help.ts
+++ b/src/lib/help.ts
@@ -103,8 +103,8 @@ function formatCommands(commands: HelpCommand[]): string {
  * Build the custom branded help output string.
  * Shows a contextual example based on authentication status.
  */
-export async function printCustomHelp(): Promise<string> {
-  const loggedIn = await isAuthenticated();
+export function printCustomHelp(): string {
+  const loggedIn = isAuthenticated();
   const example = loggedIn ? EXAMPLE_LOGGED_IN : EXAMPLE_LOGGED_OUT;
 
   const lines: string[] = [];

--- a/src/lib/init/local-ops.ts
+++ b/src/lib/init/local-ops.ts
@@ -683,7 +683,7 @@ async function resolveOrgSlug(
     // project/team creation, and may belong to a different Sentry account.
     if (NUMERIC_ORG_ID_RE.test(resolved.org)) {
       const { getOrgByNumericId } = await import("../db/regions.js");
-      const match = await getOrgByNumericId(resolved.org);
+      const match = getOrgByNumericId(resolved.org);
       if (match) {
         return match.slug;
       }

--- a/src/lib/org-list.ts
+++ b/src/lib/org-list.ts
@@ -874,7 +874,7 @@ async function resolveOrgSlugMatch(
 ): Promise<ParsedOrgProject> {
   const slug = parsed.projectSlug;
   const { getCachedOrganizations } = await import("./db/regions.js");
-  const cachedOrgs = await getCachedOrganizations();
+  const cachedOrgs = getCachedOrganizations();
   const matchingOrg = cachedOrgs.find((o) => o.slug === slug);
   if (!matchingOrg) {
     return parsed;

--- a/src/lib/region.ts
+++ b/src/lib/region.ts
@@ -64,7 +64,7 @@ export function resolveOrgRegion(orgSlug: string): Promise<string> {
  */
 async function resolveOrgRegionUncached(orgSlug: string): Promise<string> {
   // 1. Check SQLite cache first
-  const cached = await getOrgRegion(orgSlug);
+  const cached = getOrgRegion(orgSlug);
   if (cached) {
     return cached;
   }
@@ -88,7 +88,7 @@ async function resolveOrgRegionUncached(orgSlug: string): Promise<string> {
     const regionUrl = response.data?.links?.regionUrl ?? baseUrl;
 
     // Cache for future use
-    await setOrgRegion(orgSlug, regionUrl);
+    setOrgRegion(orgSlug, regionUrl);
 
     return regionUrl;
   });
@@ -120,11 +120,9 @@ export function isMultiRegionEnabled(): boolean {
  * @param orgSlug - Raw org identifier (may be a slug or `oNNNNN` DSN form)
  * @returns The resolved slug if found in cache, `undefined` on cache miss
  */
-async function resolveOrgFromCache(
-  orgSlug: string
-): Promise<string | undefined> {
+function resolveOrgFromCache(orgSlug: string): string | undefined {
   // Check if slug is directly cached
-  const cached = await getOrgRegion(orgSlug);
+  const cached = getOrgRegion(orgSlug);
   if (cached) {
     return orgSlug;
   }
@@ -132,7 +130,7 @@ async function resolveOrgFromCache(
   // Try DSN-style numeric ID lookup (e.g., `o1081365` → `1081365` → slug)
   const numericId = stripDsnOrgPrefix(orgSlug);
   if (numericId !== orgSlug) {
-    const match = await getOrgByNumericId(numericId);
+    const match = getOrgByNumericId(numericId);
     if (match) {
       return match.slug;
     }
@@ -164,7 +162,7 @@ async function resolveOrgFromCache(
  */
 export async function resolveEffectiveOrg(orgSlug: string): Promise<string> {
   // First attempt: use local cache
-  const fromCache = await resolveOrgFromCache(orgSlug);
+  const fromCache = resolveOrgFromCache(orgSlug);
   if (fromCache) {
     return fromCache;
   }
@@ -198,6 +196,6 @@ export async function resolveEffectiveOrg(orgSlug: string): Promise<string> {
   }
 
   // Retry after refresh
-  const afterRefresh = await resolveOrgFromCache(orgSlug);
+  const afterRefresh = resolveOrgFromCache(orgSlug);
   return afterRefresh ?? orgSlug;
 }

--- a/src/lib/resolve-issue.ts
+++ b/src/lib/resolve-issue.ts
@@ -62,7 +62,7 @@ async function resolveAliasSuffix(
   // Detect DSNs to get fingerprint for validation
   const detection = await detectAllDsns(cwd);
   const fingerprint = detection.fingerprint;
-  const projectEntry = await getProjectByAlias(alias, fingerprint);
+  const projectEntry = getProjectByAlias(alias, fingerprint);
 
   if (!projectEntry) {
     return null;

--- a/src/lib/resolve-target.ts
+++ b/src/lib/resolve-target.ts
@@ -171,7 +171,7 @@ export async function resolveFromDsn(
   const detectedFrom = getDsnSourceDescription(dsn);
 
   // Check cache first
-  const cached = await getCachedProject(dsn.orgId, dsn.projectId);
+  const cached = getCachedProject(dsn.orgId, dsn.projectId);
   if (cached) {
     return {
       org: cached.orgSlug,
@@ -187,7 +187,7 @@ export async function resolveFromDsn(
   const projectInfo = await getProject(dsn.orgId, dsn.projectId);
 
   if (projectInfo.organization) {
-    await setCachedProject(dsn.orgId, dsn.projectId, {
+    setCachedProject(dsn.orgId, dsn.projectId, {
       orgSlug: projectInfo.organization.slug,
       orgName: projectInfo.organization.name,
       projectSlug: projectInfo.slug,
@@ -234,7 +234,7 @@ export async function resolveOrgFromDsn(
 
   // Check cache for org slug (only if we have both org and project IDs)
   if (dsn.projectId) {
-    const cached = await getCachedProject(dsn.orgId, dsn.projectId);
+    const cached = getCachedProject(dsn.orgId, dsn.projectId);
     if (cached) {
       return {
         org: cached.orgSlug,
@@ -263,7 +263,7 @@ export async function resolveDsnByPublicKey(
   const detectedFrom = getDsnSourceDescription(dsn);
 
   // Check cache first (keyed by publicKey for DSNs without orgId)
-  const cached = await getCachedProjectByDsnKey(dsn.publicKey);
+  const cached = getCachedProjectByDsnKey(dsn.publicKey);
   if (cached) {
     return {
       org: cached.orgSlug,
@@ -285,7 +285,7 @@ export async function resolveDsnByPublicKey(
     }
 
     if (projectInfo.organization) {
-      await setCachedProjectByDsnKey(dsn.publicKey, {
+      setCachedProjectByDsnKey(dsn.publicKey, {
         orgSlug: projectInfo.organization.slug,
         orgName: projectInfo.organization.name,
         projectSlug: projectInfo.slug,
@@ -336,7 +336,7 @@ async function resolveDsnToTarget(
   const detectedFrom = getDsnSourceDescription(dsn);
 
   // Check cache first
-  const cached = await getCachedProject(orgId, dsnProjectId);
+  const cached = getCachedProject(orgId, dsnProjectId);
   if (cached) {
     return {
       org: cached.orgSlug,
@@ -354,7 +354,7 @@ async function resolveDsnToTarget(
     const projectInfo = await getProject(orgId, dsnProjectId);
 
     if (projectInfo.organization) {
-      await setCachedProject(orgId, dsnProjectId, {
+      setCachedProject(orgId, dsnProjectId, {
         orgSlug: projectInfo.organization.slug,
         orgName: projectInfo.organization.name,
         projectSlug: projectInfo.slug,
@@ -427,7 +427,7 @@ async function inferFromDirectoryName(cwd: string): Promise<ResolvedTargets> {
   }
 
   // Check cache first (reuse DSN cache with source: "inferred")
-  const cached = await getCachedDsn(projectRoot);
+  const cached = getCachedDsn(projectRoot);
   if (cached?.source === "inferred") {
     const detectedFrom = `directory name "${dirName}"`;
 
@@ -488,7 +488,7 @@ async function inferFromDirectoryName(cwd: string): Promise<ResolvedTargets> {
       projectName: m.name,
     }));
 
-    await setCachedDsn(projectRoot, {
+    setCachedDsn(projectRoot, {
       dsn: "", // No DSN for inferred
       projectId: primary.id,
       source: "inferred",
@@ -769,8 +769,8 @@ export async function resolveAllTargets(
   log.debug("No SENTRY_ORG/SENTRY_PROJECT env vars, trying config defaults");
 
   // 3. Config defaults
-  const defaultOrg = await getDefaultOrganization();
-  const defaultProject = await getDefaultProject();
+  const defaultOrg = getDefaultOrganization();
+  const defaultProject = getDefaultProject();
   if (defaultOrg && defaultProject) {
     setOrgProjectContext([defaultOrg], [defaultProject]);
     return {
@@ -939,8 +939,8 @@ export async function resolveOrgAndProject(
   }
 
   // 3. Config defaults
-  const defaultOrg = await getDefaultOrganization();
-  const defaultProject = await getDefaultProject();
+  const defaultOrg = getDefaultOrganization();
+  const defaultProject = getDefaultProject();
   if (defaultOrg && defaultProject) {
     return withTelemetryContext({
       org: defaultOrg,
@@ -1008,7 +1008,7 @@ export async function resolveOrg(
   }
 
   // 3. Config defaults
-  const defaultOrg = await getDefaultOrganization();
+  const defaultOrg = getDefaultOrganization();
   if (defaultOrg) {
     setOrgProjectContext([defaultOrg], []);
     return { org: defaultOrg };
@@ -1141,7 +1141,7 @@ export async function resolveOrgsForListing(
     return { orgs: [envVars.org] };
   }
 
-  const defaultOrg = await getDefaultOrganization();
+  const defaultOrg = getDefaultOrganization();
   if (defaultOrg) {
     setOrgProjectContext([defaultOrg], []);
     return { orgs: [defaultOrg] };

--- a/test/commands/auth/login.test.ts
+++ b/test/commands/auth/login.test.ts
@@ -113,7 +113,7 @@ describe("loginCommand.func --token path", () => {
   });
 
   test("already authenticated (non-TTY, no --force): prints re-auth message with --force hint", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
 
     const { context } = createContext();
     await func.call(context, { force: false, timeout: 900 });
@@ -123,7 +123,7 @@ describe("loginCommand.func --token path", () => {
   });
 
   test("already authenticated (env token SENTRY_AUTH_TOKEN): tells user to unset specific var", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     isEnvTokenActiveSpy.mockReturnValue(true);
     // Need to also spy on getAuthConfig for the specific env var name
     const getAuthConfigSpy = spyOn(dbAuth, "getAuthConfig");
@@ -140,7 +140,7 @@ describe("loginCommand.func --token path", () => {
   });
 
   test("already authenticated (env token SENTRY_TOKEN): shows specific var name", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     isEnvTokenActiveSpy.mockReturnValue(true);
     // Set env var directly — getActiveEnvVarName() reads env vars via getEnvToken()
     process.env.SENTRY_TOKEN = "sntrys_token_456";
@@ -153,8 +153,8 @@ describe("loginCommand.func --token path", () => {
   });
 
   test("--token: stores token, fetches user, writes success", async () => {
-    isAuthenticatedSpy.mockResolvedValue(false);
-    setAuthTokenSpy.mockResolvedValue(undefined);
+    isAuthenticatedSpy.mockReturnValue(false);
+    setAuthTokenSpy.mockReturnValue(undefined);
     getUserRegionsSpy.mockResolvedValue([]);
     getCurrentUserSpy.mockResolvedValue(SAMPLE_USER);
     setUserInfoSpy.mockReturnValue(undefined);
@@ -180,8 +180,8 @@ describe("loginCommand.func --token path", () => {
   });
 
   test("--token: null user.name is converted to undefined in setUserInfo", async () => {
-    isAuthenticatedSpy.mockResolvedValue(false);
-    setAuthTokenSpy.mockResolvedValue(undefined);
+    isAuthenticatedSpy.mockReturnValue(false);
+    setAuthTokenSpy.mockReturnValue(undefined);
     getUserRegionsSpy.mockResolvedValue([]);
     getCurrentUserSpy.mockResolvedValue({
       id: "5",
@@ -211,8 +211,8 @@ describe("loginCommand.func --token path", () => {
   });
 
   test("--token: invalid token clears auth and throws AuthError", async () => {
-    isAuthenticatedSpy.mockResolvedValue(false);
-    setAuthTokenSpy.mockResolvedValue(undefined);
+    isAuthenticatedSpy.mockReturnValue(false);
+    setAuthTokenSpy.mockReturnValue(undefined);
     getUserRegionsSpy.mockRejectedValue(new Error("401 Unauthorized"));
     clearAuthSpy.mockResolvedValue(undefined);
 
@@ -226,8 +226,8 @@ describe("loginCommand.func --token path", () => {
   });
 
   test("--token: shows 'Logged in as' when user info fetch succeeds", async () => {
-    isAuthenticatedSpy.mockResolvedValue(false);
-    setAuthTokenSpy.mockResolvedValue(undefined);
+    isAuthenticatedSpy.mockReturnValue(false);
+    setAuthTokenSpy.mockReturnValue(undefined);
     getUserRegionsSpy.mockResolvedValue([]);
     getCurrentUserSpy.mockResolvedValue({ id: "5", email: "only@email.com" });
     setUserInfoSpy.mockReturnValue(undefined);
@@ -244,8 +244,8 @@ describe("loginCommand.func --token path", () => {
   });
 
   test("--token: login succeeds even when getCurrentUser() fails transiently", async () => {
-    isAuthenticatedSpy.mockResolvedValue(false);
-    setAuthTokenSpy.mockResolvedValue(undefined);
+    isAuthenticatedSpy.mockReturnValue(false);
+    setAuthTokenSpy.mockReturnValue(undefined);
     getUserRegionsSpy.mockResolvedValue([]);
     getCurrentUserSpy.mockRejectedValue(new Error("Network error"));
 
@@ -267,7 +267,7 @@ describe("loginCommand.func --token path", () => {
   });
 
   test("no token: falls through to interactive login", async () => {
-    isAuthenticatedSpy.mockResolvedValue(false);
+    isAuthenticatedSpy.mockReturnValue(false);
     runInteractiveLoginSpy.mockResolvedValue({
       method: "oauth",
       configPath: "/tmp/db",
@@ -281,7 +281,7 @@ describe("loginCommand.func --token path", () => {
   });
 
   test("--force when authenticated: clears auth and proceeds to interactive login", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     clearAuthSpy.mockResolvedValue(undefined);
     runInteractiveLoginSpy.mockResolvedValue({
       method: "oauth",
@@ -296,9 +296,9 @@ describe("loginCommand.func --token path", () => {
   });
 
   test("--force --token when authenticated: clears auth and proceeds to token login", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     clearAuthSpy.mockResolvedValue(undefined);
-    setAuthTokenSpy.mockResolvedValue(undefined);
+    setAuthTokenSpy.mockReturnValue(undefined);
     getUserRegionsSpy.mockResolvedValue([]);
     getCurrentUserSpy.mockResolvedValue(SAMPLE_USER);
     setUserInfoSpy.mockReturnValue(undefined);
@@ -316,7 +316,7 @@ describe("loginCommand.func --token path", () => {
   });
 
   test("--force with env token: still blocks (env var case unchanged)", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     isEnvTokenActiveSpy.mockReturnValue(true);
 
     const { context } = createContext();

--- a/test/commands/auth/logout.test.ts
+++ b/test/commands/auth/logout.test.ts
@@ -79,7 +79,7 @@ describe("logoutCommand.func", () => {
   });
 
   test("not authenticated: returns loggedOut false with message", async () => {
-    isAuthenticatedSpy.mockResolvedValue(false);
+    isAuthenticatedSpy.mockReturnValue(false);
     const { context, getOutput } = createContext();
 
     await func.call(context, {});
@@ -89,7 +89,7 @@ describe("logoutCommand.func", () => {
   });
 
   test("OAuth token: clears auth and writes success to stdout", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     isEnvTokenActiveSpy.mockReturnValue(false);
     const { context, getOutput } = createContext();
 
@@ -101,7 +101,7 @@ describe("logoutCommand.func", () => {
   });
 
   test("env token (SENTRY_AUTH_TOKEN): throws AuthError with env var message", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     isEnvTokenActiveSpy.mockReturnValue(true);
     getAuthConfigSpy.mockReturnValue({
       token: "sntrys_env_123",
@@ -123,7 +123,7 @@ describe("logoutCommand.func", () => {
   });
 
   test("env token (SENTRY_TOKEN): shows correct env var name in error", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     isEnvTokenActiveSpy.mockReturnValue(true);
     // Set env var directly — getActiveEnvVarName() reads env vars via getEnvToken()
     process.env.SENTRY_TOKEN = "sntrys_token_456";
@@ -143,7 +143,7 @@ describe("logoutCommand.func", () => {
   });
 
   test("env token: error message includes env var from getActiveEnvVarName", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     isEnvTokenActiveSpy.mockReturnValue(true);
     // Simulate edge case: source doesn't start with "env:" prefix
     getAuthConfigSpy.mockReturnValue({

--- a/test/commands/auth/status.test.ts
+++ b/test/commands/auth/status.test.ts
@@ -82,8 +82,8 @@ describe("statusCommand.func", () => {
 
     // Defaults that most tests override
     getUserInfoSpy.mockReturnValue(null);
-    getDefaultOrgSpy.mockResolvedValue(null);
-    getDefaultProjectSpy.mockResolvedValue(null);
+    getDefaultOrgSpy.mockReturnValue(null);
+    getDefaultProjectSpy.mockReturnValue(null);
     getDbPathSpy.mockReturnValue("/fake/db/path");
     listOrgsSpy.mockResolvedValue([]);
 
@@ -108,7 +108,7 @@ describe("statusCommand.func", () => {
   describe("not authenticated", () => {
     test("throws AuthError with skipAutoAuth when not authenticated", async () => {
       getAuthConfigSpy.mockReturnValue(undefined);
-      isAuthenticatedSpy.mockResolvedValue(false);
+      isAuthenticatedSpy.mockReturnValue(false);
 
       const { context } = createContext();
 
@@ -130,7 +130,7 @@ describe("statusCommand.func", () => {
         expiresAt: Date.now() + 3_600_000,
         refreshToken: "refresh_xyz",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
 
       const { context, getOutput } = createContext();
       await func.call(context, humanFlags);
@@ -143,7 +143,7 @@ describe("statusCommand.func", () => {
         token: "sntrys_abc123def456",
         source: "oauth",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
 
       const { context, getOutput } = createContext();
       await func.call(context, humanFlags);
@@ -158,7 +158,7 @@ describe("statusCommand.func", () => {
         source: "oauth",
         expiresAt: Date.now() + 3_600_000,
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
 
       const { context, getOutput } = createContext();
       await func.call(context, humanFlags);
@@ -172,7 +172,7 @@ describe("statusCommand.func", () => {
         source: "oauth",
         refreshToken: "refresh_xyz",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
 
       const { context, getOutput } = createContext();
       await func.call(context, humanFlags);
@@ -186,7 +186,7 @@ describe("statusCommand.func", () => {
         token: "sntrys_abc123def456",
         source: "oauth",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
 
       const { context, getOutput } = createContext();
       await func.call(context, humanFlags);
@@ -202,7 +202,7 @@ describe("statusCommand.func", () => {
         token: "sntrys_env_token_123",
         source: "env:SENTRY_AUTH_TOKEN",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
 
       const { context, getOutput } = createContext();
       await func.call(context, humanFlags);
@@ -215,7 +215,7 @@ describe("statusCommand.func", () => {
         token: "sntrys_env_token_123",
         source: "env:SENTRY_AUTH_TOKEN",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
 
       const { context, getOutput } = createContext();
       await func.call(context, humanFlags);
@@ -230,7 +230,7 @@ describe("statusCommand.func", () => {
         token: "sntrys_env_token_123",
         source: "env:SENTRY_AUTH_TOKEN",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
 
       const { context, getOutput } = createContext();
       await func.call(context, humanFlags);
@@ -244,7 +244,7 @@ describe("statusCommand.func", () => {
         token: "sntrys_env_token_123_long_enough",
         source: "env:SENTRY_AUTH_TOKEN",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
 
       const { context, getOutput } = createContext();
       await func.call(context, humanFlags);
@@ -259,7 +259,7 @@ describe("statusCommand.func", () => {
         token: "sntrys_env_token_123_long_enough",
         source: "env:SENTRY_AUTH_TOKEN",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
 
       const { context, getOutput } = createContext();
       await func.call(context, { ...humanFlags, "show-token": true });
@@ -274,7 +274,7 @@ describe("statusCommand.func", () => {
         token: "sntrys_token_456",
         source: "env:SENTRY_TOKEN",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
 
       const { context, getOutput } = createContext();
       await func.call(context, humanFlags);
@@ -293,7 +293,7 @@ describe("statusCommand.func", () => {
         token: "sntrys_abc",
         source: "oauth",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
       listOrgsSpy.mockRejectedValue(new Error("Network error"));
 
       const { context, getOutput } = createContext();
@@ -307,7 +307,7 @@ describe("statusCommand.func", () => {
         token: "sntrys_abc",
         source: "oauth",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
       listOrgsSpy.mockResolvedValue([{ name: "My Org", slug: "my-org" }]);
 
       const { context, getOutput } = createContext();
@@ -325,9 +325,9 @@ describe("statusCommand.func", () => {
         token: "sntrys_abc",
         source: "oauth",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
-      getDefaultOrgSpy.mockResolvedValue("my-org");
-      getDefaultProjectSpy.mockResolvedValue("my-project");
+      isAuthenticatedSpy.mockReturnValue(true);
+      getDefaultOrgSpy.mockReturnValue("my-org");
+      getDefaultProjectSpy.mockReturnValue("my-project");
 
       const { context, getOutput } = createContext();
       await func.call(context, humanFlags);
@@ -342,7 +342,7 @@ describe("statusCommand.func", () => {
         token: "sntrys_abc",
         source: "oauth",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
 
       const { context, getOutput } = createContext();
       await func.call(context, humanFlags);
@@ -357,7 +357,7 @@ describe("statusCommand.func", () => {
         token: "sntrys_abc",
         source: "oauth",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
       getUserInfoSpy.mockReturnValue({
         name: "Jane Doe",
         email: "jane@example.com",
@@ -379,14 +379,14 @@ describe("statusCommand.func", () => {
         expiresAt: Date.now() + 3_600_000,
         refreshToken: "refresh_xyz",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
       getUserInfoSpy.mockReturnValue({
         name: "Jane Doe",
         email: "jane@example.com",
         username: "janedoe",
       });
-      getDefaultOrgSpy.mockResolvedValue("my-org");
-      getDefaultProjectSpy.mockResolvedValue("my-project");
+      getDefaultOrgSpy.mockReturnValue("my-org");
+      getDefaultProjectSpy.mockReturnValue("my-project");
       listOrgsSpy.mockResolvedValue([{ name: "My Org", slug: "my-org" }]);
 
       const { context, getOutput } = createContext();
@@ -410,7 +410,7 @@ describe("statusCommand.func", () => {
         token: "sntrys_abc123def456",
         source: "oauth",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
 
       const { context, getOutput } = createContext();
       await func.call(context, jsonFlags);
@@ -425,7 +425,7 @@ describe("statusCommand.func", () => {
         token: "sntrys_abc",
         source: "oauth",
       });
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
       listOrgsSpy.mockRejectedValue(new Error("Network error"));
 
       const { context, getOutput } = createContext();

--- a/test/commands/auth/whoami.test.ts
+++ b/test/commands/auth/whoami.test.ts
@@ -85,7 +85,7 @@ describe("whoamiCommand.func", () => {
 
   describe("unauthenticated", () => {
     test("throws AuthError(not_authenticated) when no token stored", async () => {
-      isAuthenticatedSpy.mockResolvedValue(false);
+      isAuthenticatedSpy.mockReturnValue(false);
 
       const { context } = createContext();
 
@@ -97,7 +97,7 @@ describe("whoamiCommand.func", () => {
     });
 
     test("does not call setUserInfo when not authenticated", async () => {
-      isAuthenticatedSpy.mockResolvedValue(false);
+      isAuthenticatedSpy.mockReturnValue(false);
 
       const { context } = createContext();
 
@@ -113,7 +113,7 @@ describe("whoamiCommand.func", () => {
 
   describe("human output", () => {
     test("displays name and email for full user", async () => {
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
       getCurrentUserSpy.mockResolvedValue(FULL_USER);
       setUserInfoSpy.mockReturnValue(undefined);
 
@@ -126,7 +126,7 @@ describe("whoamiCommand.func", () => {
     });
 
     test("falls back to email when no name", async () => {
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
       getCurrentUserSpy.mockResolvedValue(EMAIL_ONLY_USER);
       setUserInfoSpy.mockReturnValue(undefined);
 
@@ -137,7 +137,7 @@ describe("whoamiCommand.func", () => {
     });
 
     test("falls back to user ID when no name or email", async () => {
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
       getCurrentUserSpy.mockResolvedValue(ID_ONLY_USER);
       setUserInfoSpy.mockReturnValue(undefined);
 
@@ -148,7 +148,7 @@ describe("whoamiCommand.func", () => {
     });
 
     test("updates DB cache with fetched user info", async () => {
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
       getCurrentUserSpy.mockResolvedValue(FULL_USER);
       setUserInfoSpy.mockReturnValue(undefined);
 
@@ -164,7 +164,7 @@ describe("whoamiCommand.func", () => {
     });
 
     test("still displays identity when DB cache write fails", async () => {
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
       getCurrentUserSpy.mockResolvedValue(FULL_USER);
       setUserInfoSpy.mockImplementation(() => {
         throw new Error("read-only filesystem");
@@ -180,7 +180,7 @@ describe("whoamiCommand.func", () => {
 
   describe("--json output", () => {
     test("outputs valid JSON with all fields", async () => {
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
       getCurrentUserSpy.mockResolvedValue(FULL_USER);
       setUserInfoSpy.mockReturnValue(undefined);
 
@@ -195,7 +195,7 @@ describe("whoamiCommand.func", () => {
     });
 
     test("omits missing optional fields from output", async () => {
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
       getCurrentUserSpy.mockResolvedValue(ID_ONLY_USER);
       setUserInfoSpy.mockReturnValue(undefined);
 
@@ -212,7 +212,7 @@ describe("whoamiCommand.func", () => {
     });
 
     test("still updates DB cache when --json is used", async () => {
-      isAuthenticatedSpy.mockResolvedValue(true);
+      isAuthenticatedSpy.mockReturnValue(true);
       getCurrentUserSpy.mockResolvedValue(FULL_USER);
       setUserInfoSpy.mockReturnValue(undefined);
 

--- a/test/commands/event/view.test.ts
+++ b/test/commands/event/view.test.ts
@@ -507,7 +507,7 @@ describe("resolveEventTarget", () => {
     findEventAcrossOrgsSpy = spyOn(apiClient, "findEventAcrossOrgs");
     resolveOrgAndProjectSpy = spyOn(resolveTarget, "resolveOrgAndProject");
     resolveProjectBySlugSpy = spyOn(resolveTarget, "resolveProjectBySlug");
-    await setOrgRegion("acme", DEFAULT_SENTRY_URL);
+    setOrgRegion("acme", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -753,7 +753,7 @@ describe("viewCommand.func", () => {
     getSpanTreeLinesSpy = spyOn(spanTree, "getSpanTreeLines");
     openInBrowserSpy = spyOn(browser, "openInBrowser");
     resolveProjectBySlugSpy = spyOn(resolveTarget, "resolveProjectBySlug");
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -827,7 +827,7 @@ describe("viewCommand.func", () => {
       traceId: null,
       success: false,
     });
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
 
     const { context } = createMockContext();
     const func = await viewCommand.loader();

--- a/test/commands/issue/list.test.ts
+++ b/test/commands/issue/list.test.ts
@@ -54,8 +54,8 @@ beforeEach(async () => {
   originalFetch = globalThis.fetch;
   func = (await listCommand.loader()) as unknown as ListFunc;
   await setAuthToken("test-token");
-  await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
-  await setDefaults("test-org", "test-project");
+  setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+  setDefaults("test-org", "test-project");
 });
 
 afterEach(() => {
@@ -301,8 +301,8 @@ describe("issue list: partial failure handling", () => {
   //   3. listIssues(org, slug) → GET /api/0/organizations/{org}/issues/?query=project:{slug}
 
   test("JSON output includes error info on partial failures", async () => {
-    await setOrgRegion("org-one", DEFAULT_SENTRY_URL);
-    await setOrgRegion("org-two", DEFAULT_SENTRY_URL);
+    setOrgRegion("org-one", DEFAULT_SENTRY_URL);
+    setOrgRegion("org-two", DEFAULT_SENTRY_URL);
 
     globalThis.fetch = mockFetch(async (input, init) => {
       const req = new Request(input, init);
@@ -372,8 +372,8 @@ describe("issue list: partial failure handling", () => {
   });
 
   test("stderr warning on partial failures in human output", async () => {
-    await setOrgRegion("org-one", DEFAULT_SENTRY_URL);
-    await setOrgRegion("org-two", DEFAULT_SENTRY_URL);
+    setOrgRegion("org-one", DEFAULT_SENTRY_URL);
+    setOrgRegion("org-two", DEFAULT_SENTRY_URL);
 
     globalThis.fetch = mockFetch(async (input, init) => {
       const req = new Request(input, init);
@@ -520,7 +520,7 @@ describe("issue list: org-all mode (cursor pagination)", () => {
     clearPaginationCursorSpy.mockReturnValue(undefined);
 
     // Pre-populate org cache so resolveEffectiveOrg hits the fast path
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -783,8 +783,8 @@ describe("issue list: Phase 2 budget redistribution", () => {
   //   Phase 2: fetch 2 more from org-one via cursor resume.
 
   test("redistributes surplus to expandable targets", async () => {
-    await setOrgRegion("org-one", DEFAULT_SENTRY_URL);
-    await setOrgRegion("org-two", DEFAULT_SENTRY_URL);
+    setOrgRegion("org-one", DEFAULT_SENTRY_URL);
+    setOrgRegion("org-two", DEFAULT_SENTRY_URL);
 
     const issue = (id: string) => ({
       id,
@@ -897,7 +897,7 @@ describe("issue list: compound cursor resume", () => {
   // decodes compound cursor, skips exhausted targets, fetches from active ones.
 
   test("resumes from compound cursor, skipping exhausted targets", async () => {
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
 
     // Pre-store a compound cursor in the DB: 2 targets, second exhausted
     const { setPaginationCursor } = await import(

--- a/test/commands/issue/utils.test.ts
+++ b/test/commands/issue/utils.test.ts
@@ -83,10 +83,10 @@ beforeEach(async () => {
   originalFetch = globalThis.fetch;
   await setAuthToken("test-token");
   // Pre-populate region cache for orgs used in tests to avoid region resolution API calls
-  await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
-  await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
-  await setOrgRegion("cached-org", DEFAULT_SENTRY_URL);
-  await setOrgRegion("org1", DEFAULT_SENTRY_URL);
+  setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+  setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+  setOrgRegion("cached-org", DEFAULT_SENTRY_URL);
+  setOrgRegion("org1", DEFAULT_SENTRY_URL);
 });
 
 afterEach(() => {
@@ -269,7 +269,7 @@ describe("resolveOrgAndIssueId", () => {
     const { setProjectAliases } = await import(
       "../../../src/lib/db/project-aliases.js"
     );
-    await setProjectAliases(
+    setProjectAliases(
       {
         f: { orgSlug: "cached-org", projectSlug: "frontend" },
         b: { orgSlug: "cached-org", projectSlug: "backend" },
@@ -369,7 +369,7 @@ describe("resolveOrgAndIssueId", () => {
 
   test("resolves short suffix format (e.g., 'G') using project context from defaults", async () => {
     const { setDefaults } = await import("../../../src/lib/db/defaults.js");
-    await setDefaults("my-org", "my-project");
+    setDefaults("my-org", "my-project");
 
     // @ts-expect-error - partial mock
     globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -420,7 +420,7 @@ describe("resolveOrgAndIssueId", () => {
     const { clearAuth } = await import("../../../src/lib/db/auth.js");
     const { setDefaults } = await import("../../../src/lib/db/defaults.js");
     await clearAuth();
-    await setDefaults(undefined, undefined);
+    setDefaults(undefined, undefined);
 
     await expect(
       resolveOrgAndIssueId({
@@ -435,7 +435,7 @@ describe("resolveOrgAndIssueId", () => {
     const { clearProjectAliases } = await import(
       "../../../src/lib/db/project-aliases.js"
     );
-    await clearProjectAliases();
+    clearProjectAliases();
 
     // @ts-expect-error - partial mock
     globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -525,7 +525,7 @@ describe("resolveOrgAndIssueId", () => {
     const { clearProjectAliases } = await import(
       "../../../src/lib/db/project-aliases.js"
     );
-    await clearProjectAliases();
+    clearProjectAliases();
 
     // @ts-expect-error - partial mock
     globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -601,9 +601,9 @@ describe("resolveOrgAndIssueId", () => {
     const { clearProjectAliases } = await import(
       "../../../src/lib/db/project-aliases.js"
     );
-    await clearProjectAliases();
+    clearProjectAliases();
 
-    await setOrgRegion("org2", DEFAULT_SENTRY_URL);
+    setOrgRegion("org2", DEFAULT_SENTRY_URL);
 
     // @ts-expect-error - partial mock
     globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -685,7 +685,7 @@ describe("resolveOrgAndIssueId", () => {
 
   test("short suffix auth error (401) propagates", async () => {
     const { setDefaults } = await import("../../../src/lib/db/defaults.js");
-    await setDefaults("my-org", "my-project");
+    setDefaults("my-org", "my-project");
 
     // @ts-expect-error - partial mock
     globalThis.fetch = async () =>
@@ -705,7 +705,7 @@ describe("resolveOrgAndIssueId", () => {
 
   test("short suffix server error (500) propagates", async () => {
     const { setDefaults } = await import("../../../src/lib/db/defaults.js");
-    await setDefaults("my-org", "my-project");
+    setDefaults("my-org", "my-project");
 
     // @ts-expect-error - partial mock
     globalThis.fetch = async () =>
@@ -727,9 +727,9 @@ describe("resolveOrgAndIssueId", () => {
     const { clearProjectAliases } = await import(
       "../../../src/lib/db/project-aliases.js"
     );
-    await clearProjectAliases();
+    clearProjectAliases();
 
-    await setOrgRegion("org2", DEFAULT_SENTRY_URL);
+    setOrgRegion("org2", DEFAULT_SENTRY_URL);
 
     const makeShortIdResponse = (orgSlug: string, groupId: string) =>
       new Response(
@@ -810,7 +810,7 @@ describe("resolveOrgAndIssueId", () => {
     const { clearProjectAliases } = await import(
       "../../../src/lib/db/project-aliases.js"
     );
-    await clearProjectAliases();
+    clearProjectAliases();
 
     // @ts-expect-error - partial mock
     globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -866,7 +866,7 @@ describe("resolveOrgAndIssueId", () => {
     const { clearProjectAliases } = await import(
       "../../../src/lib/db/project-aliases.js"
     );
-    await clearProjectAliases();
+    clearProjectAliases();
 
     // @ts-expect-error - partial mock
     globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1595,7 +1595,7 @@ describe("ensureRootCauseAnalysis", () => {
 describe("resolveOrgAndIssueId: magic @ selectors", () => {
   test("resolves @latest to the most recent unresolved issue", async () => {
     const { setDefaults } = await import("../../../src/lib/db/defaults.js");
-    await setDefaults("test-org", undefined);
+    setDefaults("test-org", undefined);
 
     // @ts-expect-error - partial mock
     globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1644,7 +1644,7 @@ describe("resolveOrgAndIssueId: magic @ selectors", () => {
 
   test("resolves @most_frequent to the highest frequency issue", async () => {
     const { setDefaults } = await import("../../../src/lib/db/defaults.js");
-    await setDefaults("test-org", undefined);
+    setDefaults("test-org", undefined);
 
     // @ts-expect-error - partial mock
     globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1738,7 +1738,7 @@ describe("resolveOrgAndIssueId: magic @ selectors", () => {
 
   test("throws ResolutionError when no unresolved issues found", async () => {
     const { setDefaults } = await import("../../../src/lib/db/defaults.js");
-    await setDefaults("test-org", undefined);
+    setDefaults("test-org", undefined);
 
     // @ts-expect-error - partial mock
     globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1774,7 +1774,7 @@ describe("resolveOrgAndIssueId: magic @ selectors", () => {
     const { clearAuth } = await import("../../../src/lib/db/auth.js");
     const { setDefaults } = await import("../../../src/lib/db/defaults.js");
     await clearAuth();
-    await setDefaults(undefined, undefined);
+    setDefaults(undefined, undefined);
 
     await expect(
       resolveOrgAndIssueId({
@@ -1796,7 +1796,7 @@ describe("resolveIssue: numeric 404 error handling", () => {
   beforeEach(async () => {
     savedFetch = globalThis.fetch;
     await setAuthToken("test-token");
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -1896,10 +1896,10 @@ describe("resolveIssue: project-search DSN shortcut", () => {
   beforeEach(async () => {
     dsnOriginalFetch = globalThis.fetch;
     await setAuthToken("test-token");
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
     // Seed project cache so resolveFromDsn resolves without any API call.
     // orgId is "123" (DSN parser strips the "o" prefix from o123.ingest.*)
-    await setCachedProject("123", "456", {
+    setCachedProject("123", "456", {
       orgSlug: "my-org",
       orgName: "My Org",
       projectSlug: "my-project",

--- a/test/commands/log/view.test.ts
+++ b/test/commands/log/view.test.ts
@@ -435,7 +435,7 @@ describe("viewCommand.func", () => {
     getLogsSpy = spyOn(apiClient, "getLogs");
     findProjectsBySlugSpy = spyOn(apiClient, "findProjectsBySlug");
     openInBrowserSpy = spyOn(browser, "openInBrowser");
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -461,7 +461,7 @@ describe("viewCommand.func", () => {
 
   test("logs normalized slug warning when underscores present", async () => {
     getLogsSpy.mockResolvedValue([sampleLog]);
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
 
     const { context } = createMockContext();
     const func = await viewCommand.loader();
@@ -484,7 +484,7 @@ describe("viewCommand.func", () => {
       orgs: [],
     });
     getLogsSpy.mockResolvedValue([sampleLog]);
-    await setOrgRegion("acme", DEFAULT_SENTRY_URL);
+    setOrgRegion("acme", DEFAULT_SENTRY_URL);
 
     const { context } = createMockContext();
     const func = await viewCommand.loader();
@@ -508,7 +508,7 @@ describe("viewCommand.func", () => {
       orgs: [],
     });
     getLogsSpy.mockResolvedValue([sampleLog]);
-    await setOrgRegion("cam-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("cam-org", DEFAULT_SENTRY_URL);
 
     const { context } = createMockContext();
     const func = await viewCommand.loader();

--- a/test/commands/project/list.test.ts
+++ b/test/commands/project/list.test.ts
@@ -366,7 +366,7 @@ describe("handleExplicit", () => {
   beforeEach(async () => {
     originalFetch = globalThis.fetch;
     await setAuthToken("test-token");
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -436,7 +436,7 @@ describe("handleOrgAll", () => {
   beforeEach(async () => {
     originalFetch = globalThis.fetch;
     await setAuthToken("test-token");
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -616,7 +616,7 @@ describe("handleProjectSearch", () => {
   beforeEach(async () => {
     originalFetch = globalThis.fetch;
     await setAuthToken("test-token");
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -726,8 +726,8 @@ describe("handleProjectSearch", () => {
   });
 
   test("respects --limit flag", async () => {
-    await setOrgRegion("org-a", DEFAULT_SENTRY_URL);
-    await setOrgRegion("org-b", DEFAULT_SENTRY_URL);
+    setOrgRegion("org-a", DEFAULT_SENTRY_URL);
+    setOrgRegion("org-b", DEFAULT_SENTRY_URL);
 
     const project: SentryProject = {
       id: "1",
@@ -781,8 +781,8 @@ describe("handleProjectSearch", () => {
   });
 
   test("--limit also applies to result items", async () => {
-    await setOrgRegion("org-a", DEFAULT_SENTRY_URL);
-    await setOrgRegion("org-b", DEFAULT_SENTRY_URL);
+    setOrgRegion("org-a", DEFAULT_SENTRY_URL);
+    setOrgRegion("org-b", DEFAULT_SENTRY_URL);
 
     const project: SentryProject = {
       id: "1",
@@ -881,7 +881,7 @@ describe("fetchOrgProjects", () => {
   beforeEach(async () => {
     originalFetch = globalThis.fetch;
     await setAuthToken("test-token");
-    await setOrgRegion("myorg", DEFAULT_SENTRY_URL);
+    setOrgRegion("myorg", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -911,7 +911,7 @@ describe("fetchOrgProjectsSafe", () => {
   beforeEach(async () => {
     originalFetch = globalThis.fetch;
     await setAuthToken("test-token");
-    await setOrgRegion("myorg", DEFAULT_SENTRY_URL);
+    setOrgRegion("myorg", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -948,7 +948,7 @@ describe("fetchAllOrgProjects", () => {
   beforeEach(async () => {
     originalFetch = globalThis.fetch;
     await setAuthToken("test-token");
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -1007,8 +1007,8 @@ describe("fetchAllOrgProjects", () => {
       return new Response("Not found", { status: 404 });
     };
 
-    await setOrgRegion("org1", DEFAULT_SENTRY_URL);
-    await setOrgRegion("org2", DEFAULT_SENTRY_URL);
+    setOrgRegion("org1", DEFAULT_SENTRY_URL);
+    setOrgRegion("org2", DEFAULT_SENTRY_URL);
 
     const result = await fetchAllOrgProjects();
     // Only org1's projects should be returned
@@ -1022,7 +1022,7 @@ describe("handleAutoDetect", () => {
   beforeEach(async () => {
     originalFetch = globalThis.fetch;
     await setAuthToken("test-token");
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -1120,7 +1120,7 @@ describe("handleAutoDetect", () => {
 
   test("fast path: uses single-page fetch for single org without platform filter", async () => {
     // Set default org to trigger single-org resolution
-    await setDefaults("test-org");
+    setDefaults("test-org");
     globalThis.fetch = mockProjectFetch(sampleProjects);
 
     const result = await handleAutoDetect("/tmp/test-project", {
@@ -1135,7 +1135,7 @@ describe("handleAutoDetect", () => {
   });
 
   test("fast path: shows truncation message when server has more results", async () => {
-    await setDefaults("test-org");
+    setDefaults("test-org");
     globalThis.fetch = mockProjectFetch(sampleProjects, {
       hasMore: true,
       nextCursor: "1735689600000:0:0",
@@ -1153,7 +1153,7 @@ describe("handleAutoDetect", () => {
   });
 
   test("fast path: includes hasMore and jsonExtra hint when server has more results", async () => {
-    await setDefaults("test-org");
+    setDefaults("test-org");
     globalThis.fetch = mockProjectFetch(sampleProjects, {
       hasMore: true,
       nextCursor: "1735689600000:0:0",
@@ -1174,7 +1174,7 @@ describe("handleAutoDetect", () => {
   });
 
   test("fast path: non-auth API errors return empty results instead of throwing", async () => {
-    await setDefaults("test-org");
+    setDefaults("test-org");
     // Mock returns 403 for projects endpoint (stale org, no access)
     // @ts-expect-error - partial mock
     globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -1198,7 +1198,7 @@ describe("handleAutoDetect", () => {
   });
 
   test("fast path: AuthError still propagates", async () => {
-    await setDefaults("test-org");
+    setDefaults("test-org");
     // Clear auth so getAuthToken() throws AuthError before any fetch
     await clearAuth();
 
@@ -1213,7 +1213,7 @@ describe("handleAutoDetect", () => {
 
   test("slow path: uses full fetch when platform filter is active", async () => {
     // Set default org — but platform filter forces slow path
-    await setDefaults("test-org");
+    setDefaults("test-org");
     globalThis.fetch = mockProjectFetch(sampleProjects);
 
     const result = await handleAutoDetect("/tmp/test-project", {

--- a/test/commands/repo/list.test.ts
+++ b/test/commands/repo/list.test.ts
@@ -209,7 +209,7 @@ describe("listCommand.func — explicit org/project (org-scoped with note)", () 
 
   beforeEach(async () => {
     listRepositoriesSpy = spyOn(apiClient, "listRepositories");
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -263,7 +263,7 @@ describe("listCommand.func — auto-detect mode", () => {
     getDefaultOrganizationSpy = spyOn(defaults, "getDefaultOrganization");
     resolveAllTargetsSpy = spyOn(resolveTarget, "resolveAllTargets");
 
-    getDefaultOrganizationSpy.mockResolvedValue(null);
+    getDefaultOrganizationSpy.mockReturnValue(null);
     resolveAllTargetsSpy.mockResolvedValue({ targets: [] });
   });
 
@@ -275,7 +275,7 @@ describe("listCommand.func — auto-detect mode", () => {
   });
 
   test("uses default organization when no org provided", async () => {
-    getDefaultOrganizationSpy.mockResolvedValue("default-org");
+    getDefaultOrganizationSpy.mockReturnValue("default-org");
     listRepositoriesSpy.mockResolvedValue(sampleRepos);
 
     const { context } = createMockContext();
@@ -313,7 +313,7 @@ describe("listCommand.func — auto-detect mode", () => {
   });
 
   test("outputs JSON in auto-detect mode", async () => {
-    getDefaultOrganizationSpy.mockResolvedValue("auto-org");
+    getDefaultOrganizationSpy.mockReturnValue("auto-org");
     listRepositoriesSpy.mockResolvedValue(sampleRepos);
 
     const { context, stdoutWrite } = createMockContext();
@@ -327,7 +327,7 @@ describe("listCommand.func — auto-detect mode", () => {
   });
 
   test("shows 'No repositories found' in auto-detect when empty and single org", async () => {
-    getDefaultOrganizationSpy.mockResolvedValue("empty-org");
+    getDefaultOrganizationSpy.mockReturnValue("empty-org");
     listRepositoriesSpy.mockResolvedValue([]);
 
     const { context, stdoutWrite } = createMockContext();
@@ -368,7 +368,7 @@ describe("listCommand.func — org-all mode (cursor pagination)", () => {
 
     setPaginationCursorSpy.mockReturnValue(undefined);
     clearPaginationCursorSpy.mockReturnValue(undefined);
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {

--- a/test/commands/team/list.test.ts
+++ b/test/commands/team/list.test.ts
@@ -205,7 +205,7 @@ describe("listCommand.func — explicit org/project", () => {
 
   beforeEach(async () => {
     listProjectTeamsSpy = spyOn(apiClient, "listProjectTeams");
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -248,7 +248,7 @@ describe("listCommand.func — auto-detect mode", () => {
     getDefaultOrganizationSpy = spyOn(defaults, "getDefaultOrganization");
     resolveAllTargetsSpy = spyOn(resolveTarget, "resolveAllTargets");
 
-    getDefaultOrganizationSpy.mockResolvedValue(null);
+    getDefaultOrganizationSpy.mockReturnValue(null);
     resolveAllTargetsSpy.mockResolvedValue({ targets: [] });
   });
 
@@ -260,7 +260,7 @@ describe("listCommand.func — auto-detect mode", () => {
   });
 
   test("uses default organization when no org provided", async () => {
-    getDefaultOrganizationSpy.mockResolvedValue("default-org");
+    getDefaultOrganizationSpy.mockReturnValue("default-org");
     listTeamsSpy.mockResolvedValue(sampleTeams);
 
     const { context } = createMockContext();
@@ -298,7 +298,7 @@ describe("listCommand.func — auto-detect mode", () => {
   });
 
   test("outputs JSON in auto-detect mode", async () => {
-    getDefaultOrganizationSpy.mockResolvedValue("auto-org");
+    getDefaultOrganizationSpy.mockReturnValue("auto-org");
     listTeamsSpy.mockResolvedValue(sampleTeams);
 
     const { context, stdoutWrite } = createMockContext();
@@ -312,7 +312,7 @@ describe("listCommand.func — auto-detect mode", () => {
   });
 
   test("shows 'No teams found' in auto-detect when empty and single org", async () => {
-    getDefaultOrganizationSpy.mockResolvedValue("empty-org");
+    getDefaultOrganizationSpy.mockReturnValue("empty-org");
     listTeamsSpy.mockResolvedValue([]);
 
     const { context, stdoutWrite } = createMockContext();
@@ -350,7 +350,7 @@ describe("listCommand.func — org-all mode (cursor pagination)", () => {
 
     setPaginationCursorSpy.mockReturnValue(undefined);
     clearPaginationCursorSpy.mockReturnValue(undefined);
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {

--- a/test/commands/trace/list.test.ts
+++ b/test/commands/trace/list.test.ts
@@ -93,7 +93,7 @@ describe("resolveOrgProjectFromArg", () => {
     findProjectsBySlugSpy = spyOn(apiClient, "findProjectsBySlug");
     resolveOrgAndProjectSpy = spyOn(resolveTarget, "resolveOrgAndProject");
     // Pre-populate org cache so resolveEffectiveOrg hits the fast path
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {

--- a/test/commands/trace/view.func.test.ts
+++ b/test/commands/trace/view.func.test.ts
@@ -137,8 +137,8 @@ describe("viewCommand.func", () => {
     resolveOrgAndProjectSpy = spyOn(resolveTarget, "resolveOrgAndProject");
     resolveOrgSpy = spyOn(resolveTarget, "resolveOrg");
     openInBrowserSpy = spyOn(browser, "openInBrowser");
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {
@@ -356,7 +356,7 @@ describe("viewCommand.func", () => {
       orgs: [],
     });
     getDetailedTraceSpy.mockResolvedValue(sampleSpans);
-    await setOrgRegion("cam-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("cam-org", DEFAULT_SENTRY_URL);
 
     const { context } = createMockContext();
     const func = await viewCommand.loader();

--- a/test/isolated/login-reauth.test.ts
+++ b/test/isolated/login-reauth.test.ts
@@ -142,7 +142,7 @@ describe("login re-authentication interactive prompt", () => {
   });
 
   test("shows prompt with user identity when authenticated on TTY", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     getUserInfoSpy.mockReturnValue({
       userId: "42",
       name: "Jane Doe",
@@ -161,7 +161,7 @@ describe("login re-authentication interactive prompt", () => {
   });
 
   test("shows 'current user' fallback when no cached user info", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     getUserInfoSpy.mockReturnValue(undefined);
     mockPrompt.mockResolvedValue(true);
 
@@ -174,7 +174,7 @@ describe("login re-authentication interactive prompt", () => {
   });
 
   test("confirm: clears auth and proceeds to login", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     getUserInfoSpy.mockReturnValue(undefined);
     mockPrompt.mockResolvedValue(true);
 
@@ -186,7 +186,7 @@ describe("login re-authentication interactive prompt", () => {
   });
 
   test("decline: returns without re-auth", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     getUserInfoSpy.mockReturnValue(undefined);
     mockPrompt.mockResolvedValue(false);
 
@@ -199,7 +199,7 @@ describe("login re-authentication interactive prompt", () => {
   });
 
   test("cancel (Ctrl+C): returns without re-auth", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     getUserInfoSpy.mockReturnValue(undefined);
     // consola returns Symbol(clack:cancel) on Ctrl+C — truthy but not `true`.
     mockPrompt.mockResolvedValue(Symbol("clack:cancel") as unknown as boolean);
@@ -213,7 +213,7 @@ describe("login re-authentication interactive prompt", () => {
   });
 
   test("--force skips prompt even on TTY", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     getUserInfoSpy.mockReturnValue(undefined);
 
     const context = createMockContext();
@@ -225,7 +225,7 @@ describe("login re-authentication interactive prompt", () => {
   });
 
   test("confirm + --token: clears auth and re-authenticates with token", async () => {
-    isAuthenticatedSpy.mockResolvedValue(true);
+    isAuthenticatedSpy.mockReturnValue(true);
     getUserInfoSpy.mockReturnValue(undefined);
     mockPrompt.mockResolvedValue(true);
 

--- a/test/isolated/resolve-target.test.ts
+++ b/test/isolated/resolve-target.test.ts
@@ -22,8 +22,8 @@ import { formatMultipleProjectsFooter } from "../../src/lib/dsn/errors.js";
 // ============================================================================
 
 // Mock functions we'll control in tests
-const mockGetDefaultOrganization = mock(() => Promise.resolve(null));
-const mockGetDefaultProject = mock(() => Promise.resolve(null));
+const mockGetDefaultOrganization = mock(() => null);
+const mockGetDefaultProject = mock(() => null);
 const mockDetectDsn = mock(() => Promise.resolve(null));
 const mockDetectAllDsns = mock(() =>
   Promise.resolve({
@@ -42,12 +42,18 @@ const mockFindProjectRoot = mock(() =>
 const mockGetDsnSourceDescription = mock(
   () => "SENTRY_DSN environment variable"
 );
-const mockGetCachedProject = mock(() => Promise.resolve(null));
-const mockSetCachedProject = mock(() => Promise.resolve());
-const mockGetCachedProjectByDsnKey = mock(() => Promise.resolve(null));
-const mockSetCachedProjectByDsnKey = mock(() => Promise.resolve());
-const mockGetCachedDsn = mock(() => Promise.resolve(null));
-const mockSetCachedDsn = mock(() => Promise.resolve());
+const mockGetCachedProject = mock(() => null);
+const mockSetCachedProject = mock(() => {
+  /* no-op */
+});
+const mockGetCachedProjectByDsnKey = mock(() => null);
+const mockSetCachedProjectByDsnKey = mock(() => {
+  /* no-op */
+});
+const mockGetCachedDsn = mock(() => null);
+const mockSetCachedDsn = mock(() => {
+  /* no-op */
+});
 const mockGetProject = mock(() =>
   Promise.resolve({ slug: "test", name: "Test" })
 );
@@ -120,8 +126,8 @@ function resetAllMocks() {
   mockFindProjectsByPattern.mockReset();
 
   // Set sensible defaults
-  mockGetDefaultOrganization.mockResolvedValue(null);
-  mockGetDefaultProject.mockResolvedValue(null);
+  mockGetDefaultOrganization.mockReturnValue(null);
+  mockGetDefaultProject.mockReturnValue(null);
   mockDetectDsn.mockResolvedValue(null);
   mockDetectAllDsns.mockResolvedValue({
     primary: null,
@@ -136,9 +142,9 @@ function resetAllMocks() {
   mockGetDsnSourceDescription.mockReturnValue(
     "SENTRY_DSN environment variable"
   );
-  mockGetCachedProject.mockResolvedValue(null);
-  mockGetCachedProjectByDsnKey.mockResolvedValue(null);
-  mockGetCachedDsn.mockResolvedValue(null);
+  mockGetCachedProject.mockReturnValue(null);
+  mockGetCachedProjectByDsnKey.mockReturnValue(null);
+  mockGetCachedDsn.mockReturnValue(null);
   mockFindProjectsByPattern.mockResolvedValue([]);
 }
 
@@ -162,7 +168,7 @@ describe("resolveOrg", () => {
   });
 
   test("returns org from config defaults when no CLI flag", async () => {
-    mockGetDefaultOrganization.mockResolvedValue("default-org");
+    mockGetDefaultOrganization.mockReturnValue("default-org");
 
     const result = await resolveOrg({ cwd: "/test" });
 
@@ -173,7 +179,7 @@ describe("resolveOrg", () => {
   });
 
   test("falls back to DSN detection when no flag or defaults", async () => {
-    mockGetDefaultOrganization.mockResolvedValue(null);
+    mockGetDefaultOrganization.mockReturnValue(null);
     mockDetectDsn.mockResolvedValue({
       raw: "https://abc@o123.ingest.sentry.io/456",
       protocol: "https",
@@ -183,7 +189,7 @@ describe("resolveOrg", () => {
       orgId: "123",
       source: "env",
     });
-    mockGetCachedProject.mockResolvedValue({
+    mockGetCachedProject.mockReturnValue({
       orgSlug: "cached-org",
       orgName: "Cached Organization",
       projectSlug: "project",
@@ -199,7 +205,7 @@ describe("resolveOrg", () => {
   });
 
   test("returns numeric orgId when DSN detected but no cache", async () => {
-    mockGetDefaultOrganization.mockResolvedValue(null);
+    mockGetDefaultOrganization.mockReturnValue(null);
     mockDetectDsn.mockResolvedValue({
       raw: "https://abc@o123.ingest.sentry.io/456",
       protocol: "https",
@@ -209,7 +215,7 @@ describe("resolveOrg", () => {
       orgId: "123",
       source: "env",
     });
-    mockGetCachedProject.mockResolvedValue(null);
+    mockGetCachedProject.mockReturnValue(null);
 
     const result = await resolveOrg({ cwd: "/test" });
 
@@ -218,7 +224,7 @@ describe("resolveOrg", () => {
   });
 
   test("returns null when no org found from any source", async () => {
-    mockGetDefaultOrganization.mockResolvedValue(null);
+    mockGetDefaultOrganization.mockReturnValue(null);
     mockDetectDsn.mockResolvedValue(null);
 
     const result = await resolveOrg({ cwd: "/test" });
@@ -227,7 +233,7 @@ describe("resolveOrg", () => {
   });
 
   test("returns null when DSN has no orgId", async () => {
-    mockGetDefaultOrganization.mockResolvedValue(null);
+    mockGetDefaultOrganization.mockReturnValue(null);
     mockDetectDsn.mockResolvedValue({
       raw: "https://abc@sentry.io/456",
       protocol: "https",
@@ -244,7 +250,7 @@ describe("resolveOrg", () => {
   });
 
   test("returns null when DSN detection throws", async () => {
-    mockGetDefaultOrganization.mockResolvedValue(null);
+    mockGetDefaultOrganization.mockReturnValue(null);
     mockDetectDsn.mockRejectedValue(new Error("Detection failed"));
 
     const result = await resolveOrg({ cwd: "/test" });
@@ -311,7 +317,7 @@ describe("resolveFromDsn", () => {
       source: "env",
       sourcePath: "/test/.env",
     });
-    mockGetCachedProject.mockResolvedValue({
+    mockGetCachedProject.mockReturnValue({
       orgSlug: "cached-org",
       orgName: "Cached Organization",
       projectSlug: "cached-project",
@@ -339,7 +345,7 @@ describe("resolveFromDsn", () => {
       source: "env",
       sourcePath: "/test/.env",
     });
-    mockGetCachedProject.mockResolvedValue(null);
+    mockGetCachedProject.mockReturnValue(null);
     mockGetProject.mockResolvedValue({
       id: "456",
       slug: "fetched-project",
@@ -371,7 +377,7 @@ describe("resolveFromDsn", () => {
       orgId: "123",
       source: "env",
     });
-    mockGetCachedProject.mockResolvedValue(null);
+    mockGetCachedProject.mockReturnValue(null);
     mockGetProject.mockResolvedValue({
       id: "456",
       slug: "project",
@@ -428,8 +434,8 @@ describe("resolveOrgAndProject", () => {
   });
 
   test("returns target from config defaults when no flags", async () => {
-    mockGetDefaultOrganization.mockResolvedValue("default-org");
-    mockGetDefaultProject.mockResolvedValue("default-project");
+    mockGetDefaultOrganization.mockReturnValue("default-org");
+    mockGetDefaultProject.mockReturnValue("default-project");
 
     const result = await resolveOrgAndProject({ cwd: "/test" });
 
@@ -441,8 +447,8 @@ describe("resolveOrgAndProject", () => {
   });
 
   test("falls back to DSN detection when no flags or defaults", async () => {
-    mockGetDefaultOrganization.mockResolvedValue(null);
-    mockGetDefaultProject.mockResolvedValue(null);
+    mockGetDefaultOrganization.mockReturnValue(null);
+    mockGetDefaultProject.mockReturnValue(null);
     mockDetectDsn.mockResolvedValue({
       raw: "https://abc@o123.ingest.sentry.io/456",
       protocol: "https",
@@ -452,7 +458,7 @@ describe("resolveOrgAndProject", () => {
       orgId: "123",
       source: "env",
     });
-    mockGetCachedProject.mockResolvedValue({
+    mockGetCachedProject.mockReturnValue({
       orgSlug: "dsn-org",
       orgName: "DSN Org",
       projectSlug: "dsn-project",
@@ -467,8 +473,8 @@ describe("resolveOrgAndProject", () => {
   });
 
   test("falls back to directory inference when DSN detection fails", async () => {
-    mockGetDefaultOrganization.mockResolvedValue(null);
-    mockGetDefaultProject.mockResolvedValue(null);
+    mockGetDefaultOrganization.mockReturnValue(null);
+    mockGetDefaultProject.mockReturnValue(null);
     mockDetectDsn.mockResolvedValue(null);
     mockFindProjectRoot.mockResolvedValue({
       projectRoot: "/home/user/my-project",
@@ -492,8 +498,8 @@ describe("resolveOrgAndProject", () => {
   });
 
   test("returns null when no resolution method succeeds", async () => {
-    mockGetDefaultOrganization.mockResolvedValue(null);
-    mockGetDefaultProject.mockResolvedValue(null);
+    mockGetDefaultOrganization.mockReturnValue(null);
+    mockGetDefaultProject.mockReturnValue(null);
     mockDetectDsn.mockResolvedValue(null);
     // Short directory name that won't match
     mockFindProjectRoot.mockResolvedValue({
@@ -536,8 +542,8 @@ describe("resolveAllTargets", () => {
   });
 
   test("returns single target from config defaults", async () => {
-    mockGetDefaultOrganization.mockResolvedValue("default-org");
-    mockGetDefaultProject.mockResolvedValue("default-project");
+    mockGetDefaultOrganization.mockReturnValue("default-org");
+    mockGetDefaultProject.mockReturnValue("default-project");
 
     const result = await resolveAllTargets({ cwd: "/test" });
 
@@ -547,8 +553,8 @@ describe("resolveAllTargets", () => {
   });
 
   test("resolves multiple DSNs in monorepo", async () => {
-    mockGetDefaultOrganization.mockResolvedValue(null);
-    mockGetDefaultProject.mockResolvedValue(null);
+    mockGetDefaultOrganization.mockReturnValue(null);
+    mockGetDefaultProject.mockReturnValue(null);
     mockDetectAllDsns.mockResolvedValue({
       primary: {
         raw: "https://abc@o123.ingest.sentry.io/456",
@@ -586,13 +592,13 @@ describe("resolveAllTargets", () => {
       fingerprint: "abc-def",
     });
     mockGetCachedProject
-      .mockResolvedValueOnce({
+      .mockReturnValueOnce({
         orgSlug: "my-org",
         orgName: "My Org",
         projectSlug: "frontend",
         projectName: "Frontend",
       })
-      .mockResolvedValueOnce({
+      .mockReturnValueOnce({
         orgSlug: "my-org",
         orgName: "My Org",
         projectSlug: "backend",
@@ -612,8 +618,8 @@ describe("resolveAllTargets", () => {
   });
 
   test("deduplicates targets with same org+project", async () => {
-    mockGetDefaultOrganization.mockResolvedValue(null);
-    mockGetDefaultProject.mockResolvedValue(null);
+    mockGetDefaultOrganization.mockReturnValue(null);
+    mockGetDefaultProject.mockReturnValue(null);
     mockDetectAllDsns.mockResolvedValue({
       primary: {
         raw: "https://abc@o123.ingest.sentry.io/456",
@@ -650,7 +656,7 @@ describe("resolveAllTargets", () => {
       hasMultiple: true,
       fingerprint: "abc-abc",
     });
-    mockGetCachedProject.mockResolvedValue({
+    mockGetCachedProject.mockReturnValue({
       orgSlug: "my-org",
       orgName: "My Org",
       projectSlug: "my-project",
@@ -664,8 +670,8 @@ describe("resolveAllTargets", () => {
   });
 
   test("falls back to directory inference when no DSNs detected", async () => {
-    mockGetDefaultOrganization.mockResolvedValue(null);
-    mockGetDefaultProject.mockResolvedValue(null);
+    mockGetDefaultOrganization.mockReturnValue(null);
+    mockGetDefaultProject.mockReturnValue(null);
     mockDetectAllDsns.mockResolvedValue({
       primary: null,
       all: [],
@@ -694,8 +700,8 @@ describe("resolveAllTargets", () => {
   });
 
   test("returns empty targets when all DSN resolutions fail", async () => {
-    mockGetDefaultOrganization.mockResolvedValue(null);
-    mockGetDefaultProject.mockResolvedValue(null);
+    mockGetDefaultOrganization.mockReturnValue(null);
+    mockGetDefaultProject.mockReturnValue(null);
     mockDetectAllDsns.mockResolvedValue({
       primary: {
         raw: "https://abc@o123.ingest.sentry.io/456",
@@ -720,7 +726,7 @@ describe("resolveAllTargets", () => {
       hasMultiple: false,
       fingerprint: "",
     });
-    mockGetCachedProject.mockResolvedValue(null);
+    mockGetCachedProject.mockReturnValue(null);
     // getProject returns null (project not found)
     mockGetProject.mockResolvedValue(null);
     mockFindProjectRoot.mockResolvedValue({
@@ -843,8 +849,8 @@ describe("env var resolution: SENTRY_ORG + SENTRY_PROJECT", () => {
   test("resolveOrgAndProject: env vars beat config defaults", async () => {
     process.env.SENTRY_ORG = "env-org";
     process.env.SENTRY_PROJECT = "env-project";
-    mockGetDefaultOrganization.mockResolvedValue("default-org");
-    mockGetDefaultProject.mockResolvedValue("default-project");
+    mockGetDefaultOrganization.mockReturnValue("default-org");
+    mockGetDefaultProject.mockReturnValue("default-project");
 
     const result = await resolveOrgAndProject({ cwd: "/test" });
 
@@ -881,8 +887,8 @@ describe("env var resolution: SENTRY_ORG + SENTRY_PROJECT", () => {
   test("resolveAllTargets: env vars beat config defaults", async () => {
     process.env.SENTRY_ORG = "env-org";
     process.env.SENTRY_PROJECT = "env-project";
-    mockGetDefaultOrganization.mockResolvedValue("default-org");
-    mockGetDefaultProject.mockResolvedValue("default-project");
+    mockGetDefaultOrganization.mockReturnValue("default-org");
+    mockGetDefaultProject.mockReturnValue("default-project");
 
     const result = await resolveAllTargets({ cwd: "/test" });
 

--- a/test/lib/api-client.coverage.test.ts
+++ b/test/lib/api-client.coverage.test.ts
@@ -52,7 +52,7 @@ let originalFetch: typeof globalThis.fetch;
 beforeEach(async () => {
   originalFetch = globalThis.fetch;
   await setAuthToken("test-token");
-  await setOrgRegion("test-org", "https://sentry.io");
+  setOrgRegion("test-org", "https://sentry.io");
 });
 
 afterEach(() => {

--- a/test/lib/api-client.multiregion.test.ts
+++ b/test/lib/api-client.multiregion.test.ts
@@ -42,7 +42,7 @@ beforeEach(async () => {
   await setAuthToken("test-token");
 
   // Clear any existing region cache
-  await clearOrgRegions();
+  clearOrgRegions();
 });
 
 afterEach(() => {
@@ -401,7 +401,7 @@ describe("listOrganizations (fan-out)", () => {
     await listOrganizations();
 
     // Verify region cache was populated
-    const cachedRegions = await getAllOrgRegions();
+    const cachedRegions = getAllOrgRegions();
     expect(cachedRegions.size).toBe(2);
     expect(cachedRegions.get("acme-us")).toBe("https://us.sentry.io");
     expect(cachedRegions.get("acme-eu")).toBe("https://de.sentry.io");
@@ -530,7 +530,7 @@ describe("listOrganizations (fan-out)", () => {
     await listOrganizations();
 
     // Check cached regions
-    const cachedRegions = await getAllOrgRegions();
+    const cachedRegions = getAllOrgRegions();
     // Org with links should use its regionUrl
     expect(cachedRegions.get("org-with-links")).toBe(
       "https://custom.sentry.io"
@@ -809,7 +809,7 @@ describe("findProjectByDsnKey (multi-region)", () => {
 describe("org-scoped requests use region cache", () => {
   test("routes request to cached region URL", async () => {
     // Pre-populate region cache
-    await setOrgRegion("cached-org", "https://de.sentry.io");
+    setOrgRegion("cached-org", "https://de.sentry.io");
 
     let capturedUrl: string | undefined;
 

--- a/test/lib/api-client.seer-trial.test.ts
+++ b/test/lib/api-client.seer-trial.test.ts
@@ -21,7 +21,7 @@ beforeEach(async () => {
   originalFetch = globalThis.fetch;
 
   await setAuthToken("test-token");
-  await setOrgRegion("test-org", "https://sentry.io");
+  setOrgRegion("test-org", "https://sentry.io");
 });
 
 afterEach(() => {

--- a/test/lib/api-client.seer.test.ts
+++ b/test/lib/api-client.seer.test.ts
@@ -24,7 +24,7 @@ beforeEach(async () => {
   // Set up auth token (manual token, no refresh)
   await setAuthToken("test-token");
   // Pre-populate region cache to avoid region resolution API calls
-  await setOrgRegion("test-org", "https://sentry.io");
+  setOrgRegion("test-org", "https://sentry.io");
 });
 
 afterEach(() => {

--- a/test/lib/api-client.test.ts
+++ b/test/lib/api-client.test.ts
@@ -833,7 +833,7 @@ describe("findProjectsBySlug", () => {
 
     // Seed org_regions cache with full org data (slug, id, name, region)
     // so listOrganizations() returns from cache without HTTP calls.
-    await setOrgRegions([
+    setOrgRegions([
       {
         slug: "acme",
         regionUrl: DEFAULT_SENTRY_URL,
@@ -1091,7 +1091,7 @@ describe("findEventAcrossOrgs", () => {
 
 describe("listTeamsPaginated", () => {
   beforeEach(async () => {
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   test("returns teams and nextCursor from Link header", async () => {
@@ -1168,7 +1168,7 @@ describe("listTeamsPaginated", () => {
 
 describe("listRepositoriesPaginated", () => {
   beforeEach(async () => {
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   test("returns repos and nextCursor from Link header", async () => {
@@ -1225,7 +1225,7 @@ describe("listRepositoriesPaginated", () => {
 
 describe("listIssuesPaginated", () => {
   beforeEach(async () => {
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   test("returns issues and nextCursor from Link header", async () => {
@@ -1418,7 +1418,7 @@ describe("listTransactions", () => {
   };
 
   beforeEach(async () => {
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   test("returns data and nextCursor from Link header", async () => {
@@ -1555,7 +1555,7 @@ describe("listTraceLogs", () => {
   };
 
   beforeEach(async () => {
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   test("returns trace log entries", async () => {
@@ -1734,7 +1734,7 @@ describe("getLogs", () => {
   }
 
   beforeEach(async () => {
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   test("returns matching log entries", async () => {

--- a/test/lib/complete.test.ts
+++ b/test/lib/complete.test.ts
@@ -35,7 +35,7 @@ async function seedOrgs(
     orgId: o.slug,
     orgName: o.name,
   }));
-  await setOrgRegions(entries);
+  setOrgRegions(entries);
 }
 
 async function seedProjects(
@@ -48,7 +48,7 @@ async function seedProjects(
   }[]
 ): Promise<void> {
   for (const p of projects) {
-    await setCachedProject(p.orgId, p.projectId, {
+    setCachedProject(p.orgId, p.projectId, {
       orgSlug: p.orgSlug,
       orgName: p.orgSlug,
       projectSlug: p.projectSlug,
@@ -61,20 +61,20 @@ async function seedProjects(
 
 describe("getCompletions: context detection", () => {
   test("returns empty for unknown commands", async () => {
-    const result = await getCompletions(["unknown", "cmd"], "");
+    const result = getCompletions(["unknown", "cmd"], "");
     expect(result).toEqual([]);
   });
 
   test("returns org/project completions for issue list", async () => {
     await seedOrgs([{ slug: "my-org", name: "My Organization" }]);
-    const result = await getCompletions(["issue", "list"], "");
+    const result = getCompletions(["issue", "list"], "");
     expect(result.length).toBeGreaterThan(0);
     expect(result[0].value).toBe("my-org/");
   });
 
   test("returns org-only completions for org view", async () => {
     await seedOrgs([{ slug: "my-org", name: "My Organization" }]);
-    const result = await getCompletions(["org", "view"], "");
+    const result = getCompletions(["org", "view"], "");
     expect(result.length).toBeGreaterThan(0);
     expect(result[0].value).toBe("my-org"); // no trailing slash
   });
@@ -82,26 +82,26 @@ describe("getCompletions: context detection", () => {
   test("still provides completions after boolean flags", async () => {
     await seedOrgs([{ slug: "my-org", name: "My Organization" }]);
     // After --verbose (a boolean flag), completions should still work
-    const result = await getCompletions(["issue", "list", "--verbose"], "");
+    const result = getCompletions(["issue", "list", "--verbose"], "");
     expect(result.length).toBeGreaterThan(0);
   });
 
   test("returns org/project completions for project list", async () => {
     await seedOrgs([{ slug: "test-org", name: "Test" }]);
-    const result = await getCompletions(["project", "list"], "test");
+    const result = getCompletions(["project", "list"], "test");
     expect(result.some((c) => c.value === "test-org/")).toBe(true);
   });
 
   test("returns org-only completions for team list", async () => {
     await seedOrgs([{ slug: "acme", name: "Acme Inc" }]);
-    const result = await getCompletions(["team", "list"], "");
+    const result = getCompletions(["team", "list"], "");
     expect(result.some((c) => c.value === "acme")).toBe(true);
   });
 });
 
 describe("completeOrgSlugs", () => {
   test("returns empty when no orgs cached", async () => {
-    const result = await completeOrgSlugs("");
+    const result = completeOrgSlugs("");
     expect(result).toEqual([]);
   });
 
@@ -110,7 +110,7 @@ describe("completeOrgSlugs", () => {
       { slug: "alpha", name: "Alpha Org" },
       { slug: "beta", name: "Beta Org" },
     ]);
-    const result = await completeOrgSlugs("");
+    const result = completeOrgSlugs("");
     expect(result).toHaveLength(2);
     expect(result.map((c) => c.value).sort()).toEqual(["alpha", "beta"]);
   });
@@ -120,7 +120,7 @@ describe("completeOrgSlugs", () => {
       { slug: "sentry", name: "Sentry" },
       { slug: "other", name: "Other" },
     ]);
-    const result = await completeOrgSlugs("sen");
+    const result = completeOrgSlugs("sen");
     expect(result).toHaveLength(1);
     expect(result[0].value).toBe("sentry");
     expect(result[0].description).toBe("Sentry");
@@ -132,7 +132,7 @@ describe("completeOrgSlugs", () => {
       { slug: "other", name: "Other" },
     ]);
     // "senry" → "sentry" (distance 1, within threshold)
-    const result = await completeOrgSlugs("senry");
+    const result = completeOrgSlugs("senry");
     expect(result.some((c) => c.value === "sentry")).toBe(true);
   });
 });
@@ -140,7 +140,7 @@ describe("completeOrgSlugs", () => {
 describe("completeOrgSlashProject", () => {
   test("no slash returns org slugs with trailing slash + aliases", async () => {
     await seedOrgs([{ slug: "my-org", name: "My Org" }]);
-    const result = await completeOrgSlashProject("");
+    const result = completeOrgSlashProject("");
     expect(result.some((c) => c.value === "my-org/")).toBe(true);
   });
 
@@ -163,7 +163,7 @@ describe("completeOrgSlashProject", () => {
       },
     ]);
 
-    const result = await completeOrgSlashProject("my-org/");
+    const result = completeOrgSlashProject("my-org/");
     expect(result.map((c) => c.value).sort()).toEqual([
       "my-org/backend",
       "my-org/frontend",
@@ -183,14 +183,14 @@ describe("completeOrgSlashProject", () => {
     ]);
 
     // "senry/" has a typo in the org — should fuzzy-resolve to "sentry"
-    const result = await completeOrgSlashProject("senry/");
+    const result = completeOrgSlashProject("senry/");
     expect(result).toHaveLength(1);
     expect(result[0].value).toBe("sentry/cli");
   });
 
   test("with unresolvable org slug before slash returns empty", async () => {
     await seedOrgs([{ slug: "sentry", name: "Sentry" }]);
-    const result = await completeOrgSlashProject("zzzzzzz/");
+    const result = completeOrgSlashProject("zzzzzzz/");
     expect(result).toEqual([]);
   });
 
@@ -213,7 +213,7 @@ describe("completeOrgSlashProject", () => {
       },
     ]);
 
-    const result = await completeOrgSlashProject("my-org/fro");
+    const result = completeOrgSlashProject("my-org/fro");
     expect(result).toHaveLength(1);
     expect(result[0].value).toBe("my-org/frontend");
   });
@@ -221,7 +221,7 @@ describe("completeOrgSlashProject", () => {
 
 describe("completeProjectSlugs", () => {
   test("returns empty when no projects cached for org", async () => {
-    const result = await completeProjectSlugs("", "nonexistent");
+    const result = completeProjectSlugs("", "nonexistent");
     expect(result).toEqual([]);
   });
 
@@ -243,7 +243,7 @@ describe("completeProjectSlugs", () => {
       },
     ]);
 
-    const result = await completeProjectSlugs("we", "my-org");
+    const result = completeProjectSlugs("we", "my-org");
     expect(result).toHaveLength(1);
     expect(result[0].value).toBe("my-org/web");
     expect(result[0].description).toBe("Web App");
@@ -252,12 +252,12 @@ describe("completeProjectSlugs", () => {
 
 describe("completeAliases", () => {
   test("returns empty when no aliases exist", async () => {
-    const result = await completeAliases("");
+    const result = completeAliases("");
     expect(result).toEqual([]);
   });
 
   test("returns matching aliases", async () => {
-    await setProjectAliases(
+    setProjectAliases(
       {
         a: { orgSlug: "my-org", projectSlug: "frontend" },
         b: { orgSlug: "my-org", projectSlug: "backend" },
@@ -265,7 +265,7 @@ describe("completeAliases", () => {
       "fingerprint"
     );
 
-    const result = await completeAliases("");
+    const result = completeAliases("");
     expect(result).toHaveLength(2);
 
     const aCompletion = result.find((c) => c.value === "a");
@@ -274,7 +274,7 @@ describe("completeAliases", () => {
   });
 
   test("filters aliases by prefix (exact match ranks first)", async () => {
-    await setProjectAliases(
+    setProjectAliases(
       {
         a: { orgSlug: "org", projectSlug: "proj-a" },
         b: { orgSlug: "org", projectSlug: "proj-b" },
@@ -283,7 +283,7 @@ describe("completeAliases", () => {
       "fingerprint"
     );
 
-    const result = await completeAliases("a");
+    const result = completeAliases("a");
     // "a" is exact match, "abc" is prefix match, "b" is fuzzy match
     expect(result[0].value).toBe("a"); // exact match first
     expect(result.some((c) => c.value === "abc")).toBe(true); // prefix match

--- a/test/lib/config.test.ts
+++ b/test/lib/config.test.ts
@@ -97,56 +97,56 @@ describe("auth token management", () => {
 
   test("isAuthenticated returns true with valid token", async () => {
     await setAuthToken("valid-token");
-    expect(await isAuthenticated()).toBe(true);
+    expect(isAuthenticated()).toBe(true);
   });
 
   test("isAuthenticated returns false without token", async () => {
-    expect(await isAuthenticated()).toBe(false);
+    expect(isAuthenticated()).toBe(false);
   });
 
   test("isAuthenticated returns false with expired token", async () => {
     await setAuthToken("expired", -1); // Negative expires immediately
-    expect(await isAuthenticated()).toBe(false);
+    expect(isAuthenticated()).toBe(false);
   });
 });
 
 describe("defaults management", () => {
   test("setDefaults stores organization", async () => {
-    await setDefaults("my-org");
+    setDefaults("my-org");
 
-    const org = await getDefaultOrganization();
+    const org = getDefaultOrganization();
     expect(org).toBe("my-org");
   });
 
   test("setDefaults stores project", async () => {
-    await setDefaults(undefined, "my-project");
+    setDefaults(undefined, "my-project");
 
-    const project = await getDefaultProject();
+    const project = getDefaultProject();
     expect(project).toBe("my-project");
   });
 
   test("setDefaults stores both org and project", async () => {
-    await setDefaults("my-org", "my-project");
+    setDefaults("my-org", "my-project");
 
-    expect(await getDefaultOrganization()).toBe("my-org");
-    expect(await getDefaultProject()).toBe("my-project");
+    expect(getDefaultOrganization()).toBe("my-org");
+    expect(getDefaultProject()).toBe("my-project");
   });
 
   test("setDefaults preserves existing defaults", async () => {
-    await setDefaults("org1", "project1");
-    await setDefaults("org2"); // Only update org
+    setDefaults("org1", "project1");
+    setDefaults("org2"); // Only update org
 
-    expect(await getDefaultOrganization()).toBe("org2");
-    expect(await getDefaultProject()).toBe("project1");
+    expect(getDefaultOrganization()).toBe("org2");
+    expect(getDefaultProject()).toBe("project1");
   });
 
   test("getDefaultOrganization returns undefined when not set", async () => {
-    const org = await getDefaultOrganization();
+    const org = getDefaultOrganization();
     expect(org).toBeUndefined();
   });
 
   test("getDefaultProject returns undefined when not set", async () => {
-    const project = await getDefaultProject();
+    const project = getDefaultProject();
     expect(project).toBeUndefined();
   });
 });
@@ -216,12 +216,12 @@ describe("refreshToken error handling", () => {
 
 describe("project aliases", () => {
   test("setProjectAliases stores aliases", async () => {
-    await setProjectAliases({
+    setProjectAliases({
       e: { orgSlug: "sentry", projectSlug: "spotlight-electron" },
       w: { orgSlug: "sentry", projectSlug: "spotlight-website" },
     });
 
-    const aliases = await getProjectAliases();
+    const aliases = getProjectAliases();
     expect(aliases).toEqual({
       e: { orgSlug: "sentry", projectSlug: "spotlight-electron" },
       w: { orgSlug: "sentry", projectSlug: "spotlight-website" },
@@ -229,12 +229,12 @@ describe("project aliases", () => {
   });
 
   test("getProjectAliases returns stored aliases", async () => {
-    await setProjectAliases({
+    setProjectAliases({
       f: { orgSlug: "my-org", projectSlug: "frontend" },
       b: { orgSlug: "my-org", projectSlug: "backend" },
     });
 
-    const aliases = await getProjectAliases();
+    const aliases = getProjectAliases();
     expect(aliases).toEqual({
       f: { orgSlug: "my-org", projectSlug: "frontend" },
       b: { orgSlug: "my-org", projectSlug: "backend" },
@@ -242,18 +242,18 @@ describe("project aliases", () => {
   });
 
   test("getProjectAliases returns undefined when not set", async () => {
-    const aliases = await getProjectAliases();
+    const aliases = getProjectAliases();
     expect(aliases).toBeUndefined();
   });
 
   test("getProjectByAlias returns correct project", async () => {
-    await setProjectAliases({
+    setProjectAliases({
       e: { orgSlug: "sentry", projectSlug: "spotlight-electron" },
       w: { orgSlug: "sentry", projectSlug: "spotlight-website" },
       s: { orgSlug: "sentry", projectSlug: "spotlight" },
     });
 
-    const project = await getProjectByAlias("e");
+    const project = getProjectByAlias("e");
     expect(project).toEqual({
       orgSlug: "sentry",
       projectSlug: "spotlight-electron",
@@ -261,55 +261,55 @@ describe("project aliases", () => {
   });
 
   test("getProjectByAlias is case-insensitive", async () => {
-    await setProjectAliases({
+    setProjectAliases({
       e: { orgSlug: "sentry", projectSlug: "spotlight-electron" },
     });
 
-    expect(await getProjectByAlias("E")).toEqual({
+    expect(getProjectByAlias("E")).toEqual({
       orgSlug: "sentry",
       projectSlug: "spotlight-electron",
     });
-    expect(await getProjectByAlias("e")).toEqual({
+    expect(getProjectByAlias("e")).toEqual({
       orgSlug: "sentry",
       projectSlug: "spotlight-electron",
     });
   });
 
   test("getProjectByAlias returns undefined for unknown alias", async () => {
-    await setProjectAliases({
+    setProjectAliases({
       e: { orgSlug: "sentry", projectSlug: "spotlight-electron" },
     });
 
-    const project = await getProjectByAlias("x");
+    const project = getProjectByAlias("x");
     expect(project).toBeUndefined();
   });
 
   test("getProjectByAlias returns undefined when no aliases set", async () => {
-    const project = await getProjectByAlias("e");
+    const project = getProjectByAlias("e");
     expect(project).toBeUndefined();
   });
 
   test("clearProjectAliases removes all aliases", async () => {
-    await setProjectAliases({
+    setProjectAliases({
       e: { orgSlug: "sentry", projectSlug: "spotlight-electron" },
     });
 
-    await clearProjectAliases();
+    clearProjectAliases();
 
-    const aliases = await getProjectAliases();
+    const aliases = getProjectAliases();
     expect(aliases).toBeUndefined();
   });
 
   test("setProjectAliases overwrites existing aliases", async () => {
-    await setProjectAliases({
+    setProjectAliases({
       old: { orgSlug: "org1", projectSlug: "project1" },
     });
 
-    await setProjectAliases({
+    setProjectAliases({
       new: { orgSlug: "org2", projectSlug: "project2" },
     });
 
-    const aliases = await getProjectAliases();
+    const aliases = getProjectAliases();
     expect(aliases).toEqual({
       new: { orgSlug: "org2", projectSlug: "project2" },
     });
@@ -319,7 +319,7 @@ describe("project aliases", () => {
 
 describe("DSN-fingerprinted project aliases", () => {
   test("getProjectByAlias returns alias when fingerprint matches", async () => {
-    await setProjectAliases(
+    setProjectAliases(
       {
         e: { orgSlug: "sentry", projectSlug: "spotlight-electron" },
       },
@@ -327,7 +327,7 @@ describe("DSN-fingerprinted project aliases", () => {
     );
 
     // Same fingerprint
-    const project = await getProjectByAlias("e", "123:456,123:789");
+    const project = getProjectByAlias("e", "123:456,123:789");
     expect(project).toEqual({
       orgSlug: "sentry",
       projectSlug: "spotlight-electron",
@@ -335,7 +335,7 @@ describe("DSN-fingerprinted project aliases", () => {
   });
 
   test("getProjectByAlias returns undefined when fingerprint mismatches", async () => {
-    await setProjectAliases(
+    setProjectAliases(
       {
         e: { orgSlug: "sentry", projectSlug: "spotlight-electron" },
       },
@@ -343,18 +343,18 @@ describe("DSN-fingerprinted project aliases", () => {
     );
 
     // Different fingerprint (different DSN context)
-    const project = await getProjectByAlias("e", "999:111");
+    const project = getProjectByAlias("e", "999:111");
     expect(project).toBeUndefined();
   });
 
   test("getProjectByAlias returns alias when no fingerprint stored (legacy cache)", async () => {
     // No fingerprint stored
-    await setProjectAliases({
+    setProjectAliases({
       e: { orgSlug: "sentry", projectSlug: "spotlight-electron" },
     });
 
     // Should work without fingerprint validation (legacy cache)
-    const project = await getProjectByAlias("e", "123:456");
+    const project = getProjectByAlias("e", "123:456");
     expect(project).toEqual({
       orgSlug: "sentry",
       projectSlug: "spotlight-electron",
@@ -362,7 +362,7 @@ describe("DSN-fingerprinted project aliases", () => {
   });
 
   test("getProjectByAlias returns alias when no current fingerprint provided", async () => {
-    await setProjectAliases(
+    setProjectAliases(
       {
         e: { orgSlug: "sentry", projectSlug: "spotlight-electron" },
       },
@@ -370,7 +370,7 @@ describe("DSN-fingerprinted project aliases", () => {
     );
 
     // No current fingerprint provided - skip validation
-    const project = await getProjectByAlias("e");
+    const project = getProjectByAlias("e");
     expect(project).toEqual({
       orgSlug: "sentry",
       projectSlug: "spotlight-electron",
@@ -378,7 +378,7 @@ describe("DSN-fingerprinted project aliases", () => {
   });
 
   test("fingerprint does not affect case-insensitive lookup", async () => {
-    await setProjectAliases(
+    setProjectAliases(
       {
         e: { orgSlug: "sentry", projectSlug: "spotlight-electron" },
       },
@@ -386,7 +386,7 @@ describe("DSN-fingerprinted project aliases", () => {
     );
 
     // Uppercase alias with matching fingerprint
-    const project = await getProjectByAlias("E", "123:456");
+    const project = getProjectByAlias("E", "123:456");
     expect(project).toEqual({
       orgSlug: "sentry",
       projectSlug: "spotlight-electron",
@@ -395,7 +395,7 @@ describe("DSN-fingerprinted project aliases", () => {
 
   test("getProjectByAlias rejects when current fingerprint is empty but cached is not", async () => {
     // Cache was created with SaaS DSNs
-    await setProjectAliases(
+    setProjectAliases(
       {
         e: { orgSlug: "sentry", projectSlug: "spotlight-electron" },
       },
@@ -404,13 +404,13 @@ describe("DSN-fingerprinted project aliases", () => {
 
     // Current context has no SaaS DSNs (empty fingerprint)
     // This should reject - different workspace/context
-    const project = await getProjectByAlias("e", "");
+    const project = getProjectByAlias("e", "");
     expect(project).toBeUndefined();
   });
 
   test("getProjectByAlias rejects when cached fingerprint is empty but current is not", async () => {
     // Cache was created with only self-hosted DSNs (empty fingerprint)
-    await setProjectAliases(
+    setProjectAliases(
       {
         e: { orgSlug: "sentry", projectSlug: "spotlight-electron" },
       },
@@ -419,13 +419,13 @@ describe("DSN-fingerprinted project aliases", () => {
 
     // Current context has SaaS DSNs
     // This should reject - different workspace/context
-    const project = await getProjectByAlias("e", "123:456");
+    const project = getProjectByAlias("e", "123:456");
     expect(project).toBeUndefined();
   });
 
   test("getProjectByAlias accepts when both fingerprints are empty", async () => {
     // Cache was created with only self-hosted DSNs
-    await setProjectAliases(
+    setProjectAliases(
       {
         e: { orgSlug: "sentry", projectSlug: "spotlight-electron" },
       },
@@ -433,7 +433,7 @@ describe("DSN-fingerprinted project aliases", () => {
     );
 
     // Current context also has only self-hosted DSNs
-    const project = await getProjectByAlias("e", "");
+    const project = getProjectByAlias("e", "");
     expect(project).toEqual({
       orgSlug: "sentry",
       projectSlug: "spotlight-electron",
@@ -447,14 +447,14 @@ describe("DSN-fingerprinted project aliases", () => {
 
 describe("getCachedProjectByDsnKey / setCachedProjectByDsnKey", () => {
   test("caches and retrieves project by DSN public key", async () => {
-    await setCachedProjectByDsnKey("abc123publickey", {
+    setCachedProjectByDsnKey("abc123publickey", {
       orgSlug: "my-org",
       orgName: "My Organization",
       projectSlug: "my-project",
       projectName: "My Project",
     });
 
-    const cached = await getCachedProjectByDsnKey("abc123publickey");
+    const cached = getCachedProjectByDsnKey("abc123publickey");
     expect(cached).toBeDefined();
     expect(cached?.orgSlug).toBe("my-org");
     expect(cached?.projectSlug).toBe("my-project");
@@ -462,7 +462,7 @@ describe("getCachedProjectByDsnKey / setCachedProjectByDsnKey", () => {
   });
 
   test("returns undefined for unknown DSN key", async () => {
-    const cached = await getCachedProjectByDsnKey("nonexistent-key");
+    const cached = getCachedProjectByDsnKey("nonexistent-key");
     expect(cached).toBeUndefined();
   });
 });
@@ -473,14 +473,14 @@ describe("getCachedProjectByDsnKey / setCachedProjectByDsnKey", () => {
 
 describe("getCachedProject / setCachedProject / clearProjectCache", () => {
   test("caches and retrieves project by orgId and projectId", async () => {
-    await setCachedProject("123", "456", {
+    setCachedProject("123", "456", {
       orgSlug: "my-org",
       orgName: "My Organization",
       projectSlug: "my-project",
       projectName: "My Project",
     });
 
-    const cached = await getCachedProject("123", "456");
+    const cached = getCachedProject("123", "456");
     expect(cached).toBeDefined();
     expect(cached?.orgSlug).toBe("my-org");
     expect(cached?.projectSlug).toBe("my-project");
@@ -488,46 +488,46 @@ describe("getCachedProject / setCachedProject / clearProjectCache", () => {
   });
 
   test("returns undefined for unknown orgId:projectId", async () => {
-    const cached = await getCachedProject("999", "999");
+    const cached = getCachedProject("999", "999");
     expect(cached).toBeUndefined();
   });
 
   test("clearProjectCache removes all cached projects", async () => {
-    await setCachedProject("123", "456", {
+    setCachedProject("123", "456", {
       orgSlug: "org1",
       orgName: "Org 1",
       projectSlug: "project1",
       projectName: "Project 1",
     });
-    await setCachedProjectByDsnKey("key1", {
+    setCachedProjectByDsnKey("key1", {
       orgSlug: "org2",
       orgName: "Org 2",
       projectSlug: "project2",
       projectName: "Project 2",
     });
 
-    await clearProjectCache();
+    clearProjectCache();
 
-    expect(await getCachedProject("123", "456")).toBeUndefined();
-    expect(await getCachedProjectByDsnKey("key1")).toBeUndefined();
+    expect(getCachedProject("123", "456")).toBeUndefined();
+    expect(getCachedProjectByDsnKey("key1")).toBeUndefined();
   });
 
   test("multiple projects can be cached independently", async () => {
-    await setCachedProject("123", "456", {
+    setCachedProject("123", "456", {
       orgSlug: "org1",
       orgName: "Org 1",
       projectSlug: "project1",
       projectName: "Project 1",
     });
-    await setCachedProject("123", "789", {
+    setCachedProject("123", "789", {
       orgSlug: "org1",
       orgName: "Org 1",
       projectSlug: "project2",
       projectName: "Project 2",
     });
 
-    const cached1 = await getCachedProject("123", "456");
-    const cached2 = await getCachedProject("123", "789");
+    const cached1 = getCachedProject("123", "456");
+    const cached2 = getCachedProject("123", "789");
 
     expect(cached1?.projectSlug).toBe("project1");
     expect(cached2?.projectSlug).toBe("project2");
@@ -581,10 +581,10 @@ describe("JSON to SQLite migration", () => {
     const auth = await getAuthConfig();
     expect(auth?.refreshToken).toBe("migrated-refresh");
 
-    const org = await getDefaultOrganization();
+    const org = getDefaultOrganization();
     expect(org).toBe("migrated-org");
 
-    const project = await getDefaultProject();
+    const project = getDefaultProject();
     expect(project).toBe("migrated-project");
 
     // config.json should be deleted after migration

--- a/test/lib/db/auth.test.ts
+++ b/test/lib/db/auth.test.ts
@@ -76,11 +76,11 @@ describe("env var auth: getAuthConfig shape", () => {
 describe("env var auth: isAuthenticated", () => {
   test("returns true when env var is set", async () => {
     process.env.SENTRY_AUTH_TOKEN = "test_token";
-    expect(await isAuthenticated()).toBe(true);
+    expect(isAuthenticated()).toBe(true);
   });
 
   test("returns false when nothing is set", async () => {
-    expect(await isAuthenticated()).toBe(false);
+    expect(isAuthenticated()).toBe(false);
   });
 });
 

--- a/test/lib/db/concurrent-worker.ts
+++ b/test/lib/db/concurrent-worker.ts
@@ -52,7 +52,7 @@ async function writeDsn(): Promise<WorkerResult> {
   const directory = `/test/project-${workerId}`;
   const dsn = `https://key${workerId}@sentry.io/123${workerId}`;
 
-  await setCachedDsn(directory, {
+  setCachedDsn(directory, {
     dsn,
     projectId: `123${workerId}`,
     orgId: "456",
@@ -60,7 +60,7 @@ async function writeDsn(): Promise<WorkerResult> {
   });
 
   // Verify write
-  const cached = await getCachedDsn(directory);
+  const cached = getCachedDsn(directory);
   if (cached?.dsn !== dsn) {
     return {
       workerId,
@@ -82,7 +82,7 @@ async function writeProject(): Promise<WorkerResult> {
   const orgId = "org-456";
   const projectId = `proj-${workerId}`;
 
-  await setCachedProject(orgId, projectId, {
+  setCachedProject(orgId, projectId, {
     orgSlug: "test-org",
     orgName: "Test Org",
     projectSlug: `project-${workerId}`,
@@ -90,7 +90,7 @@ async function writeProject(): Promise<WorkerResult> {
   });
 
   // Verify write
-  const cached = await getCachedProject(orgId, projectId);
+  const cached = getCachedProject(orgId, projectId);
   if (cached?.projectSlug !== `project-${workerId}`) {
     return {
       workerId,
@@ -117,13 +117,13 @@ async function readWrite(): Promise<WorkerResult> {
     const directory = `/test/worker-${workerId}-iter-${i}`;
     const dsn = `https://key${workerId}${i}@sentry.io/${workerId}${i}`;
 
-    await setCachedDsn(directory, {
+    setCachedDsn(directory, {
       dsn,
       projectId: `${workerId}${i}`,
       source: "env-file",
     });
 
-    const cached = await getCachedDsn(directory);
+    const cached = getCachedDsn(directory);
     if (cached?.dsn !== dsn) {
       return {
         workerId,

--- a/test/lib/db/concurrent.test.ts
+++ b/test/lib/db/concurrent.test.ts
@@ -115,7 +115,7 @@ describe("concurrent database access", () => {
 
     for (let i = 0; i < workerCount; i++) {
       const directory = `/test/project-${i}`;
-      const cached = await getCachedDsn(directory);
+      const cached = getCachedDsn(directory);
       expect(cached).toBeDefined();
       expect(cached?.dsn).toBe(`https://key${i}@sentry.io/123${i}`);
     }
@@ -137,7 +137,7 @@ describe("concurrent database access", () => {
     process.env[CONFIG_DIR_ENV_VAR] = getConfigDir();
 
     for (let i = 0; i < workerCount; i++) {
-      const cached = await getCachedProject("org-456", `proj-${i}`);
+      const cached = getCachedProject("org-456", `proj-${i}`);
       expect(cached).toBeDefined();
       expect(cached?.projectSlug).toBe(`project-${i}`);
     }
@@ -161,7 +161,7 @@ describe("concurrent database access", () => {
     for (let w = 0; w < workerCount; w++) {
       for (let i = 0; i < 5; i++) {
         const directory = `/test/worker-${w}-iter-${i}`;
-        const cached = await getCachedDsn(directory);
+        const cached = getCachedDsn(directory);
         expect(cached).toBeDefined();
         expect(cached?.dsn).toBe(`https://key${w}${i}@sentry.io/${w}${i}`);
       }

--- a/test/lib/db/dsn-cache.model-based.test.ts
+++ b/test/lib/db/dsn-cache.model-based.test.ts
@@ -162,7 +162,7 @@ class SetCachedDsnCommand implements AsyncCommand<CacheModel, RealCache> {
   async run(model: CacheModel, _real: RealCache): Promise<void> {
     const { directory, dsn, projectId, orgId, source, sourcePath } = this.entry;
 
-    await setCachedDsn(directory, {
+    setCachedDsn(directory, {
       dsn,
       projectId,
       orgId,
@@ -194,7 +194,7 @@ class GetCachedDsnCommand implements AsyncCommand<CacheModel, RealCache> {
   check = () => true;
 
   async run(model: CacheModel, _real: RealCache): Promise<void> {
-    const realEntry = await getCachedDsn(this.directory);
+    const realEntry = getCachedDsn(this.directory);
     const modelEntry = model.dsnCache.entries.get(this.directory);
 
     if (modelEntry) {
@@ -229,7 +229,7 @@ class UpdateCachedResolutionCommand
   check = () => true;
 
   async run(model: CacheModel, _real: RealCache): Promise<void> {
-    await updateCachedResolution(this.directory, this.resolved);
+    updateCachedResolution(this.directory, this.resolved);
 
     // Only updates if entry exists
     const existing = model.dsnCache.entries.get(this.directory);
@@ -253,7 +253,7 @@ class ClearDsnCacheCommand implements AsyncCommand<CacheModel, RealCache> {
   check = () => true;
 
   async run(model: CacheModel, _real: RealCache): Promise<void> {
-    await clearDsnCache(this.directory);
+    clearDsnCache(this.directory);
 
     if (this.directory) {
       model.dsnCache.entries.delete(this.directory);
@@ -288,7 +288,7 @@ class SetCachedProjectCommand implements AsyncCommand<CacheModel, RealCache> {
 
   async run(model: CacheModel, _real: RealCache): Promise<void> {
     const { orgId, projectId, info } = this.input;
-    await setCachedProject(orgId, projectId, info);
+    setCachedProject(orgId, projectId, info);
 
     const key = `${orgId}:${projectId}`;
     model.projectCache.entries.set(key, info);
@@ -315,7 +315,7 @@ class GetCachedProjectCommand implements AsyncCommand<CacheModel, RealCache> {
 
   async run(model: CacheModel, _real: RealCache): Promise<void> {
     const { orgId, projectId } = this.lookup;
-    const realEntry = await getCachedProject(orgId, projectId);
+    const realEntry = getCachedProject(orgId, projectId);
     const key = `${orgId}:${projectId}`;
     const modelEntry = model.projectCache.entries.get(key);
 
@@ -353,7 +353,7 @@ class SetCachedProjectByDsnKeyCommand
 
   async run(model: CacheModel, _real: RealCache): Promise<void> {
     const { publicKey, info } = this.input;
-    await setCachedProjectByDsnKey(publicKey, info);
+    setCachedProjectByDsnKey(publicKey, info);
 
     const key = `dsn:${publicKey}`;
     model.projectCache.entries.set(key, info);
@@ -376,7 +376,7 @@ class GetCachedProjectByDsnKeyCommand
   check = () => true;
 
   async run(model: CacheModel, _real: RealCache): Promise<void> {
-    const realEntry = await getCachedProjectByDsnKey(this.publicKey);
+    const realEntry = getCachedProjectByDsnKey(this.publicKey);
     const key = `dsn:${this.publicKey}`;
     const modelEntry = model.projectCache.entries.get(key);
 
@@ -400,7 +400,7 @@ class ClearProjectCacheCommand implements AsyncCommand<CacheModel, RealCache> {
   check = () => true;
 
   async run(model: CacheModel, _real: RealCache): Promise<void> {
-    await clearProjectCache();
+    clearProjectCache();
     model.projectCache.entries.clear();
   }
 
@@ -514,10 +514,10 @@ describe("model-based: DSN and project cache", () => {
           const cleanup = createIsolatedDbContext();
           try {
             // Try to update resolution for non-existent entry
-            await updateCachedResolution(directory, resolved);
+            updateCachedResolution(directory, resolved);
 
             // Entry should still not exist
-            const entry = await getCachedDsn(directory);
+            const entry = getCachedDsn(directory);
             expect(entry).toBeUndefined();
           } finally {
             cleanup();
@@ -539,15 +539,15 @@ describe("model-based: DSN and project cache", () => {
           const cleanup = createIsolatedDbContext();
           try {
             // Set up two entries
-            await setCachedDsn(dir1, { dsn, projectId, source });
-            await setCachedDsn(dir2, { dsn, projectId, source });
+            setCachedDsn(dir1, { dsn, projectId, source });
+            setCachedDsn(dir2, { dsn, projectId, source });
 
             // Clear only dir1
-            await clearDsnCache(dir1);
+            clearDsnCache(dir1);
 
             // dir1 should be gone, dir2 should still exist
-            expect(await getCachedDsn(dir1)).toBeUndefined();
-            expect(await getCachedDsn(dir2)).toBeDefined();
+            expect(getCachedDsn(dir1)).toBeUndefined();
+            expect(getCachedDsn(dir2)).toBeDefined();
           } finally {
             cleanup();
           }
@@ -565,14 +565,14 @@ describe("model-based: DSN and project cache", () => {
           const cleanup = createIsolatedDbContext();
           try {
             // Set by org:project
-            await setCachedProject(orgId, projectId, info);
+            setCachedProject(orgId, projectId, info);
 
             // Getting by DSN key should return undefined
-            const byDsnKey = await getCachedProjectByDsnKey(publicKey);
+            const byDsnKey = getCachedProjectByDsnKey(publicKey);
             expect(byDsnKey).toBeUndefined();
 
             // Getting by org:project should return the entry
-            const byOrgProject = await getCachedProject(orgId, projectId);
+            const byOrgProject = getCachedProject(orgId, projectId);
             expect(byOrgProject).toBeDefined();
           } finally {
             cleanup();

--- a/test/lib/db/dsn-cache.test.ts
+++ b/test/lib/db/dsn-cache.test.ts
@@ -44,12 +44,12 @@ afterEach(() => {
 
 describe("getCachedDsn", () => {
   test("returns undefined when no cache entry exists", async () => {
-    const result = await getCachedDsn("/nonexistent/path");
+    const result = getCachedDsn("/nonexistent/path");
     expect(result).toBeUndefined();
   });
 
   test("returns cached entry when it exists", async () => {
-    await setCachedDsn(testProjectDir, {
+    setCachedDsn(testProjectDir, {
       dsn: "https://abc@o123.ingest.sentry.io/456",
       projectId: "456",
       orgId: "123",
@@ -57,7 +57,7 @@ describe("getCachedDsn", () => {
       sourcePath: ".env",
     });
 
-    const result = await getCachedDsn(testProjectDir);
+    const result = getCachedDsn(testProjectDir);
     expect(result?.dsn).toBe("https://abc@o123.ingest.sentry.io/456");
     expect(result?.projectId).toBe("456");
     expect(result?.orgId).toBe("123");
@@ -68,7 +68,7 @@ describe("getCachedDsn", () => {
 
 describe("setCachedDsn", () => {
   test("stores DSN cache entry", async () => {
-    await setCachedDsn(testProjectDir, {
+    setCachedDsn(testProjectDir, {
       dsn: "https://key@o999.ingest.sentry.io/111",
       projectId: "111",
       orgId: "999",
@@ -76,25 +76,25 @@ describe("setCachedDsn", () => {
       sourcePath: "src/index.ts",
     });
 
-    const result = await getCachedDsn(testProjectDir);
+    const result = getCachedDsn(testProjectDir);
     expect(result?.dsn).toBe("https://key@o999.ingest.sentry.io/111");
     expect(result?.projectId).toBe("111");
   });
 
   test("overwrites existing cache entry", async () => {
-    await setCachedDsn(testProjectDir, {
+    setCachedDsn(testProjectDir, {
       dsn: "https://first@o1.ingest.sentry.io/1",
       projectId: "1",
       source: "env",
     });
 
-    await setCachedDsn(testProjectDir, {
+    setCachedDsn(testProjectDir, {
       dsn: "https://second@o2.ingest.sentry.io/2",
       projectId: "2",
       source: "code",
     });
 
-    const result = await getCachedDsn(testProjectDir);
+    const result = getCachedDsn(testProjectDir);
     expect(result?.dsn).toBe("https://second@o2.ingest.sentry.io/2");
     expect(result?.projectId).toBe("2");
   });
@@ -102,20 +102,20 @@ describe("setCachedDsn", () => {
 
 describe("updateCachedResolution", () => {
   test("updates resolved org/project info", async () => {
-    await setCachedDsn(testProjectDir, {
+    setCachedDsn(testProjectDir, {
       dsn: "https://abc@o123.ingest.sentry.io/456",
       projectId: "456",
       source: "env",
     });
 
-    await updateCachedResolution(testProjectDir, {
+    updateCachedResolution(testProjectDir, {
       orgSlug: "my-org",
       orgName: "My Organization",
       projectSlug: "my-project",
       projectName: "My Project",
     });
 
-    const result = await getCachedDsn(testProjectDir);
+    const result = getCachedDsn(testProjectDir);
     expect(result?.resolved?.orgSlug).toBe("my-org");
     expect(result?.resolved?.orgName).toBe("My Organization");
     expect(result?.resolved?.projectSlug).toBe("my-project");
@@ -124,7 +124,7 @@ describe("updateCachedResolution", () => {
 
   test("does nothing if cache entry does not exist", async () => {
     // Should not throw
-    await updateCachedResolution("/nonexistent", {
+    updateCachedResolution("/nonexistent", {
       orgSlug: "org",
       orgName: "Org",
       projectSlug: "project",
@@ -135,15 +135,15 @@ describe("updateCachedResolution", () => {
 
 describe("clearDsnCache", () => {
   test("removes specific directory cache", async () => {
-    await setCachedDsn(testProjectDir, {
+    setCachedDsn(testProjectDir, {
       dsn: "https://abc@o123.ingest.sentry.io/456",
       projectId: "456",
       source: "env",
     });
 
-    await clearDsnCache(testProjectDir);
+    clearDsnCache(testProjectDir);
 
-    const result = await getCachedDsn(testProjectDir);
+    const result = getCachedDsn(testProjectDir);
     expect(result).toBeUndefined();
   });
 
@@ -153,21 +153,21 @@ describe("clearDsnCache", () => {
     mkdirSync(dir1);
     mkdirSync(dir2);
 
-    await setCachedDsn(dir1, {
+    setCachedDsn(dir1, {
       dsn: "https://a@o1.ingest.sentry.io/1",
       projectId: "1",
       source: "env",
     });
-    await setCachedDsn(dir2, {
+    setCachedDsn(dir2, {
       dsn: "https://b@o2.ingest.sentry.io/2",
       projectId: "2",
       source: "code",
     });
 
-    await clearDsnCache();
+    clearDsnCache();
 
-    expect(await getCachedDsn(dir1)).toBeUndefined();
-    expect(await getCachedDsn(dir2)).toBeUndefined();
+    expect(getCachedDsn(dir1)).toBeUndefined();
+    expect(getCachedDsn(dir2)).toBeUndefined();
   });
 });
 
@@ -189,7 +189,7 @@ const createTestDsn = (overrides: Partial<DetectedDsn> = {}): DetectedDsn => ({
 
 describe("disableDsnCache / enableDsnCache", () => {
   test("getCachedDsn returns undefined when cache is disabled", async () => {
-    await setCachedDsn(testProjectDir, {
+    setCachedDsn(testProjectDir, {
       dsn: "https://abc@o123.ingest.sentry.io/456",
       projectId: "456",
       orgId: "123",
@@ -197,14 +197,14 @@ describe("disableDsnCache / enableDsnCache", () => {
     });
 
     // Verify it exists before disabling
-    expect(await getCachedDsn(testProjectDir)).toBeDefined();
+    expect(getCachedDsn(testProjectDir)).toBeDefined();
 
     disableDsnCache();
-    expect(await getCachedDsn(testProjectDir)).toBeUndefined();
+    expect(getCachedDsn(testProjectDir)).toBeUndefined();
 
     // Re-enable and verify it's still there
     enableDsnCache();
-    expect(await getCachedDsn(testProjectDir)).toBeDefined();
+    expect(getCachedDsn(testProjectDir)).toBeDefined();
   });
 
   test("getCachedDetection returns undefined when cache is disabled", async () => {
@@ -216,7 +216,7 @@ describe("disableDsnCache / enableDsnCache", () => {
     const rootStats = await stat(testProjectDir);
     const rootDirMtime = Math.floor(rootStats.mtimeMs);
 
-    await setCachedDetection(testProjectDir, {
+    setCachedDetection(testProjectDir, {
       fingerprint: "test-fp",
       allDsns: [testDsn],
       sourceMtimes,
@@ -238,18 +238,18 @@ describe("disableDsnCache / enableDsnCache", () => {
     disableDsnCache();
 
     // Write while disabled
-    await setCachedDsn(testProjectDir, {
+    setCachedDsn(testProjectDir, {
       dsn: "https://abc@o123.ingest.sentry.io/456",
       projectId: "456",
       source: "code",
     });
 
     // Can't read while disabled
-    expect(await getCachedDsn(testProjectDir)).toBeUndefined();
+    expect(getCachedDsn(testProjectDir)).toBeUndefined();
 
     // Re-enable and verify the write persisted
     enableDsnCache();
-    const result = await getCachedDsn(testProjectDir);
+    const result = getCachedDsn(testProjectDir);
     expect(result?.dsn).toBe("https://abc@o123.ingest.sentry.io/456");
   });
 });
@@ -275,7 +275,7 @@ describe("getCachedDetection", () => {
     const rootStats = await stat(testProjectDir);
     const rootDirMtime = Math.floor(rootStats.mtimeMs);
 
-    await setCachedDetection(testProjectDir, {
+    setCachedDetection(testProjectDir, {
       fingerprint: "test-fingerprint",
       allDsns: [testDsn],
       sourceMtimes,
@@ -300,7 +300,7 @@ describe("getCachedDetection", () => {
     const rootStats = await stat(testProjectDir);
     const rootDirMtime = Math.floor(rootStats.mtimeMs);
 
-    await setCachedDetection(testProjectDir, {
+    setCachedDetection(testProjectDir, {
       fingerprint: "test-fingerprint",
       allDsns: [testDsn],
       sourceMtimes,
@@ -334,7 +334,7 @@ describe("getCachedDetection", () => {
     const rootStats = await stat(testProjectDir);
     const rootDirMtime = Math.floor(rootStats.mtimeMs);
 
-    await setCachedDetection(testProjectDir, {
+    setCachedDetection(testProjectDir, {
       fingerprint: "test-fingerprint",
       allDsns: [testDsn],
       sourceMtimes,
@@ -361,7 +361,7 @@ describe("getCachedDetection", () => {
     const rootStats = await stat(testProjectDir);
     const rootDirMtime = Math.floor(rootStats.mtimeMs);
 
-    await setCachedDetection(testProjectDir, {
+    setCachedDetection(testProjectDir, {
       fingerprint: "test-fingerprint",
       allDsns: [testDsn],
       sourceMtimes,
@@ -395,7 +395,7 @@ describe("getCachedDetection", () => {
     const srcDirMtime = Math.floor(srcStats.mtimeMs);
 
     // Store cache with tracked src/ directory mtime
-    await setCachedDetection(testProjectDir, {
+    setCachedDetection(testProjectDir, {
       fingerprint: "test-fingerprint",
       allDsns: [testDsn],
       sourceMtimes,
@@ -431,7 +431,7 @@ describe("setCachedDetection", () => {
     const rootStats = await stat(testProjectDir);
     const rootDirMtime = Math.floor(rootStats.mtimeMs);
 
-    await setCachedDetection(testProjectDir, {
+    setCachedDetection(testProjectDir, {
       fingerprint: "fp-123",
       allDsns: [testDsn],
       sourceMtimes,
@@ -456,7 +456,7 @@ describe("setCachedDetection", () => {
     const rootStats = await stat(testProjectDir);
     const rootDirMtime = Math.floor(rootStats.mtimeMs);
 
-    await setCachedDetection(testProjectDir, {
+    setCachedDetection(testProjectDir, {
       fingerprint: "fp-multi",
       allDsns: [dsn1, dsn2],
       sourceMtimes,
@@ -473,7 +473,7 @@ describe("setCachedDetection", () => {
     const rootStats = await stat(testProjectDir);
     const rootDirMtime = Math.floor(rootStats.mtimeMs);
 
-    await setCachedDetection(testProjectDir, {
+    setCachedDetection(testProjectDir, {
       fingerprint: "fp-empty",
       allDsns: [],
       sourceMtimes: {},
@@ -497,7 +497,7 @@ describe("setCachedDetection", () => {
     const rootStats = await stat(testProjectDir);
     const rootDirMtime = Math.floor(rootStats.mtimeMs);
 
-    await setCachedDetection(testProjectDir, {
+    setCachedDetection(testProjectDir, {
       fingerprint: "fp-first",
       allDsns: [dsn1],
       sourceMtimes,
@@ -505,7 +505,7 @@ describe("setCachedDetection", () => {
       rootDirMtime,
     });
 
-    await setCachedDetection(testProjectDir, {
+    setCachedDetection(testProjectDir, {
       fingerprint: "fp-second",
       allDsns: [dsn2],
       sourceMtimes,

--- a/test/lib/db/model-based.test.ts
+++ b/test/lib/db/model-based.test.ts
@@ -256,7 +256,7 @@ class IsAuthenticatedCommand implements AsyncCommand<DbModel, RealDb> {
   check = () => true;
 
   async run(model: DbModel, _real: RealDb): Promise<void> {
-    const realResult = await isAuthenticated();
+    const realResult = isAuthenticated();
 
     // Env vars take priority
     const envToken = model.envAuthToken ?? model.envSentryToken;
@@ -366,7 +366,7 @@ class SetOrgRegionCommand implements AsyncCommand<DbModel, RealDb> {
   check = () => true;
 
   async run(model: DbModel, _real: RealDb): Promise<void> {
-    await setOrgRegion(this.orgSlug, this.regionUrl);
+    setOrgRegion(this.orgSlug, this.regionUrl);
     model.regions.set(this.orgSlug, this.regionUrl);
   }
 
@@ -385,7 +385,7 @@ class GetOrgRegionCommand implements AsyncCommand<DbModel, RealDb> {
   check = () => true;
 
   async run(model: DbModel, _real: RealDb): Promise<void> {
-    const realRegion = await getOrgRegion(this.orgSlug);
+    const realRegion = getOrgRegion(this.orgSlug);
     const expectedRegion = model.regions.get(this.orgSlug);
 
     expect(realRegion).toBe(expectedRegion);
@@ -406,7 +406,7 @@ class SetOrgRegionsCommand implements AsyncCommand<DbModel, RealDb> {
   check = () => true;
 
   async run(model: DbModel, _real: RealDb): Promise<void> {
-    await setOrgRegions(
+    setOrgRegions(
       this.entries.map(([slug, regionUrl]) => ({ slug, regionUrl }))
     );
 
@@ -424,7 +424,7 @@ class GetAllOrgRegionsCommand implements AsyncCommand<DbModel, RealDb> {
   check = () => true;
 
   async run(model: DbModel, _real: RealDb): Promise<void> {
-    const realRegions = await getAllOrgRegions();
+    const realRegions = getAllOrgRegions();
 
     expect(realRegions.size).toBe(model.regions.size);
 
@@ -440,7 +440,7 @@ class ClearOrgRegionsCommand implements AsyncCommand<DbModel, RealDb> {
   check = () => true;
 
   async run(model: DbModel, _real: RealDb): Promise<void> {
-    await clearOrgRegions();
+    clearOrgRegions();
     model.regions.clear();
   }
 
@@ -464,7 +464,7 @@ class SetProjectAliasesCommand implements AsyncCommand<DbModel, RealDb> {
   check = () => true;
 
   async run(model: DbModel, _real: RealDb): Promise<void> {
-    await setProjectAliases(this.aliases, this.fingerprint);
+    setProjectAliases(this.aliases, this.fingerprint);
 
     // Clear and replace all aliases (this is the documented behavior)
     model.aliases.entries.clear();
@@ -489,7 +489,7 @@ class GetProjectAliasesCommand implements AsyncCommand<DbModel, RealDb> {
   check = () => true;
 
   async run(model: DbModel, _real: RealDb): Promise<void> {
-    const realAliases = await getProjectAliases();
+    const realAliases = getProjectAliases();
 
     if (model.aliases.entries.size === 0) {
       expect(realAliases).toBeUndefined();
@@ -518,10 +518,7 @@ class GetProjectByAliasCommand implements AsyncCommand<DbModel, RealDb> {
   check = () => true;
 
   async run(model: DbModel, _real: RealDb): Promise<void> {
-    const realProject = await getProjectByAlias(
-      this.alias,
-      this.currentFingerprint
-    );
+    const realProject = getProjectByAlias(this.alias, this.currentFingerprint);
 
     // Lookup is case-insensitive
     const modelEntry = model.aliases.entries.get(this.alias.toLowerCase());
@@ -557,7 +554,7 @@ class ClearProjectAliasesCommand implements AsyncCommand<DbModel, RealDb> {
   check = () => true;
 
   async run(model: DbModel, _real: RealDb): Promise<void> {
-    await clearProjectAliases();
+    clearProjectAliases();
     model.aliases.entries.clear();
     model.aliases.fingerprint = null;
   }
@@ -807,12 +804,12 @@ describe("model-based: database layer", () => {
           try {
             // Set up auth and some regions
             setAuthToken("test-token");
-            await setOrgRegions(
+            setOrgRegions(
               entries.map(([slug, regionUrl]) => ({ slug, regionUrl }))
             );
 
             // Verify regions were set (use unique count since setOrgRegions uses upsert)
-            const regionsBefore = await getAllOrgRegions();
+            const regionsBefore = getAllOrgRegions();
             const uniqueOrgSlugs = new Set(entries.map(([org]) => org));
             expect(regionsBefore.size).toBe(uniqueOrgSlugs.size);
 
@@ -820,7 +817,7 @@ describe("model-based: database layer", () => {
             await clearAuth();
 
             // Verify regions were also cleared (this is the invariant!)
-            const regionsAfter = await getAllOrgRegions();
+            const regionsAfter = getAllOrgRegions();
             expect(regionsAfter.size).toBe(0);
           } finally {
             cleanup();
@@ -871,16 +868,16 @@ describe("model-based: database layer", () => {
           const cleanup = createIsolatedDbContext();
           try {
             // Set alias (stored lowercase)
-            await setProjectAliases({
+            setProjectAliases({
               [alias]: { orgSlug: org, projectSlug: project },
             });
 
             // Lookup with uppercase
-            const upper = await getProjectByAlias(alias.toUpperCase());
+            const upper = getProjectByAlias(alias.toUpperCase());
             // Lookup with lowercase
-            const lower = await getProjectByAlias(alias.toLowerCase());
+            const lower = getProjectByAlias(alias.toLowerCase());
             // Lookup with original
-            const original = await getProjectByAlias(alias);
+            const original = getProjectByAlias(alias);
 
             // All should return the same result
             expect(upper).toEqual(lower);
@@ -941,17 +938,17 @@ describe("model-based: database layer", () => {
         const cleanup = createIsolatedDbContext();
         try {
           // Set alias with fingerprint 1
-          await setProjectAliases(
+          setProjectAliases(
             { [alias]: { orgSlug: org, projectSlug: project } },
             fp1
           );
 
           // Lookup with fingerprint 2 should fail
-          const result = await getProjectByAlias(alias, fp2);
+          const result = getProjectByAlias(alias, fp2);
           expect(result).toBeUndefined();
 
           // Lookup with matching fingerprint should succeed
-          const matchingResult = await getProjectByAlias(alias, fp1);
+          const matchingResult = getProjectByAlias(alias, fp1);
           expect(matchingResult?.orgSlug).toBe(org);
         } finally {
           cleanup();
@@ -981,7 +978,7 @@ describe("model-based: database layer", () => {
             for (const [a, o, p] of first) {
               aliases1[a] = { orgSlug: o, projectSlug: p };
             }
-            await setProjectAliases(aliases1);
+            setProjectAliases(aliases1);
 
             // Set second batch (should replace all)
             const aliases2: Record<
@@ -991,10 +988,10 @@ describe("model-based: database layer", () => {
             for (const [a, o, p] of second) {
               aliases2[a] = { orgSlug: o, projectSlug: p };
             }
-            await setProjectAliases(aliases2);
+            setProjectAliases(aliases2);
 
             // Only second batch should exist
-            const result = await getProjectAliases();
+            const result = getProjectAliases();
             expect(result).toBeDefined();
             expect(Object.keys(result!).length).toBe(
               Object.keys(aliases2).length

--- a/test/lib/db/project-cache.test.ts
+++ b/test/lib/db/project-cache.test.ts
@@ -20,19 +20,19 @@ useTestConfigDir("test-project-cache-");
 
 describe("getCachedProject", () => {
   test("returns undefined when no cache entry exists", async () => {
-    const result = await getCachedProject("org-123", "project-456");
+    const result = getCachedProject("org-123", "project-456");
     expect(result).toBeUndefined();
   });
 
   test("returns cached project when entry exists", async () => {
-    await setCachedProject("org-123", "project-456", {
+    setCachedProject("org-123", "project-456", {
       orgSlug: "my-org",
       orgName: "My Organization",
       projectSlug: "my-project",
       projectName: "My Project",
     });
 
-    const result = await getCachedProject("org-123", "project-456");
+    const result = getCachedProject("org-123", "project-456");
     expect(result).toBeDefined();
     expect(result?.orgSlug).toBe("my-org");
     expect(result?.orgName).toBe("My Organization");
@@ -42,47 +42,47 @@ describe("getCachedProject", () => {
   });
 
   test("returns undefined for different orgId", async () => {
-    await setCachedProject("org-123", "project-456", {
+    setCachedProject("org-123", "project-456", {
       orgSlug: "my-org",
       orgName: "My Organization",
       projectSlug: "my-project",
       projectName: "My Project",
     });
 
-    const result = await getCachedProject("org-different", "project-456");
+    const result = getCachedProject("org-different", "project-456");
     expect(result).toBeUndefined();
   });
 
   test("returns undefined for different projectId", async () => {
-    await setCachedProject("org-123", "project-456", {
+    setCachedProject("org-123", "project-456", {
       orgSlug: "my-org",
       orgName: "My Organization",
       projectSlug: "my-project",
       projectName: "My Project",
     });
 
-    const result = await getCachedProject("org-123", "project-different");
+    const result = getCachedProject("org-123", "project-different");
     expect(result).toBeUndefined();
   });
 });
 
 describe("setCachedProject", () => {
   test("creates new cache entry", async () => {
-    await setCachedProject("org-123", "project-456", {
+    setCachedProject("org-123", "project-456", {
       orgSlug: "my-org",
       orgName: "My Organization",
       projectSlug: "my-project",
       projectName: "My Project",
     });
 
-    const result = await getCachedProject("org-123", "project-456");
+    const result = getCachedProject("org-123", "project-456");
     expect(result).toBeDefined();
     expect(result?.orgSlug).toBe("my-org");
   });
 
   test("updates existing cache entry (upsert)", async () => {
     // Set initial cache
-    await setCachedProject("org-123", "project-456", {
+    setCachedProject("org-123", "project-456", {
       orgSlug: "old-org",
       orgName: "Old Organization",
       projectSlug: "old-project",
@@ -90,14 +90,14 @@ describe("setCachedProject", () => {
     });
 
     // Update cache
-    await setCachedProject("org-123", "project-456", {
+    setCachedProject("org-123", "project-456", {
       orgSlug: "new-org",
       orgName: "New Organization",
       projectSlug: "new-project",
       projectName: "New Project",
     });
 
-    const result = await getCachedProject("org-123", "project-456");
+    const result = getCachedProject("org-123", "project-456");
     expect(result).toBeDefined();
     expect(result?.orgSlug).toBe("new-org");
     expect(result?.orgName).toBe("New Organization");
@@ -108,7 +108,7 @@ describe("setCachedProject", () => {
   test("stores cachedAt timestamp", async () => {
     const before = Date.now();
 
-    await setCachedProject("org-123", "project-456", {
+    setCachedProject("org-123", "project-456", {
       orgSlug: "my-org",
       orgName: "My Organization",
       projectSlug: "my-project",
@@ -116,29 +116,29 @@ describe("setCachedProject", () => {
     });
 
     const after = Date.now();
-    const result = await getCachedProject("org-123", "project-456");
+    const result = getCachedProject("org-123", "project-456");
 
     expect(result?.cachedAt).toBeGreaterThanOrEqual(before);
     expect(result?.cachedAt).toBeLessThanOrEqual(after);
   });
 
   test("handles multiple distinct cache entries", async () => {
-    await setCachedProject("org-1", "project-1", {
+    setCachedProject("org-1", "project-1", {
       orgSlug: "org-one",
       orgName: "Org One",
       projectSlug: "project-one",
       projectName: "Project One",
     });
 
-    await setCachedProject("org-2", "project-2", {
+    setCachedProject("org-2", "project-2", {
       orgSlug: "org-two",
       orgName: "Org Two",
       projectSlug: "project-two",
       projectName: "Project Two",
     });
 
-    const result1 = await getCachedProject("org-1", "project-1");
-    const result2 = await getCachedProject("org-2", "project-2");
+    const result1 = getCachedProject("org-1", "project-1");
+    const result2 = getCachedProject("org-2", "project-2");
 
     expect(result1?.orgSlug).toBe("org-one");
     expect(result2?.orgSlug).toBe("org-two");
@@ -147,19 +147,19 @@ describe("setCachedProject", () => {
 
 describe("getCachedProjectByDsnKey", () => {
   test("returns undefined when no cache entry exists", async () => {
-    const result = await getCachedProjectByDsnKey("abc123publickey");
+    const result = getCachedProjectByDsnKey("abc123publickey");
     expect(result).toBeUndefined();
   });
 
   test("returns cached project when entry exists", async () => {
-    await setCachedProjectByDsnKey("abc123publickey", {
+    setCachedProjectByDsnKey("abc123publickey", {
       orgSlug: "dsn-org",
       orgName: "DSN Organization",
       projectSlug: "dsn-project",
       projectName: "DSN Project",
     });
 
-    const result = await getCachedProjectByDsnKey("abc123publickey");
+    const result = getCachedProjectByDsnKey("abc123publickey");
     expect(result).toBeDefined();
     expect(result?.orgSlug).toBe("dsn-org");
     expect(result?.orgName).toBe("DSN Organization");
@@ -169,55 +169,55 @@ describe("getCachedProjectByDsnKey", () => {
   });
 
   test("returns undefined for different public key", async () => {
-    await setCachedProjectByDsnKey("abc123publickey", {
+    setCachedProjectByDsnKey("abc123publickey", {
       orgSlug: "dsn-org",
       orgName: "DSN Organization",
       projectSlug: "dsn-project",
       projectName: "DSN Project",
     });
 
-    const result = await getCachedProjectByDsnKey("different-key");
+    const result = getCachedProjectByDsnKey("different-key");
     expect(result).toBeUndefined();
   });
 });
 
 describe("setCachedProjectByDsnKey", () => {
   test("creates new cache entry", async () => {
-    await setCachedProjectByDsnKey("mykey123", {
+    setCachedProjectByDsnKey("mykey123", {
       orgSlug: "key-org",
       orgName: "Key Organization",
       projectSlug: "key-project",
       projectName: "Key Project",
     });
 
-    const result = await getCachedProjectByDsnKey("mykey123");
+    const result = getCachedProjectByDsnKey("mykey123");
     expect(result).toBeDefined();
     expect(result?.orgSlug).toBe("key-org");
   });
 
   test("updates existing cache entry (upsert)", async () => {
-    await setCachedProjectByDsnKey("mykey123", {
+    setCachedProjectByDsnKey("mykey123", {
       orgSlug: "old-org",
       orgName: "Old Organization",
       projectSlug: "old-project",
       projectName: "Old Project",
     });
 
-    await setCachedProjectByDsnKey("mykey123", {
+    setCachedProjectByDsnKey("mykey123", {
       orgSlug: "new-org",
       orgName: "New Organization",
       projectSlug: "new-project",
       projectName: "New Project",
     });
 
-    const result = await getCachedProjectByDsnKey("mykey123");
+    const result = getCachedProjectByDsnKey("mykey123");
     expect(result?.orgSlug).toBe("new-org");
     expect(result?.orgName).toBe("New Organization");
   });
 
   test("dsn key cache is separate from orgId:projectId cache", async () => {
     // Cache by orgId:projectId
-    await setCachedProject("123", "456", {
+    setCachedProject("123", "456", {
       orgSlug: "by-id-org",
       orgName: "By ID Organization",
       projectSlug: "by-id-project",
@@ -225,7 +225,7 @@ describe("setCachedProjectByDsnKey", () => {
     });
 
     // Cache by DSN key
-    await setCachedProjectByDsnKey("publickey", {
+    setCachedProjectByDsnKey("publickey", {
       orgSlug: "by-dsn-org",
       orgName: "By DSN Organization",
       projectSlug: "by-dsn-project",
@@ -233,8 +233,8 @@ describe("setCachedProjectByDsnKey", () => {
     });
 
     // Both should exist independently
-    const byId = await getCachedProject("123", "456");
-    const byDsn = await getCachedProjectByDsnKey("publickey");
+    const byId = getCachedProject("123", "456");
+    const byDsn = getCachedProjectByDsnKey("publickey");
 
     expect(byId?.orgSlug).toBe("by-id-org");
     expect(byDsn?.orgSlug).toBe("by-dsn-org");
@@ -242,11 +242,11 @@ describe("setCachedProjectByDsnKey", () => {
     // Cross-lookup should fail - keys are in different formats
     // orgId:projectId format -> "123:456"
     // DSN key format -> "dsn:publickey"
-    const byIdAsDsn = await getCachedProjectByDsnKey("123:456");
+    const byIdAsDsn = getCachedProjectByDsnKey("123:456");
     expect(byIdAsDsn).toBeUndefined();
 
     // Lookup with wrong key format
-    const wrongKey = await getCachedProject("wrong", "key");
+    const wrongKey = getCachedProject("wrong", "key");
     expect(wrongKey).toBeUndefined();
   });
 });
@@ -254,21 +254,21 @@ describe("setCachedProjectByDsnKey", () => {
 describe("clearProjectCache", () => {
   test("clears all cache entries", async () => {
     // Add several entries
-    await setCachedProject("org-1", "project-1", {
+    setCachedProject("org-1", "project-1", {
       orgSlug: "org-one",
       orgName: "Org One",
       projectSlug: "project-one",
       projectName: "Project One",
     });
 
-    await setCachedProject("org-2", "project-2", {
+    setCachedProject("org-2", "project-2", {
       orgSlug: "org-two",
       orgName: "Org Two",
       projectSlug: "project-two",
       projectName: "Project Two",
     });
 
-    await setCachedProjectByDsnKey("key1", {
+    setCachedProjectByDsnKey("key1", {
       orgSlug: "key-org",
       orgName: "Key Organization",
       projectSlug: "key-project",
@@ -276,47 +276,47 @@ describe("clearProjectCache", () => {
     });
 
     // Clear all
-    await clearProjectCache();
+    clearProjectCache();
 
     // All should be undefined
-    expect(await getCachedProject("org-1", "project-1")).toBeUndefined();
-    expect(await getCachedProject("org-2", "project-2")).toBeUndefined();
-    expect(await getCachedProjectByDsnKey("key1")).toBeUndefined();
+    expect(getCachedProject("org-1", "project-1")).toBeUndefined();
+    expect(getCachedProject("org-2", "project-2")).toBeUndefined();
+    expect(getCachedProjectByDsnKey("key1")).toBeUndefined();
   });
 
   test("does not throw when cache is already empty", async () => {
     // Should not throw
-    await clearProjectCache();
-    await clearProjectCache();
+    clearProjectCache();
+    clearProjectCache();
   });
 });
 
 describe("cache key uniqueness", () => {
   test("different orgId:projectId combinations are stored separately", async () => {
-    await setCachedProject("org-A", "project-1", {
+    setCachedProject("org-A", "project-1", {
       orgSlug: "org-a",
       orgName: "Org A",
       projectSlug: "project-1",
       projectName: "Project 1 in A",
     });
 
-    await setCachedProject("org-B", "project-1", {
+    setCachedProject("org-B", "project-1", {
       orgSlug: "org-b",
       orgName: "Org B",
       projectSlug: "project-1",
       projectName: "Project 1 in B",
     });
 
-    await setCachedProject("org-A", "project-2", {
+    setCachedProject("org-A", "project-2", {
       orgSlug: "org-a",
       orgName: "Org A",
       projectSlug: "project-2",
       projectName: "Project 2 in A",
     });
 
-    const resultA1 = await getCachedProject("org-A", "project-1");
-    const resultB1 = await getCachedProject("org-B", "project-1");
-    const resultA2 = await getCachedProject("org-A", "project-2");
+    const resultA1 = getCachedProject("org-A", "project-1");
+    const resultB1 = getCachedProject("org-B", "project-1");
+    const resultA2 = getCachedProject("org-A", "project-2");
 
     expect(resultA1?.projectName).toBe("Project 1 in A");
     expect(resultB1?.projectName).toBe("Project 1 in B");
@@ -324,29 +324,26 @@ describe("cache key uniqueness", () => {
   });
 
   test("handles special characters in IDs", async () => {
-    await setCachedProject("org:with:colons", "project/with/slashes", {
+    setCachedProject("org:with:colons", "project/with/slashes", {
       orgSlug: "special-org",
       orgName: "Special Organization",
       projectSlug: "special-project",
       projectName: "Special Project",
     });
 
-    const result = await getCachedProject(
-      "org:with:colons",
-      "project/with/slashes"
-    );
+    const result = getCachedProject("org:with:colons", "project/with/slashes");
     expect(result?.orgSlug).toBe("special-org");
   });
 
   test("handles numeric-like string IDs", async () => {
-    await setCachedProject("123", "456", {
+    setCachedProject("123", "456", {
       orgSlug: "numeric-org",
       orgName: "Numeric Organization",
       projectSlug: "numeric-project",
       projectName: "Numeric Project",
     });
 
-    const result = await getCachedProject("123", "456");
+    const result = getCachedProject("123", "456");
     expect(result?.orgSlug).toBe("numeric-org");
   });
 });
@@ -359,7 +356,7 @@ describe("cacheProjectsForOrg", () => {
       { id: "3", slug: "mobile", name: "Mobile App" },
     ]);
 
-    const result = await getCachedProjectsForOrg("my-org");
+    const result = getCachedProjectsForOrg("my-org");
     expect(result).toHaveLength(3);
     expect(result).toContainEqual({
       projectSlug: "frontend",
@@ -384,18 +381,18 @@ describe("cacheProjectsForOrg", () => {
     cacheProjectsForOrg("my-org", "My Org", projects);
     cacheProjectsForOrg("my-org", "My Org", projects);
 
-    const result = await getCachedProjectsForOrg("my-org");
+    const result = getCachedProjectsForOrg("my-org");
     expect(result).toHaveLength(2);
   });
 
   test("empty array is a no-op", async () => {
     cacheProjectsForOrg("my-org", "My Org", []);
-    const result = await getCachedProjectsForOrg("my-org");
+    const result = getCachedProjectsForOrg("my-org");
     expect(result).toEqual([]);
   });
 
   test("does not conflict with orgId:projectId cache entries", async () => {
-    await setCachedProject("org-123", "proj-456", {
+    setCachedProject("org-123", "proj-456", {
       orgSlug: "my-org",
       orgName: "My Org",
       projectSlug: "frontend",
@@ -407,7 +404,7 @@ describe("cacheProjectsForOrg", () => {
     ]);
 
     // Both entries exist — getCachedProjectsForOrg deduplicates by slug
-    const result = await getCachedProjectsForOrg("my-org");
+    const result = getCachedProjectsForOrg("my-org");
     expect(result).toHaveLength(1);
     expect(result[0]?.projectSlug).toBe("frontend");
   });
@@ -415,31 +412,31 @@ describe("cacheProjectsForOrg", () => {
 
 describe("getCachedProjectsForOrg", () => {
   test("returns empty array when no projects for org", async () => {
-    const result = await getCachedProjectsForOrg("nonexistent-org");
+    const result = getCachedProjectsForOrg("nonexistent-org");
     expect(result).toEqual([]);
   });
 
   test("returns projects only for the specified org", async () => {
-    await setCachedProject("org-1", "project-1", {
+    setCachedProject("org-1", "project-1", {
       orgSlug: "alpha-org",
       orgName: "Alpha",
       projectSlug: "alpha-project",
       projectName: "Alpha Project",
     });
-    await setCachedProject("org-2", "project-2", {
+    setCachedProject("org-2", "project-2", {
       orgSlug: "beta-org",
       orgName: "Beta",
       projectSlug: "beta-project",
       projectName: "Beta Project",
     });
-    await setCachedProject("org-3", "project-3", {
+    setCachedProject("org-3", "project-3", {
       orgSlug: "alpha-org",
       orgName: "Alpha",
       projectSlug: "alpha-second",
       projectName: "Alpha Second",
     });
 
-    const result = await getCachedProjectsForOrg("alpha-org");
+    const result = getCachedProjectsForOrg("alpha-org");
     expect(result).toHaveLength(2);
     expect(result).toContainEqual({
       projectSlug: "alpha-project",
@@ -452,14 +449,14 @@ describe("getCachedProjectsForOrg", () => {
   });
 
   test("returns empty for wrong org", async () => {
-    await setCachedProject("org-1", "project-1", {
+    setCachedProject("org-1", "project-1", {
       orgSlug: "alpha-org",
       orgName: "Alpha",
       projectSlug: "alpha-project",
       projectName: "Alpha Project",
     });
 
-    const result = await getCachedProjectsForOrg("beta-org");
+    const result = getCachedProjectsForOrg("beta-org");
     expect(result).toEqual([]);
   });
 });

--- a/test/lib/dsn/cache.test.ts
+++ b/test/lib/dsn/cache.test.ts
@@ -18,13 +18,13 @@ useTestConfigDir("test-dsn-cache-");
 describe("DSN Cache", () => {
   describe("getCachedDsn", () => {
     test("returns undefined when no cache exists", async () => {
-      const result = await getCachedDsn("/some/path");
+      const result = getCachedDsn("/some/path");
       expect(result).toBeUndefined();
     });
 
     test("returns cached entry when it exists", async () => {
       const testDir = "/test/directory";
-      await setCachedDsn(testDir, {
+      setCachedDsn(testDir, {
         dsn: "https://key@o123.ingest.sentry.io/456",
         projectId: "456",
         orgId: "123",
@@ -32,7 +32,7 @@ describe("DSN Cache", () => {
         sourcePath: ".env.local",
       });
 
-      const result = await getCachedDsn(testDir);
+      const result = getCachedDsn(testDir);
 
       expect(result).toBeDefined();
       expect(result?.dsn).toBe("https://key@o123.ingest.sentry.io/456");
@@ -46,7 +46,7 @@ describe("DSN Cache", () => {
     test("creates new cache entry", async () => {
       const testDir = "/new/directory";
 
-      await setCachedDsn(testDir, {
+      setCachedDsn(testDir, {
         dsn: "https://abc@o789.ingest.sentry.io/111",
         projectId: "111",
         orgId: "789",
@@ -54,7 +54,7 @@ describe("DSN Cache", () => {
         sourcePath: "src/config.ts",
       });
 
-      const cached = await getCachedDsn(testDir);
+      const cached = getCachedDsn(testDir);
       expect(cached?.dsn).toBe("https://abc@o789.ingest.sentry.io/111");
       expect(cached?.sourcePath).toBe("src/config.ts");
     });
@@ -62,21 +62,21 @@ describe("DSN Cache", () => {
     test("updates existing cache entry", async () => {
       const testDir = "/update/test";
 
-      await setCachedDsn(testDir, {
+      setCachedDsn(testDir, {
         dsn: "https://old@o1.ingest.sentry.io/1",
         projectId: "1",
         orgId: "1",
         source: "env_file",
       });
 
-      await setCachedDsn(testDir, {
+      setCachedDsn(testDir, {
         dsn: "https://new@o2.ingest.sentry.io/2",
         projectId: "2",
         orgId: "2",
         source: "code",
       });
 
-      const cached = await getCachedDsn(testDir);
+      const cached = getCachedDsn(testDir);
       expect(cached?.dsn).toBe("https://new@o2.ingest.sentry.io/2");
       expect(cached?.projectId).toBe("2");
     });
@@ -85,14 +85,14 @@ describe("DSN Cache", () => {
       const testDir = "/timestamp/test";
       const before = Date.now();
 
-      await setCachedDsn(testDir, {
+      setCachedDsn(testDir, {
         dsn: "https://key@o1.ingest.sentry.io/1",
         projectId: "1",
         source: "env",
       });
 
       const after = Date.now();
-      const cached = await getCachedDsn(testDir);
+      const cached = getCachedDsn(testDir);
 
       expect(cached?.cachedAt).toBeGreaterThanOrEqual(before);
       expect(cached?.cachedAt).toBeLessThanOrEqual(after);
@@ -103,35 +103,35 @@ describe("DSN Cache", () => {
     test("adds resolved info to existing cache entry", async () => {
       const testDir = "/resolve/test";
 
-      await setCachedDsn(testDir, {
+      setCachedDsn(testDir, {
         dsn: "https://key@o123.ingest.sentry.io/456",
         projectId: "456",
         orgId: "123",
         source: "env_file",
       });
 
-      await updateCachedResolution(testDir, {
+      updateCachedResolution(testDir, {
         orgSlug: "my-org",
         orgName: "My Organization",
         projectSlug: "my-project",
         projectName: "My Project",
       });
 
-      const cached = await getCachedDsn(testDir);
+      const cached = getCachedDsn(testDir);
       expect(cached?.resolved).toBeDefined();
       expect(cached?.resolved?.orgSlug).toBe("my-org");
       expect(cached?.resolved?.projectName).toBe("My Project");
     });
 
     test("does nothing when no cache entry exists", async () => {
-      await updateCachedResolution("/nonexistent", {
+      updateCachedResolution("/nonexistent", {
         orgSlug: "test",
         orgName: "Test",
         projectSlug: "test",
         projectName: "Test",
       });
 
-      const cached = await getCachedDsn("/nonexistent");
+      const cached = getCachedDsn("/nonexistent");
       expect(cached).toBeUndefined();
     });
   });
@@ -141,39 +141,39 @@ describe("DSN Cache", () => {
       const dir1 = "/dir1";
       const dir2 = "/dir2";
 
-      await setCachedDsn(dir1, {
+      setCachedDsn(dir1, {
         dsn: "https://a@o1.ingest.sentry.io/1",
         projectId: "1",
         source: "env",
       });
-      await setCachedDsn(dir2, {
+      setCachedDsn(dir2, {
         dsn: "https://b@o2.ingest.sentry.io/2",
         projectId: "2",
         source: "env",
       });
 
-      await clearDsnCache(dir1);
+      clearDsnCache(dir1);
 
-      expect(await getCachedDsn(dir1)).toBeUndefined();
-      expect(await getCachedDsn(dir2)).toBeDefined();
+      expect(getCachedDsn(dir1)).toBeUndefined();
+      expect(getCachedDsn(dir2)).toBeDefined();
     });
 
     test("clears all cache when no directory specified", async () => {
-      await setCachedDsn("/dir1", {
+      setCachedDsn("/dir1", {
         dsn: "https://a@o1.ingest.sentry.io/1",
         projectId: "1",
         source: "env",
       });
-      await setCachedDsn("/dir2", {
+      setCachedDsn("/dir2", {
         dsn: "https://b@o2.ingest.sentry.io/2",
         projectId: "2",
         source: "env",
       });
 
-      await clearDsnCache();
+      clearDsnCache();
 
-      expect(await getCachedDsn("/dir1")).toBeUndefined();
-      expect(await getCachedDsn("/dir2")).toBeUndefined();
+      expect(getCachedDsn("/dir1")).toBeUndefined();
+      expect(getCachedDsn("/dir2")).toBeUndefined();
     });
   });
 });

--- a/test/lib/dsn/detector.test.ts
+++ b/test/lib/dsn/detector.test.ts
@@ -28,7 +28,7 @@ describe("DSN Detector (New Module)", () => {
     mkdirSync(testDir, { recursive: true });
     mkdirSync(join(testDir, ".git"), { recursive: true });
     // Clear any cached DSN for the test directory
-    await clearDsnCache(testDir);
+    clearDsnCache(testDir);
     // Clear SENTRY_DSN env var
     delete process.env.SENTRY_DSN;
   });
@@ -47,7 +47,7 @@ describe("DSN Detector (New Module)", () => {
       expect(result1?.raw).toBe(dsn);
 
       // Check cache was created
-      const cached = await getCachedDsn(testDir);
+      const cached = getCachedDsn(testDir);
       expect(cached).toBeDefined();
       expect(cached?.dsn).toBe(dsn);
       expect(cached?.source).toBe("env_file");
@@ -76,7 +76,7 @@ describe("DSN Detector (New Module)", () => {
       expect(result2?.raw).toBe(dsn2);
 
       // Cache should be updated
-      const cached = await getCachedDsn(testDir);
+      const cached = getCachedDsn(testDir);
       expect(cached?.dsn).toBe(dsn2);
     });
 
@@ -160,7 +160,7 @@ describe("DSN Detector (New Module)", () => {
       expect(result1?.source).toBe("env");
 
       // Verify it's cached
-      const cached = await getCachedDsn(testDir);
+      const cached = getCachedDsn(testDir);
       expect(cached?.dsn).toBe(envVarDsn);
       expect(cached?.source).toBe("env");
 
@@ -176,7 +176,7 @@ describe("DSN Detector (New Module)", () => {
       expect(result3?.source).toBe("env");
 
       // Cache should be updated
-      const updatedCache = await getCachedDsn(testDir);
+      const updatedCache = getCachedDsn(testDir);
       expect(updatedCache?.dsn).toBe(changedDsn);
     });
 
@@ -191,7 +191,7 @@ describe("DSN Detector (New Module)", () => {
       expect(result1?.source).toBe("env");
 
       // Verify it's cached
-      const cached = await getCachedDsn(testDir);
+      const cached = getCachedDsn(testDir);
       expect(cached?.source).toBe("env");
 
       // Now add a code DSN (higher priority)
@@ -208,7 +208,7 @@ describe("DSN Detector (New Module)", () => {
       expect(result2?.source).toBe("code");
 
       // Cache should be updated to code DSN
-      const updatedCache = await getCachedDsn(testDir);
+      const updatedCache = getCachedDsn(testDir);
       expect(updatedCache?.dsn).toBe(codeDsn);
       expect(updatedCache?.source).toBe("code");
     });

--- a/test/lib/help.test.ts
+++ b/test/lib/help.test.ts
@@ -39,17 +39,17 @@ describe("printCustomHelp", () => {
   useTestConfigDir("help-test-");
 
   test("returns non-empty string", async () => {
-    const output = await printCustomHelp();
+    const output = printCustomHelp();
     expect(output.length).toBeGreaterThan(0);
   });
 
   test("output contains the tagline", async () => {
-    const output = stripAnsi(await printCustomHelp());
+    const output = stripAnsi(printCustomHelp());
     expect(output).toContain("The command-line interface for Sentry");
   });
 
   test("output contains registered commands", async () => {
-    const output = stripAnsi(await printCustomHelp());
+    const output = stripAnsi(printCustomHelp());
 
     // Should include at least some core commands from routes
     expect(output).toContain("sentry");
@@ -60,13 +60,13 @@ describe("printCustomHelp", () => {
   });
 
   test("output contains docs URL", async () => {
-    const output = stripAnsi(await printCustomHelp());
+    const output = stripAnsi(printCustomHelp());
     expect(output).toContain("cli.sentry.dev");
   });
 
   test("shows login example when not authenticated", async () => {
     // useTestConfigDir provides a clean env with no auth token
-    const output = stripAnsi(await printCustomHelp());
+    const output = stripAnsi(printCustomHelp());
     expect(output).toContain("sentry auth login");
   });
 });

--- a/test/lib/init/local-ops.create-sentry-project.test.ts
+++ b/test/lib/init/local-ops.create-sentry-project.test.ts
@@ -282,7 +282,7 @@ describe("create-sentry-project", () => {
   describe("resolveOrgSlug — numeric org ID from DSN", () => {
     test("numeric ID + cache hit → resolved to slug for project creation", async () => {
       resolveOrgSpy.mockResolvedValue({ org: "4507492088676352" });
-      getOrgByNumericIdSpy.mockResolvedValue({
+      getOrgByNumericIdSpy.mockReturnValue({
         slug: "acme-corp",
         regionUrl: "https://us.sentry.io",
       });
@@ -298,7 +298,7 @@ describe("create-sentry-project", () => {
 
     test("numeric ID + cache miss → falls through to single org in listOrganizations", async () => {
       resolveOrgSpy.mockResolvedValue({ org: "4507492088676352" });
-      getOrgByNumericIdSpy.mockResolvedValue(undefined);
+      getOrgByNumericIdSpy.mockReturnValue(undefined);
       listOrgsSpy.mockResolvedValue([
         { id: "1", slug: "solo-org", name: "Solo Org" },
       ]);
@@ -313,7 +313,7 @@ describe("create-sentry-project", () => {
 
     test("numeric ID + cache miss + multiple orgs + --yes → error with org list", async () => {
       resolveOrgSpy.mockResolvedValue({ org: "4507492088676352" });
-      getOrgByNumericIdSpy.mockResolvedValue(undefined);
+      getOrgByNumericIdSpy.mockReturnValue(undefined);
       listOrgsSpy.mockResolvedValue([
         { id: "1", slug: "org-a", name: "Org A" },
         { id: "2", slug: "org-b", name: "Org B" },
@@ -340,7 +340,7 @@ describe("create-sentry-project", () => {
         raw: "https://test-key-abc@o123.ingest.sentry.io/42",
         source: "env_file" as const,
       });
-      getCachedProjectByDsnKeySpy.mockResolvedValue({
+      getCachedProjectByDsnKeySpy.mockReturnValue({
         orgSlug,
         orgName: orgSlug,
         projectSlug,
@@ -430,12 +430,12 @@ describe("create-sentry-project", () => {
         raw: "https://test-key-abc@o123.ingest.sentry.io/42",
         source: "env_file" as const,
       });
-      getCachedProjectByDsnKeySpy.mockResolvedValue(undefined); // cache miss
+      getCachedProjectByDsnKeySpy.mockReturnValue(undefined); // cache miss
       findProjectByDsnKeySpy.mockResolvedValue({
         ...sampleProject,
         organization: { id: "1", slug: "acme-corp", name: "Acme Corp" },
       });
-      setCachedProjectByDsnKeySpy.mockResolvedValue(undefined);
+      setCachedProjectByDsnKeySpy.mockReturnValue(undefined);
       selectSpy.mockResolvedValue("existing");
       getProjectSpy.mockResolvedValue(sampleProject);
       tryGetPrimaryDsnSpy.mockResolvedValue(
@@ -461,7 +461,7 @@ describe("create-sentry-project", () => {
         raw: "https://test-key-abc@o999.ingest.sentry.io/99",
         source: "env_file" as const,
       });
-      getCachedProjectByDsnKeySpy.mockResolvedValue(undefined);
+      getCachedProjectByDsnKeySpy.mockReturnValue(undefined);
       findProjectByDsnKeySpy.mockRejectedValue(new Error("403 Forbidden"));
       resolveOrgSpy.mockResolvedValue({ org: "acme-corp" });
       mockDownstreamSuccess("acme-corp");

--- a/test/lib/org-list.test.ts
+++ b/test/lib/org-list.test.ts
@@ -662,7 +662,7 @@ describe("dispatchOrgScopedList", () => {
       "resolveEffectiveOrg"
     ).mockImplementation((org: string) => Promise.resolve(org));
 
-    getDefaultOrganizationSpy.mockResolvedValue(null);
+    getDefaultOrganizationSpy.mockReturnValue(null);
     resolveAllTargetsSpy.mockResolvedValue({ targets: [] });
     setPaginationCursorSpy.mockReturnValue(undefined);
     clearPaginationCursorSpy.mockReturnValue(undefined);
@@ -915,7 +915,7 @@ describe("dispatchOrgScopedList", () => {
       getCachedOrgsSpy = spyOn(
         regions,
         "getCachedOrganizations"
-      ).mockResolvedValue([]);
+      ).mockReturnValue([]);
     });
 
     afterEach(() => {
@@ -923,7 +923,7 @@ describe("dispatchOrgScopedList", () => {
     });
 
     test("redirect converts project-search to org-all when slug matches cached org", async () => {
-      getCachedOrgsSpy.mockResolvedValue([
+      getCachedOrgsSpy.mockReturnValue([
         { slug: "acme-corp", id: "1", name: "Acme Corp" },
       ]);
 
@@ -949,7 +949,7 @@ describe("dispatchOrgScopedList", () => {
     });
 
     test("error throws ResolutionError when slug matches cached org", async () => {
-      getCachedOrgsSpy.mockResolvedValue([
+      getCachedOrgsSpy.mockReturnValue([
         { slug: "acme-corp", id: "1", name: "Acme Corp" },
       ]);
 
@@ -967,7 +967,7 @@ describe("dispatchOrgScopedList", () => {
     });
 
     test("error message includes actionable hints", async () => {
-      getCachedOrgsSpy.mockResolvedValue([
+      getCachedOrgsSpy.mockReturnValue([
         { slug: "acme-corp", id: "1", name: "Acme Corp" },
       ]);
 
@@ -991,7 +991,7 @@ describe("dispatchOrgScopedList", () => {
     });
 
     test("no orgSlugMatchBehavior skips pre-check and calls handler", async () => {
-      getCachedOrgsSpy.mockResolvedValue([
+      getCachedOrgsSpy.mockReturnValue([
         { slug: "acme-corp", id: "1", name: "Acme Corp" },
       ]);
 
@@ -1019,7 +1019,7 @@ describe("dispatchOrgScopedList", () => {
     });
 
     test("redirect with no cache match falls through to project-search handler", async () => {
-      getCachedOrgsSpy.mockResolvedValue([
+      getCachedOrgsSpy.mockReturnValue([
         { slug: "other-org", id: "2", name: "Other Org" },
       ]);
 
@@ -1046,7 +1046,7 @@ describe("dispatchOrgScopedList", () => {
     });
 
     test("redirect with empty cache falls through to project-search handler", async () => {
-      getCachedOrgsSpy.mockResolvedValue([]);
+      getCachedOrgsSpy.mockReturnValue([]);
 
       const handler = mock(() =>
         Promise.resolve({ items: [] } as ListResult<FakeWithOrg>)

--- a/test/lib/region.test.ts
+++ b/test/lib/region.test.ts
@@ -114,7 +114,7 @@ describe("isMultiRegionEnabled", () => {
 
 describe("resolveOrgRegion", () => {
   test("returns cached region when available", async () => {
-    await setOrgRegion("cached-org", "https://de.sentry.io");
+    setOrgRegion("cached-org", "https://de.sentry.io");
 
     const regionUrl = await resolveOrgRegion("cached-org");
     expect(regionUrl).toBe("https://de.sentry.io");
@@ -125,7 +125,7 @@ describe("resolveOrgRegion", () => {
     const { getOrgRegion } = await import("../../src/lib/db/regions.js");
 
     // Verify org is not in cache
-    const before = await getOrgRegion("new-org");
+    const before = getOrgRegion("new-org");
     expect(before).toBeUndefined();
 
     // Mock fetch to return org with regionUrl
@@ -161,7 +161,7 @@ describe("resolveOrgRegion", () => {
       expect(regionUrl).toBe("https://de.sentry.io");
 
       // Should have cached the region
-      const after = await getOrgRegion("new-org");
+      const after = getOrgRegion("new-org");
       expect(after).toBe("https://de.sentry.io");
     } finally {
       globalThis.fetch = originalFetch;
@@ -237,7 +237,7 @@ describe("resolveOrgRegion", () => {
 
   test("uses cached region on subsequent calls", async () => {
     // Pre-populate cache (simulating what happens after a successful API fetch)
-    await setOrgRegion("cached-org-2", "https://de.sentry.io");
+    setOrgRegion("cached-org-2", "https://de.sentry.io");
 
     // First call should use cache
     const regionUrl1 = await resolveOrgRegion("cached-org-2");
@@ -250,8 +250,8 @@ describe("resolveOrgRegion", () => {
 
   test("cache survives across multiple resolve calls", async () => {
     // Populate cache with multiple orgs
-    await setOrgRegion("org-a", "https://us.sentry.io");
-    await setOrgRegion("org-b", "https://de.sentry.io");
+    setOrgRegion("org-a", "https://us.sentry.io");
+    setOrgRegion("org-b", "https://de.sentry.io");
 
     // Resolve in different order
     expect(await resolveOrgRegion("org-b")).toBe("https://de.sentry.io");

--- a/test/lib/resolve-effective-org.test.ts
+++ b/test/lib/resolve-effective-org.test.ts
@@ -23,11 +23,11 @@ useTestConfigDir("resolve-effective-org-");
 
 describe("getOrgByNumericId", () => {
   test("returns slug and regionUrl when org_id matches", async () => {
-    await setOrgRegions([
+    setOrgRegions([
       { slug: "my-org", regionUrl: "https://us.sentry.io", orgId: "1081365" },
     ]);
 
-    const result = await getOrgByNumericId("1081365");
+    const result = getOrgByNumericId("1081365");
     expect(result).toEqual({
       slug: "my-org",
       regionUrl: "https://us.sentry.io",
@@ -35,29 +35,29 @@ describe("getOrgByNumericId", () => {
   });
 
   test("returns undefined when no org_id matches", async () => {
-    await setOrgRegions([
+    setOrgRegions([
       { slug: "my-org", regionUrl: "https://us.sentry.io", orgId: "1081365" },
     ]);
 
-    const result = await getOrgByNumericId("9999999");
+    const result = getOrgByNumericId("9999999");
     expect(result).toBeUndefined();
   });
 
   test("returns undefined when org_id column is null", async () => {
-    await setOrgRegion("my-org", "https://us.sentry.io");
+    setOrgRegion("my-org", "https://us.sentry.io");
 
-    const result = await getOrgByNumericId("1081365");
+    const result = getOrgByNumericId("1081365");
     expect(result).toBeUndefined();
   });
 
   test("returns correct org when multiple orgs exist", async () => {
-    await setOrgRegions([
+    setOrgRegions([
       { slug: "org-a", regionUrl: "https://us.sentry.io", orgId: "111" },
       { slug: "org-b", regionUrl: "https://de.sentry.io", orgId: "222" },
       { slug: "org-c", regionUrl: "https://us.sentry.io", orgId: "333" },
     ]);
 
-    const result = await getOrgByNumericId("222");
+    const result = getOrgByNumericId("222");
     expect(result).toEqual({
       slug: "org-b",
       regionUrl: "https://de.sentry.io",
@@ -69,47 +69,45 @@ describe("getOrgByNumericId", () => {
 
 describe("setOrgRegions with orgId", () => {
   test("stores org_id and allows lookup by numeric ID", async () => {
-    await setOrgRegions([
+    setOrgRegions([
       { slug: "acme", regionUrl: "https://us.sentry.io", orgId: "42" },
     ]);
 
-    const region = await getOrgRegion("acme");
+    const region = getOrgRegion("acme");
     expect(region).toBe("https://us.sentry.io");
 
-    const byId = await getOrgByNumericId("42");
+    const byId = getOrgByNumericId("42");
     expect(byId).toEqual({ slug: "acme", regionUrl: "https://us.sentry.io" });
   });
 
   test("handles entries without orgId", async () => {
-    await setOrgRegions([
-      { slug: "no-id-org", regionUrl: "https://de.sentry.io" },
-    ]);
+    setOrgRegions([{ slug: "no-id-org", regionUrl: "https://de.sentry.io" }]);
 
-    const region = await getOrgRegion("no-id-org");
+    const region = getOrgRegion("no-id-org");
     expect(region).toBe("https://de.sentry.io");
 
-    const byId = await getOrgByNumericId("no-id-org");
+    const byId = getOrgByNumericId("no-id-org");
     expect(byId).toBeUndefined();
   });
 
   test("upserts update region on slug conflict", async () => {
-    await setOrgRegions([
+    setOrgRegions([
       { slug: "my-org", regionUrl: "https://us.sentry.io", orgId: "100" },
     ]);
 
-    await setOrgRegions([
+    setOrgRegions([
       { slug: "my-org", regionUrl: "https://de.sentry.io", orgId: "100" },
     ]);
 
-    const region = await getOrgRegion("my-org");
+    const region = getOrgRegion("my-org");
     expect(region).toBe("https://de.sentry.io");
 
-    const byId = await getOrgByNumericId("100");
+    const byId = getOrgByNumericId("100");
     expect(byId?.slug).toBe("my-org");
   });
 
   test("empty entries array is a no-op", async () => {
-    await setOrgRegions([]);
+    setOrgRegions([]);
   });
 });
 
@@ -117,14 +115,14 @@ describe("setOrgRegions with orgId", () => {
 
 describe("resolveEffectiveOrg", () => {
   test("returns orgSlug when slug is already cached", async () => {
-    await setOrgRegion("my-org", "https://us.sentry.io");
+    setOrgRegion("my-org", "https://us.sentry.io");
 
     const result = await resolveEffectiveOrg("my-org");
     expect(result).toBe("my-org");
   });
 
   test("resolves DSN-style org via cached numeric ID", async () => {
-    await setOrgRegions([
+    setOrgRegions([
       {
         slug: "acme-corp",
         regionUrl: "https://us.sentry.io",
@@ -137,7 +135,7 @@ describe("resolveEffectiveOrg", () => {
   });
 
   test("resolves another DSN org ID pattern", async () => {
-    await setOrgRegions([
+    setOrgRegions([
       { slug: "test-org", regionUrl: "https://de.sentry.io", orgId: "42" },
     ]);
 
@@ -146,7 +144,7 @@ describe("resolveEffectiveOrg", () => {
   });
 
   test("resolves large numeric ID", async () => {
-    await setOrgRegions([
+    setOrgRegions([
       {
         slug: "big-org",
         regionUrl: "https://us.sentry.io",

--- a/test/lib/resolve-target-listing.test.ts
+++ b/test/lib/resolve-target-listing.test.ts
@@ -36,7 +36,7 @@ describe("resolveOrgsForListing", () => {
     getDefaultOrganizationSpy = spyOn(defaults, "getDefaultOrganization");
     resolveAllTargetsSpy = spyOn(resolveTargetModule, "resolveAllTargets");
 
-    getDefaultOrganizationSpy.mockResolvedValue(null);
+    getDefaultOrganizationSpy.mockReturnValue(null);
     resolveAllTargetsSpy.mockResolvedValue({ targets: [] });
   });
 
@@ -53,7 +53,7 @@ describe("resolveOrgsForListing", () => {
   });
 
   test("returns default org when no orgFlag and default exists", async () => {
-    getDefaultOrganizationSpy.mockResolvedValue("default-org");
+    getDefaultOrganizationSpy.mockReturnValue("default-org");
 
     const result = await resolveOrgsForListing(undefined, CWD);
     expect(result.orgs).toEqual(["default-org"]);
@@ -274,7 +274,7 @@ describe("resolveOrgProjectFromArg", () => {
       resolveTargetModule,
       "resolveOrgAndProject"
     );
-    await setOrgRegion("my-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("my-org", DEFAULT_SENTRY_URL);
   });
 
   afterEach(() => {

--- a/test/lib/resolve-target.test.ts
+++ b/test/lib/resolve-target.test.ts
@@ -342,7 +342,7 @@ describe("fetchProjectId", () => {
 
   test("returns numeric project ID on success", async () => {
     await setAuthToken("test-token");
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
     globalThis.fetch = mockFetch(async (input, init) => {
       const req = new Request(input, init);
       if (req.url.includes("/api/0/projects/test-org/test-project/")) {
@@ -357,7 +357,7 @@ describe("fetchProjectId", () => {
 
   test("throws ResolutionError on 404", async () => {
     await setAuthToken("test-token");
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
     globalThis.fetch = mockFetch(
       async () =>
         new Response(JSON.stringify({ detail: "Not found" }), {
@@ -372,7 +372,7 @@ describe("fetchProjectId", () => {
 
   test("includes similar project suggestions on 404 when projects exist", async () => {
     await setAuthToken("test-token");
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
 
     // Mock: getProject returns 404, but listProjects returns available projects.
     // The two calls hit different URL patterns.
@@ -413,7 +413,7 @@ describe("fetchProjectId", () => {
 
   test("includes project list suggestion even when listProjects fails", async () => {
     await setAuthToken("test-token");
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
 
     // Mock: all requests return 404 (both getProject and listProjects fail)
     globalThis.fetch = mockFetch(
@@ -438,7 +438,7 @@ describe("fetchProjectId", () => {
 
   test("rethrows AuthError when not authenticated", async () => {
     // No auth token set — refreshToken() will throw AuthError
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
 
     expect(fetchProjectId("test-org", "test-project")).rejects.toThrow(
       AuthError
@@ -447,7 +447,7 @@ describe("fetchProjectId", () => {
 
   test("returns undefined on transient server error", async () => {
     await setAuthToken("test-token");
-    await setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
     globalThis.fetch = mockFetch(
       async () =>
         new Response(JSON.stringify({ detail: "Internal error" }), {


### PR DESCRIPTION
## Summary

DRY up the `src/lib/db/` layer by extracting shared helpers, removing duplicated SQL patterns, and adding GritQL lint rules to prevent regression.

## Changes

### New helpers in `src/lib/db/utils.ts`
- **`getMetadata(db, keys)`** — batch read from metadata table (`SELECT ... WHERE key IN (...)`)
- **`setMetadata(db, entries)`** — batch write in a single transaction
- **`clearMetadata(db, keys)`** — batch delete (`DELETE ... WHERE key IN (...)`)
- **`touchCacheEntry(table, keyColumn, keyValue)`** — shared `last_accessed` timestamp update

### Refactored DB modules
- `install-info.ts` — 4 individual queries → 1 batch call per operation
- `version-check.ts`, `release-channel.ts` — same metadata helper adoption
- `dsn-cache.ts`, `project-cache.ts` — private `touchCacheEntry` → shared helper
- `project-cache.ts` — deduplicated 4 get/set functions via `getByKey`/`setByKey` helpers
- `project-aliases.ts` — manual `BEGIN`/`COMMIT`/`ROLLBACK` → `db.transaction()()`

### De-async synchronous functions
Removed `async`/`Promise<>` from 27 DB functions that only do synchronous SQLite operations, plus ~370 `await` removals at call sites. Narrowed the biome `useAwait: "off"` override to only files with genuinely async operations.

### GritQL lint rules (3 new)
- `no-raw-metadata-queries.grit` — enforces `getMetadata`/`setMetadata`/`clearMetadata`
- `no-manual-transactions.grit` — enforces `db.transaction()()`
- `no-inline-touch-cache.grit` — enforces shared `touchCacheEntry()`

### Documentation
- AGENTS.md — expanded SQL Utilities section, replaced stale "Async Config Functions" with accurate "DB and Config Function Signatures"
