### PR TITLE
ci: use production environment for sentry-release auth token

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -17,13 +17,14 @@ jobs:
   finalize:
     name: Finalize Sentry Release
     runs-on: ubuntu-latest
+    environment: production
     # Skip pre-releases (nightlies, dev versions) on automatic trigger;
     # always run on manual dispatch.
     if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       # Tag names are bare semver (e.g., "0.24.0", no "v" prefix),
-      # matching both the npm package version and Sentry release version.
+      # matching the npm package version, Sentry.init() release, and sourcemap uploads.
       VERSION: ${{ github.event.release.tag_name || inputs.version }}
     steps:
       - name: Setup Node.js
@@ -35,17 +36,17 @@ jobs:
         run: npm install -g "sentry@${VERSION}"
 
       - name: Create release
-        run: sentry release create "sentry/${VERSION}" --project cli
+        run: sentry release create "${VERSION}" --project cli
 
       - name: Set commits
         continue-on-error: true
-        run: sentry release set-commits "sentry/${VERSION}" --auto
+        run: sentry release set-commits "${VERSION}" --auto
 
       - name: Finalize release
-        run: sentry release finalize "sentry/${VERSION}"
+        run: sentry release finalize "${VERSION}"
 
       - name: Create deploy
-        run: sentry release deploy "sentry/${VERSION}" production
+        run: sentry release deploy "${VERSION}" production
 
       - name: File issue on failure
         if: failure()


### PR DESCRIPTION
## Summary

Fixes the [second sentry-release failure](https://github.com/getsentry/cli/actions/runs/23917846862/job/69756252213):
```
Error: Not authenticated. Run 'sentry auth login' first.
```

Two issues:

1. **Missing environment** — `SENTRY_AUTH_TOKEN` is scoped to the `production` environment. Without `environment: production` on the job, the secret resolves to empty.

2. **Wrong release version** — The workflow used `sentry/${VERSION}` (e.g., `sentry/0.24.0`) but `Sentry.init()` and sourcemap uploads both use bare semver (`0.24.0`). Events would never be associated with the release.

## Changes

- Add `environment: production` to the `finalize` job
- Drop `sentry/` prefix from all release version references to match `Sentry.init()` (`release: CLI_VERSION` in `telemetry.ts:417`) and sourcemap uploads (`release: VERSION` in `build.ts:179`)