### PR TITLE
fix(skill): avoid unnecessary auth, reinforce auto-detection, fix field examples

### DIFF
--- a/docs/src/content/docs/agent-guidance.md
+++ b/docs/src/content/docs/agent-guidance.md
@@ -7,11 +7,12 @@ Best practices and operational guidance for AI coding agents using the Sentry CL
 
 ## Key Principles
 
+- **Just run the command** — the CLI handles authentication and org/project detection automatically. Don't pre-authenticate or look up org/project before running commands. If auth is needed, the CLI prompts interactively.
 - **Prefer CLI commands over raw API calls** — the CLI has dedicated commands for most tasks. Reach for `sentry issue view`, `sentry issue list`, `sentry trace view`, etc. before constructing API calls manually or fetching external documentation.
 - **Use `sentry schema` to explore the API** — if you need to discover API endpoints, run `sentry schema` to browse interactively or `sentry schema <resource>` to search. This is faster than fetching OpenAPI specs externally.
 - **Use `sentry issue view <id>` to investigate issues** — when asked about a specific issue (e.g., `CLI-G5`, `PROJECT-123`), use `sentry issue view` directly.
 - **Use `--json` for machine-readable output** — pipe through `jq` for filtering. Human-readable output includes formatting that is hard to parse.
-- **The CLI auto-detects org/project** — most commands work without explicit targets by scanning for DSNs in `.env` files and source code.
+- **The CLI auto-detects org/project** — most commands work without explicit targets by scanning for DSNs in `.env` files, source code, config defaults, and directory names. Only specify `<org>/<project>` when the CLI reports it can't detect the target or detects the wrong one.
 
 ## Design Principles
 
@@ -22,7 +23,7 @@ The `sentry` CLI follows conventions from well-known tools — if you're familia
 
 ## Context Window Tips
 
-- Use `--json --fields` to select specific fields and reduce output size. Run `<command> --help` to see available fields. Example: `sentry issue list --json --fields shortId,title,count,userCount,lastSeen`
+- Use `--json --fields` to select specific fields and reduce output size. Run `<command> --help` to see available fields. Example: `sentry issue list --json --fields shortId,title,priority,level,status`
 - Use `--json` when piping output between commands or processing programmatically
 - Use `--limit` to cap the number of results (default is usually 10–100)
 - Prefer `sentry issue view PROJECT-123` over listing and filtering manually
@@ -31,17 +32,17 @@ The `sentry` CLI follows conventions from well-known tools — if you're familia
 ## Safety Rules
 
 - Always confirm with the user before running destructive commands: `project delete`, `trial start`
-- Verify the org/project context is correct before mutations — use `sentry auth status` to check defaults
-- Never store or log authentication tokens — use `sentry auth login` and let the CLI manage credentials
-- When in doubt about the target org/project, use explicit `<org>/<project>` arguments instead of auto-detection
+- For mutations, verify the org/project context looks correct in the command output before proceeding with further changes
+- Never store or log authentication tokens — the CLI manages credentials automatically
+- If the CLI reports the wrong org/project, override with explicit `<org>/<project>` arguments
 
 ## Workflow Patterns
 
 ### Investigate an Issue
 
 ```bash
-# 1. Find the issue
-sentry issue list my-org/my-project --query "is:unresolved" --limit 5
+# 1. Find the issue (auto-detects org/project from DSN or config)
+sentry issue list --query "is:unresolved" --limit 5
 
 # 2. Get details
 sentry issue view PROJECT-123
@@ -56,27 +57,27 @@ sentry issue plan PROJECT-123
 ### Explore Traces and Performance
 
 ```bash
-# 1. List recent traces
-sentry trace list my-org/my-project --limit 5
+# 1. List recent traces (auto-detects org/project)
+sentry trace list --limit 5
 
 # 2. View a specific trace with span tree
-sentry trace view my-org/my-project/abc123def456...
+sentry trace view abc123def456...
 
 # 3. View spans for a trace
-sentry span list my-org/my-project/abc123def456...
+sentry span list abc123def456...
 
 # 4. View logs associated with a trace
-sentry trace logs my-org/abc123def456...
+sentry trace logs abc123def456...
 ```
 
 ### Stream Logs
 
 ```bash
-# Stream logs in real-time
-sentry log list my-org/my-project --follow
+# Stream logs in real-time (auto-detects org/project)
+sentry log list --follow
 
 # Filter logs by severity
-sentry log list my-org/my-project --query "severity:error"
+sentry log list --query "severity:error"
 ```
 
 ### Explore the API Schema
@@ -152,10 +153,10 @@ sentry dashboard widget add <dashboard> "Top Endpoints" --display table \
 ## Common Mistakes
 
 - **Wrong issue ID format**: Use `PROJECT-123` (short ID), not the numeric ID `123456789`. The short ID includes the project prefix.
-- **Forgetting authentication**: Run `sentry auth login` before any other command. Check with `sentry auth status`.
+- **Pre-authenticating unnecessarily**: Don't run `sentry auth login` before every command. The CLI detects missing/expired auth and prompts automatically. Only run `sentry auth login` if you need to switch accounts.
 - **Missing `--json` for piping**: Human-readable output includes formatting. Use `--json` when parsing output programmatically.
-- **Org/project ambiguity**: Auto-detection scans for DSNs in `.env` files and source code. If the project is ambiguous, specify explicitly: `sentry issue list my-org/my-project`.
+- **Specifying org/project when not needed**: Auto-detection resolves org/project from DSNs, env vars, config defaults, and directory names. Let it work first — only add `<org>/<project>` if the CLI says it can't detect the target or detects the wrong one.
 - **Confusing `--query` syntax**: The `--query` flag uses Sentry search syntax (e.g., `is:unresolved`, `assigned:me`), not free text search.
 - **Not using `--web`**: View commands support `-w`/`--web` to open the resource in the browser — useful for sharing links.
 - **Fetching API schemas instead of using the CLI**: Prefer `sentry schema` to browse the API and `sentry api` to make requests — the CLI handles authentication and endpoint resolution, so there's rarely a need to download OpenAPI specs separately.
-- **Using `sentry api` when CLI commands suffice**: `sentry issue list --json` already includes `count`, `userCount`, `firstSeen`, `lastSeen`, `priority`, and other fields at the top level. Use `--fields` to select specific fields. Run `--help` to see all available fields. Only fall back to `sentry api` for data the CLI doesn't expose.
+- **Using `sentry api` when CLI commands suffice**: `sentry issue list --json` already includes `shortId`, `title`, `priority`, `level`, `status`, `permalink`, and other fields at the top level. Some fields like `count`, `userCount`, `firstSeen`, and `lastSeen` may be null depending on the issue. Use `--fields` to select specific fields and `--help` to see all available fields. Only fall back to `sentry api` for data the CLI doesn't expose.

--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -17,11 +17,12 @@ Best practices and operational guidance for AI coding agents using the Sentry CL
 
 ### Key Principles
 
+- **Just run the command** — the CLI handles authentication and org/project detection automatically. Don't pre-authenticate or look up org/project before running commands. If auth is needed, the CLI prompts interactively.
 - **Prefer CLI commands over raw API calls** — the CLI has dedicated commands for most tasks. Reach for `sentry issue view`, `sentry issue list`, `sentry trace view`, etc. before constructing API calls manually or fetching external documentation.
 - **Use `sentry schema` to explore the API** — if you need to discover API endpoints, run `sentry schema` to browse interactively or `sentry schema <resource>` to search. This is faster than fetching OpenAPI specs externally.
 - **Use `sentry issue view <id>` to investigate issues** — when asked about a specific issue (e.g., `CLI-G5`, `PROJECT-123`), use `sentry issue view` directly.
 - **Use `--json` for machine-readable output** — pipe through `jq` for filtering. Human-readable output includes formatting that is hard to parse.
-- **The CLI auto-detects org/project** — most commands work without explicit targets by scanning for DSNs in `.env` files and source code.
+- **The CLI auto-detects org/project** — most commands work without explicit targets by scanning for DSNs in `.env` files, source code, config defaults, and directory names. Only specify `<org>/<project>` when the CLI reports it can't detect the target or detects the wrong one.
 
 ### Design Principles
 
@@ -32,7 +33,7 @@ The `sentry` CLI follows conventions from well-known tools — if you're familia
 
 ### Context Window Tips
 
-- Use `--json --fields` to select specific fields and reduce output size. Run `<command> --help` to see available fields. Example: `sentry issue list --json --fields shortId,title,count,userCount,lastSeen`
+- Use `--json --fields` to select specific fields and reduce output size. Run `<command> --help` to see available fields. Example: `sentry issue list --json --fields shortId,title,priority,level,status`
 - Use `--json` when piping output between commands or processing programmatically
 - Use `--limit` to cap the number of results (default is usually 10–100)
 - Prefer `sentry issue view PROJECT-123` over listing and filtering manually
@@ -41,17 +42,17 @@ The `sentry` CLI follows conventions from well-known tools — if you're familia
 ### Safety Rules
 
 - Always confirm with the user before running destructive commands: `project delete`, `trial start`
-- Verify the org/project context is correct before mutations — use `sentry auth status` to check defaults
-- Never store or log authentication tokens — use `sentry auth login` and let the CLI manage credentials
-- When in doubt about the target org/project, use explicit `<org>/<project>` arguments instead of auto-detection
+- For mutations, verify the org/project context looks correct in the command output before proceeding with further changes
+- Never store or log authentication tokens — the CLI manages credentials automatically
+- If the CLI reports the wrong org/project, override with explicit `<org>/<project>` arguments
 
 ### Workflow Patterns
 
 #### Investigate an Issue
 
 ```bash
-# 1. Find the issue
-sentry issue list my-org/my-project --query "is:unresolved" --limit 5
+# 1. Find the issue (auto-detects org/project from DSN or config)
+sentry issue list --query "is:unresolved" --limit 5
 
 # 2. Get details
 sentry issue view PROJECT-123
@@ -66,27 +67,27 @@ sentry issue plan PROJECT-123
 #### Explore Traces and Performance
 
 ```bash
-# 1. List recent traces
-sentry trace list my-org/my-project --limit 5
+# 1. List recent traces (auto-detects org/project)
+sentry trace list --limit 5
 
 # 2. View a specific trace with span tree
-sentry trace view my-org/my-project/abc123def456...
+sentry trace view abc123def456...
 
 # 3. View spans for a trace
-sentry span list my-org/my-project/abc123def456...
+sentry span list abc123def456...
 
 # 4. View logs associated with a trace
-sentry trace logs my-org/abc123def456...
+sentry trace logs abc123def456...
 ```
 
 #### Stream Logs
 
 ```bash
-# Stream logs in real-time
-sentry log list my-org/my-project --follow
+# Stream logs in real-time (auto-detects org/project)
+sentry log list --follow
 
 # Filter logs by severity
-sentry log list my-org/my-project --query "severity:error"
+sentry log list --query "severity:error"
 ```
 
 #### Explore the API Schema
@@ -162,13 +163,13 @@ sentry dashboard widget add <dashboard> "Top Endpoints" --display table \
 ### Common Mistakes
 
 - **Wrong issue ID format**: Use `PROJECT-123` (short ID), not the numeric ID `123456789`. The short ID includes the project prefix.
-- **Forgetting authentication**: Run `sentry auth login` before any other command. Check with `sentry auth status`.
+- **Pre-authenticating unnecessarily**: Don't run `sentry auth login` before every command. The CLI detects missing/expired auth and prompts automatically. Only run `sentry auth login` if you need to switch accounts.
 - **Missing `--json` for piping**: Human-readable output includes formatting. Use `--json` when parsing output programmatically.
-- **Org/project ambiguity**: Auto-detection scans for DSNs in `.env` files and source code. If the project is ambiguous, specify explicitly: `sentry issue list my-org/my-project`.
+- **Specifying org/project when not needed**: Auto-detection resolves org/project from DSNs, env vars, config defaults, and directory names. Let it work first — only add `<org>/<project>` if the CLI says it can't detect the target or detects the wrong one.
 - **Confusing `--query` syntax**: The `--query` flag uses Sentry search syntax (e.g., `is:unresolved`, `assigned:me`), not free text search.
 - **Not using `--web`**: View commands support `-w`/`--web` to open the resource in the browser — useful for sharing links.
 - **Fetching API schemas instead of using the CLI**: Prefer `sentry schema` to browse the API and `sentry api` to make requests — the CLI handles authentication and endpoint resolution, so there's rarely a need to download OpenAPI specs separately.
-- **Using `sentry api` when CLI commands suffice**: `sentry issue list --json` already includes `count`, `userCount`, `firstSeen`, `lastSeen`, `priority`, and other fields at the top level. Use `--fields` to select specific fields. Run `--help` to see all available fields. Only fall back to `sentry api` for data the CLI doesn't expose.
+- **Using `sentry api` when CLI commands suffice**: `sentry issue list --json` already includes `shortId`, `title`, `priority`, `level`, `status`, `permalink`, and other fields at the top level. Some fields like `count`, `userCount`, `firstSeen`, and `lastSeen` may be null depending on the issue. Use `--fields` to select specific fields and `--help` to see all available fields. Only fall back to `sentry api` for data the CLI doesn't expose.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

- Add "Just run the command" as the first key principle so agents stop pre-authenticating or looking up org/project before every command
- Fix `--fields` example from `count,userCount,lastSeen` (often null) to `priority,level,status` (reliably populated)
- Remove `sentry auth status` pre-check from Safety Rules — the CLI's auto-auth middleware handles this
- Drop explicit `my-org/my-project` from all workflow pattern examples to reinforce auto-detection as the default
- Rewrite Common Mistakes entries: "Forgetting auth" → "Pre-authenticating unnecessarily", "Org/project ambiguity" → "Specifying org/project when not needed"

Closes #598