### PR TITLE
fix(dashboard): auto-clamp widget limit instead of erroring

### DIFF
--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -9,6 +9,7 @@
 import { z } from "zod";
 
 import { ValidationError } from "../lib/errors.js";
+import { logger } from "../lib/logger.js";
 
 // ---------------------------------------------------------------------------
 // Widget type and display type enums
@@ -442,10 +443,13 @@ const MAX_LIMITS: Partial<Record<string, number>> = {
  * Prepare widget queries for the Sentry API.
  * Auto-computes `fields` from columns + aggregates.
  * Defaults `conditions` to "" when missing.
- * Enforces per-display-type limit maximums.
+ * Clamps per-display-type limits to their maximums with a warning.
  */
-export function prepareWidgetQueries(widget: DashboardWidget): DashboardWidget {
-  // Enforce limit maximums
+export function prepareWidgetQueries(
+  inputWidget: DashboardWidget
+): DashboardWidget {
+  let widget = inputWidget;
+  // Clamp to per-display-type limit maximums
   const maxLimit = MAX_LIMITS[widget.displayType];
   if (
     maxLimit !== undefined &&
@@ -453,10 +457,10 @@ export function prepareWidgetQueries(widget: DashboardWidget): DashboardWidget {
     widget.limit !== null &&
     widget.limit > maxLimit
   ) {
-    throw new ValidationError(
-      `The maximum limit for ${widget.displayType} widgets is ${maxLimit}. Got: ${widget.limit}.`,
-      "limit"
+    logger.warn(
+      `${widget.displayType} widgets support a maximum of ${maxLimit} rows. Clamping --limit from ${widget.limit} to ${maxLimit}.`
     );
+    widget = { ...widget, limit: maxLimit };
   }
 
   if (!widget.queries) {

--- a/test/types/dashboard.test.ts
+++ b/test/types/dashboard.test.ts
@@ -521,24 +521,26 @@ describe("prepareWidgetQueries", () => {
     expect(widget.queries?.[0]?.conditions).toBe("");
   });
 
-  test("throws for table widget with limit exceeding max", () => {
-    expect(() =>
-      prepareWidgetQueries({
-        title: "Test",
-        displayType: "table",
-        limit: 25,
-      })
-    ).toThrow(/maximum limit for table widgets is 10/);
+  test("clamps table widget limit to max and warns", () => {
+    const widget = prepareWidgetQueries({
+      title: "Test",
+      displayType: "table",
+      limit: 25,
+    });
+    expect(widget.limit).toBe(10);
+    expect(widget.title).toBe("Test");
+    expect(widget.displayType).toBe("table");
   });
 
-  test("throws for bar widget with limit exceeding max", () => {
-    expect(() =>
-      prepareWidgetQueries({
-        title: "Test",
-        displayType: "bar",
-        limit: 15,
-      })
-    ).toThrow(/maximum limit for bar widgets is 10/);
+  test("clamps bar widget limit to max and warns", () => {
+    const widget = prepareWidgetQueries({
+      title: "Test",
+      displayType: "bar",
+      limit: 15,
+    });
+    expect(widget.limit).toBe(10);
+    expect(widget.title).toBe("Test");
+    expect(widget.displayType).toBe("bar");
   });
 
   test("accepts table widget with limit within max", () => {


### PR DESCRIPTION
## Summary

When a user passes `--limit 20` for a table widget (max 10), the CLI previously threw a hard `ValidationError`:

```
Error: The maximum limit for table widgets is 10. Got: 20.
```

Now it clamps the limit to the maximum and warns:

```
⚠ table widgets support a maximum of 10 rows. Clamping --limit from 20 to 10.
```

The command succeeds instead of failing. The user's intent (create the widget) is clear — the limit is just too high.

## Sentry Issue

Fixes CLI-K7 (3 users, 4 events in 0.20.0)

## Changes

- `src/types/dashboard.ts`: Changed `prepareWidgetQueries()` from throwing `ValidationError` to clamping + warning
- `test/types/dashboard.test.ts`: Updated tests to verify clamping behavior instead of throw