### PR TITLE
fix(help): show help when user passes `help` as positional arg

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -70,13 +70,13 @@ type ErrorMiddleware = (
  */
 async function runCli(cliArgs: string[]): Promise<void> {
   const { isatty } = await import("node:tty");
-  const { run } = await import("@stricli/core");
+  const { ExitCode, run } = await import("@stricli/core");
   const { app } = await import("./app.js");
   const { buildContext } = await import("./context.js");
   const { AuthError, formatError, getExitCode } = await import(
     "./lib/errors.js"
   );
-  const { error } = await import("./lib/formatters/colors.js");
+  const { error, warning } = await import("./lib/formatters/colors.js");
   const { runInteractiveLogin } = await import("./lib/interactive-login.js");
   const { getEnvLogLevel, setLogLevel } = await import("./lib/logger.js");
   const { isTrialEligible, promptAndStartTrial } = await import(
@@ -215,6 +215,30 @@ async function runCli(cliArgs: string[]): Promise<void> {
 
   try {
     await executor(cliArgs);
+
+    // When Stricli can't match a subcommand in a route group (e.g.,
+    // `sentry dashboard help`), it writes "No command registered for `help`"
+    // to stderr and sets exitCode to UnknownCommand. If the unrecognized
+    // token was "help", retry as `sentry help <group...>` which routes to
+    // the custom help command with proper introspection output.
+    // Check both raw (-5) and unsigned (251) forms because Node.js keeps
+    // the raw value while Bun converts to unsigned byte.
+    if (
+      (process.exitCode === ExitCode.UnknownCommand ||
+        process.exitCode === (ExitCode.UnknownCommand + 256) % 256) &&
+      cliArgs.length >= 2 &&
+      cliArgs.at(-1) === "help" &&
+      cliArgs[0] !== "help"
+    ) {
+      process.exitCode = 0;
+      const helpArgs = ["help", ...cliArgs.slice(0, -1)];
+      process.stderr.write(
+        warning(
+          `Tip: use --help for help (e.g., sentry ${cliArgs.slice(0, -1).join(" ")} --help)\n`
+        )
+      );
+      await executor(helpArgs);
+    }
   } catch (err) {
     process.stderr.write(`${error("Error:")} ${formatError(err)}\n`);
     process.exitCode = getExitCode(err);

--- a/src/context.ts
+++ b/src/context.ts
@@ -20,6 +20,14 @@ export interface SentryContext extends CommandContext {
   readonly stdout: Writer;
   readonly stderr: Writer;
   readonly stdin: NodeJS.ReadStream & { fd: 0 };
+  /**
+   * Command path segments set by Stricli's `forCommand` callback.
+   *
+   * Contains the full prefix including the program name, e.g.,
+   * `["sentry", "issue", "list"]`. Used by `buildCommand` to show
+   * help when a user passes `help` as a positional argument.
+   */
+  readonly commandPrefix?: readonly string[];
 }
 
 /**
@@ -47,7 +55,7 @@ export function buildContext(process: NodeJS.Process, span?: Span) {
     ...baseContext,
     forCommand: ({ prefix }: { prefix: readonly string[] }): SentryContext => {
       setCommandSpanName(span, prefix.join("."));
-      return baseContext;
+      return { ...baseContext, commandPrefix: prefix };
     },
   };
 }

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -37,7 +37,8 @@ import {
   numberParser as stricliNumberParser,
 } from "@stricli/core";
 import type { Writer } from "../types/index.js";
-import { OutputError } from "./errors.js";
+import { CliError, OutputError } from "./errors.js";
+import { warning } from "./formatters/colors.js";
 import { parseFieldsList } from "./formatters/json.js";
 import {
   ClearScreen,
@@ -393,6 +394,56 @@ export function buildCommand<
     }
   }
 
+  /**
+   * When a command throws a {@link CliError} and a positional arg was
+   * `"help"`, the user likely intended `--help`. Show the command's
+   * help instead of the confusing error.
+   *
+   * Only fires as **error recovery** — if the command succeeds with a
+   * legitimate value like a project named "help", this never runs.
+   *
+   * Catches all {@link CliError} subtypes (AuthError, ResolutionError,
+   * ValidationError, ContextError, etc.) because any failure with "help"
+   * as input strongly signals the user wanted `--help`. For example,
+   * `sentry issue list help` may throw AuthError (not logged in) before
+   * ever reaching project resolution.
+   *
+   * {@link OutputError} is excluded — it carries legitimate data to render
+   * (the "HTTP 404 body" pattern) and must fall through to `handleOutputError`.
+   *
+   * @returns `true` if help was shown and the error was recovered
+   */
+  async function maybeRecoverWithHelp(
+    err: unknown,
+    stdout: Writer,
+    ctx: { commandPrefix?: readonly string[]; stderr: Writer },
+    args: unknown[]
+  ): Promise<boolean> {
+    if (!(err instanceof CliError) || err instanceof OutputError) {
+      return false;
+    }
+    if (args.length === 0 || !args.some((a) => a === "help")) {
+      return false;
+    }
+    if (!ctx.commandPrefix) {
+      return false;
+    }
+    const pathSegments = ctx.commandPrefix.slice(1); // strip "sentry" prefix
+    // Dynamic import to avoid circular: command.ts → help.ts → app.ts → commands → command.ts
+    const { introspectCommand, formatHelpHuman } = await import("./help.js");
+    const result = introspectCommand(pathSegments);
+    if ("error" in result) {
+      return false;
+    }
+    ctx.stderr.write(
+      warning(
+        `Tip: use --help for help (e.g., sentry ${pathSegments.join(" ")} --help)\n\n`
+      )
+    );
+    stdout.write(`${formatHelpHuman(result)}\n`);
+    return true;
+  }
+
   // Wrap func to intercept logging flags, capture telemetry, then call original.
   // The wrapper is an async function that iterates the generator returned by func.
   const wrappedFunc = async function (
@@ -468,6 +519,23 @@ export function buildCommand<
       if (!cleanFlags.json) {
         writeFinalization(stdout, undefined, false, renderer);
       }
+
+      // If a positional arg was "help" and the command failed with a
+      // resolution/validation error, the user likely meant --help.
+      // Show help as recovery instead of the confusing error.
+      const recovered = await maybeRecoverWithHelp(
+        err,
+        stdout,
+        this as unknown as {
+          commandPrefix?: readonly string[];
+          stderr: Writer;
+        },
+        args
+      );
+      if (recovered) {
+        return;
+      }
+
       handleOutputError(err);
     }
   };

--- a/test/lib/help-positional.test.ts
+++ b/test/lib/help-positional.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for help-as-positional-arg error recovery in buildCommand.
+ *
+ * When a command throws a CliError and a positional arg was `"help"`,
+ * the buildCommand wrapper recovers by showing the command's help
+ * instead of the confusing error.
+ *
+ * This only fires as error recovery — if a command successfully resolves
+ * a legitimate value like a project named "help", the recovery never runs.
+ *
+ * Tests run commands through Stricli's `run()` with `help` as a positional
+ * and verify help output is shown when resolution fails.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { run } from "@stricli/core";
+import { app } from "../../src/app.js";
+import type { SentryContext } from "../../src/context.js";
+import { useTestConfigDir } from "../helpers.js";
+
+useTestConfigDir("help-positional-");
+
+/** Captured output from a command run */
+type CapturedOutput = {
+  stdout: string;
+  stderr: string;
+};
+
+/**
+ * Build a mock context with forCommand support.
+ *
+ * Stricli calls `forCommand({ prefix })` before running the command.
+ * We must provide it so `commandPrefix` is set on the context, enabling
+ * the help recovery logic in `buildCommand`.
+ */
+function buildMockContext(captured: {
+  stdout: string;
+  stderr: string;
+}): SentryContext & {
+  forCommand: (opts: { prefix: readonly string[] }) => SentryContext;
+} {
+  const stdoutWriter = {
+    write(data: string | Uint8Array) {
+      captured.stdout +=
+        typeof data === "string" ? data : new TextDecoder().decode(data);
+      return true;
+    },
+  };
+  const stderrWriter = {
+    write(data: string | Uint8Array) {
+      captured.stderr +=
+        typeof data === "string" ? data : new TextDecoder().decode(data);
+      return true;
+    },
+  };
+
+  const baseContext: SentryContext = {
+    process,
+    env: process.env,
+    cwd: process.cwd(),
+    homeDir: "/tmp",
+    configDir: "/tmp",
+    stdout: stdoutWriter,
+    stderr: stderrWriter,
+    stdin: process.stdin,
+  };
+
+  return {
+    ...baseContext,
+    forCommand: ({ prefix }: { prefix: readonly string[] }): SentryContext => ({
+      ...baseContext,
+      commandPrefix: prefix,
+    }),
+  };
+}
+
+/**
+ * Run a command through Stricli and capture stdout/stderr.
+ *
+ * Commands that hit resolution errors with "help" as a positional arg
+ * will be recovered by the buildCommand wrapper, which shows help output
+ * instead of the error.
+ */
+async function runCommand(args: string[]): Promise<CapturedOutput> {
+  const captured = { stdout: "", stderr: "" };
+  const mockContext = buildMockContext(captured);
+
+  try {
+    await run(app, args, mockContext);
+  } catch {
+    // Some commands may still throw (e.g., uncaught errors)
+  }
+
+  return captured;
+}
+
+describe("help recovery on ResolutionError", () => {
+  test("sentry issue list help → shows help for issue list", async () => {
+    // "help" is treated as a project slug, fails resolution → recovery shows help
+    const { stdout, stderr } = await runCommand(["issue", "list", "help"]);
+
+    expect(stdout).toContain("sentry issue list");
+    expect(stderr).toContain("--help");
+    expect(stderr).toContain("Tip");
+  });
+
+  test("sentry project list help → shows help for project list", async () => {
+    const { stdout, stderr } = await runCommand(["project", "list", "help"]);
+
+    expect(stdout).toContain("sentry project list");
+    expect(stderr).toContain("--help");
+  });
+
+  test("sentry span list help → shows help for span list", async () => {
+    const { stdout, stderr } = await runCommand(["span", "list", "help"]);
+
+    expect(stdout).toContain("sentry span list");
+    expect(stderr).toContain("--help");
+  });
+
+  test("stderr hint includes the correct command path", async () => {
+    const { stderr } = await runCommand(["issue", "list", "help"]);
+
+    expect(stderr).toContain("sentry issue list --help");
+  });
+});
+
+describe("help recovery on ValidationError", () => {
+  test("sentry trace view help → shows help for trace view", async () => {
+    // "help" fails hex ID validation → ValidationError → recovery shows help
+    const { stdout, stderr } = await runCommand(["trace", "view", "help"]);
+
+    expect(stdout).toContain("sentry trace view");
+    expect(stderr).toContain("--help");
+  });
+
+  test("sentry log view help → shows help for log view", async () => {
+    const { stdout, stderr } = await runCommand(["log", "view", "help"]);
+
+    expect(stdout).toContain("sentry log view");
+    expect(stderr).toContain("--help");
+  });
+});
+
+describe("help command unchanged", () => {
+  test("sentry help still shows branded help", async () => {
+    const { stdout, stderr } = await runCommand(["help"]);
+
+    // Custom help command shows branded output — no recovery needed
+    expect(stdout).toContain("sentry");
+    // Should NOT have the recovery tip
+    expect(stderr).not.toContain("Tip");
+  });
+
+  test("sentry help issue list still shows introspected help", async () => {
+    const { stdout, stderr } = await runCommand(["help", "issue", "list"]);
+
+    expect(stdout).toContain("sentry issue list");
+    // Should NOT have the recovery tip — this is the normal help path
+    expect(stderr).not.toContain("Tip");
+  });
+});


### PR DESCRIPTION
When users type `sentry log list help` (or similar) intending to see help,
the bare word `help` was parsed as a project slug positional argument,
causing confusing errors like "Project 'help' not found" (CLI-MN).

Two layers of recovery handle all cases:

### 1. `buildCommand` error recovery (leaf commands)

When a command's `func` throws any `CliError` and a positional arg was
`"help"`, we recover by showing the command's help via the existing
introspection system (same output as `sentry help <command>`). Because this
is **error recovery**, it only fires when the command actually fails — a
legitimate project named "help" that resolves successfully is unaffected.

**Covers:** `sentry issue list help`, `sentry trace view help`, `sentry log list help`, etc.

### 2. `bin.ts` route-level recovery (route groups)

When Stricli's route scanner rejects `"help"` as an unknown subcommand
(exit code 251/UnknownCommand), we retry as `sentry help <group...>` which
routes to the custom help command with proper introspection output.

**Covers:** `sentry dashboard help`, `sentry issue help`, `sentry auth help`, etc.

### Changes

- **`src/context.ts`**: Store `commandPrefix` on `SentryContext` (set by
  Stricli's `forCommand`) so `buildCommand` knows which command is running
- **`src/lib/command.ts`**: Add `maybeRecoverWithHelp()` in the catch block
  that detects `help` in positional args and renders help via
  `introspectCommand()` + `formatHelpHuman()`. Excludes `OutputError`.
  Dynamic import of `help.js` avoids circular deps.
- **`src/bin.ts`**: Add post-run route-level recovery that checks for
  `ExitCode.UnknownCommand` + trailing `"help"` and retries as
  `sentry help <args...>`.
- **`test/lib/help-positional.test.ts`**: Tests covering multiple command
  types and verifying the `sentry help` command path is unaffected.

Fixes CLI-MN