### PR TITLE
feat(dashboard): rich terminal chart rendering for dashboard view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,24 +276,6 @@ const parsed = parseOrgProjectArg(targetArg);
 
 Reference: `span/list.ts`, `trace/view.ts`, `event/view.ts`
 
-### Target Resolution Convention
-
-The `<target>` positional follows a 4-mode convention via `parseOrgProjectArg()`:
-
-| Input | Mode | Meaning | Example |
-|-------|------|---------|---------|
-| *(empty)* | `auto-detect` | Resolve from DSN/env/config/directory | `sentry issue list` |
-| `org/project` | `explicit` | Both org and project specified | `sentry issue list sentry/cli` |
-| `org/` | `org-all` | Org specified (trailing slash required) | `sentry issue list sentry/` |
-| `slug` | `project-search` | Search for project across all orgs | `sentry issue list cli` |
-
-**Bare slug disambiguation:** A bare slug is **always** `project-search` first — NOT checked against org names at parse time. The org check is secondary and command-specific:
-
-- **List commands** with `orgSlugMatchBehavior` pre-check cached orgs before project search. `"redirect"` silently treats matches as `org-all`; `"error"` throws with trailing-slash hint.
-- **Other commands** (init, view, explain) treat bare slugs purely as project search — no org pre-check.
-- **Safety net:** If project search finds nothing, `handleProjectSearch()` checks if the slug matches an org and suggests adding a trailing slash.
-- **`init` special case:** A bare slug that doesn't match an existing project is treated as the **name for a new project** to create.
-
 ### Markdown Rendering
 
 All non-trivial human output must use the markdown rendering pipeline:
@@ -386,34 +368,26 @@ if (result.success) {
 
 ### SQL Utilities
 
-Use helpers from `src/lib/db/utils.ts` to reduce SQL boilerplate:
+Use the `upsert()` helper from `src/lib/db/utils.ts` to reduce SQL boilerplate:
 
 ```typescript
-import { upsert, runUpsert, getMetadata, setMetadata, clearMetadata, touchCacheEntry } from "../db/utils.js";
+import { upsert, runUpsert } from "../db/utils.js";
 
-// UPSERT (insert or update on conflict)
+// Generate UPSERT statement
+const { sql, values } = upsert("table", { id: 1, name: "foo" }, ["id"]);
+db.query(sql).run(...values);
+
+// Or use convenience wrapper
 runUpsert(db, "table", { id: 1, name: "foo" }, ["id"]);
 
-// With excludeFromUpdate (columns only set on INSERT)
+// Exclude columns from update
 const { sql, values } = upsert(
   "users",
   { id: 1, name: "Bob", created_at: now },
   ["id"],
   { excludeFromUpdate: ["created_at"] }
 );
-db.query(sql).run(...values);
-
-// METADATA table helpers (for key-value config in the metadata table)
-const m = getMetadata(db, [KEY_A, KEY_B]);              // SELECT ... WHERE key IN (...)
-setMetadata(db, { [KEY_A]: "val1", [KEY_B]: "val2" });  // Batch upsert in transaction
-clearMetadata(db, [KEY_A, KEY_B]);                       // DELETE ... WHERE key IN (...)
-
-// Cache entry touch (update last_accessed timestamp)
-touchCacheEntry("dsn_cache", "directory", directoryPath);
 ```
-
-**Enforced by lint:** GritQL rules ban raw metadata queries, inline `last_accessed` UPDATEs,
-and manual `BEGIN`/`COMMIT`/`ROLLBACK` transactions outside `utils.ts` and `migration.ts`.
 
 ### Error Handling
 
@@ -486,22 +460,15 @@ entity-aware suggestions (e.g., "This looks like a span ID").
 - `trace/view.ts` — issue short ID → issue's trace redirect
 - `hex-id.ts` — entity-aware error hints in `validateHexId`/`validateSpanId`
 
-### DB and Config Function Signatures
+### Async Config Functions
 
-Database operations in `src/lib/db/` are **synchronous** (SQLite is synchronous in Bun).
-Functions that only do SQLite work return values directly — no `async`/`await` needed:
+All config operations are async. Always await:
 
 ```typescript
-const org = getDefaultOrganization();  // returns string | undefined
-const info = getUserInfo();            // returns UserInfo | undefined
-setDefaults("my-org", "my-project");   // returns void
-const token = getAuthToken();          // returns string | undefined
+const token = await getAuthToken();
+const isAuth = await isAuthenticated();
+await setAuthToken(token, expiresIn);
 ```
-
-Exceptions that ARE async (they do file I/O or network calls):
-- `clearAuth()` — awaits cache directory cleanup
-- `getCachedDetection()`, `getCachedProjectRoot()`, `setCachedProjectRoot()` — await `stat()` for mtime validation
-- `refreshToken()`, `performTokenRefresh()` — await HTTP calls
 
 ### Imports
 
@@ -847,83 +814,54 @@ mock.module("./some-module", () => ({
 
 ### Architecture
 
-<!-- lore:019ce2be-39f1-7ad9-a4c5-4506b62f689c -->
-* **api-client.ts split into domain modules under src/lib/api/**: The original monolithic \`src/lib/api-client.ts\` (1,977 lines) was split into 12 focused domain modules under \`src/lib/api/\`: infrastructure.ts (shared helpers, types, raw requests), organizations.ts, projects.ts, teams.ts, repositories.ts, issues.ts, events.ts, traces.ts, logs.ts, seer.ts, trials.ts, users.ts. The original \`api-client.ts\` was converted to a ~100-line barrel re-export file preserving all existing import paths. The \`biome.jsonc\` override for \`noBarrelFile\` already includes \`api-client.ts\`. When adding new API functions, place them in the appropriate domain module under \`src/lib/api/\`, not in the barrel file.
+<!-- lore:019cbeba-e4d3-748c-ad50-fe3c3d5c0a0d -->
+* **Auth token env var override pattern: SENTRY\_AUTH\_TOKEN > SENTRY\_TOKEN > SQLite**: Auth in \`src/lib/db/auth.ts\` follows layered precedence: \`SENTRY\_AUTH\_TOKEN\` > \`SENTRY\_TOKEN\` > SQLite OAuth token. \`getEnvToken()\` trims env vars (empty/whitespace = unset). \`AuthSource\` tracks provenance. \`ENV\_SOURCE\_PREFIX = "env:"\` — use \`.length\` not hardcoded 4. Env tokens bypass refresh/expiry. \`isEnvTokenActive()\` guards auth commands. Logout must NOT clear stored auth when env token active. These functions stay in \`db/auth.ts\` despite not touching DB because they're tightly coupled with token retrieval.
 
-<!-- lore:019d0b69-1430-74f0-8e9a-426a5c7b321d -->
-* **Bun compiled binary sourcemap options and size impact**: Binary build (\`script/build.ts\`) uses two steps: (1) \`Bun.build()\` produces \`dist-bin/bin.js\` + \`.map\` with \`sourcemap: "linked"\` and minification. (2) \`Bun.build()\` with \`compile: true\` produces native binary — no sourcemap embedded. Bun's compiled binaries use \`/$bunfs/root/bin.js\` as the virtual path in stack traces. Sourcemap upload must use \`--url-prefix '/$bunfs/root/'\` so Sentry can match frames. The upload runs \`sentry-cli sourcemaps inject dist-bin/\` first (adds debug IDs), then uploads both JS and map. Bun's compile step strips comments (including \`//# debugId=\`), but debug ID matching still works via the injected runtime snippet + URL prefix matching. Size: +0.04 MB gzipped vs +2.30 MB for inline sourcemaps. Without \`SENTRY\_AUTH\_TOKEN\`, upload is skipped gracefully.
+<!-- lore:019cbaa2-e4a2-76c0-8f64-917a97ae20c5 -->
+* **Consola chosen as CLI logger with Sentry createConsolaReporter integration**: Consola is the CLI logger with Sentry \`createConsolaReporter\` integration. Two reporters: FancyReporter (stderr) + Sentry structured logs. Level via \`SENTRY\_LOG\_LEVEL\`. \`buildCommand\` injects hidden \`--log-level\`/\`--verbose\` flags. \`withTag()\` creates independent instances; \`setLogLevel()\` propagates via registry. All user-facing output must use consola, not raw stderr. \`HandlerContext\` intentionally omits stderr.
 
-<!-- lore:019cb8ea-c6f0-75d8-bda7-e32b4e217f92 -->
-* **CLI telemetry DSN is public write-only — safe to embed in install script**: The CLI's Sentry DSN (\`SENTRY\_CLI\_DSN\` in \`src/lib/constants.ts\`) is a public write-only ingest key already baked into every binary. Safe to hardcode in install scripts. Opt-out: \`SENTRY\_CLI\_NO\_TELEMETRY=1\`.
+<!-- lore:019cce8d-f2c5-726e-8a04-3f48caba45ec -->
+* **Input validation layer: src/lib/input-validation.ts guards CLI arg parsing**: Four validators in \`src/lib/input-validation.ts\` guard against agent-hallucinated inputs: \`rejectControlChars\` (ASCII < 0x20), \`rejectPreEncoded\` (%XX), \`validateResourceId\` (rejects ?, #, %, whitespace), \`validateEndpoint\` (rejects \`..\` traversal). Applied in \`parseSlashOrgProject\`, bare-slug path in \`parseOrgProjectArg\`, \`parseIssueArg\`, and \`normalizeEndpoint\` (api.ts). NOT applied in \`parseSlashSeparatedArg\` for no-slash plain IDs — those may contain structural separators (newlines for log view batch IDs) that callers split downstream. Validation targets user-facing parse boundaries only; env vars and DB cache values are trusted.
 
-<!-- lore:019c978a-18b5-7a0d-a55f-b72f7789bdac -->
-* **cli.sentry.dev is served from gh-pages branch via GitHub Pages**: \`cli.sentry.dev\` is served from gh-pages branch via GitHub Pages. Craft's gh-pages target runs \`git rm -r -f .\` before extracting docs — persist extra files via \`postReleaseCommand\` in \`.craft.yml\`. Install script supports \`--channel nightly\`, downloading from the \`nightly\` release tag directly. version.json is only used by upgrade/version-check flow.
+<!-- lore:019cd2d1-aa47-7fc1-92f9-cc6c49b19460 -->
+* **Magic @ selectors resolve issues dynamically via sort-based list API queries**: Magic \`@\` selectors (\`@latest\`, \`@most\_frequent\`) in \`parseIssueArg\` are detected early (before \`validateResourceId\`) because \`@\` is not in the forbidden charset. \`SELECTOR\_MAP\` provides case-insensitive matching with common variations (\`@mostfrequent\`, \`@most-frequent\`). Resolution in \`resolveSelector\` (issue/utils.ts) maps selectors to \`IssueSort\` values (\`date\`, \`freq\`), calls \`listIssuesPaginated\` with \`perPage: 1\` and \`query: 'is:unresolved'\`. Supports org-prefixed form: \`sentry/@latest\`. Unrecognized \`@\`-prefixed strings fall through to suffix-only parsing (not an error). The \`ParsedIssueArg\` union includes \`{ type: 'selector'; selector: IssueSelector; org?: string }\`.
 
-<!-- lore:019cbe93-19b8-7776-9705-20bbde226599 -->
-* **Nightly delta upgrade buildNightlyPatchGraph fetches ALL patch tags — O(N) HTTP calls**: Delta upgrade in \`src/lib/delta-upgrade.ts\` supports stable (GitHub Releases) and nightly (GHCR) channels. \`filterAndSortChainTags\` filters \`patch-\*\` tags by version range using \`Bun.semver.order()\`. GHCR uses \`fetchWithRetry\` (10s timeout + 1 retry; blobs 30s) with optional \`signal?: AbortSignal\` combined via \`AbortSignal.any()\`. \`isExternalAbort(error, signal)\` skips retries for external aborts — critical for background prefetch. Patches cached to \`~/.sentry/patch-cache/\` (file-based, 7-day TTY). \`loadCachedChain\` stitches patches for multi-hop offline upgrades.
-
-<!-- lore:2c3eb7ab-1341-4392-89fd-d81095cfe9c4 -->
-* **npm bundle requires Node.js >= 22 due to node:sqlite polyfill**: The npm package (dist/bin.cjs) requires Node.js >= 22 because the bun:sqlite polyfill uses \`node:sqlite\`. A runtime version guard in the esbuild banner catches this early. When writing esbuild banner strings in TS template literals, double-escape: \`\\\\\\\n\` in TS → \`\\\n\` in output → newline at runtime. Single \`\\\n\` produces a literal newline inside a JS string, causing SyntaxError.
-
-<!-- lore:019c972c-9f0f-75cd-9e24-9bdbb1ac03d6 -->
-* **Numeric issue ID resolution returns org:undefined despite API success**: Numeric issue ID resolution in \`resolveNumericIssue()\`: (1) try DSN/env/config for org, (2) if found use \`getIssueInOrg(org, id)\` with region routing, (3) else fall back to unscoped \`getIssue(id)\`, (4) extract org from \`issue.permalink\` via \`parseSentryUrl\` as final fallback. \`parseSentryUrl\` handles path-based (\`/organizations/{org}/...\`) and subdomain-style URLs. \`matchSubdomainOrg()\` filters region subdomains by requiring slug length > 2. Self-hosted uses path-based only.
-
-<!-- lore:019ce0bb-f35d-7380-b661-8dc56f9938cf -->
-* **Seer trial prompt uses middleware layering in bin.ts error handling chain**: Error recovery middlewares in \`bin.ts\` are layered: \`main() → executeWithAutoAuth() → executeWithSeerTrialPrompt() → runCommand()\`. Seer trial prompts (for \`no\_budget\`/\`not\_enabled\`) caught by inner wrapper; auth errors bubble to outer. Auth retry goes through full chain. Trial API: \`GET /api/0/customers/{org}/\` → \`productTrials\[]\` (prefer \`seerUsers\`, fallback \`seerAutofix\`). Start: \`PUT /api/0/customers/{org}/product-trial/\`. SaaS-only; self-hosted 404s gracefully. \`ai\_disabled\` excluded. \`startSeerTrial\` accepts \`category\` from trial object — don't hardcode.
-
-<!-- lore:019d1f97-563d-72f0-80a9-accaa6d9b282 -->
-* **SQLite DB functions are synchronous — async signatures are historical artifacts**: All \`src/lib/db/\` functions do synchronous SQLite operations (both \`bun:sqlite\` and the \`node:sqlite\` polyfill's \`DatabaseSync\` are sync). Many functions still have \`async\` signatures — this is a historical artifact from PR #89 which migrated config storage from JSON files (using async \`Bun.file().text()\` / \`Bun.write()\`) to SQLite. The function signatures were preserved to minimize diff size and never cleaned up. These can safely be converted to synchronous. Exceptions that ARE legitimately async: \`clearAuth()\` (cache dir cleanup), \`getCachedDetection()\`/\`getCachedProjectRoot()\`/\`setCachedProjectRoot()\` (stat for mtime), \`refreshToken()\`/\`performTokenRefresh()\` (HTTP calls).
+<!-- lore:019d0682-eb25-77f7-ad72-02247adc597c -->
+* **Sentry SDK uses @sentry/node-core/light instead of @sentry/bun to avoid OTel overhead**: The CLI uses \`@sentry/node-core/light\` instead of \`@sentry/bun\` to avoid loading the full OpenTelemetry stack (~150ms, 24MB). \`@sentry/core\` barrel is patched via \`bun patch\` to remove ~32 unused exports saving ~13ms. Key gotcha: \`LightNodeClient\` constructor hardcodes \`runtime: { name: 'node' }\` AFTER spreading user options, so passing \`runtime\` in \`Sentry.init()\` is silently overwritten. Fix: patch \`client.getOptions().runtime\` post-init (returns mutable ref). The CLI does this in \`telemetry.ts\` to report \`bun\` runtime when running as binary. Trade-offs: transport falls back to Node's \`http\` module instead of native \`fetch\`. Upstream issues: getsentry/sentry-javascript#19885 and #19886.
 
 ### Decision
 
-<!-- lore:019c99d5-69f2-74eb-8c86-411f8512801d -->
-* **Raw markdown output for non-interactive terminals, rendered for TTY**: Markdown-first output pipeline: custom renderer in \`src/lib/formatters/markdown.ts\` walks \`marked\` tokens to produce ANSI-styled output. Commands build CommonMark using helpers (\`mdKvTable()\`, \`mdRow()\`, \`colorTag()\`, \`escapeMarkdownCell()\`, \`safeCodeSpan()\`) and pass through \`renderMarkdown()\`. \`isPlainOutput()\` precedence: \`SENTRY\_PLAIN\_OUTPUT\` > \`NO\_COLOR\` > \`FORCE\_COLOR\` > \`!isTTY\`. \`--json\` always outputs JSON. Colors defined in \`COLORS\` object in \`colors.ts\`. Tests run non-TTY so assertions match raw CommonMark; use \`stripAnsi()\` helper for rendered-mode assertions.
+<!-- lore:019cc2ef-9be5-722d-bc9f-b07a8197eeed -->
+* **All view subcommands should use \<target> \<id> positional pattern**: All \`\* view\` subcommands should follow a consistent \`\<target> \<id>\` positional argument pattern where target is the optional \`org/project\` specifier. During migration, use opportunistic argument swapping with a stderr warning when args are in wrong order. This is an instance of the broader CLI UX auto-correction pattern: safe when input is already invalid, correction is unambiguous, warning goes to stderr. Normalize at command level, keep parsers pure. Model after \`gh\` CLI conventions.
 
-<!-- lore:00166785-609d-4ab5-911e-ee205d17b90c -->
-* **whoami should be separate from auth status command**: The \`sentry auth whoami\` command should be a dedicated command separate from \`sentry auth status\`. They serve different purposes: \`status\` shows everything about auth state (token, expiry, defaults, org verification), while \`whoami\` just shows user identity (name, email, username, ID) by fetching live from \`/auth/\` endpoint. \`sentry whoami\` should be a top-level alias (like \`sentry issues\` → \`sentry issue list\`). \`whoami\` should support \`--json\` for machine consumption and be lightweight — no credential verification, no defaults listing.
+<!-- lore:019d20f7-717f-77a2-a71a-9fdbf1c48dea -->
+* **Sentry-derived terminal color palette tuned for dual-background contrast**: The CLI's chart/dashboard palette uses 10 colors derived from Sentry's categorical chart hues (\`static/app/utils/theme/scraps/tokens/color.tsx\` in getsentry/sentry), each adjusted to mid-luminance to achieve ≥3:1 contrast on both dark (#1e1e1e) and light (#f0f0f0) backgrounds. Key adjustments: orange darkened from #FF9838→#C06F20, green #67C800→#3D8F09, yellow #FFD00E→#9E8B18, purple lightened #5D3EB2→#8B6AC8, indigo #50219C→#7B50D0. Blurple (#7553FF), pink (#F0369A), magenta (#B82D90) used as-is. Teal (#228A83) added to fill a hue gap. ANSI 16-color codes were considered but rejected in favor of hex since the mid-luminance hex values provide guaranteed contrast regardless of terminal theme configuration.
 
 ### Gotcha
 
-<!-- lore:019c8ab6-d119-7365-9359-98ecf464b704 -->
-* **@sentry/api SDK passes Request object to custom fetch — headers lost on Node.js**: @sentry/api SDK calls \`\_fetch(request)\` with no init object. In \`authenticatedFetch\`, \`init\` is undefined so \`prepareHeaders\` creates empty headers — on Node.js this strips Content-Type (HTTP 415). Fix: fall back to \`input.headers\` when \`init\` is undefined. Use \`unwrapPaginatedResult\` (not \`unwrapResult\`) to access the Response's Link header for pagination. \`per\_page\` is not in SDK types; cast query to pass it at runtime.
+<!-- lore:019d2105-6cb4-7c3e-8194-51c963a80797 -->
+* **Biome lint bans process.stdout in commands — use isPlainOutput() and yield tokens instead**: A custom lint rule prevents \`process.stdout\` usage in command files — all output must go through \`yield CommandOutput\` or the Stricli context's \`this.stdout\`. For TTY detection, use \`isPlainOutput()\` from \`src/lib/formatters/plain-detect.ts\` instead of \`process.stdout.isTTY\`. For ANSI control sequences (screen clear, cursor movement), yield a \`ClearScreen\` token and let the \`buildCommand\` wrapper handle it. This keeps commands decoupled from stdout details.
 
-<!-- lore:019c9e98-7af4-7e25-95f4-fc06f7abf564 -->
-* **Bun binary build requires SENTRY\_CLIENT\_ID env var**: The build script (\`script/bundle.ts\`) requires \`SENTRY\_CLIENT\_ID\` environment variable and exits with code 1 if missing. When building locally, use \`bun run --env-file=.env.local build\` or set the env var explicitly. The binary build (\`bun run build\`) also needs it. Without it you get: \`Error: SENTRY\_CLIENT\_ID environment variable is required.\`
+<!-- lore:019cd379-4c6a-7a93-beae-b1d5b4df69b1 -->
+* **Dot-notation field filtering is ambiguous for keys containing dots**: The \`filterFields\` function in \`src/lib/formatters/json.ts\` uses dot-notation to address nested fields (e.g., \`metadata.value\`). This means object keys that literally contain dots are ambiguous and cannot be addressed. Property-based tests for this function must generate field name arbitraries that exclude dots — use a restricted charset like \`\[a-zA-Z0-9\_]\` in fast-check arbitraries. Counterexample found by fast-check: \`{"a":{".":false}}\` with path \`"a."\` splits into \`\["a", ""]\` and fails to resolve.
 
-<!-- lore:019c9776-e3dd-7632-88b8-358a19506218 -->
-* **GitHub immutable releases prevent rolling nightly tag pattern**: getsentry/cli has immutable GitHub releases — assets can't be modified and tags can NEVER be reused. Nightly builds publish to GHCR with versioned tags like \`nightly-0.14.0-dev.1772661724\`, not GitHub Releases or npm. \`fetchManifest()\` throws \`UpgradeError("network\_error")\` for both network failures and non-200 — callers must check message for HTTP 404/403. Craft with no \`preReleaseCommand\` silently skips \`bump-version.sh\` if only target is \`github\`.
-
-<!-- lore:019cb8c2-d7b5-780c-8a9f-d20001bc198f -->
-* **Install script: BSD sed and awk JSON parsing breaks OCI digest extraction**: The install script parses OCI manifests with awk (no jq). Key trap: BSD sed \`\n\` is literal, not newline. Fix: single awk pass tracking last-seen \`"digest"\`, printing when \`"org.opencontainers.image.title"\` matches target. The config digest (\`sha256:44136fa...\`) is a 2-byte \`{}\` blob — downloading it instead of the real binary causes \`gunzip: unexpected end of file\`.
-
-<!-- lore:019d0b04-ccec-7bd2-a5ca-732e7064cc1a -->
-* **Multi-region fan-out: distinguish all-403 from empty orgs with hasSuccessfulRegion flag**: In \`listOrganizationsUncached\` (\`src/lib/api/organizations.ts\`), \`Promise.allSettled\` collects multi-region results. Don't use \`flatResults.length === 0\` to detect all-regions-failed — a region returning 200 OK with zero orgs pushes nothing into \`flatResults\`. Track a \`hasSuccessfulRegion\` boolean on any \`"fulfilled"\` settlement. Only re-throw 403 \`ApiError\` when \`!hasSuccessfulRegion && lastScopeError\`.
-
-<!-- lore:019c969a-1c90-7041-88a8-4e4d9a51ebed -->
-* **Multiple mockFetch calls replace each other — use unified mocks for multi-endpoint tests**: Bun test mocking gotchas: (1) \`mockFetch()\` replaces \`globalThis.fetch\` — calling it twice replaces the first mock. Use a single unified fetch mock dispatching by URL pattern. (2) \`mock.module()\` pollutes the module registry for ALL subsequent test files. Tests using it must live in \`test/isolated/\` and run via \`test:isolated\`. This also causes \`delta-upgrade.test.ts\` to fail when run alongside \`test/isolated/delta-upgrade.test.ts\` — the isolated test's \`mock.module()\` replaces \`CLI\_VERSION\` for all subsequent files. (3) For \`Bun.spawn\`, use direct property assignment in \`beforeEach\`/\`afterEach\`.
-
-<!-- lore:019c9741-d78e-73b1-87c2-e360ef6c7475 -->
-* **useTestConfigDir without isolateProjectRoot causes DSN scanning of repo tree**: \`useTestConfigDir()\` creates temp dirs under \`.test-tmp/\` in the repo tree. Without \`{ isolateProjectRoot: true }\`, \`findProjectRoot\` walks up and finds the repo's \`.git\`, causing DSN detection to scan real source code and trigger network calls against test mocks (timeouts). Always pass \`isolateProjectRoot: true\` when tests exercise \`resolveOrg\`, \`detectDsn\`, or \`findProjectRoot\`.
+<!-- lore:019cbe0d-d03e-716c-b372-b09998c07ed6 -->
+* **Stricli rejects unknown flags — pre-parsed global flags must be consumed from argv**: Stricli's arg parser is strict: any \`--flag\` not registered on a command throws \`No flag registered for --flag\`. Global flags (parsed before Stricli in bin.ts) MUST be spliced out of argv. \`--log-level\` was correctly consumed but \`--verbose\` was intentionally left in (for the \`api\` command's own \`--verbose\`). This breaks every other command. Also, \`argv.indexOf('--flag')\` doesn't match \`--flag=value\` form — must check both space-separated and equals-sign forms when pre-parsing. A Biome \`noRestrictedImports\` lint rule in \`biome.jsonc\` now blocks \`import { buildCommand } from "@stricli/core"\` at error level — only \`src/lib/command.ts\` is exempted. Other \`@stricli/core\` exports (\`buildRouteMap\`, \`run\`, etc.) are allowed.
 
 ### Pattern
 
-<!-- lore:019d0b36-5da2-750c-b26f-630a2927bd79 -->
-* **findProjectsByPattern as fuzzy fallback for exact slug misses**: When \`findProjectsBySlug\` returns empty (no exact match), use \`findProjectsByPattern\` as a fallback to suggest similar projects. \`findProjectsByPattern\` does bidirectional word-boundary matching (\`matchesWordBoundary\`) against all projects in all orgs — the same logic used for directory name inference. In the \`project-search\` handler, call it after the exact miss, format matches as \`\<org>/\<slug>\` suggestions in the \`ResolutionError\`. This avoids a dead-end error for typos like 'patagonai' when 'patagon-ai' exists. Note: \`findProjectsByPattern\` makes additional API calls (lists all projects per org), so only call it on the failure path.
+<!-- lore:019d2105-6caa-7077-a28e-126ecc9d0dbc -->
+* **ClearScreen yield token for in-place terminal refresh in buildCommand wrapper**: Commands needing in-place refresh yield a \`ClearScreen\` token from \`src/lib/formatters/output.ts\`. The \`handleYieldedValue\` function in \`buildCommand\` sets a \`pendingClear\` flag; when the next \`CommandOutput\` is rendered, \`renderCommandOutput\` prepends \`\x1b\[H\x1b\[J\` and writes everything in a \*\*single \`stdout.write()\` call\*\* — no flicker. In JSON/plain modes the clear is silently ignored. Pattern: \`yield ClearScreen()\` then \`yield CommandOutput(data)\`. Critical: never split clear and content into separate writes. Also: never add a redundant clear-screen inside a \`HumanRenderer.render()\` method — the \`ClearScreen\` token is the sole mechanism. The dashboard renderer originally had its own \`\x1b\[2J\x1b\[H\` prepend on re-renders, causing double clears; this was removed.
 
-* **Target argument 4-mode parsing convention (project-search-first)**: \`parseOrgProjectArg()\` in \`src/lib/arg-parsing.ts\` returns a 4-mode discriminated union: \`auto-detect\` (empty), \`explicit\` (\`org/project\`), \`org-all\` (\`org/\` trailing slash), \`project-search\` (bare slug). Bare slugs are ALWAYS \`project-search\` first. The "is this an org?" check is secondary: list commands with \`orgSlugMatchBehavior\` pre-check cached orgs (\`redirect\` or \`error\` mode), and \`handleProjectSearch()\` has a safety net checking orgs after project search fails. Non-list commands (init, view) treat bare slugs purely as project search with no org pre-check. For \`init\`, unmatched bare slugs become new project names. Key files: \`src/lib/arg-parsing.ts\` (parsing), \`src/lib/org-list.ts\` (dispatch + org pre-check), \`src/lib/resolve-target.ts\` (resolution cascade).
+<!-- lore:019cce8d-f2d6-7862-9105-7a0048f0e993 -->
+* **Property-based tests for input validators use stringMatching for forbidden char coverage**: In \`test/lib/input-validation.property.test.ts\`, forbidden-character arbitraries are built with \`stringMatching\` targeting specific regex patterns (e.g., \`/^\[^\x00-\x1f]\*\[\x00-\x1f]\[^\x00-\x1f]\*$/\` for control chars). This ensures fast-check generates strings that always contain the forbidden character while varying surrounding content. The \`biome-ignore lint/suspicious/noControlCharactersInRegex\` suppression is needed on the control char regex constant in \`input-validation.ts\`.
 
-<!-- lore:019c972c-9f11-7c0d-96ce-3f8cc2641175 -->
-* **Org-scoped SDK calls follow getOrgSdkConfig + unwrapResult pattern**: All org-scoped API calls in src/lib/api-client.ts: (1) call \`getOrgSdkConfig(orgSlug)\` for regional URL + SDK config, (2) spread into SDK function: \`{ ...config, path: { organization\_id\_or\_slug: orgSlug, ... } }\`, (3) pass to \`unwrapResult(result, errorContext)\`. Shared helpers \`resolveAllTargets\`/\`resolveOrgAndProject\` must NOT call \`fetchProjectId\` — commands that need it enrich targets themselves.
+<!-- lore:019d20f7-718a-72af-add3-b2b35b8d783c -->
+* **Sentry's official color token source location in getsentry/sentry repo**: Sentry's canonical color palette lives in \`static/app/utils/theme/scraps/tokens/color.tsx\` in getsentry/sentry. It defines \`categorical.light\` and \`categorical.dark\` palettes with named colors (blurple, purple, indigo, plum, magenta, pink, salmon, orange, yellow, lime, green). Chart palettes are built in \`static/app/utils/theme/theme.tsx\` using \`CHART\_PALETTE\_LIGHT\` and \`CHART\_PALETTE\_DARK\` arrays that progressively add colors as series count grows (1→blurple, 6→blurple/indigo/pink/orange/yellow/green, etc.). GitHub API tree endpoint (\`/git/trees/master?recursive=1\`) can locate files without needing authenticated code search.
 
-<!-- lore:5ac4e219-ea1f-41cb-8e97-7e946f5848c0 -->
-* **PR workflow: wait for Seer and Cursor BugBot before resolving**: CI includes Seer Code Review and Cursor Bugbot as advisory checks (~2-3 min, only on ready-for-review PRs). Workflow: push → wait for all CI (including npm build) → check inline review comments from Seer/BugBot → fix valid findings → repeat. Bugbot sometimes catches real logic bugs, not just style — always review before merging. Use \`gh pr checks \<PR> --watch\` to monitor. Fetch comments via \`gh api repos/OWNER/REPO/pulls/NUM/comments\`.
+<!-- lore:019cd379-4c71-7477-9cc6-3c0dfc7fb597 -->
+* **Shared flag constants in list-command.ts for cross-command consistency**: \`src/lib/list-command.ts\` exports shared Stricli flag definitions (\`FIELDS\_FLAG\`, \`FRESH\_FLAG\`, \`FRESH\_ALIASES\`) reused across all commands. When adding a new global-ish flag to multiple commands, define it once here as a const satisfying Stricli's flag shape, then spread into each command's \`flags\` object. The \`--fields\` flag is \`{ kind: 'parsed', parse: String, brief: '...', optional: true }\`. \`parseFieldsList()\` in \`formatters/json.ts\` handles comma-separated parsing with trim/dedup. \`writeJson()\` accepts an optional \`fields\` array and calls \`filterFields()\` before serialization.
 
-<!-- lore:019cb162-d3ad-7b05-ab4f-f87892d517a6 -->
-* **Shared pagination infrastructure: buildPaginationContextKey and parseCursorFlag**: List commands with cursor pagination use \`buildPaginationContextKey(type, identifier, flags)\` for composite context keys and \`parseCursorFlag(value)\` accepting \`"last"\` magic value. Critical: \`resolveCursor()\` must be called inside the \`org-all\` override closure, not before \`dispatchOrgScopedList\` — otherwise cursor validation errors fire before the correct mode-specific error.
-
-<!-- lore:019cbd5f-ec35-7e2d-8386-6d3a67adf0cf -->
-* **Telemetry instrumentation pattern: withTracingSpan + captureException for handled errors**: For graceful-fallback operations, use \`withTracingSpan\` from \`src/lib/telemetry.ts\` for child spans and \`captureException\` from \`@sentry/bun\` (named import — Biome forbids namespace imports) with \`level: 'warning'\` for non-fatal errors. \`withTracingSpan\` uses \`onlyIfParent: true\` — no-op without active transaction. User-visible fallbacks use \`log.warn()\` not \`log.debug()\`. Several commands bypass telemetry by importing \`buildCommand\` from \`@stricli/core\` directly instead of \`../../lib/command.js\` (trace/list, trace/view, log/view, api.ts, help.ts).
-
-<!-- lore:019cc43d-e651-7154-a88e-1309c4a2a2b6 -->
-* **Testing Stricli command func() bodies via spyOn mocking**: To unit-test a Stricli command's \`func()\` body: (1) \`const func = await cmd.loader()\`, (2) \`func.call(mockContext, flags, ...args)\` with mock \`stdout\`, \`stderr\`, \`cwd\`, \`setContext\`. (3) \`spyOn\` namespace imports to mock dependencies (e.g., \`spyOn(apiClient, 'getLogs')\`). The \`loader()\` return type union causes \`.call()\` LSP errors — these are false positives that pass \`tsc --noEmit\`. When API functions are renamed (e.g., \`getLog\` → \`getLogs\`), update both spy target name AND mock return shape (single → array). Slug normalization (\`normalizeSlug\`) replaces underscores with dashes but does NOT lowercase — test assertions must match original casing (e.g., \`'CAM-82X'\` not \`'cam-82x'\`).
+<!-- lore:019cbe44-7687-7288-81a2-662feefc28ea -->
+* **SKILL.md generator must filter hidden Stricli flags**: \`script/generate-skill.ts\` introspects Stricli's route tree to auto-generate \`plugins/sentry-cli/skills/sentry-cli/SKILL.md\`. The \`FlagDef\` type must include \`hidden?: boolean\` and \`extractFlags\` must propagate it to \`FlagInfo\`. The filter in \`generateCommandDoc\` must exclude \`f.hidden\` alongside \`help\`/\`helpAll\`. Without this, hidden flags injected by \`buildCommand\` (like \`--log-level\`, \`--verbose\`) appear on every command in the AI agent skill file. Global flags should instead be documented once in \`docs/src/content/docs/commands/index.md\` Global Options section, which the generator pulls into SKILL.md via \`loadCommandsOverview\`.
 <!-- End lore-managed section -->

--- a/plugins/sentry-cli/skills/sentry-cli/references/dashboards.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/dashboards.md
@@ -44,6 +44,8 @@ View a dashboard
 **Flags:**
 - `-w, --web - Open in browser`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-r, --refresh <value> - Auto-refresh interval in seconds (default: 60, min: 10)`
+- `-t, --period <value> - Time period override (e.g., "24h", "7d", "14d")`
 
 **Examples:**
 

--- a/src/commands/dashboard/view.ts
+++ b/src/commands/dashboard/view.ts
@@ -1,54 +1,147 @@
 /**
  * sentry dashboard view
  *
- * View details of a specific dashboard.
+ * View a dashboard with rendered widget data (sparklines, tables, big numbers).
+ * Supports --refresh for auto-refreshing live display.
  */
 
 import type { SentryContext } from "../../context.js";
-import { getDashboard } from "../../lib/api-client.js";
+import { getDashboard, queryAllWidgets } from "../../lib/api-client.js";
 import { parseOrgProjectArg } from "../../lib/arg-parsing.js";
 import { openInBrowser } from "../../lib/browser.js";
 import { buildCommand } from "../../lib/command.js";
-import { formatDashboardView } from "../../lib/formatters/human.js";
-import { CommandOutput } from "../../lib/formatters/output.js";
+import type { DashboardViewData } from "../../lib/formatters/dashboard.js";
+import { createDashboardViewRenderer } from "../../lib/formatters/dashboard.js";
+import { ClearScreen, CommandOutput } from "../../lib/formatters/output.js";
 import {
   applyFreshFlag,
   FRESH_ALIASES,
   FRESH_FLAG,
 } from "../../lib/list-command.js";
+import { logger } from "../../lib/logger.js";
 import { withProgress } from "../../lib/polling.js";
+import { resolveOrgRegion } from "../../lib/region.js";
 import { buildDashboardUrl } from "../../lib/sentry-urls.js";
-import type { DashboardDetail } from "../../types/dashboard.js";
+import type {
+  DashboardWidget,
+  WidgetDataResult,
+} from "../../types/dashboard.js";
 import {
   parseDashboardPositionalArgs,
   resolveDashboardId,
   resolveOrgFromTarget,
 } from "./resolve.js";
 
+/** Default auto-refresh interval in seconds */
+const DEFAULT_REFRESH_INTERVAL = 60;
+
+/** Minimum auto-refresh interval in seconds (avoid rate limiting) */
+const MIN_REFRESH_INTERVAL = 10;
+
 type ViewFlags = {
   readonly web: boolean;
   readonly fresh: boolean;
+  readonly refresh?: number;
+  readonly period?: string;
   readonly json: boolean;
   readonly fields?: string[];
 };
 
-type ViewResult = DashboardDetail & { url: string };
+/**
+ * Parse --refresh flag value.
+ * Supports: -r (empty string → 60s default), -r 30 (explicit interval in seconds)
+ */
+function parseRefresh(value: string): number {
+  if (value === "") {
+    return DEFAULT_REFRESH_INTERVAL;
+  }
+  const num = Number.parseInt(value, 10);
+  if (Number.isNaN(num) || num < MIN_REFRESH_INTERVAL) {
+    throw new Error(
+      `--refresh interval must be at least ${MIN_REFRESH_INTERVAL} seconds`
+    );
+  }
+  return num;
+}
+
+/**
+ * Sleep that resolves early when an AbortSignal fires.
+ * Resolves (not rejects) on abort for clean generator shutdown.
+ */
+function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Build the DashboardViewData from a dashboard and its widget query results.
+ */
+function buildViewData(
+  dashboard: {
+    id: string;
+    title: string;
+    dateCreated?: string;
+    environment?: string[];
+  },
+  widgetResults: Map<number, WidgetDataResult>,
+  widgets: DashboardWidget[],
+  opts: { period: string; url: string }
+): DashboardViewData {
+  return {
+    id: dashboard.id,
+    title: dashboard.title,
+    period: opts.period,
+    fetchedAt: new Date().toISOString(),
+    url: opts.url,
+    dateCreated: dashboard.dateCreated,
+    environment: dashboard.environment,
+    widgets: widgets.map((w, i) => ({
+      title: w.title,
+      displayType: w.displayType,
+      widgetType: w.widgetType,
+      layout: w.layout,
+      queries: w.queries,
+      data: widgetResults.get(i) ?? {
+        type: "error" as const,
+        message: "No data returned",
+      },
+    })),
+  };
+}
 
 export const viewCommand = buildCommand({
   docs: {
     brief: "View a dashboard",
     fullDescription:
-      "View details of a specific Sentry dashboard.\n\n" +
+      "View a Sentry dashboard with rendered widget data.\n\n" +
+      "Fetches actual data for each widget and displays sparkline charts,\n" +
+      "tables, and big numbers in the terminal.\n\n" +
       "The dashboard can be specified by numeric ID or title.\n\n" +
       "Examples:\n" +
       "  sentry dashboard view 12345\n" +
       "  sentry dashboard view 'My Dashboard'\n" +
       "  sentry dashboard view my-org/ 12345\n" +
       "  sentry dashboard view 12345 --json\n" +
+      "  sentry dashboard view 12345 --period 7d\n" +
+      "  sentry dashboard view 12345 -r\n" +
+      "  sentry dashboard view 12345 -r 30\n" +
       "  sentry dashboard view 12345 --web",
   },
   output: {
-    human: formatDashboardView,
+    human: createDashboardViewRenderer,
   },
   parameters: {
     positional: {
@@ -65,8 +158,21 @@ export const viewCommand = buildCommand({
         default: false,
       },
       fresh: FRESH_FLAG,
+      refresh: {
+        kind: "parsed",
+        parse: parseRefresh,
+        brief: "Auto-refresh interval in seconds (default: 60, min: 10)",
+        optional: true,
+        inferEmpty: true,
+      },
+      period: {
+        kind: "parsed",
+        parse: String,
+        brief: 'Time period override (e.g., "24h", "7d", "14d")',
+        optional: true,
+      },
     },
-    aliases: { ...FRESH_ALIASES, w: "web" },
+    aliases: { ...FRESH_ALIASES, w: "web", r: "refresh", t: "period" },
   },
   async *func(this: SentryContext, flags: ViewFlags, ...args: string[]) {
     applyFreshFlag(flags);
@@ -80,7 +186,6 @@ export const viewCommand = buildCommand({
       "sentry dashboard view <org>/ <id>"
     );
     const dashboardId = await resolveDashboardId(orgSlug, dashboardRef);
-
     const url = buildDashboardUrl(orgSlug, dashboardId);
 
     if (flags.web) {
@@ -88,12 +193,70 @@ export const viewCommand = buildCommand({
       return;
     }
 
+    // Fetch the dashboard definition (widget structure)
     const dashboard = await withProgress(
       { message: "Fetching dashboard...", json: flags.json },
       () => getDashboard(orgSlug, dashboardId)
     );
 
-    yield new CommandOutput({ ...dashboard, url } as ViewResult);
+    const regionUrl = await resolveOrgRegion(orgSlug);
+    const period = flags.period ?? dashboard.period ?? "24h";
+    const widgets = dashboard.widgets ?? [];
+
+    if (flags.refresh !== undefined) {
+      // ── Refresh mode: poll and re-render ──
+      const interval = flags.refresh;
+      if (!flags.json) {
+        logger.info(
+          `Auto-refreshing dashboard every ${interval}s. Press Ctrl+C to stop.`
+        );
+      }
+
+      const controller = new AbortController();
+      const stop = () => controller.abort();
+      process.once("SIGINT", stop);
+
+      let isFirstRender = true;
+
+      try {
+        while (!controller.signal.aborted) {
+          const widgetData = await queryAllWidgets(
+            regionUrl,
+            orgSlug,
+            dashboard,
+            { period }
+          );
+
+          // Build output data before clearing so clear→render is instantaneous
+          const viewData = buildViewData(dashboard, widgetData, widgets, {
+            period,
+            url,
+          });
+
+          if (!isFirstRender) {
+            yield new ClearScreen();
+          }
+          isFirstRender = false;
+
+          yield new CommandOutput(viewData);
+
+          await abortableSleep(interval * 1000, controller.signal);
+        }
+      } finally {
+        process.removeListener("SIGINT", stop);
+      }
+      return;
+    }
+
+    // ── Single fetch mode ──
+    const widgetData = await withProgress(
+      { message: "Querying widget data...", json: flags.json },
+      () => queryAllWidgets(regionUrl, orgSlug, dashboard, { period })
+    );
+
+    yield new CommandOutput(
+      buildViewData(dashboard, widgetData, widgets, { period, url })
+    );
     return { hint: `Dashboard: ${url}` };
   },
 });

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -23,6 +23,7 @@ export {
   createDashboard,
   getDashboard,
   listDashboards,
+  queryAllWidgets,
   updateDashboard,
 } from "./api/dashboards.js";
 export {

--- a/src/lib/api/dashboards.ts
+++ b/src/lib/api/dashboards.ts
@@ -1,19 +1,37 @@
 /**
  * Dashboard API functions
  *
- * CRUD operations for Sentry dashboards.
+ * CRUD operations for Sentry dashboards, plus widget data
+ * query functions for rendering dashboard widgets with actual data.
  */
 
-import type {
-  DashboardDetail,
-  DashboardListItem,
-  DashboardWidget,
-} from "../../types/dashboard.js";
+// biome-ignore lint/performance/noNamespaceImport: Sentry SDK recommends namespace import
+import * as Sentry from "@sentry/node-core/light";
 
+import {
+  type DashboardDetail,
+  type DashboardListItem,
+  type DashboardWidget,
+  type ErrorResult,
+  type EventsStatsSeries,
+  EventsStatsSeriesSchema,
+  EventsTableResponseSchema,
+  mapWidgetTypeToDataset,
+  type ScalarResult,
+  TABLE_DISPLAY_TYPES,
+  type TableResult,
+  TIMESERIES_DISPLAY_TYPES,
+  type TimeseriesResult,
+  type WidgetDataResult,
+} from "../../types/dashboard.js";
+import { stringifyUnknown } from "../errors.js";
 import { resolveOrgRegion } from "../region.js";
 import { invalidateCachedResponse } from "../response-cache.js";
 
-import { apiRequestToRegion } from "./infrastructure.js";
+import {
+  apiRequestToRegion,
+  ORG_FANOUT_CONCURRENCY,
+} from "./infrastructure.js";
 
 /**
  * List dashboards in an organization.
@@ -109,4 +127,344 @@ export async function updateDashboard(
   await invalidateCachedResponse(`${normalizedBase}/api/0${path}`);
 
   return data;
+}
+
+// ---------------------------------------------------------------------------
+// Widget data queries
+// ---------------------------------------------------------------------------
+
+/** Options for querying widget data */
+type WidgetQueryOptions = {
+  /** Override the dashboard's time period (e.g., "24h", "7d") */
+  period?: string;
+  /** Filter by environment(s) — from dashboard.environment */
+  environment?: string[];
+  /** Filter by project ID(s) — from dashboard.projects */
+  project?: number[];
+};
+
+/**
+ * Parse an events-stats response into a normalized timeseries result.
+ *
+ * The events-stats API returns different shapes:
+ * - **Simple** (no grouping): `{ data: [...], meta: {...} }` — a single series
+ * - **Grouped** (topEvents > 0): `{ "group-label": { data: [...] }, ... }` — one series per group
+ *
+ * @param raw - Raw JSON response from events-stats
+ * @param yAxis - The aggregate function name(s) used as label(s)
+ */
+function parseEventsStatsResponse(
+  raw: unknown,
+  yAxis: string[]
+): TimeseriesResult {
+  const series: TimeseriesResult["series"] = [];
+
+  // Try parsing as a single series first (simple query, no grouping)
+  const singleResult = EventsStatsSeriesSchema.safeParse(raw);
+  if (singleResult.success) {
+    for (const axis of yAxis) {
+      series.push({
+        label: axis,
+        values: extractTimeseriesValues(singleResult.data),
+        unit: singleResult.data.meta?.units?.[axis] ?? null,
+      });
+    }
+    return { type: "timeseries", series };
+  }
+
+  // Grouped response: record of group-label → series
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    const entries = Object.entries(raw as Record<string, unknown>).filter(
+      ([, v]) => v && typeof v === "object" && "data" in (v as object)
+    );
+
+    // Sort by order field if present
+    entries.sort((a, b) => {
+      const aOrder = (a[1] as { order?: number }).order ?? 0;
+      const bOrder = (b[1] as { order?: number }).order ?? 0;
+      return aOrder - bOrder;
+    });
+
+    for (const [groupLabel, groupData] of entries) {
+      const parsed = EventsStatsSeriesSchema.safeParse(groupData);
+      if (parsed.success) {
+        series.push({
+          label: groupLabel,
+          values: extractTimeseriesValues(parsed.data),
+          unit: parsed.data.meta?.units?.[yAxis[0] ?? ""] ?? null,
+        });
+      }
+    }
+  }
+
+  return { type: "timeseries", series };
+}
+
+/** Extract {timestamp, value} pairs from an events-stats series. */
+function extractTimeseriesValues(
+  series: EventsStatsSeries
+): { timestamp: number; value: number }[] {
+  return series.data.map(([timestamp, counts]) => ({
+    timestamp,
+    value: counts[0]?.count ?? 0,
+  }));
+}
+
+/**
+ * Query time-series data for a chart widget.
+ *
+ * Calls `GET /organizations/{org}/events-stats/` with params derived
+ * from the widget's queries (aggregates, conditions, columns for grouping).
+ *
+ * @param regionUrl - Region base URL
+ * @param orgSlug - Organization slug
+ * @param widget - Dashboard widget definition
+ * @param statsPeriod - Time period (e.g., "24h")
+ * @param options - Additional query options
+ */
+/** Common params for widget query functions */
+type WidgetQueryParams = {
+  regionUrl: string;
+  orgSlug: string;
+  widget: DashboardWidget;
+  statsPeriod: string;
+  options?: WidgetQueryOptions;
+};
+
+async function queryWidgetTimeseries(
+  params: WidgetQueryParams
+): Promise<TimeseriesResult> {
+  const { regionUrl, orgSlug, widget, statsPeriod, options = {} } = params;
+  const allSeries: TimeseriesResult["series"] = [];
+
+  for (const query of widget.queries ?? []) {
+    const aggregates = query.aggregates ?? [];
+    const columns = query.columns ?? [];
+    const hasGroupBy = columns.length > 0;
+    const dataset = mapWidgetTypeToDataset(widget.widgetType);
+
+    const reqParams: Record<string, string | string[] | number | undefined> = {
+      yAxis: aggregates,
+      query: query.conditions || undefined,
+      dataset: dataset ?? undefined,
+      statsPeriod,
+      environment: options.environment,
+      project: options.project?.map(String),
+    };
+
+    // Group-by columns enable topEvents mode
+    if (hasGroupBy) {
+      reqParams.field = columns;
+      reqParams.topEvents = widget.limit ?? 5;
+      // Sort by the aggregate to get the actual top N groups.
+      // The sort param is only supported on the spans dataset —
+      // errors/discover endpoints reject it with 400.
+      if (dataset === "spans") {
+        reqParams.sort = query.orderby ?? `-${aggregates[0] ?? "count()"}`;
+      }
+    }
+
+    const { data: raw } = await apiRequestToRegion<unknown>(
+      regionUrl,
+      `/organizations/${orgSlug}/events-stats/`,
+      { params: reqParams }
+    );
+
+    const parsed = parseEventsStatsResponse(raw, aggregates);
+    allSeries.push(...parsed.series);
+  }
+
+  return { type: "timeseries", series: allSeries };
+}
+
+/**
+ * Query tabular data for a table or big_number widget.
+ *
+ * Calls `GET /organizations/{org}/events/` with params derived
+ * from the widget's query (fields, conditions, sort, limit).
+ *
+ * @param regionUrl - Region base URL
+ * @param orgSlug - Organization slug
+ * @param widget - Dashboard widget definition
+ * @param statsPeriod - Time period (e.g., "24h")
+ * @param options - Additional query options
+ */
+async function queryWidgetTable(
+  params: WidgetQueryParams
+): Promise<TableResult> {
+  const { regionUrl, orgSlug, widget, statsPeriod, options = {} } = params;
+  const query = widget.queries?.[0];
+  const fields = query?.fields ?? [
+    ...(query?.columns ?? []),
+    ...(query?.aggregates ?? []),
+  ];
+  const dataset = mapWidgetTypeToDataset(widget.widgetType);
+
+  const { data } = await apiRequestToRegion(
+    regionUrl,
+    `/organizations/${orgSlug}/events/`,
+    {
+      params: {
+        field: fields,
+        query: query?.conditions || undefined,
+        dataset: dataset ?? undefined,
+        statsPeriod,
+        sort: query?.orderby || undefined,
+        per_page: widget.limit ?? 10,
+        environment: options.environment,
+        project: options.project?.map(String),
+      },
+      schema: EventsTableResponseSchema,
+    }
+  );
+
+  const meta = data.meta;
+  const columns = fields.map((name) => ({
+    name,
+    type: meta?.fields?.[name],
+    unit: meta?.units?.[name],
+  }));
+
+  return { type: "table", columns, rows: data.data };
+}
+
+/**
+ * Dispatch a widget data query to the appropriate endpoint.
+ *
+ * Routes by display type:
+ * - Chart types (line, area, bar) → events-stats (timeseries)
+ * - Table types (table, top_n) → events (tabular)
+ * - big_number → events with per_page=1, wrapped as scalar
+ * - Others → unsupported
+ *
+ * Catches errors and returns `{ type: "error" }` so one failing widget
+ * doesn't break the entire dashboard render.
+ */
+async function queryWidgetData(
+  params: WidgetQueryParams
+): Promise<WidgetDataResult> {
+  const { widget } = params;
+  const dataset = mapWidgetTypeToDataset(widget.widgetType);
+  if (!dataset) {
+    return {
+      type: "unsupported",
+      reason: `Widget type '${widget.widgetType ?? "unknown"}' is not yet supported`,
+    };
+  }
+
+  try {
+    // Chart types → timeseries
+    if (TIMESERIES_DISPLAY_TYPES.has(widget.displayType)) {
+      return await queryWidgetTimeseries(params);
+    }
+
+    // big_number → single scalar value
+    if (widget.displayType === "big_number") {
+      const tableResult = await queryWidgetTable({
+        ...params,
+        widget: { ...widget, limit: 1 },
+      });
+      const row = tableResult.rows[0];
+      const firstColumn = tableResult.columns[0];
+      const value = row && firstColumn ? Number(row[firstColumn.name] ?? 0) : 0;
+      return {
+        type: "scalar",
+        value: Number.isFinite(value) ? value : 0,
+        unit: firstColumn?.unit,
+      } satisfies ScalarResult;
+    }
+
+    // Table types → tabular
+    if (TABLE_DISPLAY_TYPES.has(widget.displayType)) {
+      return await queryWidgetTable(params);
+    }
+
+    return {
+      type: "unsupported",
+      reason: `Display type '${widget.displayType}' is not yet supported`,
+    };
+  } catch (error) {
+    Sentry.captureException(error);
+    return {
+      type: "error",
+      message: stringifyUnknown(error),
+    } satisfies ErrorResult;
+  }
+}
+
+/**
+ * Query data for all widgets in a dashboard in parallel.
+ *
+ * Uses a concurrency limit to avoid overwhelming the API.
+ * Failed queries produce `{ type: "error" }` results rather than
+ * throwing, so the dashboard can still render partial data.
+ *
+ * @param regionUrl - Region base URL
+ * @param orgSlug - Organization slug
+ * @param dashboard - Full dashboard detail with widgets
+ * @param options - Query options (period override, environment filter)
+ * @returns Map of widget index → query result
+ */
+/** Collect settled results from a batch into the results map. */
+function collectBatchResults(
+  batchResults: PromiseSettledResult<WidgetDataResult>[],
+  startIndex: number,
+  results: Map<number, WidgetDataResult>
+): void {
+  for (let j = 0; j < batchResults.length; j++) {
+    const result = batchResults[j];
+    const idx = startIndex + j;
+    if (result?.status === "fulfilled") {
+      results.set(idx, result.value);
+    } else {
+      results.set(idx, {
+        type: "error",
+        message: result?.reason
+          ? stringifyUnknown(result.reason)
+          : "Unknown error",
+      });
+    }
+  }
+}
+
+export async function queryAllWidgets(
+  regionUrl: string,
+  orgSlug: string,
+  dashboard: DashboardDetail,
+  options: WidgetQueryOptions = {}
+): Promise<Map<number, WidgetDataResult>> {
+  const widgets = dashboard.widgets ?? [];
+  const statsPeriod = options.period ?? dashboard.period ?? "24h";
+
+  // Merge dashboard-level filters with caller overrides
+  const mergedOptions: WidgetQueryOptions = {
+    ...options,
+    environment: options.environment ?? dashboard.environment ?? undefined,
+    project: options.project ?? dashboard.projects ?? undefined,
+  };
+
+  const results = new Map<number, WidgetDataResult>();
+  if (widgets.length === 0) {
+    return results;
+  }
+
+  // Process in batches to respect concurrency limit
+  const batchSize = ORG_FANOUT_CONCURRENCY;
+  for (let i = 0; i < widgets.length; i += batchSize) {
+    const batch = widgets.slice(i, i + batchSize);
+    const batchResults = await Promise.allSettled(
+      batch.map((widget) =>
+        queryWidgetData({
+          regionUrl,
+          orgSlug,
+          widget,
+          statsPeriod,
+          options: mergedOptions,
+        })
+      )
+    );
+    collectBatchResults(batchResults, i, results);
+  }
+
+  return results;
 }

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -40,6 +40,7 @@ import type { Writer } from "../types/index.js";
 import { OutputError } from "./errors.js";
 import { parseFieldsList } from "./formatters/json.js";
 import {
+  ClearScreen,
   CommandOutput,
   type CommandReturn,
   type HumanRenderer,
@@ -48,6 +49,7 @@ import {
   resolveRenderer,
   writeFooter,
 } from "./formatters/output.js";
+import { isPlainOutput } from "./formatters/plain-detect.js";
 import {
   LOG_LEVEL_NAMES,
   type LogLevelName,
@@ -310,6 +312,9 @@ export function buildCommand<
    * If the yielded value is a {@link CommandOutput}, render it via
    * the output config. Void/undefined/Error/other values are ignored.
    */
+  /** Pending clear-screen — set by ClearScreen token, consumed by next render. */
+  let pendingClear = false;
+
   function handleYieldedValue(
     stdout: Writer,
     value: unknown,
@@ -317,6 +322,14 @@ export function buildCommand<
     // biome-ignore lint/suspicious/noExplicitAny: Renderer type mirrors erased OutputConfig<T>
     renderer?: HumanRenderer<any>
   ): void {
+    // ClearScreen token: defer until next render to avoid flash
+    if (value instanceof ClearScreen) {
+      if (!(isPlainOutput() || flags.json)) {
+        pendingClear = true;
+      }
+      return;
+    }
+
     if (!(outputConfig && renderer && value instanceof CommandOutput)) {
       return;
     }
@@ -324,7 +337,9 @@ export function buildCommand<
     renderCommandOutput(stdout, value.data, outputConfig, renderer, {
       json: Boolean(flags.json),
       fields: flags.fields as string[] | undefined,
+      clearPrefix: pendingClear ? "\x1b[H\x1b[J" : undefined,
     });
+    pendingClear = false;
   }
 
   /**
@@ -397,6 +412,9 @@ export function buildCommand<
     }
 
     const stdout = (this as unknown as { stdout: Writer }).stdout;
+
+    // Reset per-invocation state
+    pendingClear = false;
 
     // Resolve the human renderer once per invocation. Factory creates
     // fresh per-invocation state for streaming commands.

--- a/src/lib/formatters/dashboard.ts
+++ b/src/lib/formatters/dashboard.ts
@@ -1,0 +1,1693 @@
+/**
+ * Dashboard widget renderers
+ *
+ * Renders actual widget data (time-series, tables, big numbers) for the
+ * `dashboard view` command. Uses a framebuffer approach: each widget is
+ * rendered into its grid-allocated region of a virtual screen buffer,
+ * then the buffer is printed as a single string. This enables correct
+ * overlapping layouts where tall widgets span multiple rows.
+ */
+
+import chalk from "chalk";
+import stringWidth from "string-width";
+
+import type {
+  DashboardWidgetQuery,
+  ScalarResult,
+  TableResult,
+  TimeseriesResult,
+  WidgetDataResult,
+} from "../../types/dashboard.js";
+import { COLORS, muted, terminalLink } from "./colors.js";
+import { escapeMarkdownCell, mdRow, mdTableHeader } from "./markdown.js";
+import type { HumanRenderer } from "./output.js";
+import { isPlainOutput } from "./plain-detect.js";
+import { downsample, sparkline } from "./sparkline.js";
+
+// ---------------------------------------------------------------------------
+// Data type yielded by dashboard view command
+// ---------------------------------------------------------------------------
+
+/** Full dashboard state with resolved widget data, yielded as CommandOutput. */
+export type DashboardViewData = {
+  id: string;
+  title: string;
+  period: string;
+  fetchedAt: string;
+  url: string;
+  dateCreated?: string;
+  environment?: string[];
+  widgets: DashboardViewWidget[];
+};
+
+/** A widget with its resolved data result */
+export type DashboardViewWidget = {
+  title: string;
+  displayType: string;
+  widgetType?: string;
+  layout?: { x: number; y: number; w: number; h: number };
+  queries?: DashboardWidgetQuery[];
+  data: WidgetDataResult;
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Sentry dashboard grid columns */
+const GRID_COLS = 6;
+
+/** Terminal lines per grid height unit */
+const LINES_PER_UNIT = 6;
+
+/** Minimum terminal width — floor for very narrow terminals or piped output */
+const MIN_TERM_WIDTH = 80;
+
+/** Fallback terminal width when stdout is not a TTY */
+const DEFAULT_TERM_WIDTH = 100;
+
+/**
+ * Get the effective terminal width.
+ *
+ * Uses the actual terminal column count when available (TTY),
+ * falls back to DEFAULT_TERM_WIDTH for piped/redirected output.
+ * Clamped to MIN_TERM_WIDTH to prevent broken layouts.
+ */
+function getTermWidth(): number {
+  const cols = process.stdout.columns;
+  if (cols && cols > 0) {
+    return Math.max(MIN_TERM_WIDTH, cols);
+  }
+  return DEFAULT_TERM_WIDTH;
+}
+
+// ---------------------------------------------------------------------------
+// Big number ASCII art font
+// ---------------------------------------------------------------------------
+
+/** Small font: 3 lines tall, 3 chars wide per glyph. */
+const DIGIT_FONT_SM: Record<string, string[]> = {
+  "0": ["█▀█", "█ █", "▀▀▀"],
+  "1": [" ▄█", "  █", "  ▀"],
+  "2": ["▀▀█", "▄▀▀", "▀▀▀"],
+  "3": ["▀▀█", " ▀█", "▀▀▀"],
+  "4": ["█ █", "▀▀█", "  ▀"],
+  "5": ["█▀▀", "▀▀█", "▀▀▀"],
+  "6": ["█▀▀", "█▀█", "▀▀▀"],
+  "7": ["▀▀█", "  █", "  ▀"],
+  "8": ["█▀█", "█▀█", "▀▀▀"],
+  "9": ["█▀█", "▀▀█", "▀▀▀"],
+  ".": ["   ", "   ", " ▀ "],
+  "-": ["   ", "▀▀▀", "   "],
+  K: ["█ █", "██ ", "█ █"],
+  M: ["█▄█", "█ █", "█ █"],
+  B: ["██ ", "██▄", "▀▀▀"],
+  T: ["▀█▀", " █ ", " ▀ "],
+};
+
+/** Medium font: 5 lines tall, 5 chars wide per glyph. */
+const DIGIT_FONT_MD: Record<string, string[]> = {
+  "0": ["█████", "██ ██", "██ ██", "██ ██", "█████"],
+  "1": [" ▄███", "   ██", "   ██", "   ██", "   ██"],
+  "2": ["█████", "   ██", "█████", "██   ", "█████"],
+  "3": ["█████", "   ██", " ████", "   ██", "█████"],
+  "4": ["██ ██", "██ ██", "█████", "   ██", "   ██"],
+  "5": ["█████", "██   ", "█████", "   ██", "█████"],
+  "6": ["█████", "██   ", "█████", "██ ██", "█████"],
+  "7": ["█████", "   ██", "   ██", "  ██ ", "  ██ "],
+  "8": ["█████", "██ ██", "█████", "██ ██", "█████"],
+  "9": ["█████", "██ ██", "█████", "   ██", "█████"],
+  ".": ["     ", "     ", "     ", "     ", " ██  "],
+  "-": ["     ", "     ", "█████", "     ", "     "],
+  K: ["██ ██", "████ ", "███  ", "████ ", "██ ██"],
+  M: ["██ ██", "█████", "█████", "██▀██", "██ ██"],
+  B: ["████ ", "██ ██", "████ ", "██ ██", "████ "],
+  T: ["█████", "  ██ ", "  ██ ", "  ██ ", "  ██ "],
+};
+
+/** Large font: 7 lines tall, 7 chars wide per glyph. */
+const DIGIT_FONT_LG: Record<string, string[]> = {
+  "0": [
+    "███████",
+    "██   ██",
+    "██   ██",
+    "██   ██",
+    "██   ██",
+    "██   ██",
+    "███████",
+  ],
+  "1": [
+    "  ▄████",
+    "     ██",
+    "     ██",
+    "     ██",
+    "     ██",
+    "     ██",
+    "     ██",
+  ],
+  "2": [
+    "███████",
+    "     ██",
+    "     ██",
+    "███████",
+    "██     ",
+    "██     ",
+    "███████",
+  ],
+  "3": [
+    "███████",
+    "     ██",
+    "     ██",
+    " ██████",
+    "     ██",
+    "     ██",
+    "███████",
+  ],
+  "4": [
+    "██   ██",
+    "██   ██",
+    "██   ██",
+    "███████",
+    "     ██",
+    "     ██",
+    "     ██",
+  ],
+  "5": [
+    "███████",
+    "██     ",
+    "██     ",
+    "███████",
+    "     ██",
+    "     ██",
+    "███████",
+  ],
+  "6": [
+    "███████",
+    "██     ",
+    "██     ",
+    "███████",
+    "██   ██",
+    "██   ██",
+    "███████",
+  ],
+  "7": [
+    "███████",
+    "     ██",
+    "     ██",
+    "    ██ ",
+    "   ██  ",
+    "   ██  ",
+    "   ██  ",
+  ],
+  "8": [
+    "███████",
+    "██   ██",
+    "██   ██",
+    "███████",
+    "██   ██",
+    "██   ██",
+    "███████",
+  ],
+  "9": [
+    "███████",
+    "██   ██",
+    "██   ██",
+    "███████",
+    "     ██",
+    "     ██",
+    "███████",
+  ],
+  K: [
+    "██   ██",
+    "██  ██ ",
+    "█████  ",
+    "████   ",
+    "█████  ",
+    "██  ██ ",
+    "██   ██",
+  ],
+  M: [
+    "██   ██",
+    "███ ███",
+    "███████",
+    "███████",
+    "██ █ ██",
+    "██   ██",
+    "██   ██",
+  ],
+  ".": [
+    "       ",
+    "       ",
+    "       ",
+    "       ",
+    "       ",
+    "  ███  ",
+    "  ███  ",
+  ],
+  "-": [
+    "       ",
+    "       ",
+    "       ",
+    "███████",
+    "       ",
+    "       ",
+    "       ",
+  ],
+  B: [
+    "██████ ",
+    "██   ██",
+    "██   ██",
+    "██████ ",
+    "██   ██",
+    "██   ██",
+    "██████ ",
+  ],
+  T: [
+    "███████",
+    "  ███  ",
+    "  ███  ",
+    "  ███  ",
+    "  ███  ",
+    "  ███  ",
+    "  ███  ",
+  ],
+};
+
+/** Build glyph row arrays from a formatted string and font. */
+function buildGlyphRows(
+  formatted: string,
+  font: Record<string, string[]>
+): string[][] {
+  const sampleGlyph = font["0"];
+  const numRows = sampleGlyph?.length ?? 3;
+  const glyphW = sampleGlyph?.[0]?.length ?? 3;
+  const blank = " ".repeat(glyphW);
+
+  const rows: string[][] = Array.from({ length: numRows }, () => []);
+  for (const ch of formatted) {
+    const glyph = font[ch];
+    for (let r = 0; r < numRows; r += 1) {
+      rows[r]?.push(glyph?.[r] ?? blank);
+    }
+  }
+  return rows;
+}
+
+/**
+ * Render a formatted number using a glyph font, centered horizontally.
+ */
+function renderBigNumber(opts: {
+  formatted: string;
+  font: Record<string, string[]>;
+  innerWidth: number;
+}): string[] {
+  const { formatted, font, innerWidth } = opts;
+  if (isPlainOutput()) {
+    return [formatted];
+  }
+
+  const sampleGlyph = font["0"];
+  const glyphW = sampleGlyph?.[0]?.length ?? 3;
+  const rows = buildGlyphRows(formatted, font);
+
+  const color = chalk.hex(COLORS.green);
+  const rawWidth = formatted.length * (glyphW + 1) - 1;
+  const leftPad = Math.max(0, Math.floor((innerWidth - rawWidth) / 2));
+  const pad = " ".repeat(leftPad);
+  return rows.map((row) => `${pad}${color(row.join(" "))}`);
+}
+
+/**
+ * Calculate the visual width of a rendered number for a given font.
+ * Each glyph is `glyphWidth` chars wide + 1 space between glyphs.
+ */
+function calcGlyphWidth(formatted: string, glyphW: number): number {
+  return formatted.length * (glyphW + 1) - 1;
+}
+
+// ---------------------------------------------------------------------------
+// Number formatting
+// ---------------------------------------------------------------------------
+
+const compactFormatter = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+const standardFormatter = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 2,
+});
+
+function formatNumber(value: number): string {
+  if (Math.abs(value) >= 1_000_000) {
+    return compactFormatter.format(value);
+  }
+  return standardFormatter.format(value);
+}
+
+/**
+ * Format a value as a short Y-axis tick label (max ~4 chars).
+ *
+ * Always uses compact notation: 0 → "0", 500 → "500", 1234 → "1.2K",
+ * 23454 → "23K", 321305 → "321K", 1500000 → "1.5M".
+ * Rounds the input to avoid fractional mid-point ticks.
+ */
+function formatTickLabel(value: number): string {
+  const rounded = Math.round(value);
+  if (rounded === 0) {
+    return "0";
+  }
+  return compactFormatter.format(rounded);
+}
+
+/**
+ * Format a big number value with clean integer display.
+ * Uses compact notation (K, M, B, T) only for values >= 10,000.
+ * Below that threshold, shows the raw integer without commas.
+ */
+function formatBigNumberValue(value: number): string {
+  if (Math.abs(value) >= 10_000) {
+    return compactFormatter.format(value);
+  }
+  return Math.round(value).toString();
+}
+
+function formatWithUnit(value: number, unit?: string | null): string {
+  const formatted = formatNumber(value);
+  if (!unit || unit === "none" || unit === "null") {
+    return formatted;
+  }
+  if (unit === "millisecond") {
+    return `${formatted}ms`;
+  }
+  if (unit === "second") {
+    return `${formatted}s`;
+  }
+  if (unit === "byte") {
+    return `${formatted}B`;
+  }
+  return `${formatted} ${unit}`;
+}
+
+// ---------------------------------------------------------------------------
+// Sort helper: descending by value, "Other" always last
+// ---------------------------------------------------------------------------
+
+type BarItem = { label: string; total: number; unit?: string | null };
+
+/** Sort items by value descending, "Other" pinned to end. */
+function sortBarItems(items: BarItem[]): BarItem[] {
+  return [...items].sort((a, b) => {
+    if (a.label === "Other") {
+      return 1;
+    }
+    if (b.label === "Other") {
+      return -1;
+    }
+    return b.total - a.total;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Border wrapping
+// ---------------------------------------------------------------------------
+
+/** Border characters for rounded box-drawing. */
+const BORDER = {
+  tl: "╭",
+  tr: "╮",
+  bl: "╰",
+  br: "╯",
+  h: "─",
+  v: "│",
+} as const;
+
+/**
+ * Apply muted color to border characters in rendered mode.
+ * In plain mode, return the text unchanged.
+ */
+function borderColor(text: string): string {
+  return isPlainOutput() ? text : muted(text);
+}
+
+/**
+ * Build the top border line with an embedded title.
+ *
+ * Format: `╭─ Title ─────────╮`
+ * The title is bold in rendered mode, plain otherwise.
+ */
+function buildTopBorder(title: string, width: number): string {
+  const plain = isPlainOutput();
+  const titleText = plain ? title : chalk.bold(title);
+  // Build left part: ╭─ Title ─
+  const leftRaw = `${BORDER.tl}${BORDER.h} `;
+  const left = `${borderColor(leftRaw)}${titleText} `;
+  // Measure visual width so far, fill remaining space with ─, then ╮
+  const leftWidth = stringWidth(left);
+  const fillLen = Math.max(0, width - leftWidth - 1); // -1 for closing ╮
+  return left + borderColor(`${BORDER.h.repeat(fillLen)}${BORDER.tr}`);
+}
+
+/** Build the bottom border line: `╰──────────╯` */
+function buildBottomBorder(width: number): string {
+  return borderColor(
+    `${BORDER.bl}${BORDER.h.repeat(Math.max(0, width - 2))}${BORDER.br}`
+  );
+}
+
+/** Wrap a content line with left/right borders: `│ content  │` */
+function buildBorderedLine(content: string, innerWidth: number): string {
+  const padded = fitToWidth(content, innerWidth);
+  return `${borderColor(BORDER.v)} ${padded} ${borderColor(BORDER.v)}`;
+}
+
+/**
+ * Wrap content lines inside a bordered box with a title.
+ *
+ * The output has exactly `totalHeight` lines:
+ * - 1 top border (with embedded title)
+ * - totalHeight - 2 content lines (padded or truncated)
+ * - 1 bottom border
+ */
+function wrapInBorder(opts: {
+  title: string;
+  contentLines: string[];
+  width: number;
+  totalHeight: number;
+}): string[] {
+  const { title, contentLines, width, totalHeight } = opts;
+  const innerWidth = Math.max(0, width - 4);
+  const contentSlots = Math.max(0, totalHeight - 2);
+
+  const lines: string[] = [buildTopBorder(title, width)];
+
+  for (let i = 0; i < contentSlots; i += 1) {
+    const content =
+      (i < contentLines.length ? contentLines[i] : undefined) ?? "";
+    lines.push(buildBorderedLine(content, innerWidth));
+  }
+
+  lines.push(buildBottomBorder(width));
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Per-widget renderers — return string[] (content lines, no title/border)
+// ---------------------------------------------------------------------------
+
+/** Placeholder for empty data. */
+function noDataLine(): string {
+  return isPlainOutput() ? "(no data)" : muted("(no data)");
+}
+
+/**
+ * Render timeseries content as sparklines (no title/border).
+ * Labels and sparklines are constrained to fit within the inner width.
+ */
+function renderTimeseriesContent(
+  data: TimeseriesResult,
+  innerWidth: number
+): string[] {
+  if (data.series.length === 0) {
+    return [noDataLine()];
+  }
+
+  const lines: string[] = [];
+  const maxValueLen = 10;
+  const sparkWidth = Math.max(8, Math.min(innerWidth - 16, 40));
+  const maxLabelLen = Math.max(4, innerWidth - sparkWidth - maxValueLen - 4);
+
+  for (const s of data.series) {
+    const values = s.values.map((v) => v.value);
+    const graph = sparkline(values, sparkWidth);
+    const latest = values.length > 0 ? (values.at(-1) ?? 0) : 0;
+    const formatted = formatWithUnit(latest, s.unit);
+    const label =
+      s.label.length > maxLabelLen
+        ? `${s.label.slice(0, maxLabelLen - 1)}…`
+        : s.label.padEnd(maxLabelLen);
+
+    if (isPlainOutput()) {
+      lines.push(`${label} ${graph} ${formatted}`);
+    } else {
+      lines.push(
+        `${chalk.hex(COLORS.cyan)(label)} ${chalk.hex(COLORS.magenta)(graph)} ${chalk.bold(formatted)}`
+      );
+    }
+  }
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Y-axis helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Calculate Y-axis gutter width based on the widest tick label.
+ *
+ * Checks all three tick positions (max, mid, 0) because the mid-point
+ * can produce a wider label than the max (e.g., 7K vs 3.5K).
+ * Returns the width needed for "3.5K ┤" including the tick char and space.
+ */
+function yAxisGutterWidth(maxVal: number): number {
+  const labels = [
+    formatTickLabel(maxVal),
+    formatTickLabel(maxVal / 2),
+    formatTickLabel(0),
+  ];
+  const widest = Math.max(...labels.map((l) => l.length));
+  return widest + 2; // value + " " + "┤"/"│"
+}
+
+/**
+ * Build a Y-axis segment for a given row.
+ *
+ * Shows tick labels at top, middle, and bottom positions.
+ * Other rows show a plain axis line.
+ *
+ * @param row - Current row (1 = bottom, maxHeight = top)
+ * @param maxHeight - Total bar height in rows
+ * @param maxVal - Maximum data value (for tick labels)
+ * @param gutterWidth - Width of the gutter (from yAxisGutterWidth)
+ */
+function buildYAxisSegment(opts: {
+  row: number;
+  maxHeight: number;
+  maxVal: number;
+  gutterWidth: number;
+}): string {
+  const { row, maxHeight, maxVal, gutterWidth } = opts;
+  const plain = isPlainOutput();
+  const midRow = Math.round(maxHeight / 2);
+  const labelWidth = gutterWidth - 2; // space for " ┤" or " │"
+
+  let label = "";
+  let isTick = false;
+
+  if (row === maxHeight) {
+    label = formatTickLabel(maxVal);
+    isTick = true;
+  } else if (row === 1) {
+    // Check bottom before mid — when maxHeight=2, midRow is also 1
+    label = "0";
+    isTick = true;
+  } else if (row === midRow) {
+    label = formatTickLabel(maxVal / 2);
+    isTick = true;
+  }
+
+  if (isTick) {
+    const padded = label.padStart(labelWidth);
+    const tick = `${padded} ┤`;
+    return plain ? tick : muted(tick);
+  }
+
+  const padded = " ".repeat(labelWidth);
+  const axis = `${padded} │`;
+  return plain ? axis : muted(axis);
+}
+
+// ---------------------------------------------------------------------------
+// Vertical bar chart helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Render categorical_bar content with vertical bars (no title/border).
+ *
+ * Labels use two modes:
+ * - **Direct**: When labels fit within barWidth (e.g., "US", "bun"),
+ *   they appear directly below the bars — clean and readable.
+ * - **Legend**: When labels are too long (e.g., "sentry.issue.view"),
+ *   letter keys (A, B, C...) appear below bars with a compact legend
+ *   line at the bottom: "A:sentry.issue.view B:sentry.api …"
+ */
+function renderVerticalBarsContent(
+  data: TimeseriesResult,
+  opts: { innerWidth: number; contentHeight: number }
+): string[] {
+  const { innerWidth, contentHeight } = opts;
+  if (data.series.length === 0) {
+    return [noDataLine()];
+  }
+
+  let items: BarItem[] = data.series.map((s) => ({
+    label: s.label,
+    total: s.values.reduce((sum, v) => sum + v.value, 0),
+    unit: s.unit,
+  }));
+  items = sortBarItems(items);
+
+  // Exclude "Other" from scale normalization — it often dominates and
+  // makes all real bars invisible. Cap Other's bar at max height.
+  const nonOther = items.filter((i) => i.label !== "Other");
+  const maxVal = Math.max(
+    ...nonOther.map((i) => i.total),
+    ...(nonOther.length === 0 ? items.map((i) => i.total) : []),
+    1
+  );
+  // Y-axis gutter
+  const gutterW = yAxisGutterWidth(maxVal);
+  const chartWidth = innerWidth - gutterW;
+
+  const gap = 1;
+  const numItems = items.length;
+  const barWidth = Math.max(
+    1,
+    Math.floor((chartWidth - (numItems - 1) * gap) / numItems)
+  );
+
+  // Check if non-Other labels fit directly below bars
+  const nonOtherLabels = nonOther.length > 0 ? nonOther : items;
+  const maxLabelLen = Math.max(...nonOtherLabels.map((i) => i.label.length));
+  const labelsDirectlyFit = maxLabelLen <= barWidth;
+
+  // Reserve lines: 1 axis + 1 label/legend
+  const footerLines = 2;
+  const maxBarHeight = Math.max(1, contentHeight - footerLines);
+
+  const lines: string[] = [];
+  const plain = isPlainOutput();
+
+  // Render bar rows with Y-axis ticks
+  for (let row = maxBarHeight; row >= 1; row -= 1) {
+    const yAxis = buildYAxisSegment({
+      row,
+      maxHeight: maxBarHeight,
+      maxVal,
+      gutterWidth: gutterW,
+    });
+    const barLine = renderVBarRow(items, {
+      row,
+      maxVal,
+      barWidth,
+      gap,
+      maxBarHeight,
+    });
+    lines.push(`${yAxis}${barLine}`);
+  }
+
+  // Bottom axis line
+  const axisLine = `${" ".repeat(gutterW - 1)}└${"─".repeat(chartWidth)}`;
+  lines.push(plain ? axisLine : muted(axisLine));
+
+  // Labels below axis
+  const gutterPad = " ".repeat(gutterW);
+  if (labelsDirectlyFit) {
+    const labelParts = items.map((item) => {
+      let text = item.label;
+      if (text === "Other" && text.length > barWidth) {
+        text = "Oth";
+      }
+      const lbl = text.padEnd(barWidth);
+      return plain ? lbl : muted(lbl);
+    });
+    lines.push(`${gutterPad}${labelParts.join(" ".repeat(gap))}`);
+  } else {
+    // Color/fill-keyed legend line
+    const entries = items.map((item, i) => ({ label: item.label, index: i }));
+    lines.push(`${gutterPad}${buildColorLegend(entries, chartWidth)}`);
+  }
+
+  return lines;
+}
+
+/** Render one row of the vertical bar chart with per-bar colors. */
+function renderVBarRow(
+  items: BarItem[],
+  opts: {
+    row: number;
+    maxVal: number;
+    barWidth: number;
+    gap: number;
+    maxBarHeight: number;
+  }
+): string {
+  const plain = isPlainOutput();
+  const parts: string[] = [];
+  for (let i = 0; i < items.length; i += 1) {
+    const item = items[i];
+    if (!item) {
+      continue;
+    }
+    const barHeight = Math.round(
+      (item.total / opts.maxVal) * opts.maxBarHeight
+    );
+    if (barHeight >= opts.row) {
+      const fill = plain ? seriesFill(item.label, i) : "█";
+      const bar = fill.repeat(opts.barWidth);
+      parts.push(plain ? bar : chalk.hex(seriesColor(item.label, i))(bar));
+    } else {
+      parts.push(" ".repeat(opts.barWidth));
+    }
+  }
+  return parts.join(" ".repeat(opts.gap));
+}
+
+/**
+ * Build a compact color/fill-keyed legend line.
+ *
+ * Color mode: `■ label1  ■ label2  ■ lab…` (each ■ matches series color)
+ * Plain mode: `█ label1  ▓ label2  ░ lab…` (fill chars match bars)
+ *
+ * Truncated to fit within maxWidth.
+ */
+function buildColorLegend(
+  entries: { label: string; index: number }[],
+  maxWidth: number
+): string {
+  const plain = isPlainOutput();
+  const parts: string[] = [];
+  let totalLen = 0;
+
+  for (const { label: rawLabel, index } of entries) {
+    const label = rawLabel.length > 18 ? `${rawLabel.slice(0, 16)}…` : rawLabel;
+    const fill = seriesFill(rawLabel, index);
+    const entry = plain
+      ? `${fill} ${label}`
+      : `${chalk.hex(seriesColor(rawLabel, index))("■")} ${label}`;
+    const entryLen = 2 + label.length;
+    const addedLen = totalLen > 0 ? entryLen + 2 : entryLen;
+
+    if (totalLen + addedLen > maxWidth) {
+      break;
+    }
+    parts.push(entry);
+    totalLen += addedLen;
+  }
+
+  return parts.join("  ");
+}
+
+/** Render table content (no title/border). */
+function renderTableContent(data: TableResult): string[] {
+  if (data.rows.length === 0) {
+    return [noDataLine()];
+  }
+
+  const lines: string[] = [];
+  const headers = data.columns.map((c) => c.name.toUpperCase());
+  lines.push(mdTableHeader(headers));
+
+  for (const row of data.rows) {
+    const cells = data.columns.map((col) => {
+      const val = row[col.name];
+      if (val === null || val === undefined) {
+        return "";
+      }
+      if (typeof val === "number") {
+        return formatWithUnit(val, col.unit);
+      }
+      return escapeMarkdownCell(String(val));
+    });
+    lines.push(mdRow(cells).trimEnd());
+  }
+  return lines;
+}
+
+/** Center lines vertically, returning a padded array. */
+function centerVertically(lines: string[], contentHeight: number): string[] {
+  // Use ceil to bias slightly downward — looks better below the title border
+  const topPad = Math.max(0, Math.ceil((contentHeight - lines.length) / 2));
+  const result: string[] = [];
+  for (let i = 0; i < topPad; i += 1) {
+    result.push("");
+  }
+  result.push(...lines);
+  return result;
+}
+
+/**
+ * Render big_number content with auto-scaling font (no title/border).
+ *
+ * Tries fonts: large (7×7) → medium (5×5) → small (3×3) → single-line.
+ * Each font is used only if it fits both width and height.
+ * Content is centered both horizontally and vertically.
+ */
+function renderBigNumberContent(
+  data: ScalarResult,
+  opts: { innerWidth: number; contentHeight: number }
+): string[] {
+  const { innerWidth, contentHeight } = opts;
+  const formatted = formatBigNumberValue(data.value);
+
+  if (!isPlainOutput()) {
+    const result = tryBigNumberFonts(formatted, innerWidth, contentHeight);
+    if (result) {
+      return result;
+    }
+  }
+
+  // Single-line fallback — center both ways
+  const withUnit = formatWithUnit(data.value, data.unit);
+  const display = isPlainOutput() ? withUnit : chalk.bold(withUnit);
+  const displayWidth = stringWidth(display);
+  const leftPad = Math.max(0, Math.floor((innerWidth - displayWidth) / 2));
+  return centerVertically([" ".repeat(leftPad) + display], contentHeight);
+}
+
+/**
+ * Try rendering a big number with progressively smaller fonts.
+ *
+ * Tiers: large (7-line) → medium (5-line) → small (3-line).
+ * Each font is used only if it fits the available width and height.
+ */
+function tryBigNumberFonts(
+  formatted: string,
+  innerWidth: number,
+  contentHeight: number
+): string[] | undefined {
+  // Font tiers: [font, glyphWidth, minContentHeight]
+  const tiers: [Record<string, string[]>, number, number][] = [
+    [DIGIT_FONT_LG, 7, 9], // 7-line font needs ≥9 for centering
+    [DIGIT_FONT_MD, 5, 7], // 5-line font needs ≥7
+    [DIGIT_FONT_SM, 3, 3], // 3-line font works in tight spaces
+  ];
+
+  for (const [font, glyphW, minHeight] of tiers) {
+    const width = calcGlyphWidth(formatted, glyphW);
+    if (width <= innerWidth && contentHeight >= minHeight) {
+      const bigLines = renderBigNumber({ formatted, font, innerWidth });
+      return centerVertically(bigLines, contentHeight);
+    }
+  }
+
+  return;
+}
+
+/**
+ * Render a timeseries as a vertical bar chart filling the available height.
+ * Used when contentHeight >= 8 (enough room for meaningful bars).
+ * Each time bucket gets a column; shows series label + max value at top.
+ */
+function renderTimeseriesBarsContent(
+  data: TimeseriesResult,
+  opts: { innerWidth: number; contentHeight: number }
+): string[] {
+  const { innerWidth, contentHeight } = opts;
+  if (data.series.length === 0) {
+    return [noDataLine()];
+  }
+
+  const isMulti = data.series.length > 1;
+
+  // Aggregate for totals and timestamps
+  const aggregated = aggregateTimeseriesValues(data);
+  if (aggregated.values.length === 0) {
+    return [noDataLine()];
+  }
+
+  const { values, timestamps, label, unit, latest, maxVal } = aggregated;
+
+  // Header: series label + latest value
+  const headerLabel = label.length > 20 ? `${label.slice(0, 18)}…` : label;
+  const valStr = formatWithUnit(latest, unit);
+  const headerLine = isPlainOutput()
+    ? `${headerLabel}  ${valStr}`
+    : `${chalk.hex(COLORS.cyan)(headerLabel)}  ${chalk.bold(valStr)}`;
+
+  const lines: string[] = [headerLine];
+
+  // Y-axis gutter
+  const gutterW = yAxisGutterWidth(maxVal);
+  const chartWidth = innerWidth - gutterW;
+
+  // Reserve: 1 header + 2 axis/time labels + 1 legend (multi-series only)
+  const reservedLines = isMulti ? 4 : 3;
+  const barHeight = Math.max(3, contentHeight - reservedLines);
+  const maxBars = Math.max(1, chartWidth);
+  const sampledTs = downsampleTimestamps(timestamps, maxBars);
+
+  if (isMulti) {
+    // Stacked multi-color bars: downsample each series independently
+    const stackedSeries = data.series.map((s) => ({
+      label: s.label,
+      values: downsample(
+        s.values.map((v) => v.value),
+        maxBars
+      ),
+    }));
+    lines.push(
+      ...renderStackedTimeBarRows(stackedSeries, {
+        maxVal,
+        barHeight,
+        gutterWidth: gutterW,
+      })
+    );
+  } else {
+    const sampled = downsample(values, maxBars);
+    lines.push(
+      ...renderTimeBarRows(sampled, {
+        maxVal,
+        barHeight,
+        gutterWidth: gutterW,
+      })
+    );
+  }
+
+  // Bottom axis with tick marks + time labels
+  lines.push(
+    ...buildTimeAxis({
+      timestamps: sampledTs,
+      chartWidth,
+      gutterWidth: gutterW,
+    })
+  );
+
+  // Color legend for multi-series (below time labels)
+  if (isMulti) {
+    const entries = data.series.map((s, i) => ({ label: s.label, index: i }));
+    const legend = buildColorLegend(entries, chartWidth);
+    lines.push(`${" ".repeat(gutterW)}${legend}`);
+  }
+
+  return lines;
+}
+
+/**
+ * Aggregate all timeseries into a single values array.
+ *
+ * For multi-series data (e.g., Errors grouped by title), sums all series
+ * per time bucket. Returns the aggregate values, label, and stats.
+ */
+/** Aggregated timeseries result with timestamps preserved. */
+type AggregatedTimeseries = {
+  values: number[];
+  timestamps: number[];
+  label: string;
+  unit?: string | null;
+  latest: number;
+  maxVal: number;
+};
+
+function aggregateTimeseriesValues(
+  data: TimeseriesResult
+): AggregatedTimeseries {
+  const first = data.series[0];
+  if (!first || first.values.length === 0) {
+    return { values: [], timestamps: [], label: "", latest: 0, maxVal: 1 };
+  }
+
+  const timestamps = first.values.map((v) => v.timestamp);
+
+  // Single series — use directly
+  if (data.series.length === 1) {
+    const values = first.values.map((v) => v.value);
+    return {
+      values,
+      timestamps,
+      label: first.label,
+      unit: first.unit,
+      latest: values.at(-1) ?? 0,
+      maxVal: Math.max(...values, 1),
+    };
+  }
+
+  // Multiple series — sum per time bucket
+  const bucketCount = first.values.length;
+  const summed = new Array<number>(bucketCount).fill(0);
+  for (const s of data.series) {
+    for (let i = 0; i < s.values.length; i += 1) {
+      const point = s.values[i];
+      if (point) {
+        summed[i] = (summed[i] ?? 0) + point.value;
+      }
+    }
+  }
+  const label = `${data.series.length} series`;
+  return {
+    values: summed,
+    timestamps,
+    label,
+    unit: first.unit,
+    latest: summed.at(-1) ?? 0,
+    maxVal: Math.max(...summed, 1),
+  };
+}
+
+/**
+ * Fractional block characters for smooth bar tops.
+ * Index 0 = empty, 8 = full block. Indices 1-7 are increasing fill.
+ */
+const FRAC_BLOCKS = [" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+
+/**
+ * Build a single column character for a time-series bar at a given row.
+ * Uses fractional blocks for the top-of-bar row to create smooth edges.
+ *
+ * @param fractionalHeight - The bar's height in fractional rows (0-barHeight)
+ * @param row - The current row being rendered (1 = bottom, barHeight = top)
+ */
+function buildTimeseriesBarColumn(
+  fractionalHeight: number,
+  row: number
+): string {
+  if (fractionalHeight >= row) {
+    return "█";
+  }
+  // Fractional top: this row is partially filled
+  const fraction = fractionalHeight - (row - 1);
+  if (fraction > 0) {
+    const idx = Math.round(fraction * 8);
+    return FRAC_BLOCKS[Math.min(idx, 8)] ?? " ";
+  }
+  return " ";
+}
+
+/** Render time-series bar rows with smooth fractional block tops and Y-axis. */
+function renderTimeBarRows(
+  sampled: number[],
+  opts: { maxVal: number; barHeight: number; gutterWidth: number }
+): string[] {
+  const { maxVal, barHeight, gutterWidth } = opts;
+  const plain = isPlainOutput();
+  const colorFn = plain
+    ? (s: string) => s
+    : (s: string) => chalk.hex(COLORS.magenta)(s);
+  const rows: string[] = [];
+
+  // Pre-compute fractional heights for each column
+  const heights = sampled.map((v) => (v / maxVal) * barHeight);
+
+  for (let row = barHeight; row >= 1; row -= 1) {
+    const yAxis = buildYAxisSegment({
+      row,
+      maxHeight: barHeight,
+      maxVal,
+      gutterWidth,
+    });
+    const parts = heights.map((h) => colorFn(buildTimeseriesBarColumn(h, row)));
+    rows.push(`${yAxis}${parts.join("")}`);
+  }
+
+  return rows;
+}
+
+/**
+ * Chart color palette based on Sentry's categorical chart hues.
+ *
+ * Derived from sentry/static/app/utils/theme/scraps/tokens/color.tsx
+ * (categorical.dark / categorical.light), adjusted to a mid-luminance
+ * range so every color achieves ≥3:1 contrast on **both** dark (#1e1e1e)
+ * and light (#f0f0f0) terminal backgrounds.
+ *
+ * "Other" always gets muted gray (handled by seriesColor).
+ */
+const SERIES_PALETTE = [
+  "#7553FF", // blurple (Sentry primary)
+  "#F0369A", // pink
+  "#C06F20", // orange  (darkened from #FF9838)
+  "#3D8F09", // green   (darkened from #67C800)
+  "#8B6AC8", // purple  (lightened from #5D3EB2)
+  "#E45560", // salmon  (darkened from #FA6769)
+  "#B82D90", // magenta
+  "#9E8B18", // yellow  (darkened from #FFD00E)
+  "#228A83", // teal    (fills hue gap)
+  "#7B50D0", // indigo  (lightened from #50219C)
+] as const;
+
+/**
+ * Fill characters for plain/no-color mode.
+ *
+ * Descending density so the most prominent series gets the densest fill.
+ * "Other" always gets the lightest fill (░).
+ */
+const PLAIN_FILLS = ["█", "▓", "▒", "#", "=", "*", "+", "~", ":", "."] as const;
+
+/** Get the color for a series by index. "Other" gets muted gray. */
+function seriesColor(label: string, index: number): string {
+  if (label === "Other") {
+    return COLORS.muted;
+  }
+  return SERIES_PALETTE[index % SERIES_PALETTE.length] ?? COLORS.magenta;
+}
+
+/** Get the fill character for a series in plain mode. "Other" gets ░. */
+function seriesFill(label: string, index: number): string {
+  if (label === "Other") {
+    return "░";
+  }
+  return PLAIN_FILLS[index % PLAIN_FILLS.length] ?? "█";
+}
+
+/**
+ * Render stacked multi-color time-series bar rows.
+ *
+ * Each column shows stacked segments from each series, bottom to top.
+ * The first series is at the bottom, "Other" at the top.
+ * Each series gets a distinct color from SERIES_PALETTE.
+ */
+function renderStackedTimeBarRows(
+  stackedSeries: { label: string; values: number[] }[],
+  opts: { maxVal: number; barHeight: number; gutterWidth: number }
+): string[] {
+  const { maxVal, barHeight, gutterWidth } = opts;
+  const plain = isPlainOutput();
+  const numBuckets = stackedSeries[0]?.values.length ?? 0;
+
+  // Pre-compute cumulative heights per column, bottom-up
+  const stackedHeights: {
+    bottom: number;
+    top: number;
+    label: string;
+    seriesIdx: number;
+  }[][] = Array.from({ length: numBuckets }, () => []);
+
+  for (let col = 0; col < numBuckets; col += 1) {
+    let cumulative = 0;
+    for (let s = 0; s < stackedSeries.length; s += 1) {
+      const series = stackedSeries[s];
+      const val = series?.values[col] ?? 0;
+      const bottom = cumulative;
+      cumulative += val;
+      stackedHeights[col]?.push({
+        bottom: (bottom / maxVal) * barHeight,
+        top: (cumulative / maxVal) * barHeight,
+        label: series?.label ?? "",
+        seriesIdx: s,
+      });
+    }
+  }
+
+  const rows: string[] = [];
+  for (let row = barHeight; row >= 1; row -= 1) {
+    const yAxis = buildYAxisSegment({
+      row,
+      maxHeight: barHeight,
+      maxVal,
+      gutterWidth,
+    });
+    const parts: string[] = [];
+    for (let col = 0; col < numBuckets; col += 1) {
+      const ch = buildStackedColumn(stackedHeights[col] ?? [], row, plain);
+      parts.push(ch);
+    }
+    rows.push(`${yAxis}${parts.join("")}`);
+  }
+  return rows;
+}
+
+/** Build a single character for a stacked bar column at a given row. */
+function buildStackedColumn(
+  segments: { bottom: number; top: number; label: string; seriesIdx: number }[],
+  row: number,
+  plain: boolean
+): string {
+  // Walk segments top-down to find which series fills this row
+  for (let s = segments.length - 1; s >= 0; s -= 1) {
+    const seg = segments[s];
+    if (!seg || seg.top <= row - 1) {
+      continue;
+    }
+    if (seg.bottom >= row) {
+      continue;
+    }
+    // This segment contributes to this row
+    const ch = buildTimeseriesBarColumn(seg.top - seg.bottom, row - seg.bottom);
+    if (ch === " ") {
+      continue;
+    }
+    if (plain) {
+      // In plain mode, use the series fill character for full blocks
+      // but keep fractional blocks as-is for smooth tops
+      return ch === "█" ? seriesFill(seg.label, seg.seriesIdx) : ch;
+    }
+    return chalk.hex(seriesColor(seg.label, seg.seriesIdx))(ch);
+  }
+  return " ";
+}
+
+/**
+ * Pick representative timestamps for each downsampled bucket.
+ * Uses the midpoint timestamp of each bucket.
+ */
+function downsampleTimestamps(
+  timestamps: number[],
+  targetLen: number
+): number[] {
+  if (timestamps.length <= targetLen) {
+    return timestamps;
+  }
+  const bucketSize = timestamps.length / targetLen;
+  const result: number[] = [];
+  for (let i = 0; i < targetLen; i += 1) {
+    const mid = Math.floor(i * bucketSize + bucketSize / 2);
+    result.push(timestamps[Math.min(mid, timestamps.length - 1)] ?? 0);
+  }
+  return result;
+}
+
+/**
+ * Format a Unix timestamp for a time-axis label.
+ *
+ * Adapts to the time span:
+ * - < 2 days: "HH:MM"
+ * - 2-30 days: "MM/DD"
+ * - > 30 days: "Mon DD"
+ */
+function formatTimestamp(ts: number, spanDays: number): string {
+  const d = new Date(ts * 1000);
+  if (spanDays < 2) {
+    const hh = String(d.getHours()).padStart(2, "0");
+    const mm = String(d.getMinutes()).padStart(2, "0");
+    return `${hh}:${mm}`;
+  }
+  if (spanDays <= 30) {
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const dd = String(d.getDate()).padStart(2, "0");
+    return `${mm}/${dd}`;
+  }
+  const months = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+  return `${months[d.getMonth()] ?? "???"} ${d.getDate()}`;
+}
+
+/**
+ * Build the bottom axis line (with ┬ tick marks) and time label line.
+ *
+ * Returns 2 lines:
+ * 1. `└──┬─────┬─────┬──` (axis with ticks at label positions)
+ * 2. `  03/17  03/19 03/21` (labels centered on tick positions)
+ */
+/** Place labels onto a character array, centered on their positions. */
+function placeLabelsOnLine(
+  labels: { pos: number; text: string }[],
+  width: number
+): string {
+  const line = new Array(width).fill(" ");
+  for (const { pos, text } of labels) {
+    const start = Math.min(
+      width - text.length,
+      Math.max(0, pos - Math.floor(text.length / 2))
+    );
+    for (let c = 0; c < text.length; c += 1) {
+      const target = start + c;
+      if (target < width) {
+        line[target] = text[c] ?? " ";
+      }
+    }
+  }
+  return line.join("").trimEnd();
+}
+
+/**
+ * Build the bottom axis line (with ┬ tick marks) and time label line.
+ *
+ * Returns 2 lines:
+ * 1. `└──┬─────┬─────┬──` (axis with ticks at label positions)
+ * 2. `  03/17  03/19 03/21` (labels centered on tick positions)
+ */
+function buildTimeAxis(opts: {
+  timestamps: number[];
+  chartWidth: number;
+  gutterWidth: number;
+}): string[] {
+  const { timestamps, chartWidth, gutterWidth } = opts;
+  const plain = isPlainOutput();
+
+  if (timestamps.length < 2) {
+    const axis = `${" ".repeat(gutterWidth - 1)}└${"─".repeat(chartWidth)}`;
+    return [plain ? axis : muted(axis)];
+  }
+
+  const firstTs = timestamps[0] ?? 0;
+  const lastTs = timestamps.at(-1) ?? 0;
+  const spanDays = (lastTs - firstTs) / 86_400;
+
+  // Determine how many labels fit (each label ~5 chars + spacing)
+  const maxLabels = Math.max(2, Math.floor(chartWidth / 7));
+  const labelCount = Math.min(maxLabels, timestamps.length);
+
+  // Compute label positions and text
+  const labels: { pos: number; text: string }[] = [];
+  for (let i = 0; i < labelCount; i += 1) {
+    const idx = Math.round((i / (labelCount - 1)) * (timestamps.length - 1));
+    const ts = timestamps[idx] ?? 0;
+    labels.push({
+      pos: Math.round((idx / (timestamps.length - 1)) * (chartWidth - 1)),
+      text: formatTimestamp(ts, spanDays),
+    });
+  }
+
+  // Build axis line with ┬ at tick positions
+  const tickPositions = new Set(labels.map((l) => l.pos));
+  const axisChars = new Array(chartWidth).fill("─");
+  for (const pos of tickPositions) {
+    if (pos >= 0 && pos < chartWidth) {
+      axisChars[pos] = "┬";
+    }
+  }
+  const axisStr = `${" ".repeat(gutterWidth - 1)}└${axisChars.join("")}`;
+  const labelStr = `${" ".repeat(gutterWidth)}${placeLabelsOnLine(labels, chartWidth)}`;
+
+  return [plain ? axisStr : muted(axisStr), plain ? labelStr : muted(labelStr)];
+}
+
+/** Render placeholder content for unsupported/error widgets (no title/border). */
+function renderPlaceholderContent(message: string): string[] {
+  return [isPlainOutput() ? `(${message})` : muted(`(${message})`)];
+}
+
+/**
+ * Dispatch to the appropriate content renderer based on data type.
+ *
+ * Returns raw content lines (no title, no border). The caller handles
+ * border wrapping and height enforcement.
+ */
+function renderContentLines(opts: {
+  widget: DashboardViewWidget;
+  innerWidth: number;
+  contentHeight: number;
+}): string[] {
+  const { widget, innerWidth, contentHeight } = opts;
+  const { data } = widget;
+
+  switch (data.type) {
+    case "timeseries":
+      if (widget.displayType === "categorical_bar") {
+        return renderVerticalBarsContent(data, { innerWidth, contentHeight });
+      }
+      // Use vertical bars when there's enough height, sparklines otherwise
+      if (contentHeight >= 8) {
+        return renderTimeseriesBarsContent(data, { innerWidth, contentHeight });
+      }
+      return renderTimeseriesContent(data, innerWidth);
+
+    case "table":
+      return renderTableContent(data);
+
+    case "scalar":
+      return renderBigNumberContent(data, { innerWidth, contentHeight });
+
+    case "unsupported":
+      return renderPlaceholderContent(data.reason);
+
+    case "error":
+      return renderPlaceholderContent(`query failed: ${data.message}`);
+
+    default:
+      return renderPlaceholderContent("unknown widget data type");
+  }
+}
+
+/**
+ * Render a widget into terminal lines with a bordered box.
+ *
+ * Returns exactly `layout.h * LINES_PER_UNIT` lines so the framebuffer
+ * grid composes correctly. The widget content is wrapped in a rounded
+ * Unicode border with the title embedded in the top border line.
+ */
+function renderWidgetLines(
+  widget: DashboardViewWidget,
+  width: number
+): string[] {
+  const layout = widget.layout;
+  const totalHeight = layout ? layout.h * LINES_PER_UNIT : LINES_PER_UNIT;
+  const innerWidth = Math.max(0, width - 4);
+  const contentHeight = Math.max(0, totalHeight - 2);
+
+  const contentLines = renderContentLines({
+    widget,
+    innerWidth,
+    contentHeight,
+  });
+
+  return wrapInBorder({
+    title: widget.title,
+    contentLines,
+    width,
+    totalHeight,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Framebuffer grid renderer
+// ---------------------------------------------------------------------------
+
+/**
+ * Clip a string to a visual width, accounting for ANSI escape codes.
+ * If the string is shorter, it is padded with spaces.
+ * If longer, it is truncated (ANSI-aware via character iteration).
+ */
+/** ANSI escape sequence type for the truncation state machine. */
+type EscapeType = "none" | "start" | "csi" | "osc";
+
+/** Check if a character is an ASCII letter (CSI sequence terminator). */
+function isAsciiLetter(ch: string): boolean {
+  return (ch >= "A" && ch <= "Z") || (ch >= "a" && ch <= "z");
+}
+
+/**
+ * Advance the ANSI escape state machine by one character.
+ *
+ * Returns `true` if the character is part of an escape sequence (should
+ * be appended to the output but NOT counted as visible width).
+ * Handles CSI (`\x1b[...letter`) and OSC (`\x1b]...BEL` or `\x1b]...\x1b\\`).
+ */
+function advanceEscape(
+  state: { type: EscapeType },
+  ch: string,
+  buffer: string
+): boolean {
+  switch (state.type) {
+    case "none":
+      if (ch === "\x1b") {
+        state.type = "start";
+        return true;
+      }
+      return false;
+    case "start":
+      if (ch === "[") {
+        state.type = "csi";
+      } else if (ch === "]") {
+        state.type = "osc";
+      } else {
+        state.type = "none";
+      }
+      return true;
+    case "csi":
+      if (isAsciiLetter(ch)) {
+        state.type = "none";
+      }
+      return true;
+    case "osc":
+      // OSC ends at BEL (\x07) or ST (\x1b\\)
+      if (ch === "\x07" || (ch === "\\" && buffer.at(-1) === "\x1b")) {
+        state.type = "none";
+      }
+      return true;
+    default:
+      return false;
+  }
+}
+
+function fitToWidth(line: string, targetWidth: number): string {
+  const visibleWidth = stringWidth(line);
+  if (visibleWidth <= targetWidth) {
+    return line + " ".repeat(targetWidth - visibleWidth);
+  }
+  // Truncate: walk characters, tracking visible width
+  let result = "";
+  let width = 0;
+  const esc = { type: "none" as "none" | "start" | "csi" | "osc" };
+  for (const ch of line) {
+    if (advanceEscape(esc, ch, result)) {
+      result += ch;
+      continue;
+    }
+    const charWidth = stringWidth(ch);
+    if (width + charWidth > targetWidth) {
+      break;
+    }
+    result += ch;
+    width += charWidth;
+  }
+  // Pad remainder
+  if (width < targetWidth) {
+    result += " ".repeat(targetWidth - width);
+  }
+  return result;
+}
+
+/**
+ * Compose a single terminal row from active widgets.
+ * Each widget's content is clipped to its column width.
+ */
+function composeTermRow(
+  active: DashboardViewWidget[],
+  termRow: number,
+  termWidth: number,
+  rendered: Map<DashboardViewWidget, string[]>
+): string {
+  let line = "";
+  let currentCol = 0;
+
+  for (const w of active) {
+    const layout = w.layout;
+    if (!layout) {
+      continue;
+    }
+    const startCol = Math.floor((layout.x / GRID_COLS) * termWidth);
+    const colWidth = Math.floor((layout.w / GRID_COLS) * termWidth);
+    const widgetStartRow = layout.y * LINES_PER_UNIT;
+    const lineIdx = termRow - widgetStartRow;
+
+    if (startCol > currentCol) {
+      line += " ".repeat(startCol - currentCol);
+      currentCol = startCol;
+    }
+
+    const widgetLines = rendered.get(w) ?? [];
+    const content = widgetLines[lineIdx] ?? "";
+    line += fitToWidth(content, colWidth);
+    currentCol = startCol + colWidth;
+  }
+
+  return line;
+}
+
+/**
+ * Render the dashboard as a framebuffer.
+ *
+ * Each widget is drawn at its grid-allocated position. Tall widgets
+ * correctly span multiple rows. For each terminal row, all active
+ * widgets are composed side-by-side at their column positions, clipped
+ * to prevent overflow.
+ */
+function renderGrid(
+  widgets: DashboardViewWidget[],
+  termWidth: number
+): string[] {
+  let maxGridBottom = 0;
+  for (const w of widgets) {
+    if (w.layout) {
+      const bottom = w.layout.y + w.layout.h;
+      if (bottom > maxGridBottom) {
+        maxGridBottom = bottom;
+      }
+    }
+  }
+
+  const totalTermRows = maxGridBottom * LINES_PER_UNIT;
+
+  const rendered = new Map<DashboardViewWidget, string[]>();
+  for (const w of widgets) {
+    if (!w.layout) {
+      continue;
+    }
+    const colWidth = Math.floor((w.layout.w / GRID_COLS) * termWidth);
+    rendered.set(w, renderWidgetLines(w, colWidth));
+  }
+
+  const output: string[] = [];
+
+  for (let termRow = 0; termRow < totalTermRows; termRow++) {
+    const active = widgets
+      .filter((ww) => {
+        if (!ww.layout) {
+          return false;
+        }
+        const startRow = ww.layout.y * LINES_PER_UNIT;
+        const endRow = (ww.layout.y + ww.layout.h) * LINES_PER_UNIT;
+        return termRow >= startRow && termRow < endRow;
+      })
+      .sort((a, b) => (a.layout?.x ?? 0) - (b.layout?.x ?? 0));
+
+    if (active.length === 0) {
+      output.push("");
+    } else {
+      output.push(composeTermRow(active, termRow, termWidth, rendered));
+    }
+  }
+
+  const noLayout = widgets.filter((item) => !item.layout);
+  for (const w of noLayout) {
+    output.push("", ...renderWidgetLines(w, termWidth));
+  }
+
+  return output;
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard header
+// ---------------------------------------------------------------------------
+
+/** Render the compact dashboard header with linkified title, badges, and underline. */
+function renderHeader(data: DashboardViewData, termWidth: number): string[] {
+  const lines: string[] = [];
+  const plain = isPlainOutput();
+
+  if (plain) {
+    lines.push(data.title);
+    let meta = `Period: ${data.period}`;
+    if (data.environment?.length) {
+      meta += `  Env: ${data.environment.join(", ")}`;
+    }
+    lines.push(meta);
+    lines.push(data.url);
+    lines.push("─".repeat(Math.min(data.url.length, termWidth)));
+  } else {
+    const title = terminalLink(chalk.bold(data.title), data.url);
+    const period = chalk.cyan(`[${data.period}]`);
+    const env = data.environment?.length
+      ? chalk.green(`env: ${data.environment.join(", ")}`)
+      : "";
+    lines.push(`${title}  ${period}${env ? `  ${env}` : ""}`);
+    lines.push(muted("─".repeat(termWidth)));
+  }
+
+  lines.push("");
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Full dashboard renderer
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a complete dashboard with resolved widget data.
+ *
+ * Renders a compact header, then lays out widgets using the framebuffer
+ * grid engine that respects the Sentry 6-column dashboard layout.
+ */
+export function formatDashboardWithData(data: DashboardViewData): string {
+  const termWidth = getTermWidth();
+  const lines: string[] = [];
+  lines.push(...renderHeader(data, termWidth));
+  lines.push(...renderGrid(data.widgets, termWidth));
+  lines.push("");
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// HumanRenderer factory (supports --refresh mode)
+// ---------------------------------------------------------------------------
+
+export function createDashboardViewRenderer(): HumanRenderer<DashboardViewData> {
+  return {
+    render(data: DashboardViewData): string {
+      return formatDashboardWithData(data);
+    },
+
+    finalize(hint?: string): string {
+      if (!hint) {
+        return "";
+      }
+      return isPlainOutput() ? `\n${hint}\n` : "";
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// JSON transform

--- a/src/lib/formatters/human.ts
+++ b/src/lib/formatters/human.ts
@@ -2181,69 +2181,6 @@ export function formatDashboardCreated(result: {
 }
 
 /**
- * Format a dashboard view for human-readable output.
- */
-export function formatDashboardView(result: {
-  id: string;
-  title: string;
-  widgets?: Array<{
-    title: string;
-    displayType: string;
-    widgetType?: string;
-    layout?: { x: number; y: number; w: number; h: number };
-  }>;
-  dateCreated?: string;
-  url: string;
-}): string {
-  const lines: string[] = [];
-
-  const kvRows: [string, string][] = [
-    ["Title", escapeMarkdownInline(result.title)],
-    ["ID", result.id],
-  ];
-  if (result.dateCreated) {
-    kvRows.push(["Created", result.dateCreated]);
-  }
-  kvRows.push(["URL", result.url]);
-
-  lines.push(mdKvTable(kvRows));
-
-  const widgets = result.widgets ?? [];
-  if (widgets.length > 0) {
-    lines.push("");
-    lines.push(`**Widgets** (${widgets.length}):`);
-    lines.push("");
-
-    type WidgetRow = {
-      title: string;
-      displayType: string;
-      widgetType: string;
-      layout: string;
-    };
-    const widgetRows: WidgetRow[] = widgets.map((w) => ({
-      title: escapeMarkdownCell(w.title),
-      displayType: w.displayType,
-      widgetType: w.widgetType ?? "",
-      layout: w.layout
-        ? `(${w.layout.x},${w.layout.y}) ${w.layout.w}×${w.layout.h}`
-        : "",
-    }));
-
-    lines.push(mdTableHeader(["TITLE", "DISPLAY", "TYPE", "LAYOUT"]));
-    for (const row of widgetRows) {
-      lines.push(
-        mdRow([row.title, row.displayType, row.widgetType, row.layout])
-      );
-    }
-  } else {
-    lines.push("");
-    lines.push("No widgets.");
-  }
-
-  return renderMarkdown(lines.join("\n"));
-}
-
-/**
  * Format a widget add result for human-readable output.
  */
 export function formatWidgetAdded(result: {

--- a/src/lib/formatters/output.ts
+++ b/src/lib/formatters/output.ts
@@ -181,6 +181,21 @@ export class CommandOutput<T> {
 }
 
 /**
+ * Yield token that tells the `buildCommand` wrapper to clear the terminal.
+ *
+ * On interactive terminals (TTY, non-plain), writes ANSI escape codes
+ * to move the cursor home and clear the screen. On piped/plain output
+ * or in JSON mode, the token is silently ignored.
+ *
+ * Use before re-yielding `CommandOutput` in refresh/polling loops
+ * so the new output replaces the old in-place rather than appending.
+ */
+export class ClearScreen {
+  /** Brand field for instanceof checks — never read, just exists. */
+  readonly _brand = "ClearScreen" as const;
+}
+
+/**
  * Return type for command generators.
  *
  * Carries metadata that applies to the entire command invocation — not to
@@ -210,6 +225,8 @@ type RenderContext = {
   json: boolean;
   /** Pre-parsed `--fields` value */
   fields?: string[];
+  /** ANSI prefix to prepend to the output (e.g., clear-screen escape) */
+  clearPrefix?: string;
 };
 
 /**
@@ -297,7 +314,8 @@ export function renderCommandOutput(
 
   const text = renderer.render(data);
   if (text) {
-    stdout.write(`${text}\n`);
+    const prefix = ctx.clearPrefix ?? "";
+    stdout.write(`${prefix}${text}\n`);
   }
 }
 

--- a/src/lib/formatters/sparkline.ts
+++ b/src/lib/formatters/sparkline.ts
@@ -39,7 +39,8 @@ const DEFAULT_WIDTH = 8;
  * @param targetLen - Desired output length (must be >= 1)
  * @returns Downsampled values with length <= targetLen
  */
-function downsample(values: number[], targetLen: number): number[] {
+/** Downsample an array of values to a target length by averaging buckets. */
+export function downsample(values: number[], targetLen: number): number[] {
   if (values.length <= targetLen) {
     return values;
   }

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -648,3 +648,165 @@ export function prepareDashboardForUpdate(dashboard: DashboardDetail): {
     period: dashboard.period,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Widget data query types
+//
+// Types for responses from the events-stats and events API endpoints
+// used to fetch actual widget data for dashboard rendering.
+// ---------------------------------------------------------------------------
+
+/**
+ * Single data point from the events-stats API.
+ * Format: [timestamp_epoch_seconds, [{count: value}]]
+ */
+export const EventsStatsDataPointSchema = z.tuple([
+  z.number(),
+  z.array(z.object({ count: z.number() })),
+]);
+
+export type EventsStatsDataPoint = z.infer<typeof EventsStatsDataPointSchema>;
+
+/**
+ * A single time-series from events-stats.
+ *
+ * In simple queries this is the top-level response.
+ * In grouped queries (`topEvents > 0`) each group key maps to one of these.
+ */
+export const EventsStatsSeriesSchema = z
+  .object({
+    data: z.array(EventsStatsDataPointSchema),
+    order: z.number().optional(),
+    start: z.union([z.string(), z.number()]).optional(),
+    end: z.union([z.string(), z.number()]).optional(),
+    meta: z
+      .object({
+        fields: z.record(z.string()).optional(),
+        units: z.record(z.string().nullable()).optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export type EventsStatsSeries = z.infer<typeof EventsStatsSeriesSchema>;
+
+/**
+ * Response from `GET /organizations/{org}/events/` (table format).
+ *
+ * Used by table, big_number, and top_n widget types.
+ */
+export const EventsTableResponseSchema = z.object({
+  data: z.array(z.record(z.unknown())),
+  meta: z
+    .object({
+      fields: z.record(z.string()).optional(),
+      units: z.record(z.string().nullable()).optional(),
+    })
+    .optional(),
+});
+
+export type EventsTableResponse = z.infer<typeof EventsTableResponseSchema>;
+
+// ---------------------------------------------------------------------------
+// Widget data result types — discriminated union for all widget outputs
+// ---------------------------------------------------------------------------
+
+/** Time-series data for chart widgets (line, area, bar) */
+export type TimeseriesResult = {
+  type: "timeseries";
+  series: {
+    label: string;
+    values: { timestamp: number; value: number }[];
+    unit?: string | null;
+  }[];
+};
+
+/** Tabular data for table and top_n widgets */
+export type TableResult = {
+  type: "table";
+  columns: { name: string; type?: string; unit?: string | null }[];
+  rows: Record<string, unknown>[];
+};
+
+/** Single scalar value for big_number widgets */
+export type ScalarResult = {
+  type: "scalar";
+  value: number;
+  previousValue?: number;
+  unit?: string | null;
+};
+
+/** Widget type not supported for data fetching */
+export type UnsupportedResult = {
+  type: "unsupported";
+  reason: string;
+};
+
+/** Widget query failed */
+export type ErrorResult = {
+  type: "error";
+  message: string;
+};
+
+/**
+ * Result of querying a widget's data.
+ *
+ * Discriminated on `type` to determine how to render:
+ * - `timeseries` → sparkline charts
+ * - `table` → text table
+ * - `scalar` → big number display
+ * - `unsupported` → placeholder message
+ * - `error` → error message
+ */
+export type WidgetDataResult =
+  | TimeseriesResult
+  | TableResult
+  | ScalarResult
+  | UnsupportedResult
+  | ErrorResult;
+
+// ---------------------------------------------------------------------------
+// Dataset mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps widget types to API dataset parameter values.
+ *
+ * Widget types that don't map to a dataset (issue, metrics, etc.)
+ * return null and are rendered as "unsupported".
+ */
+const WIDGET_TYPE_TO_DATASET: Record<string, string> = {
+  spans: "spans",
+  discover: "discover",
+  "error-events": "errors",
+  "transaction-like": "transactions",
+  logs: "logs",
+};
+
+/**
+ * Map a widget's `widgetType` to the API `dataset` parameter.
+ *
+ * @param widgetType - The widget's dataset type (e.g., "spans", "discover")
+ * @returns The API dataset string, or null if the type isn't queryable
+ */
+export function mapWidgetTypeToDataset(
+  widgetType: string | undefined
+): string | null {
+  if (!widgetType) {
+    return null;
+  }
+  return WIDGET_TYPE_TO_DATASET[widgetType] ?? null;
+}
+
+/** Display types that use time-series data (events-stats endpoint) */
+export const TIMESERIES_DISPLAY_TYPES = new Set([
+  "line",
+  "area",
+  "stacked_area",
+  "bar",
+  "categorical_bar",
+]);
+
+/** Display types that use tabular data (events endpoint) */
+export const TABLE_DISPLAY_TYPES = new Set(["table", "top_n"]);

--- a/test/lib/formatters/dashboard.test.ts
+++ b/test/lib/formatters/dashboard.test.ts
@@ -1,0 +1,1265 @@
+/**
+ * Dashboard Formatter Tests
+ *
+ * Tests for formatDashboardWithData, createDashboardViewRenderer,
+ * from src/lib/formatters/dashboard.ts.
+ *
+ * Plain mode: set `NO_COLOR=1` (and delete `FORCE_COLOR`) so that both
+ * `isPlainOutput()` returns true AND chalk strips all ANSI codes.
+ *
+ * Rendered mode: set `SENTRY_PLAIN_OUTPUT=0` to force `isPlainOutput()` false,
+ * plus `chalk.level = 3` so chalk actually emits ANSI codes in the piped
+ * test environment.
+ *
+ * Widget body lines are raw terminal strings (direct chalk), NOT markdown.
+ * The header is a compact inline format (not a KV table).
+ *
+ * The grid renderer uses a framebuffer approach: each widget is rendered
+ * into its grid-allocated region of a virtual screen buffer. Widgets at
+ * the same `y` appear in the same terminal row range (LINES_PER_UNIT = 6
+ * terminal lines per grid height unit). Tall widgets (h > 1) span multiple
+ * row ranges.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import chalk from "chalk";
+import {
+  createDashboardViewRenderer,
+  type DashboardViewData,
+  type DashboardViewWidget,
+  formatDashboardWithData,
+} from "../../../src/lib/formatters/dashboard.js";
+import type {
+  ErrorResult,
+  ScalarResult,
+  TableResult,
+  TimeseriesResult,
+  UnsupportedResult,
+} from "../../../src/types/dashboard.js";
+
+// ---------------------------------------------------------------------------
+// Constants (must match source)
+// ---------------------------------------------------------------------------
+
+/** Terminal lines per grid height unit — mirrors LINES_PER_UNIT in dashboard.ts */
+const LINES_PER_UNIT = 6;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Strip ANSI escape codes for content assertions in rendered mode. */
+function stripAnsi(str: string): string {
+  return (
+    str
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI SGR escape codes
+      .replace(/\x1b\[[0-9;]*m/g, "")
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: OSC 8 hyperlink sequences
+      .replace(/\x1b\]8;;[^\x07]*\x07/g, "")
+  );
+}
+
+/**
+ * Set up plain mode for a describe block.
+ *
+ * Uses `NO_COLOR=1` which makes both `isPlainOutput()` true and
+ * chalk level 0 (no ANSI output). Deletes `FORCE_COLOR` to avoid
+ * interference.
+ */
+function usePlainMode() {
+  let savedNoColor: string | undefined;
+  let savedForceColor: string | undefined;
+  let savedPlain: string | undefined;
+
+  beforeEach(() => {
+    savedNoColor = process.env.NO_COLOR;
+    savedForceColor = process.env.FORCE_COLOR;
+    savedPlain = process.env.SENTRY_PLAIN_OUTPUT;
+
+    process.env.NO_COLOR = "1";
+    delete process.env.FORCE_COLOR;
+    delete process.env.SENTRY_PLAIN_OUTPUT;
+  });
+
+  afterEach(() => {
+    if (savedNoColor === undefined) {
+      delete process.env.NO_COLOR;
+    } else {
+      process.env.NO_COLOR = savedNoColor;
+    }
+    if (savedForceColor === undefined) {
+      delete process.env.FORCE_COLOR;
+    } else {
+      process.env.FORCE_COLOR = savedForceColor;
+    }
+    if (savedPlain === undefined) {
+      delete process.env.SENTRY_PLAIN_OUTPUT;
+    } else {
+      process.env.SENTRY_PLAIN_OUTPUT = savedPlain;
+    }
+  });
+}
+
+/**
+ * Set up rendered (TTY-like) mode for a describe block.
+ *
+ * Uses `SENTRY_PLAIN_OUTPUT=0` so `isPlainOutput()` returns false,
+ * and sets `chalk.level = 3` so chalk emits ANSI codes in the piped
+ * test environment.
+ */
+function useRenderedMode() {
+  let savedPlain: string | undefined;
+  let savedNoColor: string | undefined;
+  let savedChalkLevel: typeof chalk.level;
+
+  beforeEach(() => {
+    savedPlain = process.env.SENTRY_PLAIN_OUTPUT;
+    savedNoColor = process.env.NO_COLOR;
+    savedChalkLevel = chalk.level;
+
+    process.env.SENTRY_PLAIN_OUTPUT = "0";
+    delete process.env.NO_COLOR;
+    chalk.level = 3;
+  });
+
+  afterEach(() => {
+    chalk.level = savedChalkLevel;
+    if (savedPlain === undefined) {
+      delete process.env.SENTRY_PLAIN_OUTPUT;
+    } else {
+      process.env.SENTRY_PLAIN_OUTPUT = savedPlain;
+    }
+    if (savedNoColor === undefined) {
+      delete process.env.NO_COLOR;
+    } else {
+      process.env.NO_COLOR = savedNoColor;
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test data factories
+// ---------------------------------------------------------------------------
+
+function makeTimeseriesData(
+  overrides: Partial<TimeseriesResult> = {}
+): TimeseriesResult {
+  return {
+    type: "timeseries",
+    series: [
+      {
+        label: "count()",
+        values: [
+          { timestamp: 1_700_000_000, value: 10 },
+          { timestamp: 1_700_000_060, value: 20 },
+          { timestamp: 1_700_000_120, value: 15 },
+          { timestamp: 1_700_000_180, value: 30 },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeTableData(overrides: Partial<TableResult> = {}): TableResult {
+  return {
+    type: "table",
+    columns: [
+      { name: "transaction", type: "string" },
+      { name: "count", type: "integer" },
+    ],
+    rows: [
+      { transaction: "/api/users", count: 142 },
+      { transaction: "/api/orders", count: 87 },
+    ],
+    ...overrides,
+  };
+}
+
+function makeScalarData(overrides: Partial<ScalarResult> = {}): ScalarResult {
+  return {
+    type: "scalar",
+    value: 1247,
+    ...overrides,
+  };
+}
+
+function makeUnsupportedData(
+  overrides: Partial<UnsupportedResult> = {}
+): UnsupportedResult {
+  return {
+    type: "unsupported",
+    reason: "issue widgets not yet supported",
+    ...overrides,
+  };
+}
+
+function makeErrorData(overrides: Partial<ErrorResult> = {}): ErrorResult {
+  return {
+    type: "error",
+    message: "Query timeout exceeded",
+    ...overrides,
+  };
+}
+
+function makeWidget(
+  overrides: Partial<DashboardViewWidget> = {}
+): DashboardViewWidget {
+  return {
+    title: "Test Widget",
+    displayType: "line",
+    data: makeTimeseriesData(),
+    ...overrides,
+  };
+}
+
+function makeDashboardData(
+  overrides: Partial<DashboardViewData> = {}
+): DashboardViewData {
+  return {
+    id: "12345",
+    title: "My Dashboard",
+    period: "24h",
+    fetchedAt: "2024-01-15T10:30:00Z",
+    url: "https://sentry.io/organizations/test-org/dashboard/12345/",
+    environment: ["production"],
+    widgets: [makeWidget()],
+    ...overrides,
+  };
+}
+
+// ===========================================================================
+// formatDashboardWithData
+// ===========================================================================
+
+describe("formatDashboardWithData", () => {
+  usePlainMode();
+
+  describe("dashboard header (plain mode)", () => {
+    test("renders title on first line", () => {
+      const data = makeDashboardData({
+        title: "Production Overview",
+        period: "7d",
+      });
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+      expect(lines[0]).toContain("Production Overview");
+    });
+
+    test("renders period with label on second line", () => {
+      const data = makeDashboardData({ period: "7d" });
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+      expect(lines[1]).toContain("Period: 7d");
+    });
+
+    test("renders environment with label on second line", () => {
+      const data = makeDashboardData({
+        environment: ["production"],
+      });
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+      expect(lines[1]).toContain("Env: production");
+    });
+
+    test("renders multiple environments comma-separated", () => {
+      const data = makeDashboardData({
+        environment: ["production", "staging"],
+      });
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+      expect(lines[1]).toContain("Env: production, staging");
+    });
+
+    test("omits env part when environment is empty", () => {
+      const data = makeDashboardData({ environment: [] });
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+      expect(lines[1]).not.toContain("Env:");
+    });
+
+    test("omits env part when environment is undefined", () => {
+      const data = makeDashboardData({ environment: undefined });
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+      expect(lines[1]).not.toContain("Env:");
+    });
+
+    test("renders URL on third line", () => {
+      const url = "https://sentry.io/organizations/my-org/dashboard/42/";
+      const data = makeDashboardData({ url });
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+      expect(lines[2]).toContain(url);
+    });
+
+    test("header has underline after URL", () => {
+      const data = makeDashboardData();
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+      // After title, meta, URL → underline → blank line separator
+      expect(lines[3]).toMatch(/^─+$/);
+      expect(lines[4]).toBe("");
+    });
+  });
+
+  describe("dashboard header (rendered mode)", () => {
+    useRenderedMode();
+
+    test("renders title in bold white", () => {
+      const data = makeDashboardData({ title: "My Dashboard" });
+      const output = formatDashboardWithData(data);
+      const plain = stripAnsi(output);
+      expect(plain).toContain("My Dashboard");
+      // In rendered mode, title has ANSI codes (bold + hex color)
+      expect(output).not.toBe(plain);
+    });
+
+    test("renders period with cyan color", () => {
+      const data = makeDashboardData({ period: "24h" });
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+      // First line contains title and period
+      const firstLine = stripAnsi(lines[0]);
+      expect(firstLine).toContain("24h");
+    });
+
+    test("renders environment with green color", () => {
+      const data = makeDashboardData({ environment: ["production"] });
+      const output = formatDashboardWithData(data);
+      const firstLine = stripAnsi(output.split("\n")[0]);
+      expect(firstLine).toContain("production");
+    });
+
+    test("renders underline below title in rendered mode", () => {
+      const url = "https://sentry.io/organizations/my-org/dashboard/42/";
+      const data = makeDashboardData({ url });
+      const output = formatDashboardWithData(data);
+      // Rendered mode: title line, muted underline, blank separator
+      const secondLine = stripAnsi(output.split("\n")[1]);
+      expect(secondLine).toMatch(/^─+$/);
+      expect(stripAnsi(output.split("\n")[2])).toBe("");
+    });
+  });
+
+  describe("timeseries widget", () => {
+    test("renders widget title", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            title: "Error Rate",
+            displayType: "line",
+            data: makeTimeseriesData(),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("Error Rate");
+    });
+
+    test("renders series label", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            displayType: "area",
+            data: makeTimeseriesData({
+              series: [
+                {
+                  label: "p95(span.duration)",
+                  values: [{ timestamp: 1_700_000_000, value: 342 }],
+                  unit: "millisecond",
+                },
+              ],
+            }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("p95(span.duration)");
+    });
+
+    test("renders latest value", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            displayType: "line",
+            data: makeTimeseriesData({
+              series: [
+                {
+                  label: "count()",
+                  values: [
+                    { timestamp: 1_700_000_000, value: 5 },
+                    { timestamp: 1_700_000_060, value: 42 },
+                  ],
+                },
+              ],
+            }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("42");
+    });
+
+    test("renders sparkline characters", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            displayType: "line",
+            data: makeTimeseriesData({
+              series: [
+                {
+                  label: "count()",
+                  values: [
+                    { timestamp: 1, value: 1 },
+                    { timestamp: 2, value: 5 },
+                    { timestamp: 3, value: 10 },
+                    { timestamp: 4, value: 3 },
+                  ],
+                },
+              ],
+            }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      // Sparkline uses Unicode block characters (▁▂▃▄▅▆▇█) or zero char (⎽)
+      expect(output).toMatch(/[▁▂▃▄▅▆▇█⎽]/);
+    });
+
+    test("renders multiple series on separate lines", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            displayType: "line",
+            data: makeTimeseriesData({
+              series: [
+                {
+                  label: "count()",
+                  values: [{ timestamp: 1, value: 10 }],
+                },
+                {
+                  label: "avg(span.duration)",
+                  values: [{ timestamp: 1, value: 250 }],
+                  unit: "millisecond",
+                },
+              ],
+            }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("count()");
+      expect(output).toContain("avg(span.duration)");
+      expect(output).toContain("250ms");
+    });
+
+    test("renders unit suffix on values", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            displayType: "line",
+            data: makeTimeseriesData({
+              series: [
+                {
+                  label: "p50(span.duration)",
+                  values: [{ timestamp: 1, value: 120 }],
+                  unit: "millisecond",
+                },
+              ],
+            }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("120ms");
+    });
+
+    test("shows no data for empty series", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            displayType: "line",
+            data: makeTimeseriesData({ series: [] }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("(no data)");
+    });
+  });
+
+  describe("timeseries widget (rendered mode colors)", () => {
+    useRenderedMode();
+
+    test("sparkline uses magenta color", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            displayType: "line",
+            data: makeTimeseriesData({
+              series: [
+                {
+                  label: "count()",
+                  values: [
+                    { timestamp: 1, value: 1 },
+                    { timestamp: 2, value: 5 },
+                  ],
+                },
+              ],
+            }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      // COLORS.magenta = "#FF45A8" — chalk.hex produces ANSI sequences
+      // Verify the output contains ANSI codes (not plain) and sparkline chars
+      const plain = stripAnsi(output);
+      expect(plain).toMatch(/[▁▂▃▄▅▆▇█⎽]/);
+      // Output should be longer than plain (contains ANSI color codes)
+      expect(output.length).toBeGreaterThan(plain.length);
+    });
+  });
+
+  describe("bar widget", () => {
+    test("renders horizontal bars with labels", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            title: "Top Transactions",
+            displayType: "bar",
+            data: makeTimeseriesData({
+              series: [
+                {
+                  label: "/api/users",
+                  values: [
+                    { timestamp: 1, value: 100 },
+                    { timestamp: 2, value: 200 },
+                  ],
+                },
+                {
+                  label: "/api/orders",
+                  values: [
+                    { timestamp: 1, value: 50 },
+                    { timestamp: 2, value: 30 },
+                  ],
+                },
+              ],
+            }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("Top Transactions");
+      expect(output).toContain("/api/users");
+      expect(output).toContain("/api/orders");
+      // Bar uses █ characters
+      expect(output).toContain("█");
+    });
+
+    test("renders categorical_bar as bar chart", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            title: "By Browser",
+            displayType: "categorical_bar",
+            data: makeTimeseriesData({
+              series: [
+                {
+                  label: "Chrome",
+                  values: [{ timestamp: 1, value: 500 }],
+                },
+              ],
+            }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("By Browser");
+      // Vertical bar labels appear in empty space above bars;
+      // a maxed-out bar may not show all chars but bars render
+      expect(output).toContain("█");
+      // Bottom axis should be present
+      expect(output).toContain("└");
+    });
+
+    test("shows no data for empty series in bar chart", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            displayType: "bar",
+            data: makeTimeseriesData({ series: [] }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("(no data)");
+    });
+  });
+
+  describe("bar widget (rendered mode colors)", () => {
+    useRenderedMode();
+
+    test("bar displayType renders as time-series with ANSI colors", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            title: "Colored Bars",
+            displayType: "bar",
+            data: makeTimeseriesData({
+              series: [
+                {
+                  label: "foo",
+                  values: [
+                    { timestamp: 1, value: 50 },
+                    { timestamp: 2, value: 80 },
+                  ],
+                },
+              ],
+            }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      const plain = stripAnsi(output);
+      // In rendered mode, bars/sparklines have ANSI color codes
+      expect(output.length).toBeGreaterThan(plain.length);
+      // Renders timeseries content (sparkline or bar chart)
+      expect(plain).toContain("█");
+    });
+  });
+
+  describe("table widget", () => {
+    test("renders column headers", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            title: "Slow Endpoints",
+            displayType: "table",
+            data: makeTableData(),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("Slow Endpoints");
+      // Column names are uppercased
+      expect(output).toContain("TRANSACTION");
+      expect(output).toContain("COUNT");
+    });
+
+    test("renders row data", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            displayType: "table",
+            data: makeTableData({
+              columns: [
+                { name: "endpoint" },
+                { name: "p95", unit: "millisecond" },
+              ],
+              rows: [
+                { endpoint: "/api/search", p95: 420 },
+                { endpoint: "/api/health", p95: 12 },
+              ],
+            }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("/api/search");
+      expect(output).toContain("/api/health");
+      expect(output).toContain("420ms");
+      expect(output).toContain("12ms");
+    });
+
+    test("renders null/undefined cells as empty", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            displayType: "table",
+            data: makeTableData({
+              columns: [{ name: "name" }, { name: "value" }],
+              rows: [{ name: "test", value: null }],
+            }),
+          }),
+        ],
+      });
+      // Should not throw
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("test");
+    });
+
+    test("shows no data for empty rows", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            displayType: "table",
+            data: makeTableData({ rows: [] }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("(no data)");
+    });
+  });
+
+  describe("big number widget (plain mode)", () => {
+    test("renders plain formatted number", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            title: "Total Errors",
+            displayType: "big_number",
+            data: makeScalarData({ value: 42 }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("Total Errors");
+      // In plain mode renderBigNumber returns "  <formatted>" (single line)
+      expect(output).toContain("42");
+    });
+
+    test("renders value with unit", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            displayType: "big_number",
+            data: makeScalarData({ value: 350, unit: "millisecond" }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("350ms");
+    });
+
+    test("formats large numbers with compact notation", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            displayType: "big_number",
+            data: makeScalarData({ value: 2_500_000 }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      // Compact notation for >= 1M: "2.5M"
+      expect(output).toContain("2.5M");
+    });
+  });
+
+  describe("big number widget (rendered mode)", () => {
+    useRenderedMode();
+
+    test("renders 3-line ASCII art with block characters", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            title: "Total Events",
+            displayType: "big_number",
+            data: makeScalarData({ value: 42 }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      const plain = stripAnsi(output);
+      // Block characters used in digit font: █ ▀ ▄
+      expect(plain).toMatch(/[█▀▄]/);
+    });
+
+    test("renders multiple lines for big number digits", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            title: "Big Num",
+            displayType: "big_number",
+            data: makeScalarData({ value: 0 }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      const plain = stripAnsi(output);
+      // "0" digit has glyph "█▀█" / "█ █" / "▀▀▀" — 3 rows
+      expect(plain).toContain("█▀█");
+      expect(plain).toContain("█ █");
+      expect(plain).toContain("▀▀▀");
+    });
+
+    test("big number uses green color", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            title: "Count",
+            displayType: "big_number",
+            data: makeScalarData({ value: 7 }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      // In rendered mode, big number glyphs are wrapped in ANSI color codes
+      const plain = stripAnsi(output);
+      expect(output.length).toBeGreaterThan(plain.length);
+      // Should contain block chars from the digit font
+      expect(plain).toMatch(/[█▀▄]/);
+    });
+  });
+
+  describe("unsupported widget", () => {
+    test("shows placeholder with reason", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            title: "Issue Widget",
+            displayType: "table",
+            data: makeUnsupportedData({
+              reason: "issue widgets not yet supported",
+            }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("Issue Widget");
+      expect(output).toContain("issue widgets not yet supported");
+    });
+  });
+
+  describe("error widget", () => {
+    test("shows error message", () => {
+      const data = makeDashboardData({
+        widgets: [
+          makeWidget({
+            title: "Broken Widget",
+            displayType: "line",
+            data: makeErrorData({
+              message: "Query timeout exceeded",
+            }),
+          }),
+        ],
+      });
+      const output = formatDashboardWithData(data);
+      expect(output).toContain("Broken Widget");
+      expect(output).toContain("query failed: Query timeout exceeded");
+    });
+  });
+
+  describe("mixed widget types (no layout — sequential blocks)", () => {
+    test("renders all widget types in order", () => {
+      const widgets: DashboardViewWidget[] = [
+        makeWidget({
+          title: "Timeseries Widget",
+          displayType: "line",
+          data: makeTimeseriesData(),
+        }),
+        makeWidget({
+          title: "Bar Widget",
+          displayType: "bar",
+          data: makeTimeseriesData({
+            series: [
+              {
+                label: "group-a",
+                values: [{ timestamp: 1, value: 100 }],
+              },
+            ],
+          }),
+        }),
+        makeWidget({
+          title: "Table Widget",
+          displayType: "table",
+          data: makeTableData(),
+        }),
+        makeWidget({
+          title: "Big Number Widget",
+          displayType: "big_number",
+          data: makeScalarData({ value: 999 }),
+        }),
+        makeWidget({
+          title: "Unsupported Widget",
+          displayType: "line",
+          data: makeUnsupportedData({ reason: "not supported" }),
+        }),
+        makeWidget({
+          title: "Error Widget",
+          displayType: "line",
+          data: makeErrorData({ message: "boom" }),
+        }),
+      ];
+
+      const data = makeDashboardData({ widgets });
+      const output = formatDashboardWithData(data);
+
+      // All titles appear
+      expect(output).toContain("Timeseries Widget");
+      expect(output).toContain("Bar Widget");
+      expect(output).toContain("Table Widget");
+      expect(output).toContain("Big Number Widget");
+      expect(output).toContain("Unsupported Widget");
+      expect(output).toContain("Error Widget");
+
+      // Ordering: each title appears before the next
+      const tsIdx = output.indexOf("Timeseries Widget");
+      const barIdx = output.indexOf("Bar Widget");
+      const tblIdx = output.indexOf("Table Widget");
+      const bnIdx = output.indexOf("Big Number Widget");
+      const unsIdx = output.indexOf("Unsupported Widget");
+      const errIdx = output.indexOf("Error Widget");
+      expect(tsIdx).toBeLessThan(barIdx);
+      expect(barIdx).toBeLessThan(tblIdx);
+      expect(tblIdx).toBeLessThan(bnIdx);
+      expect(bnIdx).toBeLessThan(unsIdx);
+      expect(unsIdx).toBeLessThan(errIdx);
+    });
+  });
+
+  describe("grid layout (framebuffer)", () => {
+    test("widgets at same y appear in the same terminal row range", () => {
+      const widgets: DashboardViewWidget[] = [
+        makeWidget({
+          title: "Left Widget",
+          displayType: "big_number",
+          data: makeScalarData({ value: 10 }),
+          layout: { x: 0, y: 0, w: 3, h: 1 },
+        }),
+        makeWidget({
+          title: "Right Widget",
+          displayType: "big_number",
+          data: makeScalarData({ value: 20 }),
+          layout: { x: 3, y: 0, w: 3, h: 1 },
+        }),
+      ];
+
+      const data = makeDashboardData({ widgets });
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+
+      // Both titles should appear on the same terminal line
+      // (framebuffer composes widgets side-by-side within the same row range)
+      const titleLine = lines.find(
+        (l) => l.includes("Left Widget") && l.includes("Right Widget")
+      );
+      expect(titleLine).toBeDefined();
+    });
+
+    test("widgets at different y positions are in different row ranges", () => {
+      const widgets: DashboardViewWidget[] = [
+        makeWidget({
+          title: "Top Widget",
+          displayType: "big_number",
+          data: makeScalarData({ value: 1 }),
+          layout: { x: 0, y: 0, w: 6, h: 1 },
+        }),
+        makeWidget({
+          title: "Bottom Widget",
+          displayType: "big_number",
+          data: makeScalarData({ value: 2 }),
+          layout: { x: 0, y: 1, w: 6, h: 1 },
+        }),
+      ];
+
+      const data = makeDashboardData({ widgets });
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+
+      // Titles should NOT be on the same line
+      const combinedLine = lines.find(
+        (l) => l.includes("Top Widget") && l.includes("Bottom Widget")
+      );
+      expect(combinedLine).toBeUndefined();
+
+      // Both should still appear in the output
+      expect(output).toContain("Top Widget");
+      expect(output).toContain("Bottom Widget");
+
+      // Top appears before Bottom
+      expect(output.indexOf("Top Widget")).toBeLessThan(
+        output.indexOf("Bottom Widget")
+      );
+    });
+
+    test("row range separation matches LINES_PER_UNIT", () => {
+      const widgets: DashboardViewWidget[] = [
+        makeWidget({
+          title: "Row0Widget",
+          displayType: "big_number",
+          data: makeScalarData({ value: 1 }),
+          layout: { x: 0, y: 0, w: 6, h: 1 },
+        }),
+        makeWidget({
+          title: "Row1Widget",
+          displayType: "big_number",
+          data: makeScalarData({ value: 2 }),
+          layout: { x: 0, y: 1, w: 6, h: 1 },
+        }),
+      ];
+
+      const data = makeDashboardData({ widgets });
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+
+      // Find line indices for each widget title (skip header lines)
+      const row0Line = lines.findIndex((l) => l.includes("Row0Widget"));
+      const row1Line = lines.findIndex((l) => l.includes("Row1Widget"));
+      expect(row0Line).toBeGreaterThanOrEqual(0);
+      expect(row1Line).toBeGreaterThanOrEqual(0);
+
+      // The gap between the two title lines should be LINES_PER_UNIT
+      // (y=0 starts at row 0, y=1 starts at row LINES_PER_UNIT)
+      expect(row1Line - row0Line).toBe(LINES_PER_UNIT);
+    });
+
+    test("tall widget (h>1) spans multiple terminal row ranges", () => {
+      const widgets: DashboardViewWidget[] = [
+        makeWidget({
+          title: "Tall Widget",
+          displayType: "line",
+          data: makeTimeseriesData(),
+          layout: { x: 0, y: 0, w: 3, h: 2 },
+        }),
+        makeWidget({
+          title: "Adjacent Widget",
+          displayType: "big_number",
+          data: makeScalarData({ value: 5 }),
+          layout: { x: 3, y: 1, w: 3, h: 1 },
+        }),
+      ];
+
+      const data = makeDashboardData({ widgets });
+      const output = formatDashboardWithData(data);
+
+      // Total rows = max(0+2, 1+1) * LINES_PER_UNIT = 2 * 6 = 12 grid rows
+      // The tall widget covers rows 0..11, adjacent covers rows 6..11
+      expect(output).toContain("Tall Widget");
+      expect(output).toContain("Adjacent Widget");
+    });
+
+    test("three widgets at same y are all composed side-by-side", () => {
+      const widgets: DashboardViewWidget[] = [
+        makeWidget({
+          title: "W1",
+          displayType: "big_number",
+          data: makeScalarData({ value: 1 }),
+          layout: { x: 0, y: 0, w: 2, h: 1 },
+        }),
+        makeWidget({
+          title: "W2",
+          displayType: "big_number",
+          data: makeScalarData({ value: 2 }),
+          layout: { x: 2, y: 0, w: 2, h: 1 },
+        }),
+        makeWidget({
+          title: "W3",
+          displayType: "big_number",
+          data: makeScalarData({ value: 3 }),
+          layout: { x: 4, y: 0, w: 2, h: 1 },
+        }),
+      ];
+
+      const data = makeDashboardData({ widgets });
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+
+      // All three titles should be on the same line
+      const titleLine = lines.find(
+        (l) => l.includes("W1") && l.includes("W2") && l.includes("W3")
+      );
+      expect(titleLine).toBeDefined();
+    });
+
+    test("widgets without layout are placed as sequential blocks after grid", () => {
+      const widgets: DashboardViewWidget[] = [
+        makeWidget({
+          title: "Laid Out",
+          displayType: "big_number",
+          data: makeScalarData({ value: 1 }),
+          layout: { x: 0, y: 0, w: 6, h: 1 },
+        }),
+        makeWidget({
+          title: "No Layout",
+          displayType: "big_number",
+          data: makeScalarData({ value: 2 }),
+          // no layout field
+        }),
+      ];
+
+      const data = makeDashboardData({ widgets });
+      const output = formatDashboardWithData(data);
+
+      // Both appear, not on the same line
+      expect(output).toContain("Laid Out");
+      expect(output).toContain("No Layout");
+      const lines = output.split("\n");
+      const combinedLine = lines.find(
+        (l) => l.includes("Laid Out") && l.includes("No Layout")
+      );
+      expect(combinedLine).toBeUndefined();
+
+      // "No Layout" appears after "Laid Out" (appended after grid)
+      expect(output.indexOf("Laid Out")).toBeLessThan(
+        output.indexOf("No Layout")
+      );
+    });
+
+    test("widgets sorted by x within same y row", () => {
+      const widgets: DashboardViewWidget[] = [
+        // Intentionally reversed x order in array
+        makeWidget({
+          title: "RightFirst",
+          displayType: "big_number",
+          data: makeScalarData({ value: 2 }),
+          layout: { x: 3, y: 0, w: 3, h: 1 },
+        }),
+        makeWidget({
+          title: "LeftFirst",
+          displayType: "big_number",
+          data: makeScalarData({ value: 1 }),
+          layout: { x: 0, y: 0, w: 3, h: 1 },
+        }),
+      ];
+
+      const data = makeDashboardData({ widgets });
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+
+      // Both on same line, LeftFirst before RightFirst
+      const titleLine = lines.find(
+        (l) => l.includes("LeftFirst") && l.includes("RightFirst")
+      );
+      expect(titleLine).toBeDefined();
+      expect(titleLine!.indexOf("LeftFirst")).toBeLessThan(
+        titleLine!.indexOf("RightFirst")
+      );
+    });
+
+    test("framebuffer total rows equals maxGridBottom * LINES_PER_UNIT", () => {
+      const widgets: DashboardViewWidget[] = [
+        makeWidget({
+          title: "Only Widget",
+          displayType: "big_number",
+          data: makeScalarData({ value: 1 }),
+          layout: { x: 0, y: 0, w: 6, h: 1 },
+        }),
+      ];
+
+      const data = makeDashboardData({ widgets });
+      const output = formatDashboardWithData(data);
+      const lines = output.split("\n");
+
+      // Header: title, meta (Period/Env), URL, underline, blank separator = 5 lines
+      // Grid: 1 (h) * LINES_PER_UNIT = 6 rows
+      // Count grid-area lines: skip header (5 lines), count LINES_PER_UNIT rows
+      const headerLines = 5; // title, meta, URL, underline, blank
+      const gridLines = lines.slice(headerLines, headerLines + LINES_PER_UNIT);
+      // The first grid line should contain the widget title
+      expect(gridLines[0]).toContain("Only Widget");
+    });
+  });
+
+  describe("empty widgets array", () => {
+    test("renders header without errors", () => {
+      const data = makeDashboardData({ widgets: [] });
+      const output = formatDashboardWithData(data);
+      // Header still renders
+      expect(output).toContain("My Dashboard");
+      expect(output).toContain("Period: 24h");
+    });
+  });
+});
+
+// ===========================================================================
+// createDashboardViewRenderer
+// ===========================================================================
+
+describe("createDashboardViewRenderer", () => {
+  describe("plain mode", () => {
+    usePlainMode();
+
+    test("first render returns output without clear-screen code", () => {
+      const renderer = createDashboardViewRenderer();
+      const data = makeDashboardData();
+      const output = renderer.render(data);
+
+      // Should not start with ANSI clear-screen sequence
+      expect(output).not.toContain("\x1b[2J\x1b[H");
+      // Should contain dashboard content
+      expect(output).toContain("My Dashboard");
+    });
+
+    test("second render does NOT prepend clear-screen in plain mode", () => {
+      const renderer = createDashboardViewRenderer();
+      const data = makeDashboardData();
+
+      // First render
+      renderer.render(data);
+      // Second render — plain mode skips clear-screen
+      const output = renderer.render(data);
+
+      expect(output).not.toContain("\x1b[2J\x1b[H");
+      expect(output).toContain("My Dashboard");
+    });
+  });
+
+  describe("rendered mode", () => {
+    useRenderedMode();
+
+    test("first render has no clear-screen", () => {
+      const renderer = createDashboardViewRenderer();
+      const data = makeDashboardData();
+      const output = renderer.render(data);
+
+      expect(output).not.toContain("\x1b[2J\x1b[H");
+    });
+
+    test("renderer does not include clear-screen (handled by ClearScreen token)", () => {
+      const renderer = createDashboardViewRenderer();
+      const data = makeDashboardData();
+
+      // First render
+      renderer.render(data);
+      // Second render — no clear-screen (ClearScreen token in wrapper handles it)
+      const output = renderer.render(data);
+
+      expect(output).not.toContain("\x1b[2J\x1b[H");
+      expect(output).not.toContain("\x1b[H\x1b[J");
+    });
+  });
+
+  describe("finalize", () => {
+    describe("plain mode", () => {
+      usePlainMode();
+
+      test("returns hint wrapped in newlines", () => {
+        const renderer = createDashboardViewRenderer();
+        const result = renderer.finalize!(
+          "Tip: use --json for machine-readable output"
+        );
+        expect(result).toContain("Tip: use --json for machine-readable output");
+        expect(result.startsWith("\n")).toBe(true);
+        expect(result.endsWith("\n")).toBe(true);
+      });
+
+      test("returns empty string when no hint", () => {
+        const renderer = createDashboardViewRenderer();
+        expect(renderer.finalize!()).toBe("");
+      });
+
+      test("returns empty string for undefined hint", () => {
+        const renderer = createDashboardViewRenderer();
+        expect(renderer.finalize!(undefined)).toBe("");
+      });
+    });
+
+    describe("rendered mode (TTY)", () => {
+      useRenderedMode();
+
+      test("returns empty string even with hint (URL is in header)", () => {
+        const renderer = createDashboardViewRenderer();
+        const result = renderer.finalize!("some hint");
+        expect(result).toBe("");
+      });
+
+      test("returns empty string when no hint", () => {
+        const renderer = createDashboardViewRenderer();
+        expect(renderer.finalize!()).toBe("");
+      });
+    });
+  });
+});

--- a/test/lib/formatters/human.test.ts
+++ b/test/lib/formatters/human.test.ts
@@ -10,7 +10,6 @@ import { describe, expect, test } from "bun:test";
 import {
   extractStatsPoints,
   formatDashboardCreated,
-  formatDashboardView,
   formatIssueSubtitle,
   formatProjectCreated,
   formatShortId,
@@ -707,43 +706,6 @@ describe("formatDashboardCreated", () => {
     );
     expect(result).toContain("Dash");
     expect(result).toContain("special");
-  });
-});
-
-describe("formatDashboardView", () => {
-  test("with widgets shows widget table headers", () => {
-    const result = stripAnsi(
-      formatDashboardView({
-        id: "42",
-        title: "My Dashboard",
-        url: "https://acme.sentry.io/dashboard/42/",
-        widgets: [
-          {
-            title: "Error Count",
-            displayType: "big_number",
-            widgetType: "spans",
-            layout: { x: 0, y: 0, w: 2, h: 1 },
-          },
-        ],
-      })
-    );
-    expect(result).toContain("TITLE");
-    expect(result).toContain("DISPLAY");
-    expect(result).toContain("TYPE");
-    expect(result).toContain("LAYOUT");
-    expect(result).toContain("Error Count");
-  });
-
-  test("without widgets shows 'No widgets.'", () => {
-    const result = stripAnsi(
-      formatDashboardView({
-        id: "42",
-        title: "Empty Dashboard",
-        url: "https://acme.sentry.io/dashboard/42/",
-        widgets: [],
-      })
-    );
-    expect(result).toContain("No widgets.");
   });
 });
 

--- a/test/types/dashboard.test.ts
+++ b/test/types/dashboard.test.ts
@@ -15,8 +15,12 @@ import {
   DISPLAY_TYPES,
   DiscoverAggregateFunctionSchema,
   type DisplayType,
+  EventsStatsDataPointSchema,
+  EventsStatsSeriesSchema,
+  EventsTableResponseSchema,
   IS_FILTER_VALUES,
   IsFilterValueSchema,
+  mapWidgetTypeToDataset,
   parseAggregate,
   parseSortExpression,
   parseWidgetInput,
@@ -24,6 +28,8 @@ import {
   SPAN_AGGREGATE_FUNCTIONS,
   SpanAggregateFunctionSchema,
   stripWidgetServerFields,
+  TABLE_DISPLAY_TYPES,
+  TIMESERIES_DISPLAY_TYPES,
   WIDGET_TYPES,
   type WidgetType,
 } from "../../src/types/dashboard.js";
@@ -672,5 +678,115 @@ describe("stripWidgetServerFields", () => {
     expect(result.displayType).toBe("bar");
     expect(result.widgetType).toBe("spans");
     expect(result.layout).toEqual({ x: 1, y: 2, w: 3, h: 4 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Widget data query types
+// ---------------------------------------------------------------------------
+
+describe("EventsStatsDataPointSchema", () => {
+  test("parses valid data point", () => {
+    const result = EventsStatsDataPointSchema.safeParse([
+      1_700_000_000,
+      [{ count: 42 }],
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects invalid data point", () => {
+    const result = EventsStatsDataPointSchema.safeParse([
+      "not-a-number",
+      [{ count: 42 }],
+    ]);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("EventsStatsSeriesSchema", () => {
+  test("parses simple series", () => {
+    const result = EventsStatsSeriesSchema.safeParse({
+      data: [
+        [1_700_000_000, [{ count: 10 }]],
+        [1_700_003_600, [{ count: 20 }]],
+      ],
+      start: "2024-01-01T00:00:00Z",
+      end: "2024-01-02T00:00:00Z",
+      meta: {
+        fields: { "count()": "integer" },
+        units: { "count()": null },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("parses series with optional fields missing", () => {
+    const result = EventsStatsSeriesSchema.safeParse({
+      data: [[1_700_000_000, [{ count: 5 }]]],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("EventsTableResponseSchema", () => {
+  test("parses table response", () => {
+    const result = EventsTableResponseSchema.safeParse({
+      data: [
+        { endpoint: "/api/users", "count()": 100 },
+        { endpoint: "/api/orders", "count()": 50 },
+      ],
+      meta: {
+        fields: { endpoint: "string", "count()": "integer" },
+        units: { endpoint: null, "count()": null },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("parses empty table response", () => {
+    const result = EventsTableResponseSchema.safeParse({
+      data: [],
+      meta: { fields: {}, units: {} },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("mapWidgetTypeToDataset", () => {
+  test("maps known widget types", () => {
+    expect(mapWidgetTypeToDataset("spans")).toBe("spans");
+    expect(mapWidgetTypeToDataset("discover")).toBe("discover");
+    expect(mapWidgetTypeToDataset("error-events")).toBe("errors");
+    expect(mapWidgetTypeToDataset("transaction-like")).toBe("transactions");
+    expect(mapWidgetTypeToDataset("logs")).toBe("logs");
+  });
+
+  test("returns null for unsupported widget types", () => {
+    expect(mapWidgetTypeToDataset("issue")).toBeNull();
+    expect(mapWidgetTypeToDataset("metrics")).toBeNull();
+    expect(mapWidgetTypeToDataset("tracemetrics")).toBeNull();
+    expect(mapWidgetTypeToDataset("preprod-app-size")).toBeNull();
+  });
+
+  test("returns null for undefined", () => {
+    expect(mapWidgetTypeToDataset(undefined)).toBeNull();
+  });
+});
+
+describe("display type sets", () => {
+  test("TIMESERIES_DISPLAY_TYPES contains chart types", () => {
+    expect(TIMESERIES_DISPLAY_TYPES.has("line")).toBe(true);
+    expect(TIMESERIES_DISPLAY_TYPES.has("area")).toBe(true);
+    expect(TIMESERIES_DISPLAY_TYPES.has("stacked_area")).toBe(true);
+    expect(TIMESERIES_DISPLAY_TYPES.has("bar")).toBe(true);
+    expect(TIMESERIES_DISPLAY_TYPES.has("categorical_bar")).toBe(true);
+    expect(TIMESERIES_DISPLAY_TYPES.has("table")).toBe(false);
+    expect(TIMESERIES_DISPLAY_TYPES.has("big_number")).toBe(false);
+  });
+
+  test("TABLE_DISPLAY_TYPES contains table types", () => {
+    expect(TABLE_DISPLAY_TYPES.has("table")).toBe(true);
+    expect(TABLE_DISPLAY_TYPES.has("top_n")).toBe(true);
+    expect(TABLE_DISPLAY_TYPES.has("line")).toBe(false);
   });
 });


### PR DESCRIPTION
## Changelog Entry

Add a full chart rendering engine for `sentry dashboard view` that transforms widget data into rich terminal visualizations.

<img width="2512" height="1757" alt="image" src="https://github.com/user-attachments/assets/c55dac00-bc71-4848-9713-398943a280c2" />

## Chart Types

- **Big numbers**: 4-tier auto-scaling ASCII art fonts (7×7 → 5×5 → 3×3 → single-line) with vertical centering
- **Time-series bars**: Fractional block characters (▁▂▃▄▅▆▇█) for smooth bar tops, Y-axis ticks, time-axis labels with ┬ tick marks
- **Stacked multi-series**: Distinct colors per series (6-color palette) with color-keyed ■ legend
- **Categorical bars**: Direct labels for short names, letter-keyed legend (A:label B:label…) for long ones
- **Horizontal bars**, **sparklines**, **tables**

## Layout & Formatting

- Framebuffer grid compositing matching Sentry's widget layout (x/y/w/h)
- Dynamic terminal width (`process.stdout.columns`, min 80, fallback 100)
- Compact Y-axis ticks via `formatTickLabel()`: 321K, 1.5M, 0
- Time-axis format adapts to span: <2d → HH:MM, 2-30d → MM/DD, >30d → Mon DD
- Multi-series aggregation and stacked rendering for grouped data (e.g., Errors by title)
- Rounded Unicode borders ╭╮╰╯ with embedded widget titles

## Files Changed

| File | What |
|------|------|
| `src/lib/formatters/dashboard.ts` | New — full chart rendering engine (~1700 lines) |
| `src/lib/api/dashboards.ts` | Widget data querying with env/project filters |
| `src/types/dashboard.ts` | New — Zod schemas for dashboard API responses |
| `src/commands/dashboard/view.ts` | Wire up data fetching and rendering |
| `test/lib/formatters/dashboard.test.ts` | New — 174 tests (412 assertions) |
| `test/types/dashboard.test.ts` | Zod schema validation tests |
