### PR TITLE
feat(ci): add delta patch generation for stable releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,6 @@ jobs:
           fi
       - name: Check fork eval status
         if: steps.detect-fork.outputs.is_fork == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           SHA="${{ github.event.pull_request.head.sha }}"
           STATUS=$(gh api "repos/${{ github.repository }}/commits/$SHA/statuses" \
@@ -392,8 +390,6 @@ jobs:
 
       - name: Download previous release binaries (release/**)
         if: startsWith(github.ref, 'refs/heads/release/')
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           PREV_TAG=$(gh api "repos/${{ github.repository }}/releases?per_page=5" \
             --jq '[.[] | select(.prerelease == false and .draft == false)] | .[0].tag_name // empty')
@@ -451,8 +447,6 @@ jobs:
 
       - name: File issue on failure
         if: failure()
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           TITLE="Delta patch generation failed"
           BODY="The \`generate-patches\` job failed on [\`${GITHUB_REF_NAME}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}).


### PR DESCRIPTION
## Summary

- Extracts delta patch generation from `publish-nightly` into a shared `generate-patches` job
- Runs on both `main` (nightlies) and `release/**` (stable) branches, skips PRs
- Old-binary source switches by branch: `main` → previous nightly from GHCR, `release/**` → previous stable release from GitHub Releases
- Patches uploaded as `sentry-patches` workflow artifact — craft picks these up for stable releases via the existing `/^sentry-.*$/` pattern
- `publish-nightly` slimmed down: downloads pre-generated patches from the artifact and pushes to GHCR (no more inline bsdiff)
- On failure, a GitHub issue is filed automatically (with deduplication)
- `continue-on-error: true` ensures patch failures never block releases or nightlies

## Motivation

The client-side delta upgrade code (`src/lib/delta-upgrade.ts`) expects `.patch` assets on GitHub Releases but no CI step was generating them for stable releases. Delta upgrades silently fell back to full binary download every time. This PR closes that gap while unifying the patch generation logic between both channels.