### PR TITLE
fix(dashboard): show actionable error messages instead of raw API errors

### DIFF
--- a/src/commands/dashboard/create.ts
+++ b/src/commands/dashboard/create.ts
@@ -24,6 +24,7 @@ import {
 import { buildDashboardUrl } from "../../lib/sentry-urls.js";
 import { setOrgProjectContext } from "../../lib/telemetry.js";
 import type { DashboardDetail } from "../../types/dashboard.js";
+import { enrichDashboardError } from "./resolve.js";
 
 type CreateFlags = {
   readonly json: boolean;
@@ -170,7 +171,9 @@ export const createCommand = buildCommand({
       title,
       widgets: [],
       projects: projectIds.length > 0 ? projectIds : undefined,
-    });
+    }).catch((error: unknown) =>
+      enrichDashboardError(error, { orgSlug, operation: "create" })
+    );
     const url = buildDashboardUrl(orgSlug, dashboard.id);
 
     yield new CommandOutput({ ...dashboard, url } as CreateResult);

--- a/src/commands/dashboard/list.ts
+++ b/src/commands/dashboard/list.ts
@@ -36,7 +36,11 @@ import {
 } from "../../lib/sentry-urls.js";
 import type { DashboardListItem } from "../../types/dashboard.js";
 import type { Writer } from "../../types/index.js";
-import { parseDashboardListArgs, resolveOrgFromTarget } from "./resolve.js";
+import {
+  enrichDashboardError,
+  parseDashboardListArgs,
+  resolveOrgFromTarget,
+} from "./resolve.js";
 
 /** Command key for pagination cursor storage */
 export const PAGINATION_KEY = "dashboard-list";
@@ -456,6 +460,8 @@ export const listCommand = buildListCommand("dashboard", {
           afterId,
           glob,
         })
+    ).catch((error: unknown) =>
+      enrichDashboardError(error, { orgSlug, operation: "list" })
     );
 
     // Advance the pagination cursor stack

--- a/src/commands/dashboard/resolve.ts
+++ b/src/commands/dashboard/resolve.ts
@@ -11,7 +11,12 @@ import {
   listDashboardsPaginated,
 } from "../../lib/api-client.js";
 import type { parseOrgProjectArg } from "../../lib/arg-parsing.js";
-import { ContextError, ValidationError } from "../../lib/errors.js";
+import {
+  ApiError,
+  ContextError,
+  ResolutionError,
+  ValidationError,
+} from "../../lib/errors.js";
 import { fuzzyMatch } from "../../lib/fuzzy.js";
 import { resolveOrg } from "../../lib/resolve-target.js";
 import { setOrgProjectContext } from "../../lib/telemetry.js";
@@ -232,7 +237,9 @@ export async function resolveDashboardId(
     const { data, nextCursor } = await listDashboardsPaginated(orgSlug, {
       perPage: API_MAX_PER_PAGE,
       cursor,
-    });
+    }).catch((error: unknown) =>
+      enrichDashboardError(error, { orgSlug, operation: "list" })
+    );
     // Match by ID/slug first (e.g. "default-overview"), then fall back to title
     const match =
       data.find((d) => d.id.toLowerCase() === lowerRef) ??
@@ -356,6 +363,115 @@ export function buildWidgetFromFlags(opts: {
     ...(opts.limit !== undefined && { limit: opts.limit }),
   };
   return prepareWidgetQueries(parseWidgetInput(raw));
+}
+
+/** Context for enriching dashboard API errors with actionable messages */
+export type DashboardErrorContext = {
+  /** Organization slug (when known) */
+  orgSlug?: string;
+  /** Dashboard ID (when known) */
+  dashboardId?: string;
+  /** The operation being performed, for error messages */
+  operation: "list" | "view" | "create" | "update";
+};
+
+/** Build an enriched error for a 404 response on a dashboard API call */
+function build404Error(ctx: DashboardErrorContext, org: string): never {
+  if (ctx.operation === "list") {
+    throw new ResolutionError(
+      `Organization ${org}`,
+      "not found or has no dashboards",
+      "sentry dashboard list <org>/",
+      [
+        "Verify the organization slug with: sentry org list",
+        "Check that you have access to the organization",
+      ]
+    );
+  }
+  const listHint = `sentry dashboard list ${ctx.orgSlug ?? "<org>"}/`;
+  if (ctx.dashboardId) {
+    throw new ResolutionError(
+      `Dashboard ${ctx.dashboardId} in ${org}`,
+      "not found",
+      listHint,
+      [
+        "The dashboard may have been deleted",
+        "Check the dashboard ID or title with: sentry dashboard list",
+      ]
+    );
+  }
+  // Generic 404 for create or other operations
+  throw new ResolutionError(
+    `Organization ${org}`,
+    "not found",
+    "sentry org list",
+    ["Verify the organization slug and your access"]
+  );
+}
+
+/** Build an enriched error for a 403 response on a dashboard API call */
+function build403Error(
+  ctx: DashboardErrorContext,
+  org: string,
+  detail: string | undefined
+): never {
+  const message = detail ?? "You do not have permission.";
+  if (ctx.dashboardId) {
+    throw new ResolutionError(
+      `Dashboard ${ctx.dashboardId} in ${org}`,
+      "access denied",
+      `sentry dashboard list ${ctx.orgSlug ?? "<org>"}/`,
+      [message, "Check your organization membership and role"]
+    );
+  }
+  throw new ResolutionError(
+    `Dashboards in ${org}`,
+    "access denied",
+    "sentry org list",
+    [message, "Check your organization membership and role"]
+  );
+}
+
+/**
+ * Enrich an API error from a dashboard command with actionable suggestions.
+ *
+ * Catches 404, 403, and 400 errors and converts them to `ResolutionError`
+ * or enriched `ApiError` instances with hints about what to try next.
+ * Re-throws non-`ApiError` and unhandled statuses unchanged.
+ *
+ * @param error - The caught error
+ * @param ctx - Context about the operation for building error messages
+ */
+export function enrichDashboardError(
+  error: unknown,
+  ctx: DashboardErrorContext
+): never {
+  if (!(error instanceof ApiError)) {
+    throw error;
+  }
+
+  const org = ctx.orgSlug ? `'${ctx.orgSlug}'` : "this organization";
+
+  if (error.status === 404) {
+    build404Error(ctx, org);
+  }
+
+  if (error.status === 403) {
+    build403Error(ctx, org, error.detail);
+  }
+
+  // 400 on update — likely invalid widget config; preserve API detail
+  if (error.status === 400 && ctx.operation === "update") {
+    throw new ApiError(
+      `Dashboard update failed in ${org}`,
+      error.status,
+      error.detail ??
+        "The API rejected the request. Check widget configuration.",
+      error.endpoint
+    );
+  }
+
+  throw error;
 }
 
 /**

--- a/src/commands/dashboard/view.ts
+++ b/src/commands/dashboard/view.ts
@@ -27,6 +27,7 @@ import type {
   WidgetDataResult,
 } from "../../types/dashboard.js";
 import {
+  enrichDashboardError,
   parseDashboardPositionalArgs,
   resolveDashboardId,
   resolveOrgFromTarget,
@@ -200,6 +201,12 @@ export const viewCommand = buildCommand({
     const dashboard = await withProgress(
       { message: "Fetching dashboard...", json: flags.json },
       () => getDashboard(orgSlug, dashboardId)
+    ).catch((error: unknown) =>
+      enrichDashboardError(error, {
+        orgSlug,
+        dashboardId,
+        operation: "view",
+      })
     );
 
     const regionUrl = await resolveOrgRegion(orgSlug);

--- a/src/commands/dashboard/widget/add.ts
+++ b/src/commands/dashboard/widget/add.ts
@@ -20,6 +20,7 @@ import {
 } from "../../../types/dashboard.js";
 import {
   buildWidgetFromFlags,
+  enrichDashboardError,
   parseDashboardPositionalArgs,
   resolveDashboardId,
   resolveOrgFromTarget,
@@ -187,12 +188,25 @@ export const addCommand = buildCommand({
     });
 
     // GET current dashboard → append widget with auto-layout → PUT
-    const current = await getDashboard(orgSlug, dashboardId);
+    const current = await getDashboard(orgSlug, dashboardId).catch(
+      (error: unknown) =>
+        enrichDashboardError(error, { orgSlug, dashboardId, operation: "view" })
+    );
     const updateBody = prepareDashboardForUpdate(current);
     newWidget = assignDefaultLayout(newWidget, updateBody.widgets);
     updateBody.widgets.push(newWidget);
 
-    const updated = await updateDashboard(orgSlug, dashboardId, updateBody);
+    const updated = await updateDashboard(
+      orgSlug,
+      dashboardId,
+      updateBody
+    ).catch((error: unknown) =>
+      enrichDashboardError(error, {
+        orgSlug,
+        dashboardId,
+        operation: "update",
+      })
+    );
     const url = buildDashboardUrl(orgSlug, dashboardId);
 
     yield new CommandOutput({

--- a/src/commands/dashboard/widget/delete.ts
+++ b/src/commands/dashboard/widget/delete.ts
@@ -17,6 +17,7 @@ import {
   prepareDashboardForUpdate,
 } from "../../../types/dashboard.js";
 import {
+  enrichDashboardError,
   parseDashboardPositionalArgs,
   resolveDashboardId,
   resolveOrgFromTarget,
@@ -95,7 +96,10 @@ export const deleteCommand = buildCommand({
     const dashboardId = await resolveDashboardId(orgSlug, dashboardRef);
 
     // GET current dashboard → find widget → splice → PUT
-    const current = await getDashboard(orgSlug, dashboardId);
+    const current = await getDashboard(orgSlug, dashboardId).catch(
+      (error: unknown) =>
+        enrichDashboardError(error, { orgSlug, dashboardId, operation: "view" })
+    );
     const widgets = current.widgets ?? [];
 
     const widgetIndex = resolveWidgetIndex(widgets, flags.index, flags.title);
@@ -104,7 +108,17 @@ export const deleteCommand = buildCommand({
     const updateBody = prepareDashboardForUpdate(current);
     updateBody.widgets.splice(widgetIndex, 1);
 
-    const updated = await updateDashboard(orgSlug, dashboardId, updateBody);
+    const updated = await updateDashboard(
+      orgSlug,
+      dashboardId,
+      updateBody
+    ).catch((error: unknown) =>
+      enrichDashboardError(error, {
+        orgSlug,
+        dashboardId,
+        operation: "update",
+      })
+    );
     const url = buildDashboardUrl(orgSlug, dashboardId);
 
     yield new CommandOutput({

--- a/src/commands/dashboard/widget/edit.ts
+++ b/src/commands/dashboard/widget/edit.ts
@@ -24,6 +24,7 @@ import {
   validateAggregateNames,
 } from "../../../types/dashboard.js";
 import {
+  enrichDashboardError,
   parseDashboardPositionalArgs,
   resolveDashboardId,
   resolveOrgFromTarget,
@@ -246,7 +247,10 @@ export const editCommand = buildCommand({
     const dashboardId = await resolveDashboardId(orgSlug, dashboardRef);
 
     // GET current dashboard → find widget → merge changes → PUT
-    const current = await getDashboard(orgSlug, dashboardId);
+    const current = await getDashboard(orgSlug, dashboardId).catch(
+      (error: unknown) =>
+        enrichDashboardError(error, { orgSlug, dashboardId, operation: "view" })
+    );
     const widgets = current.widgets ?? [];
     const widgetIndex = resolveWidgetIndex(widgets, flags.index, flags.title);
 
@@ -255,7 +259,17 @@ export const editCommand = buildCommand({
     const replacement = buildReplacement(flags, existing);
     updateBody.widgets[widgetIndex] = replacement;
 
-    const updated = await updateDashboard(orgSlug, dashboardId, updateBody);
+    const updated = await updateDashboard(
+      orgSlug,
+      dashboardId,
+      updateBody
+    ).catch((error: unknown) =>
+      enrichDashboardError(error, {
+        orgSlug,
+        dashboardId,
+        operation: "update",
+      })
+    );
     const url = buildDashboardUrl(orgSlug, dashboardId);
 
     yield new CommandOutput({

--- a/test/commands/dashboard/resolve.test.ts
+++ b/test/commands/dashboard/resolve.test.ts
@@ -7,6 +7,7 @@
 
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import {
+  enrichDashboardError,
   parseDashboardListArgs,
   parseDashboardPositionalArgs,
   resolveDashboardId,
@@ -15,7 +16,12 @@ import {
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as apiClient from "../../../src/lib/api-client.js";
 import { parseOrgProjectArg } from "../../../src/lib/arg-parsing.js";
-import { ContextError, ValidationError } from "../../../src/lib/errors.js";
+import {
+  ApiError,
+  ContextError,
+  ResolutionError,
+  ValidationError,
+} from "../../../src/lib/errors.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as resolveTarget from "../../../src/lib/resolve-target.js";
 
@@ -354,5 +360,151 @@ describe("resolveOrgFromTarget", () => {
     await expect(
       resolveOrgFromTarget(parsed, "/tmp", "sentry dashboard view")
     ).rejects.toThrow(ContextError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enrichDashboardError
+// ---------------------------------------------------------------------------
+
+describe("enrichDashboardError", () => {
+  test("re-throws non-ApiError unchanged", () => {
+    const original = new Error("network failure");
+    expect(() =>
+      enrichDashboardError(original, { orgSlug: "my-org", operation: "list" })
+    ).toThrow(original);
+  });
+
+  test("re-throws ApiError with unhandled status unchanged", () => {
+    const original = new ApiError("rate limited", 429, "Too many requests");
+    expect(() =>
+      enrichDashboardError(original, { orgSlug: "my-org", operation: "list" })
+    ).toThrow(ApiError);
+    try {
+      enrichDashboardError(original, { orgSlug: "my-org", operation: "list" });
+    } catch (error) {
+      expect(error).toBe(original);
+    }
+  });
+
+  // -- 404 errors --
+
+  test("404 on list throws ResolutionError mentioning org", () => {
+    const apiErr = new ApiError("Not Found", 404);
+    try {
+      enrichDashboardError(apiErr, { orgSlug: "my-org", operation: "list" });
+      expect.unreachable("Should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ResolutionError);
+      const msg = (error as ResolutionError).message;
+      expect(msg).toContain("'my-org'");
+      expect(msg).toContain("not found");
+      expect(msg).toContain("sentry dashboard list");
+      expect(msg).toContain("sentry org list");
+    }
+  });
+
+  test("404 on view with dashboardId throws ResolutionError for dashboard", () => {
+    const apiErr = new ApiError("Not Found", 404);
+    try {
+      enrichDashboardError(apiErr, {
+        orgSlug: "my-org",
+        dashboardId: "12345",
+        operation: "view",
+      });
+      expect.unreachable("Should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ResolutionError);
+      const msg = (error as ResolutionError).message;
+      expect(msg).toContain("Dashboard 12345");
+      expect(msg).toContain("'my-org'");
+      expect(msg).toContain("not found");
+      expect(msg).toContain("sentry dashboard list");
+    }
+  });
+
+  test("404 on create without dashboardId throws ResolutionError for org", () => {
+    const apiErr = new ApiError("Not Found", 404);
+    try {
+      enrichDashboardError(apiErr, { orgSlug: "bad-org", operation: "create" });
+      expect.unreachable("Should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ResolutionError);
+      const msg = (error as ResolutionError).message;
+      expect(msg).toContain("'bad-org'");
+      expect(msg).toContain("not found");
+    }
+  });
+
+  // -- 403 errors --
+
+  test("403 with dashboardId throws ResolutionError for dashboard access", () => {
+    const apiErr = new ApiError("Forbidden", 403, "No permission");
+    try {
+      enrichDashboardError(apiErr, {
+        orgSlug: "my-org",
+        dashboardId: "99",
+        operation: "view",
+      });
+      expect.unreachable("Should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ResolutionError);
+      const msg = (error as ResolutionError).message;
+      expect(msg).toContain("Dashboard 99");
+      expect(msg).toContain("access denied");
+      expect(msg).toContain("No permission");
+    }
+  });
+
+  test("403 without dashboardId throws ResolutionError for org dashboards", () => {
+    const apiErr = new ApiError("Forbidden", 403);
+    try {
+      enrichDashboardError(apiErr, { orgSlug: "my-org", operation: "list" });
+      expect.unreachable("Should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ResolutionError);
+      const msg = (error as ResolutionError).message;
+      expect(msg).toContain("Dashboards in 'my-org'");
+      expect(msg).toContain("access denied");
+    }
+  });
+
+  test("403 includes default detail when API provides none", () => {
+    const apiErr = new ApiError("Forbidden", 403);
+    try {
+      enrichDashboardError(apiErr, { orgSlug: "my-org", operation: "list" });
+      expect.unreachable("Should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ResolutionError);
+      const msg = (error as ResolutionError).message;
+      expect(msg).toContain("You do not have permission.");
+    }
+  });
+
+  // -- 400 errors --
+
+  test("400 on update throws enriched ApiError with dashboard context", () => {
+    const apiErr = new ApiError("Bad Request", 400, "Invalid widget config");
+    try {
+      enrichDashboardError(apiErr, {
+        orgSlug: "my-org",
+        dashboardId: "42",
+        operation: "update",
+      });
+      expect.unreachable("Should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      const msg = (error as ApiError).message;
+      expect(msg).toContain("Dashboard update failed");
+      expect(msg).toContain("'my-org'");
+      expect((error as ApiError).detail).toContain("Invalid widget config");
+    }
+  });
+
+  test("400 on non-update operation re-throws unchanged", () => {
+    const apiErr = new ApiError("Bad Request", 400, "some detail");
+    expect(() =>
+      enrichDashboardError(apiErr, { orgSlug: "my-org", operation: "list" })
+    ).toThrow(apiErr);
   });
 });


### PR DESCRIPTION
## Summary

- Add shared `enrichDashboardError()` helper that converts raw 404/403/400 API errors into `ResolutionError` instances with actionable suggestions
- Wire into all dashboard API calls across `list`, `view`, `create`, and `widget add/edit/delete` commands
- Add 9 unit tests covering each error status code mapping

Before:
```
Error: API request failed: 404 Not Found
  Endpoint: /organizations/my-org/dashboards/
```

After:
```
Organization 'my-org' not found or has no dashboards.

Try:
  sentry dashboard list <org>/

Or:
  - Verify the organization slug with: sentry org list
  - Check that you have access to the organization
```

Closes #448