### PR TITLE
refactor(init): reuse resolveOrg for offline-first org detection

### DIFF
--- a/src/lib/init/local-ops.ts
+++ b/src/lib/init/local-ops.ts
@@ -16,7 +16,6 @@ import {
   tryGetPrimaryDsn,
 } from "../api-client.js";
 import { ApiError } from "../errors.js";
-import { resolveOrg } from "../resolve-target.js";
 import { resolveOrCreateTeam } from "../resolve-team.js";
 import { buildProjectUrl } from "../sentry-urls.js";
 import { slugify } from "../utils.js";
@@ -26,6 +25,7 @@ import {
   MAX_FILE_BYTES,
   MAX_OUTPUT_BYTES,
 } from "./constants.js";
+import { resolveOrgPrefetched } from "./prefetch.js";
 import type {
   ApplyPatchsetPayload,
   CreateSentryProjectPayload,
@@ -706,11 +706,18 @@ async function applyPatchset(
   return { ok: true, data: { applied } };
 }
 
+/** Matches a bare numeric org ID extracted from a DSN (e.g. "4507492088676352"). */
+const NUMERIC_ORG_ID_RE = /^\d+$/;
+
 /**
  * Resolve the org slug using the shared offline-first resolver, falling back
  * to interactive selection when multiple orgs are available.
  *
- * Resolution priority (via {@link resolveOrg}):
+ * Uses the prefetch-aware helper from `./prefetch.ts` — if
+ * {@link warmOrgDetection} was called earlier (by `init.ts`), the result is
+ * already cached and returns near-instantly.
+ *
+ * Resolution priority (via `resolveOrg`):
  * 1. CLI `--org` flag
  * 2. `SENTRY_ORG` / `SENTRY_PROJECT` env vars
  * 3. Config defaults (SQLite)
@@ -725,9 +732,11 @@ export async function resolveOrgSlug(
   cwd: string,
   yes: boolean
 ): Promise<string | LocalOpResult> {
-  // Reuse the shared offline-first resolver (flags, env vars, defaults, DSN)
-  const resolved = await resolveOrg({ cwd });
-  if (resolved) {
+  // normalizeNumericOrg inside resolveOrg may return a raw numeric ID when
+  // the cache is cold and the API refresh fails. Numeric IDs break write
+  // operations (project/team creation), so fall through to the org picker.
+  const resolved = await resolveOrgPrefetched(cwd);
+  if (resolved && !NUMERIC_ORG_ID_RE.test(resolved.org)) {
     return resolved.org;
   }
 

--- a/test/lib/init/local-ops.create-sentry-project.test.ts
+++ b/test/lib/init/local-ops.create-sentry-project.test.ts
@@ -194,7 +194,7 @@ describe("create-sentry-project", () => {
 
   describe("resolveOrgSlug (called directly)", () => {
     test("single org fallback when resolveOrg returns null", async () => {
-      resolveOrgSpy.mockResolvedValue(null);
+      resolveOrgPrefetchedSpy.mockResolvedValue(null);
       listOrgsSpy.mockResolvedValue([
         { id: "1", slug: "solo-org", name: "Solo Org" },
       ]);
@@ -206,7 +206,7 @@ describe("create-sentry-project", () => {
     });
 
     test("no orgs (not authenticated) returns error result", async () => {
-      resolveOrgSpy.mockResolvedValue(null);
+      resolveOrgPrefetchedSpy.mockResolvedValue(null);
       listOrgsSpy.mockResolvedValue([]);
 
       const result = await resolveOrgSlug("/tmp/test", false);
@@ -218,7 +218,7 @@ describe("create-sentry-project", () => {
     });
 
     test("multiple orgs + yes flag returns error with slug list", async () => {
-      resolveOrgSpy.mockResolvedValue(null);
+      resolveOrgPrefetchedSpy.mockResolvedValue(null);
       listOrgsSpy.mockResolvedValue([
         { id: "1", slug: "org-a", name: "Org A" },
         { id: "2", slug: "org-b", name: "Org B" },
@@ -235,7 +235,7 @@ describe("create-sentry-project", () => {
     });
 
     test("multiple orgs + interactive select picks chosen org", async () => {
-      resolveOrgSpy.mockResolvedValue(null);
+      resolveOrgPrefetchedSpy.mockResolvedValue(null);
       listOrgsSpy.mockResolvedValue([
         { id: "1", slug: "org-a", name: "Org A" },
         { id: "2", slug: "org-b", name: "Org B" },
@@ -249,7 +249,7 @@ describe("create-sentry-project", () => {
     });
 
     test("multiple orgs + user cancels select throws WizardCancelledError", async () => {
-      resolveOrgSpy.mockResolvedValue(null);
+      resolveOrgPrefetchedSpy.mockResolvedValue(null);
       listOrgsSpy.mockResolvedValue([
         { id: "1", slug: "org-a", name: "Org A" },
         { id: "2", slug: "org-b", name: "Org B" },
@@ -296,8 +296,8 @@ describe("create-sentry-project", () => {
   });
 
   describe("resolveOrgSlug — resolveOrg integration", () => {
-    test("returns org from resolveOrg when it resolves", async () => {
-      resolveOrgSpy.mockResolvedValue({ org: "acme-corp" });
+    test("returns org slug when resolveOrg resolves", async () => {
+      resolveOrgPrefetchedSpy.mockResolvedValue({ org: "acme-corp" });
 
       const result = await resolveOrgSlug("/tmp/test", false);
 
@@ -306,7 +306,18 @@ describe("create-sentry-project", () => {
     });
 
     test("falls through to listOrganizations when resolveOrg returns null", async () => {
-      resolveOrgSpy.mockResolvedValue(null);
+      resolveOrgPrefetchedSpy.mockResolvedValue(null);
+      listOrgsSpy.mockResolvedValue([
+        { id: "1", slug: "solo-org", name: "Solo Org" },
+      ]);
+
+      const result = await resolveOrgSlug("/tmp/test", false);
+
+      expect(result).toBe("solo-org");
+    });
+
+    test("numeric ID from resolveOrg falls through to org picker", async () => {
+      resolveOrgPrefetchedSpy.mockResolvedValue({ org: "4507492088676352" });
       listOrgsSpy.mockResolvedValue([
         { id: "1", slug: "solo-org", name: "Solo Org" },
       ]);


### PR DESCRIPTION
## Summary

The init wizard's `resolveOrgSlug()` was reimplementing org detection that `resolveOrg()` in `resolve-target.ts` already handles. The shared resolver covers CLI flags, env vars (`SENTRY_ORG`), config defaults, and DSN auto-detection with numeric ID normalization — the init version only did DSN scanning and missed env vars and config defaults entirely.

Now `resolveOrgSlug()` calls `resolveOrg({ cwd })` first, and only falls through to `listOrganizations()` + interactive select when nothing is detected offline.

## Test Plan

- [x] `bun test test/lib/init/` — 165 tests passing
- [ ] `sentry init` with `SENTRY_ORG=<slug>` set — should pick it up without prompting
- [ ] `sentry init` without env vars — should still show org picker as before