### PR TITLE
ci: fix sentry-release workflow Node.js version and add manual trigger

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -2,22 +2,35 @@ name: Sentry Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g., 0.24.0)"
+        required: true
+        type: string
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   finalize:
     name: Finalize Sentry Release
     runs-on: ubuntu-latest
-    # Skip pre-releases (nightlies, dev versions)
-    if: "!github.event.release.prerelease"
+    # Skip pre-releases (nightlies, dev versions) on automatic trigger;
+    # always run on manual dispatch.
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       # Tag names are bare semver (e.g., "0.24.0", no "v" prefix),
       # matching both the npm package version and Sentry release version.
-      VERSION: ${{ github.event.release.tag_name }}
+      VERSION: ${{ github.event.release.tag_name || inputs.version }}
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
       - name: Install CLI
         run: npm install -g "sentry@${VERSION}"
 
@@ -33,3 +46,21 @@ jobs:
 
       - name: Create deploy
         run: sentry release deploy "sentry/${VERSION}" production
+
+      - name: File issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Sentry release finalization failed for ${VERSION}" \
+            --body "The [Sentry Release workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) failed for version \`${VERSION}\`.
+
+          Trigger: \`${{ github.event_name }}\`
+
+          Please investigate and re-run manually if needed:
+          \`\`\`
+          gh workflow run sentry-release.yml -f version=${VERSION}
+          \`\`\`" \
+            --label bug


### PR DESCRIPTION
## Summary

Fixes the [failed Sentry Release workflow](https://github.com/getsentry/cli/actions/runs/23912025434/job/69736210175) for 0.24.0.

**Root cause:** `ubuntu-latest` ships Node.js v20.20.2 but the `sentry` npm package requires `>=22`:
```
Error: sentry requires Node.js 22 or later (found v20.20.2).
```

## Changes

- Add `actions/setup-node@v6` with `node-version: 22` before `npm install`
- Add `workflow_dispatch` trigger with a `version` input for manual re-runs
- Add `gh issue create` step on `failure()` so broken releases file a bug automatically
- Add `issues: write` permission for the failure step

## After merging

Re-run for 0.24.0:
```
gh workflow run sentry-release.yml -f version=0.24.0
```