### PR TITLE
fix(init): run commands without shell to eliminate injection surface

### DIFF
--- a/src/lib/init/local-ops.ts
+++ b/src/lib/init/local-ops.ts
@@ -532,8 +532,9 @@ async function runCommands(
   return { ok: true, data: { results } };
 }
 
-// Note: shell: true targets Unix shells. Windows cmd.exe metacharacters
-// (%, ^) are not blocked; the CLI assumes a Unix Node.js environment.
+// Runs the executable directly (no shell) to eliminate shell injection as an
+// attack vector. The command string is split on whitespace into [exe, ...args].
+// validateCommand() still blocks metacharacters as defense-in-depth.
 function runSingleCommand(
   command: string,
   cwd: string,
@@ -545,8 +546,8 @@ function runSingleCommand(
   stderr: string;
 }> {
   return new Promise((resolve) => {
-    const child = spawn(command, [], {
-      shell: true,
+    const [executable = "", ...args] = command.trim().split(WHITESPACE_RE);
+    const child = spawn(executable, args, {
       cwd,
       stdio: ["ignore", "pipe", "pipe"],
       timeout: timeoutMs,

--- a/test/lib/init/local-ops.test.ts
+++ b/test/lib/init/local-ops.test.ts
@@ -616,7 +616,7 @@ describe("handleLocalOp", () => {
         type: "local-op",
         operation: "run-commands",
         cwd: testDir,
-        params: { commands: ["echo hello"] },
+        params: { commands: ["/bin/echo hello"] },
       };
 
       const result = await handleLocalOp(payload, options);
@@ -664,7 +664,9 @@ describe("handleLocalOp", () => {
         type: "local-op",
         operation: "run-commands",
         cwd: testDir,
-        params: { commands: ["false", "echo should_not_run"] },
+        params: {
+          commands: ["/usr/bin/false", "/bin/echo should_not_run"],
+        },
       };
 
       const result = await handleLocalOp(payload, options);
@@ -675,7 +677,7 @@ describe("handleLocalOp", () => {
         }
       ).results;
       expect(results).toHaveLength(1);
-      expect(results[0].command).toBe("false");
+      expect(results[0].command).toBe("/usr/bin/false");
     });
 
     test("dry-run validates commands but skips execution", async () => {
@@ -697,7 +699,7 @@ describe("handleLocalOp", () => {
         type: "local-op",
         operation: "run-commands",
         cwd: testDir,
-        params: { commands: ["npm install @sentry/node", "echo hello"] },
+        params: { commands: ["npm install @sentry/node", "/bin/echo hello"] },
       };
 
       const dryRunOptions = makeOptions({ dryRun: true, directory: testDir });
@@ -718,7 +720,7 @@ describe("handleLocalOp", () => {
         type: "local-op",
         operation: "run-commands",
         cwd: testDir,
-        params: { commands: ["echo hello", "rm -rf /"] },
+        params: { commands: ["/bin/echo hello", "rm -rf /"] },
       };
 
       const result = await handleLocalOp(payload, options);


### PR DESCRIPTION
## Summary
- Replace `spawn({ shell: true })` with direct executable invocation — command strings are split into `[executable, ...args]` and passed to `spawn` without a shell
- Eliminates shell injection as an attack vector entirely: metacharacters become harmless literal arguments when no shell interprets them
- The existing `validateCommand()` blocklist (metachar, env var, blocked executable checks) is retained as defense-in-depth

Addresses [this review comment](https://github.com/getsentry/cli/pull/657#discussion_r2107405886).

## Test plan
- [x] Updated tests to use `/bin/echo` and `/usr/bin/false` instead of shell builtins
- [x] All existing `run-commands` tests pass (stdout capture, error handling, blocked commands, dry-run, batch validation)
- [x] `tsc --noEmit` passes
- [x] `biome check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)