### PR TITLE
fix(init): rename 'Custom Metrics' feature label to 'Metrics'

### DIFF
--- a/src/lib/init/clack-utils.ts
+++ b/src/lib/init/clack-utils.ts
@@ -43,7 +43,7 @@ const FEATURE_INFO: Record<string, { label: string; hint: string }> = {
     hint: "Code-level performance insights",
   },
   logs: { label: "Logging", hint: "Structured log ingestion" },
-  metrics: { label: "Custom Metrics", hint: "Track custom business metrics" },
+  metrics: { label: "Metrics", hint: "Track business metrics" },
   sourceMaps: {
     label: "Source Maps",
     hint: "See original source code in production errors",


### PR DESCRIPTION
## Summary

- Renames the metrics feature label from "Custom Metrics" to "Metrics" in the `sentry init` feature selection prompt
- Updates the hint text from "Track custom business metrics" to "Track business metrics"

The "Custom" qualifier is inaccurate and doesn't match how the feature is described elsewhere in Sentry's terminology.

Closes getsentry/cli-init-api#59