### PR TITLE
fix(init): block @sentry/wizard in validateCommand

### DIFF
--- a/src/lib/init/local-ops.ts
+++ b/src/lib/init/local-ops.ts
@@ -224,6 +224,15 @@ export function validateCommand(command: string): string | undefined {
     return `Blocked command: disallowed executable "${executable}" — "${command}"`;
   }
 
+  // Layer 4: Block interactive Sentry setup CLIs. These require a TTY to
+  // prompt the user and will always fail when run non-interactively.
+  // `sentry init` is itself the replacement for @sentry/wizard — it should
+  // never need to invoke the old wizard as a subprocess.
+  const tokens = command.split(WHITESPACE_RE);
+  if (tokens.some((t) => t.includes("@sentry/wizard"))) {
+    return `Blocked command: "@sentry/wizard" is an interactive CLI that requires a TTY. Use a direct package manager install command instead (e.g. "npm install @sentry/nextjs") — "${command}"`;
+  }
+
   return;
 }
 


### PR DESCRIPTION
## Summary

Defense-in-depth guard against `@sentry/wizard` being spawned as a subprocess of `sentry init`. If the AI ever generates a command containing `@sentry/wizard`, `validateCommand()` now rejects it immediately with a clear error message instead of letting it fail with a cryptic `ERR_TTY_INIT_FAILED`.

`sentry init` is itself the replacement for the old wizard — it should never invoke the old wizard as a subprocess.

Primary fix is in `getsentry/cli-init-api` (`fix/block-wizard-install-commands`), which updates the AI prompts to prohibit wizard commands. This PR is the safety net in case that ever regresses.

## Test Plan

- Add a test asserting `validateCommand("npx @sentry/wizard@latest -i nextjs")` returns an error string
- Verify `validateCommand("npm install @sentry/nextjs")` still passes