### PR TITLE
test: remove stale debug-level stderr assertions and fix logger state leak

### DIFF
--- a/test/commands/cli.test.ts
+++ b/test/commands/cli.test.ts
@@ -130,17 +130,12 @@ describe("upgradeCommand.func", () => {
       })) as typeof fetch;
 
     const func = await upgradeCommand.loader();
-    const { context, getStderr, getStdout, restore } = createMockContext();
+    const { context, getStdout, restore } = createMockContext();
     restoreStderr = restore;
 
     // Use method flag to bypass detection (curl uses GitHub).
     // Pass json: true so the output config renders structured JSON to stdout.
     await func.call(context, { check: false, method: "curl", json: true });
-
-    // Progress messages go to stderr
-    const stderr = getStderr();
-    expect(stderr).toContain("Installation method: curl");
-    expect(stderr).toContain("Current version:");
 
     // Final result is rendered as JSON to stdout by the output system
     const data = JSON.parse(getStdout()) as UpgradeResult;
@@ -176,7 +171,7 @@ describe("upgradeCommand.func", () => {
       })) as typeof fetch;
 
     const func = await upgradeCommand.loader();
-    const { context, getStderr, getStdout, restore } = createMockContext();
+    const { context, getStdout, restore } = createMockContext();
     restoreStderr = restore;
 
     await func.call(
@@ -184,10 +179,6 @@ describe("upgradeCommand.func", () => {
       { check: true, method: "curl", json: true },
       "2.0.0"
     );
-
-    // Target version is still logged as progress to stderr
-    const stderr = getStderr();
-    expect(stderr).toContain("Target version: 2.0.0");
 
     const data = JSON.parse(getStdout()) as UpgradeResult;
     expect(data.action).toBe("checked");

--- a/test/lib/command.test.ts
+++ b/test/lib/command.test.ts
@@ -375,6 +375,16 @@ describe("applyLoggingFlags", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildCommand", () => {
+  let originalLevel: number;
+
+  beforeEach(() => {
+    originalLevel = logger.level;
+  });
+
+  afterEach(() => {
+    setLogLevel(originalLevel);
+  });
+
   test("builds a valid command object", () => {
     const command = buildCommand({
       auth: false,
@@ -426,84 +436,69 @@ describe("buildCommand", () => {
   });
 
   test("--verbose sets logger to debug level", async () => {
-    const originalLevel = logger.level;
-    try {
-      const command = buildCommand<Record<string, never>, [], TestContext>({
-        auth: false,
-        docs: { brief: "Test" },
-        parameters: {},
-        async *func() {
-          // no-op
-        },
-      });
+    const command = buildCommand<Record<string, never>, [], TestContext>({
+      auth: false,
+      docs: { brief: "Test" },
+      parameters: {},
+      async *func() {
+        // no-op
+      },
+    });
 
-      const routeMap = buildRouteMap({
-        routes: { test: command },
-        docs: { brief: "Test app" },
-      });
-      const app = buildApplication(routeMap, { name: "test" });
-      const ctx = createTestContext();
+    const routeMap = buildRouteMap({
+      routes: { test: command },
+      docs: { brief: "Test app" },
+    });
+    const app = buildApplication(routeMap, { name: "test" });
+    const ctx = createTestContext();
 
-      await run(app, ["test", "--verbose"], ctx as TestContext);
+    await run(app, ["test", "--verbose"], ctx as TestContext);
 
-      expect(logger.level).toBe(4); // debug
-    } finally {
-      setLogLevel(originalLevel);
-    }
+    expect(logger.level).toBe(4); // debug
   });
 
   test("--log-level sets logger to specified level", async () => {
-    const originalLevel = logger.level;
-    try {
-      const command = buildCommand<Record<string, never>, [], TestContext>({
-        auth: false,
-        docs: { brief: "Test" },
-        parameters: {},
-        async *func() {
-          // no-op
-        },
-      });
+    const command = buildCommand<Record<string, never>, [], TestContext>({
+      auth: false,
+      docs: { brief: "Test" },
+      parameters: {},
+      async *func() {
+        // no-op
+      },
+    });
 
-      const routeMap = buildRouteMap({
-        routes: { test: command },
-        docs: { brief: "Test app" },
-      });
-      const app = buildApplication(routeMap, { name: "test" });
-      const ctx = createTestContext();
+    const routeMap = buildRouteMap({
+      routes: { test: command },
+      docs: { brief: "Test app" },
+    });
+    const app = buildApplication(routeMap, { name: "test" });
+    const ctx = createTestContext();
 
-      await run(app, ["test", "--log-level", "trace"], ctx as TestContext);
+    await run(app, ["test", "--log-level", "trace"], ctx as TestContext);
 
-      expect(logger.level).toBe(5); // trace
-    } finally {
-      setLogLevel(originalLevel);
-    }
+    expect(logger.level).toBe(5); // trace
   });
 
   test("--log-level=value (equals form) works", async () => {
-    const originalLevel = logger.level;
-    try {
-      const command = buildCommand<Record<string, never>, [], TestContext>({
-        auth: false,
-        docs: { brief: "Test" },
-        parameters: {},
-        async *func() {
-          // no-op
-        },
-      });
+    const command = buildCommand<Record<string, never>, [], TestContext>({
+      auth: false,
+      docs: { brief: "Test" },
+      parameters: {},
+      async *func() {
+        // no-op
+      },
+    });
 
-      const routeMap = buildRouteMap({
-        routes: { test: command },
-        docs: { brief: "Test app" },
-      });
-      const app = buildApplication(routeMap, { name: "test" });
-      const ctx = createTestContext();
+    const routeMap = buildRouteMap({
+      routes: { test: command },
+      docs: { brief: "Test app" },
+    });
+    const app = buildApplication(routeMap, { name: "test" });
+    const ctx = createTestContext();
 
-      await run(app, ["test", "--log-level=error"], ctx as TestContext);
+    await run(app, ["test", "--log-level=error"], ctx as TestContext);
 
-      expect(logger.level).toBe(0); // error
-    } finally {
-      setLogLevel(originalLevel);
-    }
+    expect(logger.level).toBe(0); // error
   });
 
   test("strips logging flags from func's flags parameter", async () => {
@@ -549,103 +544,92 @@ describe("buildCommand", () => {
   });
 
   test("preserves command's own --verbose flag when already defined", async () => {
-    const originalLevel = logger.level;
     let receivedFlags: Record<string, unknown> | null = null;
 
-    try {
-      // Simulates the api command: defines its own --verbose with HTTP semantics
-      const command = buildCommand<
-        { verbose: boolean; silent: boolean },
-        [],
-        TestContext
-      >({
-        auth: false,
-        docs: { brief: "Test" },
-        parameters: {
-          flags: {
-            verbose: {
-              kind: "boolean",
-              brief: "Show HTTP details",
-              default: false,
-            },
-            silent: {
-              kind: "boolean",
-              brief: "Suppress output",
-              default: false,
-            },
+    // Simulates the api command: defines its own --verbose with HTTP semantics
+    const command = buildCommand<
+      { verbose: boolean; silent: boolean },
+      [],
+      TestContext
+    >({
+      auth: false,
+      docs: { brief: "Test" },
+      parameters: {
+        flags: {
+          verbose: {
+            kind: "boolean",
+            brief: "Show HTTP details",
+            default: false,
+          },
+          silent: {
+            kind: "boolean",
+            brief: "Suppress output",
+            default: false,
           },
         },
-        // biome-ignore lint/correctness/useYield: test command — no output to yield
-        async *func(
-          this: TestContext,
-          flags: { verbose: boolean; silent: boolean }
-        ) {
-          receivedFlags = flags as unknown as Record<string, unknown>;
-        },
-      });
+      },
+      // biome-ignore lint/correctness/useYield: test command — no output to yield
+      async *func(
+        this: TestContext,
+        flags: { verbose: boolean; silent: boolean }
+      ) {
+        receivedFlags = flags as unknown as Record<string, unknown>;
+      },
+    });
 
-      const routeMap = buildRouteMap({
-        routes: { test: command },
-        docs: { brief: "Test app" },
-      });
-      const app = buildApplication(routeMap, { name: "test" });
-      const ctx = createTestContext();
+    const routeMap = buildRouteMap({
+      routes: { test: command },
+      docs: { brief: "Test app" },
+    });
+    const app = buildApplication(routeMap, { name: "test" });
+    const ctx = createTestContext();
 
-      await run(
-        app,
-        ["test", "--verbose", "--log-level", "trace"],
-        ctx as TestContext
-      );
+    await run(
+      app,
+      ["test", "--verbose", "--log-level", "trace"],
+      ctx as TestContext
+    );
 
-      // Command's own --verbose is passed through (not stripped)
-      expect(receivedFlags).toBeDefined();
-      expect(receivedFlags!.verbose).toBe(true);
-      expect(receivedFlags!.silent).toBe(false);
-      // --log-level is always stripped (it's ours)
-      expect(receivedFlags!["log-level"]).toBeUndefined();
-      // --verbose also sets debug-level logging as a side-effect
-      // but --log-level=trace takes priority
-      expect(logger.level).toBe(5); // trace
-    } finally {
-      setLogLevel(originalLevel);
-    }
+    // Command's own --verbose is passed through (not stripped)
+    expect(receivedFlags).toBeDefined();
+    expect(receivedFlags!.verbose).toBe(true);
+    expect(receivedFlags!.silent).toBe(false);
+    // --log-level is always stripped (it's ours)
+    expect(receivedFlags!["log-level"]).toBeUndefined();
+    // --verbose also sets debug-level logging as a side-effect
+    // but --log-level=trace takes priority
+    expect(logger.level).toBe(5); // trace
   });
 
   test("command's own --verbose sets debug log level as side-effect", async () => {
-    const originalLevel = logger.level;
-
-    try {
-      const command = buildCommand<{ verbose: boolean }, [], TestContext>({
-        auth: false,
-        docs: { brief: "Test" },
-        parameters: {
-          flags: {
-            verbose: {
-              kind: "boolean",
-              brief: "Show HTTP details",
-              default: false,
-            },
+    const command = buildCommand<{ verbose: boolean }, [], TestContext>({
+      auth: false,
+      docs: { brief: "Test" },
+      parameters: {
+        flags: {
+          verbose: {
+            kind: "boolean",
+            brief: "Show HTTP details",
+            default: false,
           },
         },
-        async *func() {
-          // no-op
-        },
-      });
+      },
+      async *func() {
+        // no-op
+      },
+    });
 
-      const routeMap = buildRouteMap({
-        routes: { test: command },
-        docs: { brief: "Test app" },
-      });
-      const app = buildApplication(routeMap, { name: "test" });
-      const ctx = createTestContext();
+    const routeMap = buildRouteMap({
+      routes: { test: command },
+      docs: { brief: "Test app" },
+    });
+    const app = buildApplication(routeMap, { name: "test" });
+    const ctx = createTestContext();
 
-      await run(app, ["test", "--verbose"], ctx as TestContext);
+    await run(app, ["test", "--verbose"], ctx as TestContext);
 
-      // Even though verbose is command-owned, it triggers debug-level logging
-      expect(logger.level).toBe(4); // debug
-    } finally {
-      setLogLevel(originalLevel);
-    }
+    // Even though verbose is command-owned, it triggers debug-level logging
+    expect(logger.level).toBe(4); // debug
   });
 });
 
@@ -680,6 +664,16 @@ describe("FIELDS_FLAG", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildCommand output config", () => {
+  let originalLevel: number;
+
+  beforeEach(() => {
+    originalLevel = logger.level;
+  });
+
+  afterEach(() => {
+    setLogLevel(originalLevel);
+  });
+
   test("injects --json flag when output: 'json'", async () => {
     let receivedFlags: Record<string, unknown> | null = null;
 


### PR DESCRIPTION
## Summary

- Removes stale stderr assertions in `cli.test.ts` that checked for `log.debug()` output (demoted from `log.info()` in #454) without ensuring the logger was at debug level
- Adds `beforeEach`/`afterEach` logger level cleanup to the `"buildCommand output config"` describe block in `command.test.ts` to prevent the `--verbose` test from leaking debug-level state into subsequent test files

## Root cause

The upgrade command tests asserted on `log.debug()` output but only passed on CI due to a logger state leak: `command.test.ts` runs a `--verbose` test that calls `setLogLevel(4)` without cleanup. Since Bun shares module singletons across test files, this leaked debug-level logging persisted. On CI, `command.test.ts` happens to run before `cli.test.ts` (making debug messages visible), but locally the order is reversed.

## Verification

- `bun test test/commands/cli.test.ts test/lib/command.test.ts` — 56 pass, 0 fail
- Full suite: 4435 pass, 0 fail across 171 files