### PR TITLE
feat(init): propagate sentry-trace headers to wizard API calls

### DIFF
--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -9,7 +9,7 @@
 import { randomBytes } from "node:crypto";
 import { cancel, confirm, intro, log, spinner } from "@clack/prompts";
 import { MastraClient } from "@mastra/client-js";
-import { captureException } from "@sentry/node-core/light";
+import { captureException, getTraceData } from "@sentry/node-core/light";
 import { formatBanner } from "../banner.js";
 import { CLI_VERSION } from "../constants.js";
 import { getAuthToken } from "../db/auth.js";
@@ -271,6 +271,19 @@ export async function runWizard(options: WizardOptions): Promise<void> {
   const client = new MastraClient({
     baseUrl: MASTRA_API_URL,
     headers: token ? { Authorization: `Bearer ${token}` } : {},
+    fetch: ((url, init) => {
+      const traceData = getTraceData();
+      return fetch(url, {
+        ...init,
+        headers: {
+          ...(init?.headers as Record<string, string> | undefined),
+          ...(traceData["sentry-trace"] && {
+            "sentry-trace": traceData["sentry-trace"],
+          }),
+          ...(traceData.baggage && { baggage: traceData.baggage }),
+        },
+      });
+    }) as typeof fetch,
   });
   const workflow = client.getWorkflow(WORKFLOW_ID);
 


### PR DESCRIPTION
When `sentry init` runs, the CLI makes three types of calls to the wizard API: `create-run`, `start-async`, and a `resume-async` per suspend/resume cycle. Each call spins up a fresh Cloudflare Worker which currently creates its own isolated Sentry transaction — there's no link back to the CLI's root span.

## What this does

Adds a custom `fetch` interceptor to `MastraClient` that injects `sentry-trace` and `baggage` headers into every request. These come from `getTraceData()` which reads the currently active Sentry span, so each Worker invocation inherits the CLI's trace context and shows up as part of the same distributed trace.

Result: one `sentry init` run = one full trace, with CLI spans and all server-side Worker spans connected.

## Test plan

- Run `sentry init` against a test project with Sentry instrumented
- Open the `sentry.init` transaction in Sentry
- Server-side spans (`invoke_workflow sentry-wizard`, `POST /api/workflows/sentry-wizard/*`) should appear nested under it