### PR TITLE
fix(upgrade): add blank lines around changelog in upgrade output

### DIFF
--- a/src/lib/formatters/human.ts
+++ b/src/lib/formatters/human.ts
@@ -2282,7 +2282,7 @@ export function formatUpgradeResult(data: UpgradeResult): string {
   // Append changelog if available
   const changelogOutput = formatChangelog(data);
   if (changelogOutput) {
-    return `${result}\n${changelogOutput}`;
+    return `${result}\n\n${changelogOutput}\n`;
   }
 
   return result;

--- a/test/lib/formatters/human.test.ts
+++ b/test/lib/formatters/human.test.ts
@@ -817,4 +817,34 @@ describe("formatUpgradeResult", () => {
       expect(result).not.toContain("(from");
     });
   });
+
+  test("changelog is separated from metadata by a blank line", () => {
+    withPlain(() => {
+      const result = formatUpgradeResult({
+        action: "upgraded",
+        currentVersion: "0.5.0",
+        targetVersion: "0.6.0",
+        channel: "stable",
+        method: "curl",
+        forced: false,
+        changelog: {
+          fromVersion: "0.5.0",
+          toVersion: "0.6.0",
+          sections: [
+            { category: "features", markdown: "- add cool feature (#1)" },
+          ],
+          totalItems: 1,
+          truncated: false,
+          originalCount: 1,
+        },
+      });
+      // Blank line between metadata and changelog heading
+      expect(result).toContain("Channel: stable\n\n");
+      // Changelog content present
+      expect(result).toContain("New Features");
+      expect(result).toContain("add cool feature (#1)");
+      // Trailing newline after changelog
+      expect(result).toMatch(/\n$/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a blank line before and after the changelog section in `sentry cli upgrade` output for better readability
- Single-line change in `formatUpgradeResult()` in `src/lib/formatters/human.ts`

### Before
```
✓ Upgraded to  0.24.0-dev.1775146118  (from 0.24.0-dev.1775088345)
  Method: curl · Channel: nightly
New Features ✨
• ...
```

### After
```
✓ Upgraded to  0.24.0-dev.1775146118  (from 0.24.0-dev.1775088345)
  Method: curl · Channel: nightly

New Features ✨
• ...
```