### PR TITLE
fix(build): normalize Windows backslash paths for sourcemap resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
             skill:
               - 'src/**'
               - 'docs/**'
+              - 'package.json'
               - 'script/generate-skill.ts'
               - 'script/generate-command-docs.ts'
               - 'script/eval-skill.ts'

--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli
-version: 0.26.0
+version: 0.27.0-dev.0
 description: Guide for using the Sentry CLI to interact with Sentry from the command line. Use when the user asks about viewing issues, events, projects, organizations, making API calls, or authenticating with Sentry via CLI.
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/api.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/api.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-api
-version: 0.26.0
+version: 0.27.0-dev.0
 description: Make an authenticated API request
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/auth.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/auth.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-auth
-version: 0.26.0
+version: 0.27.0-dev.0
 description: Authenticate with Sentry
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/cli.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/cli.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-cli
-version: 0.26.0
+version: 0.27.0-dev.0
 description: CLI-related commands
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/dashboard.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/dashboard.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-dashboard
-version: 0.26.0
+version: 0.27.0-dev.0
 description: Manage Sentry dashboards
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/event.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/event.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-event
-version: 0.26.0
+version: 0.27.0-dev.0
 description: View and list Sentry events
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/init.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/init.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-init
-version: 0.26.0
+version: 0.27.0-dev.0
 description: Initialize Sentry in your project (experimental)
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/issue.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/issue.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-issue
-version: 0.26.0
+version: 0.27.0-dev.0
 description: Manage Sentry issues
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/log.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/log.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-log
-version: 0.26.0
+version: 0.27.0-dev.0
 description: View Sentry logs
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/org.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/org.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-org
-version: 0.26.0
+version: 0.27.0-dev.0
 description: Work with Sentry organizations
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/project.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/project.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-project
-version: 0.26.0
+version: 0.27.0-dev.0
 description: Work with Sentry projects
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/release.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/release.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-release
-version: 0.26.0
+version: 0.27.0-dev.0
 description: Work with Sentry releases
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/repo.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/repo.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-repo
-version: 0.26.0
+version: 0.27.0-dev.0
 description: Work with Sentry repositories
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/schema.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/schema.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-schema
-version: 0.26.0
+version: 0.27.0-dev.0
 description: Browse the Sentry API schema
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/sourcemap.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/sourcemap.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-sourcemap
-version: 0.26.0
+version: 0.27.0-dev.0
 description: Manage sourcemaps
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/span.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/span.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-span
-version: 0.26.0
+version: 0.27.0-dev.0
 description: List and view spans in projects or traces
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/team.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/team.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-team
-version: 0.26.0
+version: 0.27.0-dev.0
 description: Work with Sentry teams
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/trace.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/trace.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-trace
-version: 0.26.0
+version: 0.27.0-dev.0
 description: View distributed traces
 requires:
   bins: ["sentry"]

--- a/plugins/sentry-cli/skills/sentry-cli/references/trial.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/trial.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cli-trial
-version: 0.26.0
+version: 0.27.0-dev.0
 description: Manage product trials
 requires:
   bins: ["sentry"]

--- a/src/lib/sourcemap/debug-id.ts
+++ b/src/lib/sourcemap/debug-id.ts
@@ -133,9 +133,19 @@ export async function injectDebugId(
   // Parse, adjust mappings, add debug ID fields
   const map = JSON.parse(mapContent) as {
     mappings: string;
+    sources?: string[];
     debug_id?: string;
     debugId?: string;
   };
+
+  // Normalize Windows backslashes in the sources array so uploaded
+  // sourcemaps have consistent forward-slash paths regardless of build
+  // platform. Bundlers on Windows (esbuild, Bun) may produce paths like
+  // "src\\bin.ts". No-op on Linux/macOS.
+  if (map.sources) {
+    map.sources = map.sources.map((s) => s.replaceAll("\\", "/"));
+  }
+
   if (!skipSnippet) {
     // Prepend one `;` to mappings — tells decoders "no mappings for the
     // first line" (the injected snippet line). Each `;` in VLQ mappings

--- a/src/lib/sourcemap/debug-id.ts
+++ b/src/lib/sourcemap/debug-id.ts
@@ -133,7 +133,7 @@ export async function injectDebugId(
   // Parse, adjust mappings, add debug ID fields
   const map = JSON.parse(mapContent) as {
     mappings: string;
-    sources?: string[];
+    sources?: (string | null)[];
     debug_id?: string;
     debugId?: string;
   };
@@ -143,7 +143,7 @@ export async function injectDebugId(
   // platform. Bundlers on Windows (esbuild, Bun) may produce paths like
   // "src\\bin.ts". No-op on Linux/macOS.
   if (map.sources) {
-    map.sources = map.sources.map((s) => s.replaceAll("\\", "/"));
+    map.sources = map.sources.map((s) => (s ? s.replaceAll("\\", "/") : s));
   }
 
   if (!skipSnippet) {

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -387,7 +387,12 @@ export function initSentry(
   }
 
   function ensureAbsolute(p: string): string {
-    return isRelativePath(p) ? `/${p}` : p;
+    // Normalize Windows backslashes to forward slashes for sourcemap URL
+    // matching. Bun on Windows produces paths like "dist-bin\bin.js" in
+    // Error.stack — the symbolicator expects forward slashes to match
+    // artifacts at "~/dist-bin/bin.js".
+    const normalized = p.replaceAll("\\", "/");
+    return isRelativePath(normalized) ? `/${normalized}` : normalized;
   }
 
   function normalizeExceptionFrames(event: Sentry.ErrorEvent): void {

--- a/test/script/debug-id.test.ts
+++ b/test/script/debug-id.test.ts
@@ -285,6 +285,46 @@ describe("injectDebugId", () => {
     expect(jsAfterSecond).toBe(jsAfterFirst);
   });
 
+  test("normalizes backslashes in sourcemap sources array", async () => {
+    const jsPath = join(tmpDir, "bundle.js");
+    const mapPath = join(tmpDir, "bundle.js.map");
+
+    await writeFile(jsPath, 'console.log("hello");\n');
+    await writeFile(
+      mapPath,
+      JSON.stringify({
+        version: 3,
+        sources: ["src\\lib\\utils.ts", "src\\bin.ts"],
+        mappings: "AAAA",
+      })
+    );
+
+    await injectDebugId(jsPath, mapPath);
+
+    const mapResult = JSON.parse(await readFile(mapPath, "utf-8"));
+    expect(mapResult.sources).toEqual(["src/lib/utils.ts", "src/bin.ts"]);
+  });
+
+  test("preserves forward-slash sources unchanged", async () => {
+    const jsPath = join(tmpDir, "bundle.js");
+    const mapPath = join(tmpDir, "bundle.js.map");
+
+    await writeFile(jsPath, 'console.log("hello");\n');
+    await writeFile(
+      mapPath,
+      JSON.stringify({
+        version: 3,
+        sources: ["src/lib/utils.ts", "src/bin.ts"],
+        mappings: "AAAA",
+      })
+    );
+
+    await injectDebugId(jsPath, mapPath);
+
+    const mapResult = JSON.parse(await readFile(mapPath, "utf-8"));
+    expect(mapResult.sources).toEqual(["src/lib/utils.ts", "src/bin.ts"]);
+  });
+
   test("debug ID is deterministic based on sourcemap content", async () => {
     // Create two different JS files with the same sourcemap content
     const jsPath1 = join(tmpDir, "a.js");

--- a/test/script/debug-id.test.ts
+++ b/test/script/debug-id.test.ts
@@ -305,6 +305,26 @@ describe("injectDebugId", () => {
     expect(mapResult.sources).toEqual(["src/lib/utils.ts", "src/bin.ts"]);
   });
 
+  test("preserves null entries in sourcemap sources array", async () => {
+    const jsPath = join(tmpDir, "bundle.js");
+    const mapPath = join(tmpDir, "bundle.js.map");
+
+    await writeFile(jsPath, 'console.log("hello");\n');
+    await writeFile(
+      mapPath,
+      JSON.stringify({
+        version: 3,
+        sources: [null, "src\\bin.ts", null],
+        mappings: "AAAA",
+      })
+    );
+
+    await injectDebugId(jsPath, mapPath);
+
+    const mapResult = JSON.parse(await readFile(mapPath, "utf-8"));
+    expect(mapResult.sources).toEqual([null, "src/bin.ts", null]);
+  });
+
   test("preserves forward-slash sources unchanged", async () => {
     const jsPath = join(tmpDir, "bundle.js");
     const mapPath = join(tmpDir, "bundle.js.map");


### PR DESCRIPTION
## Summary

- Normalize Windows backslashes (`\`) to forward slashes (`/`) in the telemetry `beforeSend` hook so frame paths match uploaded sourcemap artifact URLs
- Normalize the sourcemap `sources` array during debug ID injection so bundlers on Windows produce consistent paths

Fixes https://sentry.sentry.io/issues/7402821077/

## Problem

On Windows, Bun compiled binaries resolve `Error.stack` frame paths with backslashes (e.g., `dist-bin\bin.js`). The `ensureAbsolute()` function in `telemetry.ts` prepended `/` but didn't convert backslashes, producing `/dist-bin\bin.js`. The Sentry symbolicator couldn't match this to the uploaded artifact at `~/dist-bin/bin.js`, so sourcemaps were never applied — stack traces showed minified function names like `ut` with no source context.

## Changes

- **`src/lib/telemetry.ts`**: Add `.replaceAll("\\", "/")` in `ensureAbsolute()` before the relative-path check. Covers `frame.filename`, `frame.abs_path`, and `debug_meta.images[].code_file`.
- **`src/lib/sourcemap/debug-id.ts`**: Normalize `sources` array to forward slashes after parsing the sourcemap JSON. Benefits both the CLI's own build and user-facing `sentry sourcemap inject`.
- **`test/script/debug-id.test.ts`**: Two new test cases for backslash normalization in `sources` and forward-slash preservation.