### PR TITLE
fix(dashboard): resolve dashboard by ID/slug in addition to title

### DIFF
--- a/src/commands/dashboard/resolve.ts
+++ b/src/commands/dashboard/resolve.ts
@@ -126,7 +126,10 @@ export async function resolveDashboardId(
 
   const dashboards = await listDashboards(orgSlug);
   const lowerRef = ref.toLowerCase();
-  const match = dashboards.find((d) => d.title.toLowerCase() === lowerRef);
+  // Match by ID/slug first (e.g. "default-overview"), then fall back to title
+  const match =
+    dashboards.find((d) => d.id.toLowerCase() === lowerRef) ??
+    dashboards.find((d) => d.title.toLowerCase() === lowerRef);
 
   if (!match) {
     const available = dashboards
@@ -136,8 +139,8 @@ export async function resolveDashboardId(
     const suffix =
       dashboards.length > 5 ? `\n  ... and ${dashboards.length - 5} more` : "";
     throw new ValidationError(
-      `No dashboard with title '${ref}' found in '${orgSlug}'.\n\n` +
-        `Available dashboards:\n${available}${suffix}`
+      `No dashboard matching '${ref}' found in '${orgSlug}'.\n\n` +
+        `Available dashboards (ID  Title):\n${available}${suffix}`
     );
   }
 

--- a/test/commands/dashboard/resolve.test.ts
+++ b/test/commands/dashboard/resolve.test.ts
@@ -92,7 +92,45 @@ describe("resolveDashboardId", () => {
     expect(id).toBe("10");
   });
 
-  test("no match throws ValidationError with available dashboards", async () => {
+  test("ID/slug match returns matching dashboard ID", async () => {
+    listDashboardsSpy.mockResolvedValue([
+      { id: "default-overview", title: "General" },
+      { id: "20", title: "Performance" },
+    ]);
+
+    const id = await resolveDashboardId("test-org", "default-overview");
+    expect(id).toBe("default-overview");
+  });
+
+  test("ID match is case-insensitive", async () => {
+    listDashboardsSpy.mockResolvedValue([
+      { id: "default-overview", title: "General" },
+    ]);
+
+    const id = await resolveDashboardId("test-org", "Default-Overview");
+    expect(id).toBe("default-overview");
+  });
+
+  test("ID match takes priority over title match", async () => {
+    listDashboardsSpy.mockResolvedValue([
+      { id: "perf", title: "Performance Dashboard" },
+      { id: "30", title: "perf" },
+    ]);
+
+    const id = await resolveDashboardId("test-org", "perf");
+    expect(id).toBe("perf");
+  });
+
+  test("title match still works when no ID matches", async () => {
+    listDashboardsSpy.mockResolvedValue([
+      { id: "default-overview", title: "General" },
+    ]);
+
+    const id = await resolveDashboardId("test-org", "General");
+    expect(id).toBe("default-overview");
+  });
+
+  test("no match throws ValidationError with improved error message", async () => {
     listDashboardsSpy.mockResolvedValue([
       { id: "10", title: "Errors Overview" },
       { id: "20", title: "Performance" },
@@ -105,6 +143,8 @@ describe("resolveDashboardId", () => {
       expect(error).toBeInstanceOf(ValidationError);
       const message = (error as ValidationError).message;
       expect(message).toContain("Missing Dashboard");
+      expect(message).toContain("matching");
+      expect(message).toContain("(ID  Title)");
       expect(message).toContain("Errors Overview");
       expect(message).toContain("Performance");
     }


### PR DESCRIPTION
Fixes CLI-MK

`resolveDashboardId()` only matched non-numeric references against dashboard
titles. Sentry's built-in dashboard has `id: "default-overview"` but
`title: "General"`, so `sentry dashboard view default-overview` threw a
`ValidationError` despite listing the dashboard as available in the error.

### Changes

- **ID-first matching**: `resolveDashboardId()` now tries `d.id` before
  falling back to `d.title` (both case-insensitive). ID match takes priority
  when a value collides with a different dashboard's title.
- **Clearer error message**: Says "matching" instead of "with title" and
  labels the available list columns as `(ID  Title)`.
- **Tests**: 5 new cases covering slug match, case-insensitivity, ID vs title
  priority, title fallback, and improved error wording.