### PR TITLE
fix(issue-list): auto-correct AND and reject OR in --query to prevent 400

### DIFF
--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -204,6 +204,49 @@ function parseSort(value: string): SortValue {
   return value as SortValue;
 }
 
+/** Matches standalone boolean OR operator (word boundary, not inside a qualifier value). */
+const BOOLEAN_OR_RE = /\bOR\b/;
+/** Matches standalone boolean AND operator. */
+const BOOLEAN_AND_RE = /\bAND\b/;
+
+/**
+ * Sanitize `--query` before sending to the Sentry API.
+ *
+ * - **AND**: Sentry search implicitly ANDs space-separated terms, so explicit
+ *   `AND` has identical semantics. Strip it and warn — the user's intent is
+ *   fulfilled without error.
+ * - **OR**: Genuinely different semantics (union vs intersection). The API
+ *   rejects it with 400. Throw a helpful ValidationError since we cannot
+ *   silently approximate the intent.
+ *
+ * @returns The sanitized query string (AND stripped, OR rejected)
+ */
+function sanitizeQuery(
+  query: string,
+  log: { warn: (msg: string) => void }
+): string {
+  if (BOOLEAN_OR_RE.test(query)) {
+    throw new ValidationError(
+      "Sentry search does not support the OR operator.\n\n" +
+        "Alternatives:\n" +
+        '  - Use space-separated terms (implicit AND): --query "error timeout"\n' +
+        "  - Run separate queries for each term\n" +
+        '  - Use wildcards for partial matching: --query "*error*"\n\n' +
+        "Search syntax: https://docs.sentry.io/concepts/search/",
+      "query"
+    );
+  }
+  if (BOOLEAN_AND_RE.test(query)) {
+    const sanitized = query.replace(/\s*\bAND\b\s*/g, " ").trim();
+    log.warn(
+      "Sentry search implicitly ANDs terms — removed explicit AND operator. " +
+        `Running query: "${sanitized}"`
+    );
+    return sanitized;
+  }
+  return query;
+}
+
 /**
  * Format the issue list header with column titles.
  *
@@ -1450,6 +1493,7 @@ export const __testing = {
   getComparator,
   compareDates,
   parseSort,
+  sanitizeQuery,
   CURSOR_SEP,
   MAX_LIMIT: LIST_MAX_LIMIT,
   VALID_SORT_VALUES,
@@ -1599,6 +1643,7 @@ export const listCommand = buildListCommand("issue", {
   },
   async *func(this: SentryContext, flags: ListFlags, target?: string) {
     const { cwd } = this;
+    const log = logger.withTag("issue.list");
 
     const parsed = parseOrgProjectArg(target);
 
@@ -1616,20 +1661,25 @@ export const listCommand = buildListCommand("issue", {
       );
     }
 
-    const timeRange = parsePeriod(flags.period ?? DEFAULT_PERIOD);
+    // Sanitize --query: auto-correct AND (same semantics), reject OR (different semantics).
+    const effectiveFlags: ListFlags = flags.query
+      ? { ...flags, query: sanitizeQuery(flags.query, log) }
+      : flags;
+
+    const timeRange = parsePeriod(effectiveFlags.period ?? DEFAULT_PERIOD);
 
     // biome-ignore lint/suspicious/noExplicitAny: shared handler accepts any mode variant
     const resolveAndHandle: ModeHandler<any> = (ctx) =>
       handleResolvedTargets({
         ...ctx,
-        flags,
+        flags: effectiveFlags,
         timeRange,
       });
 
     const result = (await dispatchOrgScopedList({
       config: issueListMeta,
       cwd,
-      flags,
+      flags: effectiveFlags,
       parsed,
       // When a bare slug matches a cached org, silently redirect to org-all
       // mode instead of erroring (CLI-MC, 17 users). The user typed an org
@@ -1645,7 +1695,7 @@ export const listCommand = buildListCommand("issue", {
         "org-all": (ctx) =>
           handleOrgAllIssues({
             org: ctx.parsed.org,
-            flags,
+            flags: effectiveFlags,
             timeRange,
           }),
       },

--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -205,19 +205,21 @@ function parseSort(value: string): SortValue {
 }
 
 /**
- * Matches standalone boolean OR operator — surrounded by whitespace or
- * string boundaries, ensuring it doesn't match inside qualifier values
- * like `tag:OR` where `:` would create a false word boundary.
+ * Tokenize a Sentry search query respecting quoted strings.
+ *
+ * Handles `key:"quoted value with spaces"` as a single token by matching
+ * optional non-whitespace before a quoted section, then any remaining
+ * non-whitespace characters. Bare words and `key:value` pairs without
+ * quotes are also single tokens.
  */
-const BOOLEAN_OR_RE = /(^|\s)OR(\s|$)/;
-/**
- * Matches standalone boolean AND operator — same whitespace/boundary
- * guard as OR to avoid false matches in qualifier values.
- */
-const BOOLEAN_AND_RE = /(^|\s)AND(\s|$)/;
+const QUERY_TOKEN_RE = /\S*"[^"]*"\S*|\S+/g;
 
 /**
  * Sanitize `--query` before sending to the Sentry API.
+ *
+ * Tokenizes the query respecting quoted strings, then checks for standalone
+ * `OR` / `AND` tokens (not inside quoted values or qualifier values like
+ * `tag:OR`).
  *
  * - **AND**: Sentry search implicitly ANDs space-separated terms, so explicit
  *   `AND` has identical semantics. Strip it and warn — the user's intent is
@@ -232,7 +234,23 @@ function sanitizeQuery(
   query: string,
   log: { warn: (msg: string) => void }
 ): string {
-  if (BOOLEAN_OR_RE.test(query)) {
+  const tokens = query.match(QUERY_TOKEN_RE) ?? [];
+
+  let hasOr = false;
+  let hasAnd = false;
+  const cleaned: string[] = [];
+
+  for (const token of tokens) {
+    if (token === "OR") {
+      hasOr = true;
+    } else if (token === "AND") {
+      hasAnd = true;
+    } else {
+      cleaned.push(token);
+    }
+  }
+
+  if (hasOr) {
     throw new ValidationError(
       "Sentry search does not support the OR operator.\n\n" +
         "Alternatives:\n" +
@@ -243,14 +261,16 @@ function sanitizeQuery(
       "query"
     );
   }
-  if (BOOLEAN_AND_RE.test(query)) {
-    const sanitized = query.replace(/\s+AND(?=\s|$)/g, "").trim();
+
+  if (hasAnd) {
+    const sanitized = cleaned.join(" ");
     log.warn(
       "Sentry search implicitly ANDs terms — removed explicit AND operator. " +
         `Running query: "${sanitized}"`
     );
     return sanitized;
   }
+
   return query;
 }
 

--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -204,10 +204,17 @@ function parseSort(value: string): SortValue {
   return value as SortValue;
 }
 
-/** Matches standalone boolean OR operator (word boundary, not inside a qualifier value). */
-const BOOLEAN_OR_RE = /\bOR\b/;
-/** Matches standalone boolean AND operator. */
-const BOOLEAN_AND_RE = /\bAND\b/;
+/**
+ * Matches standalone boolean OR operator — surrounded by whitespace or
+ * string boundaries, ensuring it doesn't match inside qualifier values
+ * like `tag:OR` where `:` would create a false word boundary.
+ */
+const BOOLEAN_OR_RE = /(^|\s)OR(\s|$)/;
+/**
+ * Matches standalone boolean AND operator — same whitespace/boundary
+ * guard as OR to avoid false matches in qualifier values.
+ */
+const BOOLEAN_AND_RE = /(^|\s)AND(\s|$)/;
 
 /**
  * Sanitize `--query` before sending to the Sentry API.
@@ -237,7 +244,7 @@ function sanitizeQuery(
     );
   }
   if (BOOLEAN_AND_RE.test(query)) {
-    const sanitized = query.replace(/\s*\bAND\b\s*/g, " ").trim();
+    const sanitized = query.replace(/\s+AND(?=\s|$)/g, "").trim();
     log.warn(
       "Sentry search implicitly ANDs terms — removed explicit AND operator. " +
         `Running query: "${sanitized}"`

--- a/test/commands/issue/list.property.test.ts
+++ b/test/commands/issue/list.property.test.ts
@@ -494,3 +494,67 @@ describe("property: buildProjectAliasMap", () => {
     expect(Object.keys(entries).length).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// sanitizeQuery
+// ---------------------------------------------------------------------------
+
+const { sanitizeQuery } = __testing;
+
+/** Generates a non-empty string that does NOT contain standalone OR or AND. */
+const safeTermArb = constantFrom(
+  "is:unresolved",
+  "level:error",
+  "timeout",
+  "crash",
+  "http.status:500",
+  "assigned:me",
+  "sandbox",
+  "order",
+  "android"
+);
+
+// biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op
+const noopLog = { warn: () => {} };
+
+describe("property: sanitizeQuery", () => {
+  test("query with OR always throws ValidationError", () => {
+    fcAssert(
+      property(
+        tuple(safeTermArb, safeTermArb).map(([a, b]) => `${a} OR ${b}`),
+        (query) => {
+          expect(() => sanitizeQuery(query, noopLog)).toThrow();
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("AND removal preserves all non-AND tokens", () => {
+    fcAssert(
+      property(
+        tuple(safeTermArb, safeTermArb).map(([a, b]) => `${a} AND ${b}`),
+        (query) => {
+          const result = sanitizeQuery(query, noopLog);
+          // Both original terms must be present in the result
+          const parts = query.split(/\s+AND\s+/);
+          for (const part of parts) {
+            expect(result).toContain(part.trim());
+          }
+          // AND must not be present
+          expect(result).not.toContain("AND");
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("safe queries pass through unchanged", () => {
+    fcAssert(
+      property(safeTermArb, (term) => {
+        expect(sanitizeQuery(term, noopLog)).toBe(term);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});

--- a/test/commands/issue/list.test.ts
+++ b/test/commands/issue/list.test.ts
@@ -15,6 +15,7 @@ import {
   test,
 } from "bun:test";
 import {
+  __testing,
   listCommand,
   PAGINATION_KEY,
 } from "../../../src/commands/issue/list.js";
@@ -29,7 +30,11 @@ import {
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as paginationDb from "../../../src/lib/db/pagination.js";
 import { setOrgRegion } from "../../../src/lib/db/regions.js";
-import { ApiError, ResolutionError } from "../../../src/lib/errors.js";
+import {
+  ApiError,
+  ResolutionError,
+  ValidationError,
+} from "../../../src/lib/errors.js";
 import { mockFetch, useTestConfigDir } from "../../helpers.js";
 
 type ListFlags = {
@@ -1120,5 +1125,83 @@ describe("issue list: collapse parameter optimization", () => {
     const callArgs = listIssuesPaginatedSpy.mock.calls[0];
     const options = callArgs?.[2] as Record<string, unknown> | undefined;
     expect(options?.groupStatsPeriod).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeQuery
+// ---------------------------------------------------------------------------
+
+const { sanitizeQuery } = __testing;
+
+/** No-op logger for tests that don't check warnings */
+// biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op
+const noopLog = { warn: () => {} };
+
+describe("sanitizeQuery", () => {
+  test("passes through a simple query unchanged", () => {
+    expect(sanitizeQuery("is:unresolved level:error", noopLog)).toBe(
+      "is:unresolved level:error"
+    );
+  });
+
+  test("passes through a plain text query unchanged", () => {
+    expect(sanitizeQuery("timeout crash", noopLog)).toBe("timeout crash");
+  });
+
+  test("throws ValidationError for OR operator", () => {
+    expect(() => sanitizeQuery("error OR timeout", noopLog)).toThrow(
+      ValidationError
+    );
+  });
+
+  test("ValidationError for OR includes field and suggestions", () => {
+    try {
+      sanitizeQuery("login OR auth OR token", noopLog);
+      expect.unreachable("Should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError);
+      const ve = error as ValidationError;
+      expect(ve.field).toBe("query");
+      expect(ve.message).toContain("OR");
+      expect(ve.message).toContain("docs.sentry.io");
+    }
+  });
+
+  test("strips AND and returns cleaned query", () => {
+    expect(sanitizeQuery("error AND timeout", noopLog)).toBe("error timeout");
+  });
+
+  test("strips multiple AND operators", () => {
+    expect(sanitizeQuery("error AND timeout AND crash", noopLog)).toBe(
+      "error timeout crash"
+    );
+  });
+
+  test("AND removal emits a warning", () => {
+    const warnings: string[] = [];
+    const log = { warn: (msg: string) => warnings.push(msg) };
+    sanitizeQuery("error AND timeout", log);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("AND");
+    expect(warnings[0]).toContain("error timeout");
+  });
+
+  test("does not match lowercase 'and' or 'or'", () => {
+    // Sentry search operators are case-sensitive uppercase
+    expect(sanitizeQuery("sandbox handler", noopLog)).toBe("sandbox handler");
+    expect(sanitizeQuery("order error", noopLog)).toBe("order error");
+  });
+
+  test("rejects OR even with qualifiers mixed in", () => {
+    expect(() =>
+      sanitizeQuery("is:unresolved error OR timeout", noopLog)
+    ).toThrow(ValidationError);
+  });
+
+  test("strips AND with qualifiers", () => {
+    expect(sanitizeQuery("is:unresolved AND level:error", noopLog)).toBe(
+      "is:unresolved level:error"
+    );
   });
 });

--- a/test/commands/issue/list.test.ts
+++ b/test/commands/issue/list.test.ts
@@ -1218,4 +1218,24 @@ describe("sanitizeQuery", () => {
       "is:unresolved tag:OR_something"
     );
   });
+
+  test("does not match OR inside quoted strings", () => {
+    expect(sanitizeQuery('message:"error OR timeout"', noopLog)).toBe(
+      'message:"error OR timeout"'
+    );
+  });
+
+  test("does not match AND inside quoted strings", () => {
+    expect(sanitizeQuery('title:"error AND timeout"', noopLog)).toBe(
+      'title:"error AND timeout"'
+    );
+  });
+
+  test("handles leading AND", () => {
+    expect(sanitizeQuery("AND error timeout", noopLog)).toBe("error timeout");
+  });
+
+  test("handles trailing AND", () => {
+    expect(sanitizeQuery("error timeout AND", noopLog)).toBe("error timeout");
+  });
 });

--- a/test/commands/issue/list.test.ts
+++ b/test/commands/issue/list.test.ts
@@ -1204,4 +1204,18 @@ describe("sanitizeQuery", () => {
       "is:unresolved level:error"
     );
   });
+
+  test("does not match OR inside qualifier values (tag:OR)", () => {
+    expect(sanitizeQuery("tag:OR", noopLog)).toBe("tag:OR");
+  });
+
+  test("does not match AND inside qualifier values (tag:AND)", () => {
+    expect(sanitizeQuery("tag:AND", noopLog)).toBe("tag:AND");
+  });
+
+  test("does not match OR in qualifier values with more context", () => {
+    expect(sanitizeQuery("is:unresolved tag:OR_something", noopLog)).toBe(
+      "is:unresolved tag:OR_something"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Auto-correct explicit `AND` operators in `--query` by stripping them (Sentry search implicitly ANDs space-separated terms — identical semantics) with a `log.warn()` nudge
- Reject `OR` operators with a helpful `ValidationError` including alternatives (separate queries, wildcards, docs link) since OR has genuinely different semantics that can't be silently approximated
- Prevents 400 Bad Request from reaching the Sentry API, which was previously counted as a CLI bug per project convention

## Sentry Issues Resolved
- CLI-BM (136 users, 353 events): `--query` with OR operators
- CLI-97 (47 users, 173 events): `--query` with OR/AND operators  
- CLI-7B: `--query` with OR operators across 2 projects

## Testing
- Unit tests for `sanitizeQuery`: AND stripping, OR rejection, passthrough for valid queries, warning emission
- Property-based tests: OR always throws, AND preserves all non-AND tokens, safe queries pass through