### PR TITLE
feat(ci): integrate Linear Releases into release and nightly workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,10 +400,12 @@ jobs:
 
           echo "Pushed patch manifest: patch-${VERSION} (from ${PREV_VERSION})"
 
+      # linear-release-action needs full history to scan commits for Linear issue IDs
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Notify Linear nightly release
+        continue-on-error: true
         uses: linear/linear-release-action@v0
         with:
           access_key: ${{ secrets.LINEAR_NIGHTLY_RELEASE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,15 @@ jobs:
 
           echo "Pushed patch manifest: patch-${VERSION} (from ${PREV_VERSION})"
 
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Notify Linear nightly release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_NIGHTLY_RELEASE_KEY }}
+          version: ${{ needs.changes.outputs.nightly-version }}
+
   test-e2e:
     name: E2E Tests
     needs: [build-binary]

--- a/.github/workflows/notify-issues.yml
+++ b/.github/workflows/notify-issues.yml
@@ -1,0 +1,34 @@
+name: "Automation: Notify issues for release"
+permissions:
+  contents: read
+  issues: write
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Which version to notify issues for
+        required: false
+
+jobs:
+  release-comment-issues:
+    runs-on: ubuntu-latest
+    name: Notify issues
+    steps:
+      - name: Get version
+        id: get_version
+        env:
+          INPUTS_VERSION: ${{ github.event.inputs.version }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: echo "version=${INPUTS_VERSION:-$RELEASE_TAG_NAME}" >> "$GITHUB_OUTPUT"
+      - name: Comment on linked issues mentioned in release
+        # Skip nightly/dev builds — only comment on stable releases
+        if: |
+          steps.get_version.outputs.version != ''
+          && !contains(steps.get_version.outputs.version, '-dev.')
+        uses: getsentry/release-comment-issues-gh-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/notify-linear.yml
+++ b/.github/workflows/notify-linear.yml
@@ -1,0 +1,28 @@
+name: "Automation: Notify Linear releases"
+permissions:
+  contents: read
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to notify Linear for
+        required: false
+
+jobs:
+  notify-linear:
+    runs-on: ubuntu-latest
+    name: Notify Linear
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # linear-release-action needs full history to scan commits for Linear issue IDs
+          fetch-depth: 0
+      - name: Notify Linear release
+        continue-on-error: true
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_STABLE_RELEASE_KEY }}
+          version: ${{ github.event.release.tag_name || inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,8 @@ jobs:
         version: ${{ inputs.version }}
         force: ${{ inputs.force }}
         merge_target: ${{ inputs.merge_target }}
+    - name: Notify Linear release
+      if: success()
+      uses: linear/linear-release-action@v0
+      with:
+        access_key: ${{ secrets.LINEAR_STABLE_RELEASE_KEY }}


### PR DESCRIPTION
Hooks up [Linear Releases](https://linear.app/docs/releases) to our CI so the team can see which issues shipped in each build.

Two pipelines:
- **Stable** — fires in `release.yml` after Craft completes, tracking everything that goes out to npm/GitHub/Brew
- **Nightly** — fires in `publish-nightly` after the GHCR push, tagged with the nightly version string

Linear scans commits for issue identifiers and attaches them to the release automatically. Secrets (`LINEAR_STABLE_RELEASE_KEY`, `LINEAR_NIGHTLY_RELEASE_KEY`) are already set in the repo.