### PR TITLE
fix: reject @-selectors in parseOrgProjectArg with helpful redirect

### DIFF
--- a/src/lib/arg-parsing.ts
+++ b/src/lib/arg-parsing.ts
@@ -419,6 +419,39 @@ function issueArgFromUrl(parsed: ParsedSentryUrl): ParsedIssueArg | null {
 }
 
 /**
+ * Reject `@`-prefixed values in org/project positions.
+ *
+ * `@latest` and `@most_frequent` are issue selectors supported by
+ * `parseIssueArg()` (for `issue view`, `explain`, `plan`). They are not
+ * valid project slugs. This guard provides a helpful redirect instead of
+ * the confusing "Project '@latest' not found" resolution error.
+ *
+ * Unknown `@`-prefixed values are also rejected — `@` is never valid in
+ * Sentry slugs.
+ */
+function rejectAtSelector(value: string, label: string): void {
+  if (!value.startsWith("@")) {
+    return;
+  }
+
+  const selector = parseSelector(value);
+  if (selector) {
+    const article = "aeiouAEIOU".includes(label.charAt(0)) ? "an" : "a";
+    throw new ValidationError(
+      `'${value}' is an issue selector, not ${article} ${label}.\n` +
+        `  Use: sentry issue view ${value}`,
+      label
+    );
+  }
+
+  throw new ValidationError(
+    `Invalid ${label}: '${value}' starts with '@'.\n` +
+      "  Slugs contain only letters, numbers, hyphens, and underscores.",
+    label
+  );
+}
+
+/**
  * Parse a slash-delimited `org/project` string into a {@link ParsedOrgProject}.
  * Applies {@link normalizeSlug} to both components and validates against
  * URL injection characters.
@@ -435,6 +468,7 @@ function parseSlashOrgProject(input: string): ParsedOrgProject {
         'Invalid format: "/" requires a project slug (e.g., "/cli")'
       );
     }
+    rejectAtSelector(rawProject, "project slug");
     validateResourceId(rawProject, "project slug");
     const np = normalizeSlug(rawProject);
     return {
@@ -444,6 +478,7 @@ function parseSlashOrgProject(input: string): ParsedOrgProject {
     };
   }
 
+  rejectAtSelector(rawOrg, "organization slug");
   validateResourceId(rawOrg, "organization slug");
   const no = normalizeSlug(rawOrg);
 
@@ -457,6 +492,7 @@ function parseSlashOrgProject(input: string): ParsedOrgProject {
   }
 
   // "sentry/cli" → explicit org and project
+  rejectAtSelector(rawProject, "project slug");
   validateResourceId(rawProject, "project slug");
   const np = normalizeSlug(rawProject);
   const normalized = no.normalized || np.normalized;
@@ -508,6 +544,7 @@ export function parseOrgProjectArg(arg: string | undefined): ParsedOrgProject {
     parsed = parseSlashOrgProject(trimmed);
   } else {
     // No slash → search for project across all orgs
+    rejectAtSelector(trimmed, "project slug");
     validateResourceId(trimmed, "project slug");
     const np = normalizeSlug(trimmed);
     parsed = {

--- a/test/lib/arg-parsing.test.ts
+++ b/test/lib/arg-parsing.test.ts
@@ -251,6 +251,66 @@ describe("parseOrgProjectArg", () => {
       expect(stderrOutput).not.toContain("Normalized slug");
     });
   });
+
+  describe("@-selector rejection", () => {
+    test("@latest throws with redirect to issue view", () => {
+      expect(() => parseOrgProjectArg("@latest")).toThrow(
+        "is an issue selector, not a project slug"
+      );
+      expect(() => parseOrgProjectArg("@latest")).toThrow(
+        "sentry issue view @latest"
+      );
+    });
+
+    test("@most_frequent throws with redirect to issue view", () => {
+      expect(() => parseOrgProjectArg("@most_frequent")).toThrow(
+        "is an issue selector, not a project slug"
+      );
+      expect(() => parseOrgProjectArg("@most_frequent")).toThrow(
+        "sentry issue view @most_frequent"
+      );
+    });
+
+    test("case-insensitive selector variants are rejected", () => {
+      expect(() => parseOrgProjectArg("@Latest")).toThrow(
+        "is an issue selector"
+      );
+      expect(() => parseOrgProjectArg("@LATEST")).toThrow(
+        "is an issue selector"
+      );
+      expect(() => parseOrgProjectArg("@mostFrequent")).toThrow(
+        "is an issue selector"
+      );
+    });
+
+    test("unknown @-prefixed value throws as invalid slug", () => {
+      expect(() => parseOrgProjectArg("@unknown")).toThrow("starts with '@'");
+    });
+
+    test("/@latest (leading slash) throws with redirect", () => {
+      expect(() => parseOrgProjectArg("/@latest")).toThrow(
+        "is an issue selector"
+      );
+    });
+
+    test("sentry/@latest (org/selector) throws with redirect", () => {
+      expect(() => parseOrgProjectArg("sentry/@latest")).toThrow(
+        "is an issue selector"
+      );
+    });
+
+    test("@latest/project (selector as org) throws", () => {
+      expect(() => parseOrgProjectArg("@latest/cli")).toThrow(
+        "is an issue selector, not an organization slug"
+      );
+    });
+
+    test("@unknown/project (unknown @ as org) throws", () => {
+      expect(() => parseOrgProjectArg("@unknown/cli")).toThrow(
+        "starts with '@'"
+      );
+    });
+  });
 });
 
 describe("parseIssueArg", () => {


### PR DESCRIPTION
Fixes [CLI-MH](https://sentry.sentry.io/issues/7361340621/): `ResolutionError: Project '@latest' not found.`

A user ran `sentry issues @latest` expecting the `@latest` magic selector to work. However, `@latest` is only recognized by `parseIssueArg()` (used in `issue view/explain/plan`), not by `parseOrgProjectArg()` (used in list commands). Since `@` was not in `RESOURCE_ID_FORBIDDEN`, it passed validation, entered `project-search` mode, and produced a confusing "Project '@latest' not found" error.

### Fix

Added `rejectAtSelector()` in `src/lib/arg-parsing.ts` that catches `@`-prefixed values before they reach project resolution:

- **Known selectors** (`@latest`, `@most_frequent`) → `ValidationError` with redirect: `Use: sentry issue view @latest`
- **Unknown `@`-prefixed values** → `ValidationError`: slugs don't start with `@`

Applied in three locations:
1. `parseOrgProjectArg()` bare-slug branch (`@latest`)
2. `parseSlashOrgProject()` leading-slash branch (`/@latest`)
3. `parseSlashOrgProject()` explicit org branch (`sentry/@latest`)