### PR TITLE
fix(build): disable identifier minification to fix marked crash

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -96,7 +96,11 @@ async function bundleJs(): Promise<boolean> {
       "process.env.NODE_ENV": JSON.stringify("production"),
     },
     sourcemap: "external",
-    minify: true,
+    // Identifier minification causes name collisions in the `marked` library's
+    // token walker — renderInline gets the same minified name as an unrelated
+    // object, crashing `auth status` and other markdown-rendering paths.
+    // Whitespace + syntax minification still reduces size significantly.
+    minify: { whitespace: true, syntax: true, identifiers: false },
     target: "bun",
   });
 


### PR DESCRIPTION
## Summary

Fixes the compiled binary crash that affected all commands rendering markdown output (auth status, issue explain, etc.):

```
TypeError: _4 is not a function. (In '_4(_4.tokens)', '_4' is an instance of Object)
```

## Root Cause

Bun's identifier minification assigns short names (`_4`, `_5`, etc.) to all functions/variables. A name collision caused `renderInline` (a function in `markdown.ts`) to get the same minified name as an unrelated object. When `renderOneInline` calls `renderInline(token.tokens)`, the minified code calls `_4(_4.tokens)` — but `_4` is the object, not the function.

Triggered by PR #602 (716e2bad) which removed ~380 lines of code, shifting the minifier's naming sequence. The bug is in Bun's bundler, not our source code — any future code change could re-trigger it.

## Fix

Change `minify: true` to `minify: { whitespace: true, syntax: true, identifiers: false }` in `script/build.ts`. This keeps whitespace removal and syntax transforms while avoiding identifier renaming.

**Size impact:** Bundle grows from 2.87 MB to 3.64 MB raw (~27%). Gzip compression absorbs most of the difference since original identifier names compress well.

## Bisect

- `27a9f0f8` (PR #610) — works
- `716e2bad` (PR #602) — crashes
- Specifically: the change to `src/commands/issue/explain.ts` triggers the collision by shifting import ordering

## Test plan

- `SENTRY_CLI_BINARY=./dist-bin/sentry-darwin-arm64 bun test --timeout 15000 test/e2e` — 122 pass, 0 fail
- `SENTRY_AUTH_TOKEN=test ./dist-bin/sentry-darwin-arm64 auth status` — renders markdown without crash

Made with [Cursor](https://cursor.com)