### PR TITLE
fix(init): add size guard and deduplicate JSON minification in preReadCommonFiles

### DIFF
--- a/src/lib/init/local-ops.ts
+++ b/src/lib/init/local-ops.ts
@@ -80,6 +80,15 @@ function prettyPrintJson(content: string, indent: JsonIndent): string {
   }
 }
 
+/** Strip whitespace/formatting from JSON. Returns input unchanged if not valid JSON. */
+function minifyJson(content: string): string {
+  try {
+    return JSON.stringify(JSON.parse(content));
+  } catch {
+    return content;
+  }
+}
+
 /**
  * Patterns that indicate shell injection. Commands run via `spawn` (no shell),
  * so these have no runtime effect — they are defense-in-depth against command
@@ -387,13 +396,13 @@ export async function preReadCommonFiles(
     }
     try {
       const absPath = path.join(directory, filePath);
+      const stat = await fs.promises.stat(absPath);
+      if (stat.size > MAX_FILE_BYTES) {
+        continue;
+      }
       let content = await fs.promises.readFile(absPath, "utf-8");
       if (filePath.endsWith(".json")) {
-        try {
-          content = JSON.stringify(JSON.parse(content));
-        } catch {
-          // Not valid JSON — send as-is
-        }
+        content = minifyJson(content);
       }
       if (totalBytes + content.length <= MAX_PREREAD_TOTAL_BYTES) {
         cache[filePath] = content;
@@ -540,13 +549,8 @@ async function readSingleFile(
       content = await fs.promises.readFile(absPath, "utf-8");
     }
 
-    // Minify JSON files by stripping whitespace/formatting
     if (filePath.endsWith(".json")) {
-      try {
-        content = JSON.stringify(JSON.parse(content));
-      } catch {
-        // Not valid JSON (truncated, JSONC, etc.) — send as-is
-      }
+      content = minifyJson(content);
     }
 
     return content;


### PR DESCRIPTION
## Summary

Two fixes for `preReadCommonFiles`:

1. **Per-file size guard** -- Stat files before reading and skip anything over `MAX_FILE_BYTES` (256KB). Prevents memory spikes from large files like `Gemfile.lock` that could eat the entire 512KB budget in one read.

2. **Deduplicate JSON minification** -- Extract `minifyJson()` helper used by both `preReadCommonFiles` and `readSingleFile`. Prevents the two identical `JSON.stringify(JSON.parse())` blocks from drifting out of sync.

## Test plan

- [x] All 68 local-ops tests pass
- [x] Typecheck clean
- [x] Lint clean

Made with [Cursor](https://cursor.com)