### PR TITLE
fix(init): remove JSON minification that breaks edit-based codemods

### DIFF
--- a/src/lib/init/local-ops.ts
+++ b/src/lib/init/local-ops.ts
@@ -80,15 +80,6 @@ function prettyPrintJson(content: string, indent: JsonIndent): string {
   }
 }
 
-/** Strip whitespace/formatting from JSON. Returns input unchanged if not valid JSON. */
-function minifyJson(content: string): string {
-  try {
-    return JSON.stringify(JSON.parse(content));
-  } catch {
-    return content;
-  }
-}
-
 /**
  * Patterns that indicate shell injection. Commands run via `spawn` (no shell),
  * so these have no runtime effect — they are defense-in-depth against command
@@ -400,10 +391,7 @@ export async function preReadCommonFiles(
       if (stat.size > MAX_FILE_BYTES) {
         continue;
       }
-      let content = await fs.promises.readFile(absPath, "utf-8");
-      if (filePath.endsWith(".json")) {
-        content = minifyJson(content);
-      }
+      const content = await fs.promises.readFile(absPath, "utf-8");
       if (totalBytes + content.length <= MAX_PREREAD_TOTAL_BYTES) {
         cache[filePath] = content;
         totalBytes += content.length;
@@ -547,10 +535,6 @@ async function readSingleFile(
       }
     } else {
       content = await fs.promises.readFile(absPath, "utf-8");
-    }
-
-    if (filePath.endsWith(".json")) {
-      content = minifyJson(content);
     }
 
     return content;


### PR DESCRIPTION
## Summary

Removes JSON minification (`JSON.stringify(JSON.parse())`) from `readSingleFile` and `preReadCommonFiles`. This was causing all `package.json` edit-based codemods to fail.

### Root cause

The server's codemod-planner agent saw minified JSON (all whitespace stripped) and generated `oldString`/`newString` edits based on it. But `applyEdits` reads the actual file from disk (pretty-printed with indentation). The fuzzy replacer chain can't bridge minified vs pretty-printed JSON — it's structurally too different.

### Evidence

All three reference projects (opencode, gemini-cli, cline) read files **raw without any content transformation**. The model always sees exactly what's on disk. Our minification was an outlier that broke when we switched from full-content replacement to edit-based codemods.

Fixes failures on node-express and remix test projects:
```
Applying changes failed after 4 attempts: Edit #1 failed on "package.json":
Could not find oldString in the file.
```

## Test plan

- [x] All 68 local-ops tests pass
- [x] Typecheck clean
- [x] Lint clean

Made with [Cursor](https://cursor.com)