### PR TITLE
fix(init): add reactFeatures to feature display info

### DIFF
--- a/src/lib/init/clack-utils.ts
+++ b/src/lib/init/clack-utils.ts
@@ -60,6 +60,10 @@ const FEATURE_INFO: Record<string, { label: string; hint: string }> = {
     label: "User Feedback",
     hint: "Collect in-app user feedback and reports",
   },
+  reactFeatures: {
+    label: "React Features",
+    hint: "Redux, component tracking, source maps, and integrations",
+  },
 };
 
 export function featureLabel(id: string): string {
@@ -81,6 +85,7 @@ const FEATURE_DISPLAY_ORDER = [
   "crons",
   "aiMonitoring",
   "userFeedback",
+  "reactFeatures",
 ];
 
 /** Sort features into canonical display order for the multi-select prompt. */


### PR DESCRIPTION
## Summary

Companion change for getsentry/cli-init-api#67 (fixes getsentry/cli-init-api#65).

The server now sends `reactFeatures` as a known feature for React projects. Without this change, the CLI would display the raw camelCase string `"reactFeatures"` in the multi-select prompt.

## Changes

- Added `reactFeatures` to `FEATURE_INFO` in `src/lib/init/clack-utils.ts` with label `"React Features"` and hint `"Redux, component tracking, source maps, and integrations"`
- Added `reactFeatures` to `FEATURE_DISPLAY_ORDER` so it appears in a consistent position in the multi-select prompt

## Testing

All 11 clack-utils tests pass.