### PR TITLE
feat(output): add Zod schema registration to OutputConfig for self-documenting JSON fields

### DIFF
--- a/docs/src/content/docs/agent-guidance.md
+++ b/docs/src/content/docs/agent-guidance.md
@@ -22,7 +22,7 @@ The `sentry` CLI follows conventions from well-known tools — if you're familia
 
 ## Context Window Tips
 
-- Use `--fields id,title,status` on list commands to reduce output size
+- Use `--json --fields` to select specific fields and reduce output size. Run `<command> --help` to see available fields. Example: `sentry issue list --json --fields shortId,title,count,userCount,lastSeen`
 - Use `--json` when piping output between commands or processing programmatically
 - Use `--limit` to cap the number of results (default is usually 10–100)
 - Prefer `sentry issue view PROJECT-123` over listing and filtering manually
@@ -158,3 +158,4 @@ sentry dashboard widget add <dashboard> "Top Endpoints" --display table \
 - **Confusing `--query` syntax**: The `--query` flag uses Sentry search syntax (e.g., `is:unresolved`, `assigned:me`), not free text search.
 - **Not using `--web`**: View commands support `-w`/`--web` to open the resource in the browser — useful for sharing links.
 - **Fetching API schemas instead of using the CLI**: Prefer `sentry schema` to browse the API and `sentry api` to make requests — the CLI handles authentication and endpoint resolution, so there's rarely a need to download OpenAPI specs separately.
+- **Using `sentry api` when CLI commands suffice**: `sentry issue list --json` already includes `count`, `userCount`, `firstSeen`, `lastSeen`, `priority`, and other fields at the top level. Use `--fields` to select specific fields. Run `--help` to see all available fields. Only fall back to `sentry api` for data the CLI doesn't expose.

--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -32,7 +32,7 @@ The `sentry` CLI follows conventions from well-known tools — if you're familia
 
 ### Context Window Tips
 
-- Use `--fields id,title,status` on list commands to reduce output size
+- Use `--json --fields` to select specific fields and reduce output size. Run `<command> --help` to see available fields. Example: `sentry issue list --json --fields shortId,title,count,userCount,lastSeen`
 - Use `--json` when piping output between commands or processing programmatically
 - Use `--limit` to cap the number of results (default is usually 10–100)
 - Prefer `sentry issue view PROJECT-123` over listing and filtering manually
@@ -168,6 +168,7 @@ sentry dashboard widget add <dashboard> "Top Endpoints" --display table \
 - **Confusing `--query` syntax**: The `--query` flag uses Sentry search syntax (e.g., `is:unresolved`, `assigned:me`), not free text search.
 - **Not using `--web`**: View commands support `-w`/`--web` to open the resource in the browser — useful for sharing links.
 - **Fetching API schemas instead of using the CLI**: Prefer `sentry schema` to browse the API and `sentry api` to make requests — the CLI handles authentication and endpoint resolution, so there's rarely a need to download OpenAPI specs separately.
+- **Using `sentry api` when CLI commands suffice**: `sentry issue list --json` already includes `count`, `userCount`, `firstSeen`, `lastSeen`, `priority`, and other fields at the top level. Use `--fields` to select specific fields. Run `--help` to see all available fields. Only fall back to `sentry api` for data the CLI doesn't expose.
 
 ## Prerequisites
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/issues.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/issues.md
@@ -24,6 +24,30 @@ List issues in a project
 - `--compact - Single-line rows for compact output (auto-detects if omitted)`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Numeric issue ID |
+| `shortId` | string | Human-readable short ID (e.g. PROJ-ABC) |
+| `title` | string | Issue title |
+| `culprit` | string | Culprit string |
+| `count` | string | Total event count |
+| `userCount` | number | Number of affected users |
+| `firstSeen` | string \| null | First occurrence (ISO 8601) |
+| `lastSeen` | string \| null | Most recent occurrence (ISO 8601) |
+| `level` | string | Severity level |
+| `status` | string | Issue status |
+| `priority` | string | Triage priority |
+| `platform` | string | Platform |
+| `permalink` | string | URL to the issue in Sentry |
+| `project` | object | Project info |
+| `metadata` | object | Issue metadata |
+| `assignedTo` | unknown \| null | Assigned user or team |
+| `substatus` | string \| null | Issue substatus |
+| `isUnhandled` | boolean | Whether the issue is unhandled |
+| `seerFixabilityScore` | number \| null | Seer AI fixability score (0-1) |
+
 **Examples:**
 
 ```bash

--- a/plugins/sentry-cli/skills/sentry-cli/references/logs.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/logs.md
@@ -22,6 +22,17 @@ List logs from a project
 - `-t, --period <value> - Time period (e.g., "90d", "14d", "24h"). Default: 90d (project mode), 14d (trace mode)`
 - `--fresh - Bypass cache, re-detect projects, and fetch fresh data`
 
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sentry.item_id` | string | Unique log entry ID |
+| `timestamp` | string | Log timestamp (ISO 8601) |
+| `timestamp_precise` | number | Nanosecond-precision timestamp |
+| `message` | string \| null | Log message |
+| `severity` | string \| null | Severity level (error, warning, info, debug) |
+| `trace` | string \| null | Trace ID for correlation |
+
 **Examples:**
 
 ```bash

--- a/plugins/sentry-cli/skills/sentry-cli/references/teams.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/teams.md
@@ -22,6 +22,20 @@ List repositories
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Repository ID |
+| `name` | string | Repository name |
+| `url` | string \| null | Repository URL |
+| `provider` | object | Version control provider |
+| `status` | string | Integration status |
+| `dateCreated` | string | Creation date (ISO 8601) |
+| `integrationId` | string | Integration ID |
+| `externalSlug` | string \| null | External slug (e.g. org/repo) |
+| `externalId` | string \| null | External ID |
+
 ### `sentry team list <org/project>`
 
 List teams
@@ -30,6 +44,18 @@ List teams
 - `-n, --limit <value> - Maximum number of teams to list - (default: "30")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Team ID |
+| `slug` | string | Team slug |
+| `name` | string | Team name |
+| `dateCreated` | string | Creation date (ISO 8601) |
+| `isMember` | boolean | Whether you are a member |
+| `teamRole` | string \| null | Your role in the team |
+| `memberCount` | number | Number of members |
 
 **Examples:**
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/traces.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/traces.md
@@ -25,6 +25,20 @@ List spans in a project or trace
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Span ID |
+| `parent_span` | string \| null | Parent span ID |
+| `span.op` | string \| null | Span operation (e.g. http.client, db) |
+| `description` | string \| null | Span description |
+| `span.duration` | number \| null | Duration (ms) |
+| `timestamp` | string | Timestamp (ISO 8601) |
+| `project` | string | Project slug |
+| `transaction` | string \| null | Transaction name |
+| `trace` | string | Trace ID |
+
 ### `sentry span view <trace-id/span-id...>`
 
 View details of specific spans
@@ -44,6 +58,17 @@ List recent traces in a project
 - `-t, --period <value> - Time period (e.g., "1h", "24h", "7d", "30d") - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `trace` | string | Trace ID |
+| `id` | string | Event ID |
+| `transaction` | string | Transaction name |
+| `timestamp` | string | Timestamp (ISO 8601) |
+| `transaction.duration` | number | Duration (ms) |
+| `project` | string | Project slug |
 
 ### `sentry trace view <org/project/trace-id...>`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/trials.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/trials.md
@@ -15,6 +15,17 @@ Manage product trials
 
 List product trials
 
+**JSON Fields** (use `--json --fields` to select specific fields):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `category` | string | Trial category (e.g. seerUsers, seerAutofix) |
+| `startDate` | string \| null | Start date (ISO 8601) |
+| `endDate` | string \| null | End date (ISO 8601) |
+| `reasonCode` | number | Reason code |
+| `isStarted` | boolean | Whether the trial has started |
+| `lengthDays` | number \| null | Trial duration in days |
+
 ### `sentry trial start <name> <org>`
 
 Start a product trial

--- a/script/generate-skill.ts
+++ b/script/generate-skill.ts
@@ -496,6 +496,22 @@ function generateFullCommandDoc(cmd: CommandInfo): string {
     }
   }
 
+  if (cmd.jsonFields && cmd.jsonFields.length > 0) {
+    lines.push("");
+    lines.push(
+      "**JSON Fields** (use `--json --fields` to select specific fields):"
+    );
+    lines.push("");
+    lines.push("| Field | Type | Description |");
+    lines.push("|-------|------|-------------|");
+    for (const field of cmd.jsonFields) {
+      // Escape pipe characters to avoid breaking the markdown table structure
+      const safeType = field.type.replaceAll("|", "\\|");
+      const safeDesc = (field.description ?? "").replaceAll("|", "\\|");
+      lines.push(`| \`${field.name}\` | ${safeType} | ${safeDesc} |`);
+    }
+  }
+
   if (cmd.examples.length > 0) {
     lines.push("");
     lines.push("**Examples:**");

--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -79,10 +79,11 @@ import {
 } from "../../lib/resolve-target.js";
 import { getApiBaseUrl } from "../../lib/sentry-client.js";
 import { setOrgProjectContext } from "../../lib/telemetry.js";
-import type {
-  ProjectAliasEntry,
-  SentryIssue,
-  Writer,
+import {
+  type ProjectAliasEntry,
+  type SentryIssue,
+  SentryIssueSchema,
+  type Writer,
 } from "../../types/index.js";
 
 /** Command key for pagination cursor storage */
@@ -1502,6 +1503,7 @@ const jsonTransformIssueList = jsonTransformListResult;
 const issueListOutput: OutputConfig<IssueListResult> = {
   human: formatIssueListHuman,
   jsonTransform: jsonTransformIssueList,
+  schema: SentryIssueSchema,
 };
 
 // ---------------------------------------------------------------------------

--- a/src/commands/log/list.ts
+++ b/src/commands/log/list.ts
@@ -40,6 +40,7 @@ import {
   warnIfNormalized,
 } from "../../lib/trace-target.js";
 import { getUpdateNotification } from "../../lib/version-check.js";
+import { SentryLogSchema } from "../../types/index.js";
 
 type ListFlags = {
   readonly limit: number;
@@ -598,6 +599,7 @@ export const listCommand = buildListCommand(
     output: {
       human: createLogRenderer,
       jsonTransform: jsonTransformLogOutput,
+      schema: SentryLogSchema,
     },
     parameters: {
       positional: {

--- a/src/commands/repo/list.ts
+++ b/src/commands/repo/list.ts
@@ -21,7 +21,10 @@ import {
   type OrgListCommandDocs,
 } from "../../lib/list-command.js";
 import type { OrgListConfig } from "../../lib/org-list.js";
-import type { SentryRepository } from "../../types/index.js";
+import {
+  type SentryRepository,
+  SentryRepositorySchema,
+} from "../../types/index.js";
 
 /** Command key for pagination cursor storage */
 export const PAGINATION_KEY = "repo-list";
@@ -49,6 +52,7 @@ const repoListConfig: OrgListConfig<SentryRepository, RepositoryWithOrg> = {
   withOrg: (repo, orgSlug) => ({ ...repo, orgSlug }),
   displayTable: (repos: RepositoryWithOrg[]) =>
     formatTable(repos, REPO_COLUMNS),
+  schema: SentryRepositorySchema,
 };
 
 const docs: OrgListCommandDocs = {

--- a/src/commands/span/list.ts
+++ b/src/commands/span/list.ts
@@ -44,6 +44,7 @@ import {
   resolveTraceOrgProject,
   warnIfNormalized,
 } from "../../lib/trace-target.js";
+import { SpanListItemSchema } from "../../types/index.js";
 
 type ListFlags = {
   readonly limit: number;
@@ -454,6 +455,7 @@ export const listCommand = buildListCommand("span", {
   output: {
     human: formatSpanListHuman,
     jsonTransform: jsonTransformSpanList,
+    schema: SpanListItemSchema,
   },
   parameters: {
     positional: {

--- a/src/commands/team/list.ts
+++ b/src/commands/team/list.ts
@@ -22,7 +22,7 @@ import {
   type OrgListCommandDocs,
 } from "../../lib/list-command.js";
 import type { OrgListConfig } from "../../lib/org-list.js";
-import type { SentryTeam } from "../../types/index.js";
+import { type SentryTeam, SentryTeamSchema } from "../../types/index.js";
 
 /** Command key for pagination cursor storage */
 export const PAGINATION_KEY = "team-list";
@@ -53,6 +53,7 @@ const teamListConfig: OrgListConfig<SentryTeam, TeamWithOrg> = {
   withOrg: (team, orgSlug) => ({ ...team, orgSlug }),
   displayTable: (teams: TeamWithOrg[]) => formatTable(teams, TEAM_COLUMNS),
   listForProject: (org, project) => listProjectTeams(org, project),
+  schema: SentryTeamSchema,
 };
 
 const docs: OrgListCommandDocs = {

--- a/src/commands/trace/list.ts
+++ b/src/commands/trace/list.ts
@@ -25,7 +25,10 @@ import {
 } from "../../lib/list-command.js";
 import { withProgress } from "../../lib/polling.js";
 import { resolveOrgProjectFromArg } from "../../lib/resolve-target.js";
-import type { TransactionListItem } from "../../types/index.js";
+import {
+  type TransactionListItem,
+  TransactionListItemSchema,
+} from "../../types/index.js";
 
 type ListFlags = {
   readonly limit: number;
@@ -210,6 +213,7 @@ export const listCommand = buildListCommand("trace", {
   output: {
     human: formatTraceListHuman,
     jsonTransform: jsonTransformTraceList,
+    schema: TransactionListItemSchema,
   },
   parameters: {
     positional: {

--- a/src/commands/trial/list.ts
+++ b/src/commands/trial/list.ts
@@ -23,7 +23,11 @@ import {
   getTrialStatus,
   type TrialStatus,
 } from "../../lib/trials.js";
-import type { CustomerTrialInfo, Writer } from "../../types/index.js";
+import {
+  type CustomerTrialInfo,
+  ProductTrialSchema,
+  type Writer,
+} from "../../types/index.js";
 
 type ListFlags = {
   readonly json: boolean;
@@ -207,6 +211,7 @@ export const listCommand = buildCommand({
   output: {
     human: formatTrialListHuman,
     jsonExclude: ["displayName"],
+    schema: ProductTrialSchema,
   },
   parameters: {
     positional: {

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -44,6 +44,8 @@ import {
   ClearScreen,
   CommandOutput,
   type CommandReturn,
+  extractSchemaFields,
+  formatSchemaForHelp,
   type HumanRenderer,
   type OutputConfig,
   renderCommandOutput,
@@ -267,6 +269,52 @@ export function applyLoggingFlags(
  *   plus an optional `output` mode
  * @returns A fully-wrapped Stricli Command
  */
+
+/**
+ * Build the `--fields` flag definition, enriched with available field names
+ * when a schema is registered on the output config.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: OutputConfig type is erased at the builder level
+function buildFieldsFlag(outputConfig?: OutputConfig<any>) {
+  if (!outputConfig?.schema) {
+    return FIELDS_FLAG;
+  }
+  const schemaFields = extractSchemaFields(outputConfig.schema);
+  if (schemaFields.length === 0) {
+    return FIELDS_FLAG;
+  }
+  const fieldNames = schemaFields.map((f) => f.name).join(", ");
+  return {
+    ...FIELDS_FLAG,
+    brief: `${FIELDS_FLAG.brief}. Available: ${fieldNames}`,
+  };
+}
+
+/**
+ * Enrich command docs with a JSON fields section when a schema is registered.
+ * Appends available field names and types to `fullDescription` so they appear
+ * in Stricli's `--help` output.
+ */
+function enrichDocsWithSchema(
+  docs: CommandDocumentation,
+  // biome-ignore lint/suspicious/noExplicitAny: OutputConfig type is erased at the builder level
+  outputConfig?: OutputConfig<any>
+): CommandDocumentation {
+  if (!outputConfig?.schema) {
+    return docs;
+  }
+  const schemaFields = extractSchemaFields(outputConfig.schema);
+  if (schemaFields.length === 0) {
+    return docs;
+  }
+  const jsonFieldsDoc = formatSchemaForHelp(schemaFields);
+  const baseFull = docs.fullDescription ?? docs.brief;
+  return {
+    ...docs,
+    fullDescription: `${baseFull}\n\n${jsonFieldsDoc}`,
+  };
+}
+
 export function buildCommand<
   const FLAGS extends BaseFlags = NonNullable<unknown>,
   const ARGS extends BaseArgs = [],
@@ -303,9 +351,12 @@ export function buildCommand<
     if (!commandOwnsJson) {
       mergedFlags.json = JSON_FLAG;
     }
-    // --fields is always injected (no command defines its own)
-    mergedFlags.fields = FIELDS_FLAG;
+    mergedFlags.fields = buildFieldsFlag(outputConfig);
   }
+
+  // Enrich fullDescription with JSON fields when schema is registered.
+  // This makes field info visible in Stricli's --help output.
+  const enrichedDocs = enrichDocsWithSchema(builderArgs.docs, outputConfig);
 
   const mergedParams = { ...existingParams, flags: mergedFlags };
 
@@ -545,9 +596,20 @@ export function buildCommand<
   // hidden flags) and `func` (wrapping with telemetry/output logic),
   // which breaks the original FLAGS/ARGS type alignment that Stricli's
   // `CommandBuilderArguments` enforces via `NoInfer`.
-  return stricliCommand({
+  const cmd = stricliCommand({
     ...builderArgs,
+    docs: enrichedDocs,
     parameters: mergedParams,
     func: wrappedFunc,
   } as unknown as StricliBuilderArgs<CONTEXT>);
+
+  // Attach the JSON schema to the built command as a non-standard property.
+  // introspect.ts reads this to populate CommandInfo.jsonFields for help
+  // output and SKILL.md generation.
+  if (outputConfig?.schema) {
+    (cmd as unknown as Record<string, unknown>).__jsonSchema =
+      outputConfig.schema;
+  }
+
+  return cmd;
 }

--- a/src/lib/formatters/output.ts
+++ b/src/lib/formatters/output.ts
@@ -26,6 +26,7 @@
  * `formatHuman` — there is no divergent-data path.
  */
 
+import type { ZodType } from "zod";
 import type { Writer } from "../../types/index.js";
 import { plainSafeMuted } from "./human.js";
 import { formatJson, writeJson } from "./json.js";
@@ -158,6 +159,18 @@ export type OutputConfig<T> = {
    * When `jsonTransform` is set, `jsonExclude` is ignored.
    */
   jsonTransform?: (data: T, fields?: string[]) => unknown;
+  /**
+   * Zod schema describing the shape of JSON output (after transform/exclude).
+   *
+   * For list commands with {@link jsonTransform}, this should describe the
+   * **item** type (what `--fields` operates on), not the envelope.
+   *
+   * Used for:
+   * - `--help` output: appends available JSON fields to the command description
+   * - `sentry help <cmd>`: structured field documentation
+   * - `generate-skill.ts`: SKILL.md field tables for AI agents
+   */
+  schema?: ZodType;
 };
 
 /**
@@ -317,6 +330,133 @@ export function renderCommandOutput(
     const prefix = ctx.clearPrefix ?? "";
     stdout.write(`${prefix}${text}\n`);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Schema introspection
+// ---------------------------------------------------------------------------
+
+/**
+ * Field metadata extracted from a Zod schema for documentation.
+ *
+ * Populated by {@link extractSchemaFields} and consumed by:
+ * - `introspect.ts` → `CommandInfo.jsonFields`
+ * - `help.ts` → human help output
+ * - `generate-skill.ts` → SKILL.md field tables
+ */
+export type SchemaFieldInfo = {
+  /** Field name (top-level key in the JSON object) */
+  name: string;
+  /** Human-readable type string (e.g. "string", "number", "object", "string | null") */
+  type: string;
+  /** Description from `z.describe()` */
+  description?: string;
+  /** Whether the field is optional in the schema */
+  optional: boolean;
+};
+
+/**
+ * Map a Zod type's internal `typeName` to a human-readable string.
+ *
+ * Unwraps wrapper types (Optional, Nullable, Default) and builds a
+ * composite type string (e.g. "string | null" for ZodNullable<ZodString>).
+ */
+function zodTypeToString(schema: ZodType): { type: string; optional: boolean } {
+  const def = (schema as { _def?: { typeName?: string; innerType?: ZodType } })
+    ._def;
+  if (!def?.typeName) {
+    return { type: "unknown", optional: false };
+  }
+
+  // Unwrap wrapper types recursively
+  if (def.typeName === "ZodOptional" && def.innerType) {
+    const inner = zodTypeToString(def.innerType);
+    return { type: inner.type, optional: true };
+  }
+  if (def.typeName === "ZodNullable" && def.innerType) {
+    const inner = zodTypeToString(def.innerType);
+    const nullableType = inner.type.includes(" | null")
+      ? inner.type
+      : `${inner.type} | null`;
+    return { type: nullableType, optional: inner.optional };
+  }
+  if (def.typeName === "ZodDefault" && def.innerType) {
+    return zodTypeToString(def.innerType);
+  }
+
+  const TYPE_MAP: Record<string, string> = {
+    ZodString: "string",
+    ZodNumber: "number",
+    ZodBoolean: "boolean",
+    ZodObject: "object",
+    ZodArray: "array",
+    ZodUnknown: "unknown",
+    ZodAny: "any",
+    ZodEnum: "string",
+  };
+
+  return { type: TYPE_MAP[def.typeName] ?? "unknown", optional: false };
+}
+
+/**
+ * Extract field metadata from a Zod object schema.
+ *
+ * Returns an array of {@link SchemaFieldInfo} describing each top-level
+ * field's name, type, description, and optionality. Returns an empty
+ * array for non-object schemas.
+ *
+ * @param schema - A Zod schema (typically `z.object({...})`)
+ */
+export function extractSchemaFields(schema: ZodType): SchemaFieldInfo[] {
+  const def = (
+    schema as {
+      _def?: { typeName?: string };
+      shape?: Record<string, ZodType>;
+    }
+  )._def;
+
+  if (def?.typeName !== "ZodObject") {
+    return [];
+  }
+
+  const shape = (schema as { shape?: Record<string, ZodType> }).shape;
+  if (!shape) {
+    return [];
+  }
+
+  return Object.entries(shape).map(([name, fieldSchema]) => {
+    const { type, optional } = zodTypeToString(fieldSchema);
+    const fieldDef = (fieldSchema as { description?: string }).description;
+    return {
+      name,
+      type,
+      description: fieldDef,
+      optional,
+    };
+  });
+}
+
+/**
+ * Format schema fields as a help text block for `--help` output.
+ *
+ * Produces a compact field list like:
+ * ```
+ * JSON fields (use --json --fields to select):
+ *   id (string) — Numeric issue ID
+ *   count (string, optional) — Total event count
+ * ```
+ */
+export function formatSchemaForHelp(fields: SchemaFieldInfo[]): string {
+  if (fields.length === 0) {
+    return "";
+  }
+  const lines = ["JSON fields (use --json --fields to select):"];
+  for (const field of fields) {
+    const optStr = field.optional ? ", optional" : "";
+    const desc = field.description ? ` — ${field.description}` : "";
+    lines.push(`  ${field.name} (${field.type}${optStr})${desc}`);
+  }
+  return lines.join("\n");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/help.ts
+++ b/src/lib/help.ts
@@ -262,6 +262,16 @@ function formatCommandHuman(cmd: CommandInfo): string {
     }
   }
 
+  if (cmd.jsonFields && cmd.jsonFields.length > 0) {
+    lines.push("");
+    lines.push("  JSON fields (use --json --fields to select):");
+    for (const field of cmd.jsonFields) {
+      const optStr = field.optional ? ", optional" : "";
+      const desc = field.description ? ` — ${field.description}` : "";
+      lines.push(`    ${field.name} (${field.type}${optStr})${desc}`);
+    }
+  }
+
   return lines.join("\n");
 }
 

--- a/src/lib/introspect.ts
+++ b/src/lib/introspect.ts
@@ -10,6 +10,10 @@
  * for introspection and documentation generation.
  */
 
+import {
+  extractSchemaFields,
+  type SchemaFieldInfo,
+} from "./formatters/output.js";
 import { fuzzyMatch } from "./fuzzy.js";
 
 // ---------------------------------------------------------------------------
@@ -42,6 +46,12 @@ export type Command = {
     flags?: Record<string, FlagDef>;
     aliases?: Record<string, string>;
   };
+  /**
+   * JSON output schema attached by `buildCommand` when `output.schema` is set.
+   * Non-standard property — Stricli doesn't know about it, but introspection
+   * reads it to populate {@link CommandInfo.jsonFields}.
+   */
+  __jsonSchema?: import("zod").ZodType;
 };
 
 /** Positional parameter definitions — either fixed-length tuple or variadic array */
@@ -79,6 +89,8 @@ export type CommandInfo = {
   positional: string;
   aliases: Record<string, string>;
   examples: string[];
+  /** JSON output field metadata extracted from `OutputConfig.schema` */
+  jsonFields?: SchemaFieldInfo[];
 };
 
 /** Extracted metadata for a single flag */
@@ -215,6 +227,10 @@ export function buildCommandInfo(
   path: string,
   examples: string[] = []
 ): CommandInfo {
+  const jsonFields = cmd.__jsonSchema
+    ? extractSchemaFields(cmd.__jsonSchema)
+    : undefined;
+
   return {
     path,
     brief: cmd.brief,
@@ -223,6 +239,7 @@ export function buildCommandInfo(
     positional: getPositionalString(cmd.parameters.positional),
     aliases: cmd.parameters.aliases ?? {},
     examples,
+    jsonFields: jsonFields?.length ? jsonFields : undefined,
   };
 }
 

--- a/src/lib/list-command.ts
+++ b/src/lib/list-command.ts
@@ -609,6 +609,7 @@ export function buildOrgListCommand<TEntity, TWithOrg>(
       human: (result: ListResult<TWithOrg>) => formatListHuman(result, config),
       jsonTransform: (result: ListResult<TWithOrg>, fields?: string[]) =>
         jsonTransformListResult(result, fields),
+      schema: config.schema,
     } satisfies OutputConfig<ListResult<TWithOrg>>,
     parameters: {
       positional: LIST_TARGET_POSITIONAL,

--- a/src/lib/org-list.ts
+++ b/src/lib/org-list.ts
@@ -209,6 +209,13 @@ export type OrgListConfig<TEntity, TWithOrg> = ListCommandMeta & {
    *   project's parent org.
    */
   listForProject?: (orgSlug: string, projectSlug: string) => Promise<TEntity[]>;
+
+  /**
+   * Zod schema describing the JSON output shape of each list item.
+   * Forwarded to `OutputConfig.schema` by `buildOrgListCommand` so
+   * `--help`, `sentry help`, and SKILL.md can document available fields.
+   */
+  schema?: import("zod").ZodType;
 };
 
 /** Extract a specific variant from the {@link ParsedOrgProject} union by its `type` discriminant. */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -110,6 +110,7 @@ export {
   ProductTrialSchema,
   RegionSchema,
   RepositoryProviderSchema,
+  SentryIssueSchema,
   SentryLogSchema,
   SentryRepositorySchema,
   SentryTeamSchema,

--- a/src/types/sentry.ts
+++ b/src/types/sentry.ts
@@ -121,6 +121,75 @@ export type SentryIssue = Omit<Partial<SdkIssueDetail>, "metadata"> & {
   seerFixabilityScore?: number | null;
 };
 
+/**
+ * Zod schema describing the key fields of a {@link SentryIssue} for JSON output.
+ *
+ * This is a documentation-oriented schema — it describes the commonly-available
+ * fields that appear in `--json` output, used by the help system and SKILL.md
+ * generation to inform agents and users about available `--fields` selections.
+ *
+ * Not a validation schema — the actual API response may include additional
+ * SDK-derived fields not listed here. Fields listed as optional may still be
+ * present in most responses; optionality reflects the TypeScript type.
+ */
+export const SentryIssueSchema = z
+  .object({
+    id: z.string().describe("Numeric issue ID"),
+    shortId: z.string().describe("Human-readable short ID (e.g. PROJ-ABC)"),
+    title: z.string().describe("Issue title"),
+    culprit: z.string().optional().describe("Culprit string"),
+    count: z.string().optional().describe("Total event count"),
+    userCount: z.number().optional().describe("Number of affected users"),
+    firstSeen: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("First occurrence (ISO 8601)"),
+    lastSeen: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("Most recent occurrence (ISO 8601)"),
+    level: z.string().optional().describe("Severity level"),
+    status: z.string().optional().describe("Issue status"),
+    priority: z.string().optional().describe("Triage priority"),
+    platform: z.string().optional().describe("Platform"),
+    permalink: z.string().optional().describe("URL to the issue in Sentry"),
+    project: z
+      .object({
+        id: z.string(),
+        name: z.string(),
+        slug: z.string(),
+      })
+      .optional()
+      .describe("Project info"),
+    metadata: z
+      .object({
+        type: z.string().optional(),
+        value: z.string().optional(),
+        filename: z.string().optional(),
+        function: z.string().optional(),
+      })
+      .optional()
+      .describe("Issue metadata"),
+    assignedTo: z
+      .unknown()
+      .nullable()
+      .optional()
+      .describe("Assigned user or team"),
+    substatus: z.string().nullable().optional().describe("Issue substatus"),
+    isUnhandled: z
+      .boolean()
+      .optional()
+      .describe("Whether the issue is unhandled"),
+    seerFixabilityScore: z
+      .number()
+      .nullable()
+      .optional()
+      .describe("Seer AI fixability score (0-1)"),
+  })
+  .describe("Sentry issue");
+
 // Event
 
 /**
@@ -485,19 +554,29 @@ export type RequestEntry = {
 export const SentryLogSchema = z
   .object({
     /** Unique identifier for deduplication */
-    "sentry.item_id": z.string(),
+    "sentry.item_id": z.string().describe("Unique log entry ID"),
     /** ISO timestamp of the log entry */
-    timestamp: z.string(),
+    timestamp: z.string().describe("Log timestamp (ISO 8601)"),
     /** Nanosecond-precision timestamp for accurate ordering and filtering.
      * Coerced from string because the API may return large integers as strings
      * to avoid precision loss beyond Number.MAX_SAFE_INTEGER. */
-    timestamp_precise: z.coerce.number(),
+    timestamp_precise: z.coerce
+      .number()
+      .describe("Nanosecond-precision timestamp"),
     /** Log message content */
-    message: z.string().nullable().optional(),
+    message: z.string().nullable().optional().describe("Log message"),
     /** Log severity level (error, warning, info, debug, etc.) */
-    severity: z.string().nullable().optional(),
+    severity: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("Severity level (error, warning, info, debug)"),
     /** Trace ID for correlation with traces */
-    trace: z.string().nullable().optional(),
+    trace: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("Trace ID for correlation"),
   })
   .passthrough();
 
@@ -646,17 +725,17 @@ export type TraceLogsResponse = z.infer<typeof TraceLogsResponseSchema>;
 export const TransactionListItemSchema = z
   .object({
     /** Trace ID this transaction belongs to */
-    trace: z.string(),
+    trace: z.string().describe("Trace ID"),
     /** Event ID of the transaction */
-    id: z.string(),
+    id: z.string().describe("Event ID"),
     /** Transaction name (e.g., "GET /api/users") */
-    transaction: z.string(),
+    transaction: z.string().describe("Transaction name"),
     /** ISO timestamp of the transaction */
-    timestamp: z.string(),
+    timestamp: z.string().describe("Timestamp (ISO 8601)"),
     /** Transaction duration in milliseconds */
-    "transaction.duration": z.number(),
+    "transaction.duration": z.number().describe("Duration (ms)"),
     /** Project slug */
-    project: z.string(),
+    project: z.string().describe("Project slug"),
   })
   .passthrough();
 
@@ -678,15 +757,19 @@ export type TransactionsResponse = z.infer<typeof TransactionsResponseSchema>;
 /** A single span item from the EAP spans search endpoint */
 export const SpanListItemSchema = z
   .object({
-    id: z.string(),
-    parent_span: z.string().nullable().optional(),
-    "span.op": z.string().nullable().optional(),
-    description: z.string().nullable().optional(),
-    "span.duration": z.number().nullable().optional(),
-    timestamp: z.string(),
-    project: z.string(),
-    transaction: z.string().nullable().optional(),
-    trace: z.string(),
+    id: z.string().describe("Span ID"),
+    parent_span: z.string().nullable().optional().describe("Parent span ID"),
+    "span.op": z
+      .string()
+      .nullable()
+      .optional()
+      .describe("Span operation (e.g. http.client, db)"),
+    description: z.string().nullable().optional().describe("Span description"),
+    "span.duration": z.number().nullable().optional().describe("Duration (ms)"),
+    timestamp: z.string().describe("Timestamp (ISO 8601)"),
+    project: z.string().describe("Project slug"),
+    transaction: z.string().nullable().optional().describe("Transaction name"),
+    trace: z.string().describe("Trace ID"),
   })
   .passthrough();
 
@@ -719,16 +802,20 @@ export type RepositoryProvider = z.infer<typeof RepositoryProviderSchema>;
 export const SentryRepositorySchema = z
   .object({
     // Core identifiers (required)
-    id: z.string(),
-    name: z.string(),
-    url: z.string().nullable(),
-    provider: RepositoryProviderSchema,
-    status: z.string(),
+    id: z.string().describe("Repository ID"),
+    name: z.string().describe("Repository name"),
+    url: z.string().nullable().describe("Repository URL"),
+    provider: RepositoryProviderSchema.describe("Version control provider"),
+    status: z.string().describe("Integration status"),
     // Optional metadata
-    dateCreated: z.string().optional(),
-    integrationId: z.string().optional(),
-    externalSlug: z.string().nullable().optional(),
-    externalId: z.string().nullable().optional(),
+    dateCreated: z.string().optional().describe("Creation date (ISO 8601)"),
+    integrationId: z.string().optional().describe("Integration ID"),
+    externalSlug: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("External slug (e.g. org/repo)"),
+    externalId: z.string().nullable().optional().describe("External ID"),
   })
   .passthrough();
 
@@ -740,14 +827,18 @@ export type SentryRepository = z.infer<typeof SentryRepositorySchema>;
 export const SentryTeamSchema = z
   .object({
     // Core identifiers (required)
-    id: z.string(),
-    slug: z.string(),
-    name: z.string(),
+    id: z.string().describe("Team ID"),
+    slug: z.string().describe("Team slug"),
+    name: z.string().describe("Team name"),
     // Optional metadata
-    dateCreated: z.string().optional(),
-    isMember: z.boolean().optional(),
-    teamRole: z.string().nullable().optional(),
-    memberCount: z.number().optional(),
+    dateCreated: z.string().optional().describe("Creation date (ISO 8601)"),
+    isMember: z.boolean().optional().describe("Whether you are a member"),
+    teamRole: z
+      .string()
+      .nullable()
+      .optional()
+      .describe("Your role in the team"),
+    memberCount: z.number().optional().describe("Number of members"),
   })
   .passthrough();
 
@@ -758,17 +849,17 @@ export type SentryTeam = z.infer<typeof SentryTeamSchema>;
 /** A product trial from the customer endpoint */
 export const ProductTrialSchema = z.object({
   /** Trial category (e.g., "seerUsers", "seerAutofix") */
-  category: z.string(),
+  category: z.string().describe("Trial category (e.g. seerUsers, seerAutofix)"),
   /** ISO date when the trial started, null if not started */
-  startDate: z.string().nullable(),
+  startDate: z.string().nullable().describe("Start date (ISO 8601)"),
   /** ISO date when the trial ends, null if not started */
-  endDate: z.string().nullable(),
+  endDate: z.string().nullable().describe("End date (ISO 8601)"),
   /** Reason code for the trial */
-  reasonCode: z.number(),
+  reasonCode: z.number().describe("Reason code"),
   /** Whether the trial has been activated */
-  isStarted: z.boolean(),
+  isStarted: z.boolean().describe("Whether the trial has started"),
   /** Duration of the trial in days, null if unknown */
-  lengthDays: z.number().nullable(),
+  lengthDays: z.number().nullable().describe("Trial duration in days"),
 });
 
 export type ProductTrial = z.infer<typeof ProductTrialSchema>;


### PR DESCRIPTION
## Summary

- Adds optional `schema` field to `OutputConfig<T>` accepting a Zod schema that describes the JSON output shape
- When registered, the schema automatically enriches `--help` output and the `--fields` flag with available field names and types
- Exposes structured `jsonFields` on `CommandInfo` for `sentry help` and SKILL.md generation
- Creates `SentryIssueSchema` with 19 documented fields (id, shortId, title, count, userCount, firstSeen, lastSeen, status, priority, etc.)
- Registers schemas on all 7 list commands: issue, team, repo, trace, span, log, trial
- Updates agent guidance docs to mention available fields and warn against unnecessary `sentry api` fallbacks

## Motivation

Agents fall back to raw `sentry api` calls when they need fields like `count`, `userCount`, `firstSeen`, or `lastSeen` because the CLI doesn't document what `--json` returns. This makes the JSON output self-documenting through `--help`, `sentry help <cmd>`, and SKILL.md field tables.

Closes #566