### PR TITLE
fix(dashboard): default issue dataset table columns to ["issue"]

### DIFF
--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -157,10 +157,6 @@ sentry dashboard widget add <dashboard> "Latency Over Time" --display line --que
 sentry dashboard widget add <dashboard> "Top Endpoints" --display table \
   --query count --query p95:span.duration \
   --group-by transaction --sort -count --limit 10
-
-# Top Issues table — issue dataset defaults to --group-by issue automatically
-sentry dashboard widget add <dashboard> "Top Issues" --display table \
-  --dataset issue --sort -count --limit 10
 ```
 
 ### Common Mistakes

--- a/plugins/sentry-cli/skills/sentry-cli/references/dashboards.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/dashboards.md
@@ -101,26 +101,6 @@ Add a widget to a dashboard
 - `-s, --sort <value> - Order by (prefix - for desc, e.g. -count)`
 - `-n, --limit <value> - Result limit`
 
-**Examples:**
-
-```bash
-# Spans dataset table — top endpoints by p95 and count
-sentry dashboard widget add <dashboard> "Top Endpoints" --display table \
-  --query count --query p95:span.duration \
-  --group-by transaction --sort -count --limit 10
-
-# Issue dataset table — columns default to "issue" automatically
-sentry dashboard widget add <dashboard> "Top Issues" --display table \
-  --dataset issue --sort -count --limit 10
-
-# KPI big number
-sentry dashboard widget add <dashboard> "Error Count" --display big_number --query count
-
-# Line chart with filter
-sentry dashboard widget add <dashboard> "5xx Errors" --display line \
-  --query count --where "http.status_code:>=500"
-```
-
 ### `sentry dashboard widget edit <args...>`
 
 Edit a widget in a dashboard


### PR DESCRIPTION
Fixes #536.

Issue dataset table widgets were being created with `columns: []`, which causes Sentry to render them as empty with "Columns: None". The widget had `fields: ["count()"]` but no non-aggregate column, so there was nothing to group/display by.

## What this does

When `--dataset issue` is used without an explicit `--group-by`, `buildWidgetFromFlags` now defaults `columns` to `["issue"]`. The existing orderby auto-default logic then also fires, so sort defaults to `-count()` automatically.

This means a bare `sentry dashboard widget add <dashboard> "Top Issues" --display table --dataset issue` now produces a fully functional widget — no flags required beyond the dataset.

Explicit `--group-by` still takes precedence, so existing usage isn't affected.

## Test plan

- New test: `issue dataset defaults columns to ['issue'] and orderby to -count()` — verify widget query has `columns: ["issue"]`, `fields` contains `"issue"`, and `orderby` is `"-count()"`
- New test: `issue dataset respects explicit --group-by over default` — verify explicit `--group-by project` wins
- Run `sentry dashboard widget add <dashboard> "Top Issues" --display table --dataset issue --limit 10` and open the dashboard in Sentry — should show issue and count() columns