### PR TITLE
fix(upgrade): remove "What's new" header from changelog output

### DIFF
--- a/src/lib/formatters/human.ts
+++ b/src/lib/formatters/human.ts
@@ -2164,7 +2164,7 @@ function formatChangelog(data: UpgradeResult): string {
   }
 
   const { changelog } = data;
-  const lines: string[] = ["", "### What's new", ""];
+  const lines: string[] = [""];
 
   for (const section of changelog.sections) {
     lines.push(CATEGORY_HEADINGS[section.category]);


### PR DESCRIPTION
## Summary

- Remove the `### What's new` markdown heading from the post-upgrade changelog output in `formatChangelog()`
- Keep a leading empty line for visual separation between the upgrade status and the changelog sections

## Changes

Single-line change in `src/lib/formatters/human.ts`: the initial `lines` array in `formatChangelog()` changes from `["", "### What's new", ""]` to `[""]`. The category subheadings (New Features, Bug Fixes, Performance) remain unchanged.