### PR TITLE
ci: restore sentry/ org prefix in sentry-release workflow

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       # Tag names are bare semver (e.g., "0.24.0", no "v" prefix),
-      # matching the npm package version, Sentry.init() release, and sourcemap uploads.
+      # matching both the npm package version and Sentry release version.
       VERSION: ${{ github.event.release.tag_name || inputs.version }}
     steps:
       - name: Setup Node.js
@@ -36,17 +36,17 @@ jobs:
         run: npm install -g "sentry@${VERSION}"
 
       - name: Create release
-        run: sentry release create "${VERSION}" --project cli
+        run: sentry release create "sentry/${VERSION}" --project cli
 
       - name: Set commits
         continue-on-error: true
-        run: sentry release set-commits "${VERSION}" --auto
+        run: sentry release set-commits "sentry/${VERSION}" --auto
 
       - name: Finalize release
-        run: sentry release finalize "${VERSION}"
+        run: sentry release finalize "sentry/${VERSION}"
 
       - name: Create deploy
-        run: sentry release deploy "${VERSION}" production
+        run: sentry release deploy "sentry/${VERSION}" production
 
       - name: File issue on failure
         if: failure()


### PR DESCRIPTION
## Summary

Fixes the [third sentry-release failure](https://github.com/getsentry/cli/actions/runs/23918696701/job/69759189495):
```
Error: Organization is required.
```

The previous PR (#645) mistakenly removed the `sentry/` prefix thinking it was a version prefix. It's actually the **org slug** — `parseReleaseArg("sentry/0.24.0")` splits into org=`sentry`, version=`0.24.0`. Restoring it provides the org without needing `SENTRY_ORG`.

Fixes #647.