### PR TITLE
fix(upgrade): add shell option on Windows for .cmd package managers

### DIFF
--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -129,6 +129,10 @@ export function startCleanupOldBinary(): void {
 /**
  * Run a shell command and capture stdout.
  *
+ * On Windows, package managers (npm, pnpm, yarn) are `.cmd` batch files.
+ * `spawn()` without `shell: true` cannot execute `.cmd` files (ENOENT),
+ * so we route through cmd.exe on Windows.
+ *
  * @param command - Command to execute
  * @param args - Command arguments
  * @returns stdout content and exit code
@@ -140,6 +144,7 @@ function runCommand(
   return new Promise((resolve, reject) => {
     const proc = spawn(command, args, {
       stdio: ["ignore", "pipe", "pipe"],
+      shell: process.platform === "win32",
     });
 
     let stdout = "";
@@ -723,6 +728,7 @@ function executeUpgradeHomebrew(): Promise<void> {
   return new Promise((resolve, reject) => {
     const proc = spawn("brew", ["upgrade", "getsentry/tools/sentry"], {
       stdio: "inherit",
+      shell: process.platform === "win32",
     });
 
     proc.on("close", (code) => {
@@ -763,7 +769,12 @@ function executeUpgradePackageManager(
         ? ["global", "add", `sentry@${version}`]
         : ["install", "-g", `sentry@${version}`];
 
-    const proc = spawn(pm, args, { stdio: "inherit" });
+    // npm/pnpm/yarn are .cmd batch files on Windows; spawn() without
+    // shell: true cannot execute .cmd files (ENOENT).
+    const proc = spawn(pm, args, {
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    });
 
     proc.on("close", (code) => {
       if (code === 0) {

--- a/test/isolated/brew-upgrade.test.ts
+++ b/test/isolated/brew-upgrade.test.ts
@@ -153,14 +153,17 @@ describe("executeUpgrade (brew)", () => {
   test("invokes brew with correct arguments", async () => {
     let capturedCmd = "";
     let capturedArgs: string[] = [];
-    spawnImpl = (cmd, args) => {
+    let capturedOpts: object = {};
+    spawnImpl = (cmd, args, opts) => {
       capturedCmd = cmd;
       capturedArgs = args;
+      capturedOpts = opts;
       return fakeProcess(0);
     };
     await executeUpgrade("brew", "1.0.0");
     expect(capturedCmd).toBe("brew");
     expect(capturedArgs).toEqual(["upgrade", "getsentry/tools/sentry"]);
+    expect(capturedOpts).toHaveProperty("shell", process.platform === "win32");
   });
 });
 
@@ -177,14 +180,17 @@ describe("executeUpgrade (package managers)", () => {
   test("npm: uses correct install arguments", async () => {
     let capturedCmd = "";
     let capturedArgs: string[] = [];
-    spawnImpl = (cmd, args) => {
+    let capturedOpts: object = {};
+    spawnImpl = (cmd, args, opts) => {
       capturedCmd = cmd;
       capturedArgs = args;
+      capturedOpts = opts;
       return fakeProcess(0);
     };
     await executeUpgrade("npm", "1.2.3");
     expect(capturedCmd).toBe("npm");
     expect(capturedArgs).toEqual(["install", "-g", "sentry@1.2.3"]);
+    expect(capturedOpts).toHaveProperty("shell", process.platform === "win32");
   });
 
   test("pnpm: uses correct install arguments", async () => {
@@ -210,14 +216,17 @@ describe("executeUpgrade (package managers)", () => {
   test("yarn: uses 'global add' arguments", async () => {
     let capturedCmd = "";
     let capturedArgs: string[] = [];
-    spawnImpl = (cmd, args) => {
+    let capturedOpts: object = {};
+    spawnImpl = (cmd, args, opts) => {
       capturedCmd = cmd;
       capturedArgs = args;
+      capturedOpts = opts;
       return fakeProcess(0);
     };
     await executeUpgrade("yarn", "1.2.3");
     expect(capturedCmd).toBe("yarn");
     expect(capturedArgs).toEqual(["global", "add", "sentry@1.2.3"]);
+    expect(capturedOpts).toHaveProperty("shell", process.platform === "win32");
   });
 
   test("npm: throws UpgradeError on non-zero exit", async () => {
@@ -289,10 +298,15 @@ describe("detectInstallationMethod — legacy pm detection via isInstalledWith",
   });
 
   test("detects npm when 'npm list -g sentry' output includes 'sentry@'", async () => {
-    spawnImpl = (_cmd, args) =>
-      fakeProcess(0, args.includes("sentry") ? "sentry@1.0.0" : "");
+    let capturedOpts: object = {};
+    spawnImpl = (_cmd, args, opts) => {
+      capturedOpts = opts;
+      return fakeProcess(0, args.includes("sentry") ? "sentry@1.0.0" : "");
+    };
     const method = await detectInstallationMethod();
     expect(method).toBe("npm");
+    // runCommand passes shell: true on Windows for .cmd compatibility
+    expect(capturedOpts).toHaveProperty("shell", process.platform === "win32");
   });
 
   test("detects yarn when 'yarn global list' output includes 'sentry@'", async () => {


### PR DESCRIPTION
## Summary

Fixes [CLI-13T](https://sentry.sentry.io/issues/7407520017/) — `UpgradeError: npm failed: spawn npm ENOENT`

On Windows, `npm`/`pnpm`/`yarn` are `.cmd` batch files. `child_process.spawn()` without `shell: true` cannot execute `.cmd` files, causing ENOENT. This affects users who installed the CLI via npm under nvm (or similar Node.js version managers) on Windows.

## Changes

- Add `shell: process.platform === "win32"` to all three `spawn()` calls in `src/lib/upgrade.ts` (`runCommand`, `executeUpgradeHomebrew`, `executeUpgradePackageManager`)
- Update `runCommand` JSDoc to document the Windows `.cmd` issue
- Update tests in `test/isolated/brew-upgrade.test.ts` to capture and assert the `shell` spawn option

No behavior change on Linux/macOS — the condition evaluates to `false` (the existing default).