### PR TITLE
feat(init): add debug report prompt after wizard failures

### DIFF
--- a/src/lib/init/debug-report.ts
+++ b/src/lib/init/debug-report.ts
@@ -1,0 +1,162 @@
+/**
+ * Debug Report
+ *
+ * After a wizard failure, offers to send a reproduction bundle to the Sentry
+ * team: a tar.gz of the project, structured error metadata, and optionally
+ * the local config DB (which contains the auth token and user info needed to
+ * reproduce Sentry API calls with the user's exact setup).
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+// biome-ignore lint/performance/noNamespaceImport: Sentry SDK recommends namespace import
+import * as Sentry from "@sentry/node-core/light";
+import { isCancel, log, select, spinner as clackSpinner } from "@clack/prompts";
+import { CLI_VERSION, getConfiguredSentryUrl } from "../constants.js";
+import { getAuthToken } from "../db/auth.js";
+import { getDbPath } from "../db/index.js";
+import { getUserInfo } from "../db/user.js";
+import type { DirEntry, WizardOptions } from "./types.js";
+
+export type DebugReportContext = {
+  error: string;
+  traceId: string;
+  directory: string;
+  dirListing?: DirEntry[];
+  platform?: string;
+  exitCode?: number;
+};
+
+/**
+ * Create a gzipped tar archive of the project directory.
+ * Excludes common large/irrelevant directories. Returns null if tar is unavailable.
+ */
+function createProjectArchive(directory: string): Buffer | null {
+  try {
+    return execFileSync(
+      "tar",
+      [
+        "czf",
+        "-",
+        "--exclude=node_modules",
+        "--exclude=.git",
+        "--exclude=dist",
+        "--exclude=build",
+        "--exclude=.next",
+        "--exclude=out",
+        "--exclude=.turbo",
+        "--exclude=coverage",
+        "--exclude=*.log",
+        "-C",
+        directory,
+        ".",
+      ],
+      { maxBuffer: 20 * 1024 * 1024 }
+    ) as unknown as Buffer;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * After a wizard error, prompt the user to send a debug bundle.
+ * Skipped silently in non-interactive mode (--yes) or when telemetry is off.
+ */
+export async function offerDebugReport(
+  ctx: DebugReportContext,
+  options: Pick<WizardOptions, "yes">
+): Promise<void> {
+  if (options.yes || !process.stdin.isTTY || !Sentry.isEnabled()) return;
+
+  const choice = await select({
+    message: "Help us fix this? We'll send a debug report to the Sentry team.",
+    options: [
+      {
+        value: "yes",
+        label: "Yes — send project files and error details",
+        hint: "tar.gz of your project (no node_modules/.git) + error trace",
+      },
+      {
+        value: "yes-token",
+        label: "Yes — also include my auth token and config DB",
+        hint: "Lets us reproduce with your exact Sentry setup. Includes cli.db (auth, user info). Only accessible to the Sentry team.",
+      },
+      { value: "no", label: "No thanks" },
+    ],
+    initialValue: "no",
+  });
+
+  if (isCancel(choice) || choice === "no") return;
+
+  const spin = clackSpinner();
+  spin.start("Preparing debug bundle...");
+
+  const archiveBuffer = createProjectArchive(ctx.directory);
+
+  const meta: Record<string, unknown> = {
+    error: ctx.error,
+    exitCode: ctx.exitCode,
+    traceId: ctx.traceId,
+    platform: ctx.platform,
+    projectDir: path.basename(ctx.directory),
+    cliVersion: CLI_VERSION,
+    os: process.platform,
+    arch: process.arch,
+    nodeVersion: process.version,
+    sentryHost: getConfiguredSentryUrl() ?? "sentry.io",
+    hasProjectArchive: !!archiveBuffer,
+  };
+
+  if (choice === "yes-token") {
+    const token = getAuthToken();
+    if (token) meta.authToken = token;
+    const user = getUserInfo();
+    if (user?.email) meta.sentryEmail = user.email;
+  }
+
+  Sentry.withScope((scope) => {
+    scope.setExtra("debugReport", meta);
+
+    if (archiveBuffer) {
+      scope.addAttachment({
+        filename: "project.tar.gz",
+        data: archiveBuffer,
+        contentType: "application/gzip",
+      });
+    } else if (ctx.dirListing) {
+      // tar unavailable (Windows?) — attach directory structure as fallback
+      scope.addAttachment({
+        filename: "project-structure.json",
+        data: Buffer.from(JSON.stringify(ctx.dirListing, null, 2)),
+        contentType: "application/json",
+      });
+    }
+
+    scope.addAttachment({
+      filename: "debug-report.json",
+      data: Buffer.from(JSON.stringify(meta, null, 2)),
+      contentType: "application/json",
+    });
+
+    // Include the local SQLite config DB (auth token, user info, caches).
+    // Only when the user explicitly consented to sharing credentials.
+    if (choice === "yes-token") {
+      try {
+        scope.addAttachment({
+          filename: "cli.db",
+          data: readFileSync(getDbPath()),
+          contentType: "application/octet-stream",
+        });
+      } catch {
+        // DB may not exist or be locked — skip silently
+      }
+    }
+
+    Sentry.captureMessage("Init wizard debug report", "info");
+  });
+
+  spin.message("Sending...");
+  await Sentry.flush(5000);
+  spin.stop("Debug bundle sent. Thank you!");
+}

--- a/src/lib/init/formatters.ts
+++ b/src/lib/init/formatters.ts
@@ -4,7 +4,7 @@
  * Format wizard results and errors for terminal display using clack.
  */
 
-import { cancel, log, note, outro } from "@clack/prompts";
+import { log, note, outro } from "@clack/prompts";
 import { terminalLink } from "../formatters/colors.js";
 import { featureLabel } from "./clack-utils.js";
 import {
@@ -109,6 +109,4 @@ export function formatError(result: WorkflowRunResult): void {
   if (docsUrl) {
     log.info(`Docs: ${terminalLink(docsUrl)}`);
   }
-
-  cancel("Setup failed");
 }

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -26,6 +26,7 @@ import {
   VERIFY_CHANGES_STEP,
   WORKFLOW_ID,
 } from "./constants.js";
+import { offerDebugReport, type DebugReportContext } from "./debug-report.js";
 import { formatError, formatResult } from "./formatters.js";
 import { checkGitStatus } from "./git.js";
 import { handleInteractive } from "./interactive.js";
@@ -120,6 +121,23 @@ async function handleSuspendedStep(
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function buildDebugCtx(
+  error: string,
+  traceId: string,
+  directory: string,
+  dirListing: ReturnType<typeof precomputeDirListing>,
+  result?: WorkflowRunResult
+): DebugReportContext {
+  return {
+    error,
+    traceId,
+    directory,
+    dirListing,
+    platform: result?.result?.platform,
+    exitCode: result?.result?.exitCode,
+  };
 }
 
 function assertWorkflowResult(raw: unknown): WorkflowRunResult {
@@ -280,10 +298,11 @@ export async function runWizard(options: WizardOptions): Promise<void> {
   spin.start("Scanning project...");
   spinState.running = true;
 
+  const dirListing = precomputeDirListing(directory);
+
   let run: Awaited<ReturnType<typeof workflow.createRun>>;
   let result: WorkflowRunResult;
   try {
-    const dirListing = precomputeDirListing(directory);
     spin.message("Connecting to wizard...");
     run = await workflow.createRun();
     result = assertWorkflowResult(
@@ -300,6 +319,10 @@ export async function runWizard(options: WizardOptions): Promise<void> {
     spin.stop("Connection failed", 1);
     spinState.running = false;
     log.error(errorMessage(err));
+    await offerDebugReport(
+      buildDebugCtx(errorMessage(err), tracingOptions.traceId, directory, dirListing),
+      options
+    );
     cancel("Setup failed");
     process.exitCode = 1;
     return;
@@ -317,7 +340,12 @@ export async function runWizard(options: WizardOptions): Promise<void> {
       if (!extracted) {
         spin.stop("Error", 1);
         spinState.running = false;
-        log.error(`No suspend payload found for step "${stepId}"`);
+        const missingPayloadMsg = `No suspend payload found for step "${stepId}"`;
+        log.error(missingPayloadMsg);
+        await offerDebugReport(
+          buildDebugCtx(missingPayloadMsg, tracingOptions.traceId, directory, dirListing, result),
+          options
+        );
         cancel("Setup failed");
         process.exitCode = 1;
         return;
@@ -360,19 +388,37 @@ export async function runWizard(options: WizardOptions): Promise<void> {
       spinState.running = false;
     }
     log.error(errorMessage(err));
+    await offerDebugReport(
+      buildDebugCtx(errorMessage(err), tracingOptions.traceId, directory, dirListing),
+      options
+    );
     cancel("Setup failed");
     process.exitCode = 1;
     return;
   }
 
-  handleFinalResult(result, spin, spinState);
+  const hadError = handleFinalResult(result, spin, spinState);
+  if (hadError) {
+    await offerDebugReport(
+      buildDebugCtx(
+        result.error ?? result.result?.message ?? "Wizard failed with an unknown error",
+        tracingOptions.traceId,
+        directory,
+        dirListing,
+        result
+      ),
+      options
+    );
+    cancel("Setup failed");
+    process.exitCode = 1;
+  }
 }
 
 function handleFinalResult(
   result: WorkflowRunResult,
   spin: Spinner,
   spinState: SpinState
-): void {
+): boolean {
   const hasError = result.status !== "success" || result.result?.exitCode;
 
   if (hasError) {
@@ -381,14 +427,15 @@ function handleFinalResult(
       spinState.running = false;
     }
     formatError(result);
-    process.exitCode = 1;
-  } else {
-    if (spinState.running) {
-      spin.stop("Done");
-      spinState.running = false;
-    }
-    formatResult(result);
+    return true;
   }
+
+  if (spinState.running) {
+    spin.stop("Done");
+    spinState.running = false;
+  }
+  formatResult(result);
+  return false;
 }
 
 function extractSuspendPayload(


### PR DESCRIPTION
## Summary

After any error in `sentry init`, prompt the user to send a reproduction bundle to the Sentry team. This makes it possible to clone the user's exact environment and re-run `sentry init` to reproduce the failure.

- Adds a 3-option `select` prompt after wizard errors (skipped with `--yes`, no TTY, or telemetry off)
- Sends a Sentry event with structured metadata + attachments via the existing telemetry DSN

**Option 1 — project files + error details:**
- `project.tar.gz`: full project dir minus `node_modules`, `.git`, `dist`, `.next`, etc. (20MB cap)
- `debug-report.json`: error message, traceId (for server log correlation), platform, CLI version/OS/arch

**Option 2 — also include auth token and config DB:**
- Everything above, plus `cli.db` (the local SQLite config DB with auth token, user info, caches)
- With this, the team can copy the DB to `~/.sentry/cli.db`, extract the project, and run `sentry init` authenticated as the user with their exact Sentry org/project setup

Falls back to a JSON directory structure attachment on Windows where `tar` is unavailable.

## Test plan

- [ ] Run `sentry init` in a dir with no recognizable framework → wizard fails → debug prompt appears after error
- [ ] Select "Yes — project files and error details" → Sentry event received with `project.tar.gz` and `debug-report.json` attachments
- [ ] Select "Yes — also include my auth token and config DB" → `debug-report.json` includes `authToken`, `cli.db` attachment present
- [ ] Run with `--yes` flag → no prompt shown
- [ ] Run with `SENTRY_CLI_NO_TELEMETRY=1` → no prompt shown
- [ ] Press Ctrl+C at the prompt → graceful skip, process exits cleanly
- [ ] Simulate connection failure (`MASTRA_API_URL=http://localhost:9999`) → prompt appears after connection error

🤖 Generated with [Claude Code](https://claude.com/claude-code)