### PR TITLE
feat: AsyncIterable streaming support for library SDK

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -893,6 +893,9 @@ mock.module("./some-module", () => ({
 
 ### Architecture
 
+<!-- lore:019d2d10-671c-77d8-9dbc-c32d1604dcf7 -->
+* **AsyncIterable streaming for SDK implemented via AsyncChannel push/pull pattern**: \`src/lib/async-channel.ts\` provides a dual-queue channel: producer calls \`push()\`/\`close()\`/\`error()\`, consumer iterates via \`for await...of\`. \`break\` triggers \`onReturn\` callback for cleanup. \`executeWithStream()\` in \`sdk-invoke.ts\` runs the command in background, pipes \`captureObject\` calls to the channel, and returns the channel immediately. Streaming detection: \`hasStreamingFlag()\` checks for \`--refresh\`/\`--follow\`/\`-f\`. \`buildInvoker\` accepts \`meta.streaming\` flag; \`buildRunner\` auto-detects from args. Abort wiring: \`AbortController\` created per stream, signal placed on fake \`process.abortSignal\`, \`channel.onReturn\` calls \`controller.abort()\`. Both \`log/list.ts\` and \`dashboard/view.ts\` check \`this.process?.abortSignal\` alongside SIGINT. Codegen generates callable interface overloads for streaming commands.
+
 <!-- lore:019cbeba-e4d3-748c-ad50-fe3c3d5c0a0d -->
 * **Auth token env var override pattern: SENTRY\_AUTH\_TOKEN > SENTRY\_TOKEN > SQLite**: Auth in \`src/lib/db/auth.ts\` follows layered precedence: \`SENTRY\_AUTH\_TOKEN\` > \`SENTRY\_TOKEN\` > SQLite OAuth token. \`getEnvToken()\` trims env vars (empty/whitespace = unset). \`AuthSource\` tracks provenance. \`ENV\_SOURCE\_PREFIX = "env:"\` — use \`.length\` not hardcoded 4. Env tokens bypass refresh/expiry. \`isEnvTokenActive()\` guards auth commands. Logout must NOT clear stored auth when env token active. These functions stay in \`db/auth.ts\` despite not touching DB because they're tightly coupled with token retrieval.
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ Options (all optional):
 - `project` — Default project slug.
 - `text` — Return human-readable string instead of parsed JSON (affects `run()` only).
 - `cwd` — Working directory for DSN auto-detection. Defaults to `process.cwd()`.
+- `signal` — `AbortSignal` to cancel streaming commands (`--follow`, `--refresh`).
+
+Streaming commands return `AsyncIterable` — use `for await...of` and `break` to stop.
 
 Errors are thrown as `SentryError` with `.exitCode` and `.stderr`.
 

--- a/docs/src/content/docs/library-usage.md
+++ b/docs/src/content/docs/library-usage.md
@@ -151,6 +151,7 @@ const sdk = createSentrySDK({ token: "...", text: true, cwd: "/my/project" });
 | `project` | `string` | Auto-detected | Default project slug |
 | `text` | `boolean` | `false` | Return human-readable text instead of parsed JSON (`run()` only) |
 | `cwd` | `string` | `process.cwd()` | Working directory for DSN auto-detection |
+| `signal` | `AbortSignal` | — | Abort signal for cancelling streaming commands |
 
 ## Return Values
 
@@ -217,7 +218,49 @@ Calls should be sequential (awaited one at a time).
 - **Node.js >= 22** (required for `node:sqlite`)
 - Or **Bun** (any recent version)
 
-:::caution
-Streaming flags (`--refresh`, `--follow`) are not supported in library mode
-and will throw a `SentryError`. Use the CLI binary directly for live-streaming commands.
+## Streaming Commands
+
+Two commands support real-time streaming: `log list --follow` and `dashboard view --refresh`.
+When using streaming flags, methods return an `AsyncIterable` instead of a `Promise`:
+
+```typescript
+const sdk = createSentrySDK({ token: "sntrys_..." });
+
+// Stream logs as they arrive (polls every 5 seconds)
+for await (const log of sdk.log.list({ follow: "5", orgProject: "acme/backend" })) {
+  console.log(log);
+}
+
+// Auto-refresh dashboard (polls every 30 seconds)
+for await (const snapshot of sdk.run("dashboard", "view", "123", "--refresh", "30")) {
+  console.log(snapshot);
+}
+
+// Stop streaming by breaking out of the loop
+for await (const log of sdk.log.list({ follow: "2" })) {
+  if (someCondition) break; // Streaming stops immediately
+}
+```
+
+### Cancellation
+
+`break` in a `for await...of` loop immediately signals the streaming command to stop.
+You can also pass an `AbortSignal` via `SentryOptions` for programmatic cancellation:
+
+```typescript
+const controller = new AbortController();
+const sdk = createSentrySDK({ token: "...", signal: controller.signal });
+
+// Cancel after 30 seconds
+setTimeout(() => controller.abort(), 30_000);
+
+for await (const log of sdk.log.list({ follow: "5" })) {
+  console.log(log);
+}
+// Loop exits when signal fires
+```
+
+:::note
+Concurrent streaming calls are not supported. Each streaming invocation
+uses an isolated environment — only one can be active at a time.
 :::

--- a/script/bundle.ts
+++ b/script/bundle.ts
@@ -226,6 +226,14 @@ const CORE_DECLARATIONS = `export type SentryOptions = {
   text?: boolean;
   /** Working directory (affects DSN detection, project root). Defaults to process.cwd(). */
   cwd?: string;
+  /** AbortSignal to cancel streaming commands (e.g. log list --follow). */
+  signal?: AbortSignal;
+};
+
+export type AsyncChannel<T> = AsyncIterable<T> & {
+  push(value: T): void;
+  close(): void;
+  error(err: Error): void;
 };
 
 export declare class SentryError extends Error {
@@ -235,8 +243,8 @@ export declare class SentryError extends Error {
 }
 
 export declare function createSentrySDK(options?: SentryOptions): SentrySDK & {
-  /** Run an arbitrary CLI command (escape hatch). */
-  run(...args: string[]): Promise<unknown>;
+  /** Run an arbitrary CLI command (escape hatch). Streaming flags return AsyncIterable. */
+  run(...args: string[]): Promise<unknown> | AsyncIterable<unknown>;
 };
 
 export default createSentrySDK;

--- a/script/generate-sdk.ts
+++ b/script/generate-sdk.ts
@@ -34,10 +34,10 @@ const INTERNAL_FLAGS = new Set([
   "log-level",
   "verbose",
   "fields",
-  // Streaming flags produce infinite output — not supported in library mode
-  "refresh",
-  "follow",
 ]);
+
+/** Flags that trigger streaming mode — included in params but change return type */
+const STREAMING_FLAGS = new Set(["refresh", "follow"]);
 
 /** Regex for stripping angle-bracket/ellipsis decorators from placeholder names */
 const PLACEHOLDER_CLEAN_RE = /[<>.]/g;
@@ -341,13 +341,12 @@ function generateParamsInterface(
   return { name: interfaceName, code };
 }
 
-/** Generate the method body (invoke call) for a command. */
-function generateMethodBody(
+/** Build the flag object expression and positional expression for an invoke call. */
+function buildInvokeArgs(
   path: string[],
   positional: PositionalInfo,
-  flags: SdkFlagInfo[],
-  returnType: string
-): string {
+  flags: SdkFlagInfo[]
+): { flagObj: string; positionalExpr: string; pathStr: string } {
   const flagEntries = flags.map((f) => {
     const camel = camelCase(f.name);
     if (f.name !== camel) {
@@ -368,8 +367,65 @@ function generateMethodBody(
 
   const flagObj =
     flagEntries.length > 0 ? `{ ${flagEntries.join(", ")} }` : "{}";
+  const pathStr = JSON.stringify(path);
 
-  return `invoke<${returnType}>(${JSON.stringify(path)}, ${flagObj}, ${positionalExpr})`;
+  return { flagObj, positionalExpr, pathStr };
+}
+
+/**
+ * Generate the method body (invoke call) for a non-streaming command.
+ * Uses `as Promise<T>` to narrow the invoke union return type, since
+ * non-streaming calls never pass `meta.streaming` and always return a Promise.
+ */
+function generateMethodBody(
+  path: string[],
+  positional: PositionalInfo,
+  flags: SdkFlagInfo[],
+  returnType: string
+): string {
+  const { flagObj, positionalExpr, pathStr } = buildInvokeArgs(
+    path,
+    positional,
+    flags
+  );
+  return `invoke<${returnType}>(${pathStr}, ${flagObj}, ${positionalExpr}) as Promise<${returnType}>`;
+}
+
+/** Options for generating a streaming method body. */
+type StreamingMethodOpts = {
+  path: string[];
+  positional: PositionalInfo;
+  flags: SdkFlagInfo[];
+  returnType: string;
+  streamingFlagNames: string[];
+  indent: string;
+};
+
+/**
+ * Generate the method body for a streaming-capable command.
+ *
+ * Detects at runtime whether any streaming flag is present and passes
+ * `{ streaming: true }` to the invoker when it is.
+ */
+function generateStreamingMethodBody(opts: StreamingMethodOpts): string {
+  const { flagObj, positionalExpr, pathStr } = buildInvokeArgs(
+    opts.path,
+    opts.positional,
+    opts.flags
+  );
+
+  // Build the streaming condition: params?.follow !== undefined || params?.refresh !== undefined
+  const conditions = opts.streamingFlagNames
+    .map((name) => `params?.${camelCase(name)} !== undefined`)
+    .join(" || ");
+
+  const lines = [
+    "{",
+    `${opts.indent}    const streaming = ${conditions};`,
+    `${opts.indent}    return invoke<${opts.returnType}>(${pathStr}, ${flagObj}, ${positionalExpr}, { streaming });`,
+    `${opts.indent}  }`,
+  ];
+  return lines.join("\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -472,6 +528,12 @@ for (const { path, command } of allCommands) {
   const flags = extractSdkFlags(command);
   const positional = derivePositional(command);
 
+  // Detect streaming-capable commands
+  const streamingFlagNames = flags
+    .filter((f) => STREAMING_FLAGS.has(f.name))
+    .map((f) => f.name);
+  const isStreaming = streamingFlagNames.length > 0;
+
   // Generate return type from schema
   const schemaTypeName = `${buildTypeName(path)}Result`;
   const returnTypeInfo = generateReturnType(command, schemaTypeName);
@@ -493,6 +555,10 @@ for (const { path, command } of allCommands) {
   let paramsArg: string;
   let body: string;
 
+  const brief = command.brief || path.join(" ");
+  const methodName = path.at(-1) ?? path[0];
+  const indent = "    ".repeat(path.length - 1);
+
   if (hasVariadicPositional) {
     // Variadic: (params: XParams, ...positional: string[]) or (params?: XParams, ...positional: string[])
     // Required flags make params required even with variadic positionals
@@ -500,33 +566,76 @@ for (const { path, command } of allCommands) {
     paramsArg = params
       ? `params${paramsOpt}: ${params.name}, ...positional: string[]`
       : "...positional: string[]";
-    body = generateMethodBody(path, positional, flags, returnType);
+    body = isStreaming
+      ? generateStreamingMethodBody({
+          path,
+          positional,
+          flags,
+          returnType,
+          streamingFlagNames,
+          indent,
+        })
+      : generateMethodBody(path, positional, flags, returnType);
   } else if (params) {
     const paramsRequired = hasRequiredFlags;
     paramsArg = paramsRequired
       ? `params: ${params.name}`
       : `params?: ${params.name}`;
-    body = generateMethodBody(path, positional, flags, returnType);
+    body = isStreaming
+      ? generateStreamingMethodBody({
+          path,
+          positional,
+          flags,
+          returnType,
+          streamingFlagNames,
+          indent,
+        })
+      : generateMethodBody(path, positional, flags, returnType);
   } else {
     body = generateMethodBody(path, positional, flags, returnType);
     paramsArg = "";
   }
 
-  const brief = command.brief || path.join(" ");
-  const methodName = path.at(-1) ?? path[0];
-  const indent = "    ".repeat(path.length - 1);
   const sig = paramsArg ? `(${paramsArg})` : "()";
-  const methodCode = [
-    `${indent}    /** ${brief} */`,
-    `${indent}    ${methodName}: ${sig}: Promise<${returnType}> =>`,
-    `${indent}      ${body},`,
-  ].join("\n");
 
-  // Type declaration: method signature without implementation
-  const typeDecl = [
-    `${indent}    /** ${brief} */`,
-    `${indent}    ${methodName}${sig}: Promise<${returnType}>;`,
-  ].join("\n");
+  let methodCode: string;
+  let typeDecl: string;
+
+  if (isStreaming) {
+    // Streaming commands use a function body (not arrow expression)
+    // because they need runtime streaming detection
+    methodCode = [
+      `${indent}    /** ${brief} */`,
+      `${indent}    ${methodName}: ${sig} => ${body},`,
+    ].join("\n");
+
+    // Type declaration: callable interface with overloaded signatures
+    const streamingFlagTypes = streamingFlagNames.map((name) => {
+      const flag = flags.find((f) => f.name === name);
+      return `${camelCase(name)}: ${flag?.tsType ?? "string"}`;
+    });
+    const streamingConstraint = streamingFlagTypes.join("; ");
+
+    typeDecl = [
+      `${indent}    /** ${brief} */`,
+      `${indent}    ${methodName}: {`,
+      `${indent}      (params: ${params?.name ?? "Record<string, never>"} & { ${streamingConstraint} }): AsyncIterable<unknown>;`,
+      `${indent}      ${sig}: Promise<${returnType}>;`,
+      `${indent}    };`,
+    ].join("\n");
+  } else {
+    methodCode = [
+      `${indent}    /** ${brief} */`,
+      `${indent}    ${methodName}: ${sig}: Promise<${returnType}> =>`,
+      `${indent}      ${body},`,
+    ].join("\n");
+
+    // Type declaration: method signature without implementation
+    typeDecl = [
+      `${indent}    /** ${brief} */`,
+      `${indent}    ${methodName}${sig}: Promise<${returnType}>;`,
+    ].join("\n");
+  }
 
   insertMethod(root, path, methodCode, typeDecl);
 }

--- a/src/commands/dashboard/view.ts
+++ b/src/commands/dashboard/view.ts
@@ -219,6 +219,13 @@ export const viewCommand = buildCommand({
       const stop = () => controller.abort();
       process.once("SIGINT", stop);
 
+      // Library mode: honor external abort signal (e.g., consumer break)
+      const externalSignal = (this.process as { abortSignal?: AbortSignal })
+        ?.abortSignal;
+      if (externalSignal) {
+        externalSignal.addEventListener("abort", stop, { once: true });
+      }
+
       let isFirstRender = true;
 
       try {

--- a/src/commands/log/list.ts
+++ b/src/commands/log/list.ts
@@ -256,6 +256,11 @@ type FollowGeneratorConfig<T extends LogLike> = {
    * Use this to seed dedup state (e.g., tracking seen log IDs).
    */
   onInitialLogs?: (logs: T[]) => void;
+  /**
+   * External abort signal (library mode). When aborted, the follow
+   * generator stops on the next poll cycle. Complements SIGINT handling.
+   */
+  abortSignal?: AbortSignal;
 };
 
 /** Find the highest timestamp_precise in a batch, or undefined if none have it. */
@@ -343,10 +348,15 @@ async function* generateFollowLogs<T extends LogLike>(
   // timestamp_precise is nanoseconds; Date.now() is milliseconds → convert
   let lastTimestamp = Date.now() * 1_000_000;
 
-  // AbortController for clean SIGINT handling
+  // AbortController for clean SIGINT handling + library mode abort
   const controller = new AbortController();
   const stop = () => controller.abort();
   process.once("SIGINT", stop);
+
+  // Library mode: honor external abort signal (e.g., consumer break)
+  if (config.abortSignal) {
+    config.abortSignal.addEventListener("abort", stop, { once: true });
+  }
 
   try {
     // Initial fetch
@@ -695,6 +705,8 @@ export const listCommand = buildListCommand(
           const generator = generateFollowLogs({
             flags,
             onDiagnostic: (msg) => logger.warn(msg),
+            abortSignal: (this.process as { abortSignal?: AbortSignal })
+              ?.abortSignal,
             fetch: (statsPeriod) =>
               listTraceLogs(org, traceId, {
                 query: flags.query,
@@ -757,6 +769,8 @@ export const listCommand = buildListCommand(
           const generator = generateFollowLogs({
             flags,
             onDiagnostic: (msg) => logger.warn(msg),
+            abortSignal: (this.process as { abortSignal?: AbortSignal })
+              ?.abortSignal,
             fetch: (statsPeriod, afterTimestamp) =>
               listLogs(org, project, {
                 query: flags.query,

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@
 import { buildInvoker, buildRunner } from "./lib/sdk-invoke.js";
 import { createSDKMethods } from "./sdk.generated.js";
 
+export type { AsyncChannel } from "./lib/async-channel.js";
 // Re-export public types and error class from the shared module.
 // These re-exports exist to break a circular dependency between
 // index.ts ↔ sdk-invoke.ts. SentryError and SentryOptions live

--- a/src/lib/async-channel.ts
+++ b/src/lib/async-channel.ts
@@ -1,0 +1,135 @@
+/**
+ * Minimal push/pull async channel for streaming SDK results.
+ *
+ * Producer calls `push(value)` for each item, `close()` when done,
+ * or `error(err)` on failure. Consumer iterates with `for await...of`.
+ *
+ * Backpressure is not implemented — producers push freely. This is
+ * acceptable for streaming commands (bounded by poll interval).
+ *
+ * @module
+ */
+
+/** Options for creating an async channel. */
+export type AsyncChannelOptions = {
+  /**
+   * Called when the consumer calls `return()` on the iterator
+   * (e.g., `break` in a `for await...of` loop). Use this to signal
+   * the producer to stop.
+   */
+  onReturn?: () => void;
+};
+
+/**
+ * A push/pull async channel that implements `AsyncIterable<T>`.
+ *
+ * The producer side pushes values, the consumer side iterates.
+ * When the producer is done, it calls `close()`. On error, `error(err)`.
+ * Push after close is a silent no-op.
+ */
+export type AsyncChannel<T> = AsyncIterable<T> & {
+  /** Push a value to the consumer. Buffers if no one is waiting. No-op after close/error. */
+  push(value: T): void;
+  /** Signal normal completion. Consumer's next() returns { done: true }. */
+  close(): void;
+  /** Signal an error. Consumer's next() rejects with this error. */
+  error(err: Error): void;
+};
+
+/**
+ * Create a new async channel.
+ *
+ * Uses a dual-queue pattern: a buffer for values pushed before `next()`
+ * is called, and a pending resolver for when `next()` is called first.
+ */
+export function createAsyncChannel<T>(
+  options?: AsyncChannelOptions
+): AsyncChannel<T> {
+  const buffer: T[] = [];
+  let pending:
+    | {
+        resolve: (result: IteratorResult<T>) => void;
+        reject: (err: Error) => void;
+      }
+    | undefined;
+  let closed = false;
+  let errorValue: Error | undefined;
+
+  function push(value: T): void {
+    if (closed || errorValue) {
+      return;
+    }
+    if (pending) {
+      const p = pending;
+      pending = undefined;
+      p.resolve({ value, done: false });
+    } else {
+      buffer.push(value);
+    }
+  }
+
+  function close(): void {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    if (pending) {
+      const p = pending;
+      pending = undefined;
+      p.resolve({ value: undefined as T, done: true });
+    }
+  }
+
+  function error(err: Error): void {
+    if (closed || errorValue) {
+      return;
+    }
+    errorValue = err;
+    closed = true;
+    if (pending) {
+      const p = pending;
+      pending = undefined;
+      p.reject(err);
+    }
+  }
+
+  function next(): Promise<IteratorResult<T>> {
+    if (buffer.length > 0) {
+      const value = buffer.shift() as T;
+      return Promise.resolve({ value, done: false });
+    }
+    if (errorValue) {
+      return Promise.reject(errorValue);
+    }
+    if (closed) {
+      return Promise.resolve({ value: undefined as T, done: true });
+    }
+    return new Promise<IteratorResult<T>>((resolve, reject) => {
+      pending = { resolve, reject };
+    });
+  }
+
+  const iterator: AsyncIterator<T> = {
+    next,
+    return(): Promise<IteratorResult<T>> {
+      closed = true;
+      buffer.length = 0;
+      if (pending) {
+        const p = pending;
+        pending = undefined;
+        p.resolve({ value: undefined as T, done: true });
+      }
+      options?.onReturn?.();
+      return Promise.resolve({ value: undefined as T, done: true });
+    },
+  };
+
+  return {
+    push,
+    close,
+    error,
+    [Symbol.asyncIterator](): AsyncIterator<T> {
+      return iterator;
+    },
+  };
+}

--- a/src/lib/sdk-invoke.ts
+++ b/src/lib/sdk-invoke.ts
@@ -17,11 +17,17 @@
 import { homedir } from "node:os";
 import type { Span } from "@sentry/core";
 import type { Writer } from "../types/index.js";
+import { type AsyncChannel, createAsyncChannel } from "./async-channel.js";
 import { setEnv } from "./env.js";
 import { SentryError, type SentryOptions } from "./sdk-types.js";
 
-/** Flags that trigger infinite streaming — not supported in library mode. */
-const STREAMING_FLAGS = new Set(["--refresh", "--follow", "-f"]);
+/** CLI flag names/aliases that trigger infinite streaming output. */
+const STREAMING_FLAG_NAMES = new Set(["--refresh", "--follow", "-f"]);
+
+/** Check if CLI args contain any streaming flag. */
+function hasStreamingFlag(args: string[]): boolean {
+  return args.some((arg) => STREAMING_FLAG_NAMES.has(arg));
+}
 
 /**
  * Build an isolated env from options, inheriting the consumer's process.env.
@@ -166,22 +172,37 @@ type CaptureContext = {
   getCapturedResult: () => unknown;
 };
 
+/** Options for building a capture context. */
+type CaptureOptions = {
+  /** When set, captureObject pushes to this channel instead of accumulating. */
+  channel?: AsyncChannel<unknown>;
+  /** When set, placed on the fake process for streaming commands to honor. */
+  abortSignal?: AbortSignal;
+};
+
 /** Build output capture writers and a SentryContext-compatible context object. */
 async function buildCaptureContext(
   env: NodeJS.ProcessEnv,
-  cwd: string
+  cwd: string,
+  opts?: CaptureOptions
 ): Promise<CaptureContext> {
   const stdoutChunks: string[] = [];
   const stderrChunks: string[] = [];
   const capturedResults: unknown[] = [];
 
+  const captureObject = opts?.channel
+    ? (obj: unknown) => {
+        opts.channel?.push(obj);
+      }
+    : (obj: unknown) => {
+        capturedResults.push(obj);
+      };
+
   const stdout: Writer = {
     write: (s: string) => {
       stdoutChunks.push(s);
     },
-    captureObject: (obj: unknown) => {
-      capturedResults.push(obj);
-    },
+    captureObject,
   };
   const stderr: Writer = {
     write: (s: string) => {
@@ -191,15 +212,22 @@ async function buildCaptureContext(
 
   const { getConfigDir } = await import("./db/index.js");
 
+  // biome-ignore lint/suspicious/noExplicitAny: abortSignal is an internal extension to the fake process
+  const fakeProcess: any = {
+    stdout,
+    stderr,
+    stdin: process.stdin,
+    env,
+    cwd: () => cwd,
+    exitCode: 0,
+  };
+
+  if (opts?.abortSignal) {
+    fakeProcess.abortSignal = opts.abortSignal;
+  }
+
   const context = {
-    process: {
-      stdout,
-      stderr,
-      stdin: process.stdin,
-      env,
-      cwd: () => cwd,
-      exitCode: 0,
-    },
+    process: fakeProcess,
     stdout,
     stderr,
     stdin: process.stdin,
@@ -286,18 +314,118 @@ async function executeWithCapture<T>(
 }
 
 /**
+ * Streaming execution wrapper — runs the command in the background and
+ * returns an AsyncChannel that yields values as they arrive.
+ *
+ * An AbortController is created per call. Consumer `break` (iterator return)
+ * and `SentryOptions.signal` both cascade to the controller. The abort signal
+ * is placed on the fake process so streaming commands can honor it.
+ */
+function executeWithStream<T>(
+  options: SentryOptions | undefined,
+  executor: (
+    captureCtx: CaptureContext,
+    span: Span | undefined
+  ) => Promise<void>
+): AsyncChannel<T> {
+  const controller = new AbortController();
+
+  // Cascade external signal to our controller
+  if (options?.signal) {
+    if (options.signal.aborted) {
+      controller.abort();
+    } else {
+      options.signal.addEventListener("abort", () => controller.abort(), {
+        once: true,
+      });
+    }
+  }
+
+  const channel = createAsyncChannel<T>({
+    onReturn: () => controller.abort(),
+  });
+
+  // Fire-and-forget — command runs in background
+  (async () => {
+    const env = buildIsolatedEnv(options);
+    const cwd = options?.cwd ?? process.cwd();
+    setEnv(env);
+
+    let captureCtx: CaptureContext | undefined;
+    try {
+      captureCtx = await buildCaptureContext(env, cwd, {
+        channel: channel as AsyncChannel<unknown>,
+        abortSignal: controller.signal,
+      });
+
+      const { withTelemetry } = await import("./telemetry.js");
+
+      // biome-ignore lint/style/noNonNullAssertion: captureCtx is assigned on the line above
+      await withTelemetry(async (span) => executor(captureCtx!, span), {
+        libraryMode: true,
+      });
+
+      // Check exit code — Stricli sets it without throwing for some errors
+      if (captureCtx.context.process.exitCode !== 0) {
+        channel.error(
+          buildSdkError(
+            captureCtx.stderrChunks,
+            captureCtx.context.process.exitCode
+          )
+        );
+      } else {
+        channel.close();
+      }
+    } catch (thrown) {
+      const stderrChunks = captureCtx?.stderrChunks ?? [];
+      const exitCode =
+        extractExitCode(thrown) || captureCtx?.context.process.exitCode || 1;
+      const err =
+        thrown instanceof SentryError
+          ? thrown
+          : buildSdkError(stderrChunks, exitCode, thrown);
+      channel.error(err);
+    } finally {
+      await flushTelemetry();
+      setEnv(process.env);
+    }
+  })();
+
+  return channel;
+}
+
+/**
  * Build an invoker function bound to the given options.
  *
  * The invoker handles env isolation, context building, telemetry,
  * zero-copy capture, and error wrapping — used by the typed SDK methods.
+ *
+ * When `meta.streaming` is true, returns an AsyncIterable that yields
+ * values as the command produces them (for `--follow`/`--refresh` commands).
  */
 export function buildInvoker(options?: SentryOptions) {
-  return async function invokeCommand<T>(
+  return function invokeCommand<T>(
     commandPath: string[],
     flags: Record<string, unknown>,
-    positionalArgs: string[]
-  ): Promise<T> {
-    return await executeWithCapture<T>(options, async (ctx, span) => {
+    positionalArgs: string[],
+    meta?: { streaming?: boolean }
+  ): Promise<T> | AsyncIterable<T> {
+    if (meta?.streaming) {
+      return executeWithStream<T>(options, async (ctx, span) => {
+        const func = await resolveCommand(commandPath);
+        if (span) {
+          const { setCommandSpanName } = await import("./telemetry.js");
+          setCommandSpanName(span, commandPath.join("."));
+        }
+        await func.call(
+          ctx.context,
+          { ...flags, json: true },
+          ...positionalArgs
+        );
+      });
+    }
+
+    return executeWithCapture<T>(options, async (ctx, span) => {
       const func = await resolveCommand(commandPath);
       if (span) {
         const { setCommandSpanName } = await import("./telemetry.js");
@@ -316,25 +444,25 @@ export function buildInvoker(options?: SentryOptions) {
  * typed SDK methods (or for passing raw CLI flags).
  *
  * Returns parsed JSON by default, or trimmed text for commands
- * without JSON support.
- *
- * @throws {SentryError} When a streaming flag (`--refresh`, `--follow`, `-f`)
- *   is passed — streaming is not supported in library mode.
+ * without JSON support. When streaming flags are detected, returns
+ * an AsyncIterable instead.
  */
 export function buildRunner(options?: SentryOptions) {
-  return async function run(...args: string[]): Promise<unknown> {
-    // Reject streaming flags — they produce infinite output unsuitable for library mode
-    for (const arg of args) {
-      if (STREAMING_FLAGS.has(arg)) {
-        throw new SentryError(
-          `Streaming flag "${arg}" is not supported in library mode. Use the CLI directly for streaming commands.`,
-          1,
-          ""
-        );
-      }
+  return function run(
+    ...args: string[]
+  ): Promise<unknown> | AsyncIterable<unknown> {
+    if (hasStreamingFlag(args)) {
+      return executeWithStream<unknown>(options, async (ctx, span) => {
+        const { run: stricliRun } = await import("@stricli/core");
+        const { app } = await import("../app.js");
+        const { buildContext } = await import("../context.js");
+        // biome-ignore lint/suspicious/noExplicitAny: fakeProcess duck-types the process interface
+        const process_ = ctx.context.process as any;
+        await stricliRun(app, args, buildContext(process_, span));
+      });
     }
 
-    return await executeWithCapture<unknown>(options, async (ctx, span) => {
+    return executeWithCapture<unknown>(options, async (ctx, span) => {
       const { run: stricliRun } = await import("@stricli/core");
       const { app } = await import("../app.js");
       const { buildContext } = await import("../context.js");

--- a/src/lib/sdk-types.ts
+++ b/src/lib/sdk-types.ts
@@ -46,6 +46,14 @@ export type SentryOptions = {
    * Defaults to `process.cwd()`.
    */
   cwd?: string;
+
+  /**
+   * Abort signal for cancelling streaming commands.
+   * When aborted, streaming iterables stop on the next poll cycle.
+   * Consumer `break` in `for await...of` also triggers abort automatically.
+   * Has no effect on non-streaming (Promise-based) commands.
+   */
+  signal?: AbortSignal;
 };
 
 /**

--- a/test/lib/async-channel.test.ts
+++ b/test/lib/async-channel.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test";
+import { createAsyncChannel } from "../../src/lib/async-channel.js";
+
+describe("createAsyncChannel", () => {
+  test("push-then-pull: values are received in FIFO order", async () => {
+    const ch = createAsyncChannel<number>();
+    ch.push(1);
+    ch.push(2);
+    ch.push(3);
+    ch.close();
+
+    const results: number[] = [];
+    for await (const v of ch) {
+      results.push(v);
+    }
+    expect(results).toEqual([1, 2, 3]);
+  });
+
+  test("pull-then-push: next() resolves when value is pushed later", async () => {
+    const ch = createAsyncChannel<string>();
+    const iter = ch[Symbol.asyncIterator]();
+
+    // Start waiting before any value is pushed
+    const promise = iter.next();
+    ch.push("hello");
+
+    const result = await promise;
+    expect(result).toEqual({ value: "hello", done: false });
+  });
+
+  test("close: next() returns done after close", async () => {
+    const ch = createAsyncChannel<number>();
+    const iter = ch[Symbol.asyncIterator]();
+
+    ch.close();
+
+    const result = await iter.next();
+    expect(result.done).toBe(true);
+  });
+
+  test("close: pending next() resolves as done when close is called", async () => {
+    const ch = createAsyncChannel<number>();
+    const iter = ch[Symbol.asyncIterator]();
+
+    const promise = iter.next();
+    ch.close();
+
+    const result = await promise;
+    expect(result.done).toBe(true);
+  });
+
+  test("error: next() rejects after error", async () => {
+    const ch = createAsyncChannel<number>();
+    const iter = ch[Symbol.asyncIterator]();
+
+    const err = new Error("boom");
+    ch.error(err);
+
+    await expect(iter.next()).rejects.toThrow("boom");
+  });
+
+  test("error: pending next() rejects when error is called", async () => {
+    const ch = createAsyncChannel<number>();
+    const iter = ch[Symbol.asyncIterator]();
+
+    const promise = iter.next();
+    ch.error(new Error("fail"));
+
+    await expect(promise).rejects.toThrow("fail");
+  });
+
+  test("for-await-of: iterates buffered values then stops on close", async () => {
+    const ch = createAsyncChannel<string>();
+    ch.push("a");
+    ch.push("b");
+    ch.close();
+
+    const results: string[] = [];
+    for await (const v of ch) {
+      results.push(v);
+    }
+    expect(results).toEqual(["a", "b"]);
+  });
+
+  test("for-await-of: break triggers onReturn callback", async () => {
+    let returnCalled = false;
+    const ch = createAsyncChannel<number>({
+      onReturn: () => {
+        returnCalled = true;
+      },
+    });
+
+    ch.push(1);
+    ch.push(2);
+    ch.push(3);
+
+    for await (const _v of ch) {
+      break;
+    }
+
+    expect(returnCalled).toBe(true);
+  });
+
+  test("push after close is a silent no-op", async () => {
+    const ch = createAsyncChannel<number>();
+    ch.push(1);
+    ch.close();
+
+    // Should not throw
+    ch.push(2);
+    ch.push(3);
+
+    const results: number[] = [];
+    for await (const v of ch) {
+      results.push(v);
+    }
+    // Only the value pushed before close should appear
+    expect(results).toEqual([1]);
+  });
+
+  test("push after error is a silent no-op", async () => {
+    const ch = createAsyncChannel<number>();
+    const iter = ch[Symbol.asyncIterator]();
+
+    ch.error(new Error("oops"));
+
+    // Should not throw
+    ch.push(42);
+
+    await expect(iter.next()).rejects.toThrow("oops");
+  });
+
+  test("multiple close calls are idempotent", async () => {
+    const ch = createAsyncChannel<number>();
+    const iter = ch[Symbol.asyncIterator]();
+
+    ch.close();
+    ch.close();
+    ch.close();
+
+    const result = await iter.next();
+    expect(result.done).toBe(true);
+  });
+
+  test("interleaved push/pull: FIFO order preserved", async () => {
+    const ch = createAsyncChannel<number>();
+    const iter = ch[Symbol.asyncIterator]();
+
+    ch.push(1);
+    const r1 = await iter.next();
+    expect(r1).toEqual({ value: 1, done: false });
+
+    ch.push(2);
+    const r2 = await iter.next();
+    expect(r2).toEqual({ value: 2, done: false });
+
+    ch.push(3);
+    ch.push(4);
+    const r3 = await iter.next();
+    const r4 = await iter.next();
+    expect(r3).toEqual({ value: 3, done: false });
+    expect(r4).toEqual({ value: 4, done: false });
+  });
+
+  test("return() clears buffer and marks as done", async () => {
+    const ch = createAsyncChannel<number>();
+    const iter = ch[Symbol.asyncIterator]();
+
+    ch.push(1);
+    ch.push(2);
+
+    const result = await iter.return!();
+    expect(result.done).toBe(true);
+
+    // Subsequent next() also returns done
+    const after = await iter.next();
+    expect(after.done).toBe(true);
+  });
+
+  test("for-await-of with error throws inside loop", async () => {
+    const ch = createAsyncChannel<number>();
+    ch.push(1);
+
+    const results: number[] = [];
+    await expect(async () => {
+      for await (const v of ch) {
+        results.push(v);
+        if (v === 1) {
+          // Simulate producer error after first value is consumed
+          ch.error(new Error("stream failed"));
+        }
+      }
+    }).toThrow("stream failed");
+
+    expect(results).toEqual([1]);
+  });
+});

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -88,37 +88,22 @@ describe("createSentrySDK() library API", () => {
     { timeout: 15_000 }
   );
 
-  test("sdk.run rejects streaming flag --follow", async () => {
+  test("sdk.run returns AsyncIterable for streaming flag --follow", () => {
     const sdk = createSentrySDK();
-    try {
-      await sdk.run("log", "list", "--follow");
-      expect.unreachable("Should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(SentryError);
-      expect((err as SentryError).message).toContain("--follow");
-      expect((err as SentryError).message).toContain("not supported");
-    }
+    const result = sdk.run("log", "list", "--follow");
+    // Streaming flags return an AsyncIterable, not a Promise
+    expect(Symbol.asyncIterator in (result as object)).toBe(true);
   });
 
-  test("sdk.run rejects streaming flag --refresh", async () => {
+  test("sdk.run returns AsyncIterable for streaming flag --refresh", () => {
     const sdk = createSentrySDK();
-    try {
-      await sdk.run("issue", "list", "--refresh");
-      expect.unreachable("Should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(SentryError);
-      expect((err as SentryError).message).toContain("--refresh");
-    }
+    const result = sdk.run("issue", "list", "--refresh");
+    expect(Symbol.asyncIterator in (result as object)).toBe(true);
   });
 
-  test("sdk.run rejects streaming short flag -f", async () => {
+  test("sdk.run returns AsyncIterable for streaming short flag -f", () => {
     const sdk = createSentrySDK();
-    try {
-      await sdk.run("log", "list", "-f");
-      expect.unreachable("Should have thrown");
-    } catch (err) {
-      expect(err).toBeInstanceOf(SentryError);
-      expect((err as SentryError).message).toContain("-f");
-    }
+    const result = sdk.run("log", "list", "-f");
+    expect(Symbol.asyncIterator in (result as object)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Streaming commands (`log list --follow`, `dashboard view --refresh`) now return `AsyncIterable` instead of throwing in library mode
- Consumer `break` and `AbortSignal` both wire through to command abort for clean shutdown
- New `AsyncChannel<T>` primitive bridges command generators with consumer iteration

## Consumer API

```typescript
const sdk = createSentrySDK({ token: "sntrys_..." });

// Streaming — returns AsyncIterable
for await (const log of sdk.log.list({ follow: "5", orgProject: "acme/backend" })) {
  console.log(log);
}

// Stop by breaking (triggers immediate abort)
for await (const log of sdk.log.list({ follow: "2" })) {
  if (done) break;
}

// External cancellation via AbortSignal
const controller = new AbortController();
const sdk2 = createSentrySDK({ signal: controller.signal });
setTimeout(() => controller.abort(), 30_000);
for await (const log of sdk2.log.list({ follow: "5" })) {
  console.log(log);
}
```

## Changes

- **`src/lib/async-channel.ts`** (new) — Push/pull async channel with dual-queue pattern
- **`src/lib/sdk-invoke.ts`** — New `executeWithStream<T>()` parallel to `executeWithCapture<T>()`; `buildRunner`/`buildInvoker` branch on streaming flag detection
- **`src/lib/sdk-types.ts`** — Added `signal?: AbortSignal` to `SentryOptions`
- **`src/commands/log/list.ts`** — Thread `abortSignal` through `FollowGeneratorConfig` for library mode abort
- **`src/commands/dashboard/view.ts`** — Honor external `abortSignal` in refresh loop
- **`script/generate-sdk.ts`** — Streaming flags moved from `INTERNAL_FLAGS` to `STREAMING_FLAGS`; generates overloaded type signatures (`Promise<T>` vs `AsyncIterable<unknown>`)
- **`script/bundle.ts`** — Added `signal` to npm type declarations + `AsyncChannel` type export
- **Docs** — Streaming section in library-usage.md, `signal` option in README

## Tests

- 14 new async-channel unit tests (push/pull, close, error, for-await, break/return, interleaved)
- 3 updated SDK tests (streaming flags now return AsyncIterable instead of throwing)
- All 4349 unit tests pass (2 pre-existing failures in upgrade tests)

Closes #585