### PR TITLE
refactor(event): replace "latest" magic string with @latest sentinel constant

### DIFF
--- a/src/commands/event/view.ts
+++ b/src/commands/event/view.ts
@@ -106,6 +106,12 @@ function jsonTransformEventView(
 const USAGE_HINT = "sentry event view <org>/<project> <event-id>";
 
 /**
+ * Sentinel eventId for "fetch the latest event for this issue."
+ * Uses the @-prefix convention from {@link IssueSelector} magic selectors.
+ */
+const LATEST_EVENT_SENTINEL = "@latest";
+
+/**
  * Parse a single positional arg for event view, handling issue short ID
  * detection both in bare form ("BRUNCHIE-APP-29") and org-prefixed form
  * ("figma/FULLSCREEN-2RN").
@@ -128,7 +134,7 @@ function parseSingleArg(arg: string): ParsedPositionalArgs {
       // Use "org/" (trailing slash) to signal OrgAll mode so downstream
       // parseOrgProjectArg interprets this as an org, not a project search.
       return {
-        eventId: "latest",
+        eventId: LATEST_EVENT_SENTINEL,
         targetArg: `${beforeSlash}/`,
         issueShortId: afterSlash,
       };
@@ -159,7 +165,7 @@ function parseSingleArg(arg: string): ParsedPositionalArgs {
   // Detect bare issue short ID passed as event ID (e.g., "BRUNCHIE-APP-29").
   if (!targetArg && looksLikeIssueShortId(eventId)) {
     return {
-      eventId: "latest",
+      eventId: LATEST_EVENT_SENTINEL,
       targetArg: undefined,
       issueShortId: eventId,
     };
@@ -222,9 +228,9 @@ export function parsePositionalArgs(args: string[]): ParsedPositionalArgs {
     }
     if (urlParsed.issueId) {
       // Issue URL without event ID — fetch the latest event for this issue.
-      // Use a placeholder eventId; the caller uses issueId to fetch via getLatestEvent.
+      // The caller uses issueId to fetch via getLatestEvent.
       return {
-        eventId: "latest",
+        eventId: LATEST_EVENT_SENTINEL,
         targetArg: `${urlParsed.org}/`,
         issueId: urlParsed.issueId,
       };
@@ -258,7 +264,7 @@ export function parsePositionalArgs(args: string[]): ParsedPositionalArgs {
   // are uppercase). The second arg is ignored since we fetch the latest event.
   if (looksLikeIssueShortId(first)) {
     return {
-      eventId: "latest",
+      eventId: LATEST_EVENT_SENTINEL,
       targetArg: undefined,
       issueShortId: first,
       warning: `'${first}' is an issue short ID, not a project slug. Ignoring second argument '${second}'.`,
@@ -593,7 +599,7 @@ async function resolveIssueShortcut(
 
     // When the user specified a specific event ID (SHORT-ID/EVENT-ID),
     // resolve the issue to get the project, then fetch the specific event.
-    if (eventId !== "latest") {
+    if (eventId !== LATEST_EVENT_SENTINEL) {
       const issue = await getIssueByShortId(resolved.org, issueShortId);
       const issueProject = issue.project?.slug;
       if (!issueProject) {
@@ -681,8 +687,8 @@ export const viewCommand = buildCommand({
     const parsed = parseOrgProjectArg(targetArg);
 
     // Handle issue-based shortcuts (issue URLs and short IDs) before
-    // normal event resolution. When eventId is "latest", fetches the
-    // latest event; otherwise fetches the specific event.
+    // normal event resolution. When eventId is LATEST_EVENT_SENTINEL,
+    // fetches the latest event; otherwise fetches the specific event.
     const issueShortcut = await resolveIssueShortcut({
       parsed,
       eventId,

--- a/test/commands/event/view.test.ts
+++ b/test/commands/event/view.test.ts
@@ -67,14 +67,14 @@ describe("parsePositionalArgs", () => {
 
     test("detects issue short ID and sets issueShortId", () => {
       const result = parsePositionalArgs(["BRUNCHIE-APP-29"]);
-      expect(result.eventId).toBe("latest");
+      expect(result.eventId).toBe("@latest");
       expect(result.targetArg).toBeUndefined();
       expect(result.issueShortId).toBe("BRUNCHIE-APP-29");
     });
 
     test("detects short issue ID like CLI-G", () => {
       const result = parsePositionalArgs(["CLI-G"]);
-      expect(result.eventId).toBe("latest");
+      expect(result.eventId).toBe("@latest");
       expect(result.issueShortId).toBe("CLI-G");
     });
 
@@ -86,7 +86,7 @@ describe("parsePositionalArgs", () => {
 
     test("detects org/ISSUE-SHORT-ID pattern (CLI-9K)", () => {
       const result = parsePositionalArgs(["figma/FULLSCREEN-2RN"]);
-      expect(result.eventId).toBe("latest");
+      expect(result.eventId).toBe("@latest");
       // Trailing slash signals OrgAll mode so downstream resolves org correctly
       expect(result.targetArg).toBe("figma/");
       expect(result.issueShortId).toBe("FULLSCREEN-2RN");
@@ -94,7 +94,7 @@ describe("parsePositionalArgs", () => {
 
     test("detects org/CLI-G pattern", () => {
       const result = parsePositionalArgs(["sentry/CLI-G"]);
-      expect(result.eventId).toBe("latest");
+      expect(result.eventId).toBe("@latest");
       expect(result.targetArg).toBe("sentry/");
       expect(result.issueShortId).toBe("CLI-G");
     });
@@ -128,7 +128,7 @@ describe("parsePositionalArgs", () => {
     test("org/SHORT-ID takes precedence over SHORT-ID/EVENT-ID", () => {
       // "figma/FULLSCREEN-2RN" → org + issue, not issue + event
       const result = parsePositionalArgs(["figma/FULLSCREEN-2RN"]);
-      expect(result.eventId).toBe("latest");
+      expect(result.eventId).toBe("@latest");
       expect(result.targetArg).toBe("figma/");
       expect(result.issueShortId).toBe("FULLSCREEN-2RN");
     });
@@ -169,7 +169,7 @@ describe("parsePositionalArgs", () => {
         "abc123def456",
       ]);
       expect(result.issueShortId).toBe("JAVASCRIPT-NUXT-52");
-      expect(result.eventId).toBe("latest");
+      expect(result.eventId).toBe("@latest");
       expect(result.targetArg).toBeUndefined();
       expect(result.warning).toContain("issue short ID");
     });
@@ -177,7 +177,7 @@ describe("parsePositionalArgs", () => {
     test("auto-redirects simple issue short ID like CAM-82X", () => {
       const result = parsePositionalArgs(["CAM-82X", "95fd7f5a"]);
       expect(result.issueShortId).toBe("CAM-82X");
-      expect(result.eventId).toBe("latest");
+      expect(result.eventId).toBe("@latest");
       expect(result.targetArg).toBeUndefined();
       expect(result.warning).toContain("issue short ID");
     });
@@ -304,7 +304,7 @@ describe("parsePositionalArgs", () => {
         "https://sentry.io/organizations/my-org/issues/32886/",
       ]);
       expect(result.issueId).toBe("32886");
-      expect(result.eventId).toBe("latest");
+      expect(result.eventId).toBe("@latest");
       expect(result.targetArg).toBe("my-org/");
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #574 — the bare string `"latest"` was used as a sentinel `eventId` value across 4 assignment sites and 1 comparison with no named constant.

Replaced with `LATEST_EVENT_SENTINEL = "@latest"`, using the `@`-prefix convention established by `IssueSelector` magic selectors (`@latest`, `@most_frequent`) in `arg-parsing.ts`.

## Changes

- `src/commands/event/view.ts`: Added `LATEST_EVENT_SENTINEL` constant, replaced all 5 occurrences + updated comment
- `test/commands/event/view.test.ts`: Updated 8 assertions to expect `"@latest"`