### PR TITLE
fix(commands): add regression test for Stricli numberParser defaults (#640)

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -127,7 +127,7 @@ export const loginCommand = buildCommand({
         kind: "parsed",
         parse: numberParser,
         brief: "Timeout for OAuth flow in seconds (default: 900)",
-        // Stricli requires string defaults (raw CLI input); numberParser converts to number
+        // Stricli passes string defaults through parse(); numberParser converts to number
         default: "900",
       },
       force: {

--- a/src/commands/release/set-commits.ts
+++ b/src/commands/release/set-commits.ts
@@ -210,7 +210,7 @@ export const setCommitsCommand = buildCommand({
         kind: "parsed",
         parse: numberParser,
         brief: "Number of commits to read with --local",
-        default: "20",
+        default: "20", // Stricli passes string defaults through parse(); numberParser converts to number
       },
     },
   },

--- a/src/lib/list-command.ts
+++ b/src/lib/list-command.ts
@@ -252,7 +252,8 @@ export function paginationHint(opts: {
  * Build the `--limit` / `-n` flag for a list command.
  *
  * @param entityPlural - Plural entity name used in the brief (e.g. "teams")
- * @param defaultValue - Default limit as a string (default: "30")
+ * @param defaultValue - Default limit as a string — Stricli passes it through
+ *   numberParser at runtime, so the command receives a number (default: "30")
  */
 export function buildListLimitFlag(
   entityPlural: string,

--- a/test/lib/command.test.ts
+++ b/test/lib/command.test.ts
@@ -168,6 +168,44 @@ describe("buildCommand telemetry integration", () => {
     expect(setTagSpy).toHaveBeenCalledWith("flag.limit", "50");
   });
 
+  test("passes string defaults through parse() — numberParser default is number at runtime", async () => {
+    let receivedFlags: Record<string, unknown> | null = null;
+
+    const command = buildCommand<{ limit: number }, [], TestContext>({
+      auth: false,
+      docs: { brief: "Test" },
+      parameters: {
+        flags: {
+          limit: {
+            kind: "parsed",
+            parse: numberParser,
+            brief: "Limit",
+            default: "10",
+          },
+        },
+      },
+      // biome-ignore lint/correctness/useYield: test command — no output to yield
+      async *func(this: TestContext, flags: { limit: number }) {
+        receivedFlags = flags as unknown as Record<string, unknown>;
+      },
+    });
+
+    const routeMap = buildRouteMap({
+      routes: { test: command },
+      docs: { brief: "Test app" },
+    });
+    const app = buildApplication(routeMap, { name: "test" });
+    const ctx = createTestContext();
+
+    // Run WITHOUT --limit to exercise the default path
+    await run(app, ["test"], ctx as TestContext);
+
+    expect(receivedFlags).not.toBeNull();
+    // Critical: must be number 10, not string "10"
+    expect(receivedFlags!.limit).toBe(10);
+    expect(typeof receivedFlags!.limit).toBe("number");
+  });
+
   test("skips false boolean flags in telemetry", async () => {
     const command = buildCommand<{ json: boolean }, [], TestContext>({
       auth: false,


### PR DESCRIPTION
## Summary

- Verified that Stricli **does** pass `kind: "parsed"` flag string defaults through `parse()` at runtime — this is not a bug
- Added a regression test that exercises the default path (no flag provided) and asserts the value is `number`, not `string`
- Clarified comments at all 3 affected `numberParser` + string default sites: `auth login --timeout`, `release set-commits --initial-depth`, and `buildListLimitFlag`

Closes #640