### PR TITLE
fix(issue): auto-redirect bare org slug to org-all mode in issue list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -575,7 +575,7 @@ Key rules when writing overrides:
 - Commands with extra fields (e.g., `stderr`, `setContext`) spread the context and add them: `(ctx) => handle({ ...ctx, flags, stderr, setContext })`. Override `ctx.flags` with the command-specific flags type when needed.
 - `resolveCursor()` must be called **inside** the `org-all` override closure, not before `dispatchOrgScopedList`, so that `--cursor` validation errors fire correctly for non-org-all modes.
 - `handleProjectSearch` errors must use `"Project"` as the `ContextError` resource, not `config.entityName`.
-- Always set `orgSlugMatchBehavior` on `dispatchOrgScopedList` to declare how bare-slug org matches are handled. Use `"redirect"` for commands where listing all entities in the org makes sense (e.g., `project list`, `team list`). Use `"error"` for commands with custom per-project logic that can't auto-redirect (e.g., `issue list`). The pre-check uses cached orgs to avoid N API calls — individual handlers don't need their own org-slug fallback.
+- Always set `orgSlugMatchBehavior` on `dispatchOrgScopedList` to declare how bare-slug org matches are handled. Use `"redirect"` for commands where listing all entities in the org makes sense (e.g., `project list`, `team list`, `issue list`). Use `"error"` for commands where org-all redirect is inappropriate. The pre-check uses cached orgs to avoid N API calls — when the cache is cold, the handler's own org-slug check serves as a safety net (throws `ResolutionError` with a hint).
 
 3. **Standalone list commands** (e.g., `span list`, `trace list`) that don't use org-scoped dispatch wire pagination directly in `func()`. See the "List Command Pagination" section above for the pattern.
 

--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -462,10 +462,11 @@ async function resolveTargetsFromParsedArg(
 
       if (matches.length === 0) {
         // Check if the slug matches an organization — common mistake.
-        // Unlike simpler list commands that auto-redirect via orgAllFallback,
-        // issue list has custom per-project query logic (query rewriting,
-        // budget redistribution) that doesn't support org-all mode here.
-        // Throwing with actionable hints is the correct behavior.
+        // The orgSlugMatchBehavior: "redirect" pre-check handles this for
+        // cached orgs (hot path). This is the cold-cache fallback: org
+        // isn't cached yet, so the pre-check couldn't fire. We throw a
+        // ResolutionError with a hint — after this command, the org will
+        // be cached and future runs will auto-redirect.
         const isOrg = orgs.some((o) => o.slug === parsed.projectSlug);
         if (isOrg) {
           throw new ResolutionError(
@@ -1601,6 +1602,10 @@ export const listCommand = buildListCommand("issue", {
       cwd,
       flags,
       parsed,
+      // When a bare slug matches a cached org, silently redirect to org-all
+      // mode instead of erroring (CLI-MC, 17 users). The user typed an org
+      // slug — their intent is clear, and org-all handles it correctly.
+      orgSlugMatchBehavior: "redirect",
       // Multi-target modes (auto-detect, explicit, project-search) handle
       // compound cursor pagination themselves via handleResolvedTargets.
       allowCursorInModes: ["auto-detect", "explicit", "project-search"],


### PR DESCRIPTION
## Summary

When a user runs `sentry issue list my-org` (bare org slug, no trailing slash), the CLI previously threw:

```
Error: 'my-org' is an organization, not a project.
  Try: sentry issue list my-org/
```

The user's intent is clear — they want to list issues in that org. The trailing slash requirement is unintuitive.

## Fix

Set `orgSlugMatchBehavior: "redirect"` on the `dispatchOrgScopedList` call. This uses the existing infrastructure that checks cached organizations for slug matches and auto-redirects to org-all mode with a warning:

```
⚠ 'my-org' is an organization, not a project. Listing all issues in 'my-org'.
```

When the org cache is cold (very first CLI run), the inner handler's own org-slug check still fires as a safety net, showing the original `ResolutionError` with a hint to add `/`. After that first run, the org cache is populated and future redirects work automatically.

## Sentry Issues

Fixes CLI-MC (17 users on 0.20.0), CLI-JS (8 users on 0.19.0)

## Changes

- `src/commands/issue/list.ts`: Added `orgSlugMatchBehavior: "redirect"` and updated cold-cache fallback comment
- `AGENTS.md`: Updated `orgSlugMatchBehavior` guidance to include `issue list` in the redirect list