### PR TITLE
fix(ci): restore GH_TOKEN for gh CLI steps in generate-patches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,8 @@ jobs:
           fi
       - name: Check fork eval status
         if: steps.detect-fork.outputs.is_fork == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           SHA="${{ github.event.pull_request.head.sha }}"
           STATUS=$(gh api "repos/${{ github.repository }}/commits/$SHA/statuses" \
@@ -390,6 +392,8 @@ jobs:
 
       - name: Download previous release binaries (release/**)
         if: startsWith(github.ref, 'refs/heads/release/')
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           PREV_TAG=$(gh api "repos/${{ github.repository }}/releases?per_page=5" \
             --jq '[.[] | select(.prerelease == false and .draft == false)] | .[0].tag_name // empty')
@@ -447,6 +451,8 @@ jobs:
 
       - name: File issue on failure
         if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           TITLE="Delta patch generation failed"
           BODY="The \`generate-patches\` job failed on [\`${GITHUB_REF_NAME}\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}).


### PR DESCRIPTION
## Summary

- Restores `GH_TOKEN: ${{ github.token }}` env for all `gh` CLI steps in `generate-patches` job
- Also restores it for the `eval-skill` fork check step that was inadvertently removed in #618

`gh` CLI supports both `GH_TOKEN` and `GITHUB_TOKEN` as env vars, but GitHub Actions does not automatically expose `GITHUB_TOKEN` as a shell environment variable — it's only available in `${{ }}` expressions. The token must be explicitly mapped via `env:` for `gh` to find it.

This fixes the `generate-patches` failure on `release/0.24.0`: https://github.com/getsentry/cli/actions/runs/23875917691/job/69619096534