### PR TITLE
feat(init): cache project and DSN after create/init

### DIFF
--- a/src/lib/api/projects.ts
+++ b/src/lib/api/projects.ts
@@ -21,8 +21,13 @@ import type {
   SentryProject,
 } from "../../types/index.js";
 
-import { cacheProjectsForOrg } from "../db/project-cache.js";
+import {
+  cacheProjectsForOrg,
+  setCachedProject,
+  setCachedProjectByDsnKey,
+} from "../db/project-cache.js";
 import { getCachedOrganizations } from "../db/regions.js";
+import { parseDsn } from "../dsn/parser.js";
 import { type AuthGuardSuccess, withAuthGuard } from "../errors.js";
 import { logger } from "../logger.js";
 import { getApiBaseUrl } from "../sentry-client.js";
@@ -190,6 +195,32 @@ export async function createProjectWithDsn(
   const project = await createProject(orgSlug, teamSlug, body);
   const dsn = await tryGetPrimaryDsn(orgSlug, project.slug);
   const url = buildProjectUrl(orgSlug, project.slug);
+
+  // Seed project_cache so the next command doesn't re-resolve via API
+  try {
+    const parsed = dsn ? parseDsn(dsn) : null;
+    if (parsed?.orgId) {
+      setCachedProject(parsed.orgId, parsed.projectId, {
+        orgSlug,
+        orgName: orgSlug,
+        projectSlug: project.slug,
+        projectName: project.name,
+        projectId: project.id,
+      });
+    }
+    if (parsed?.publicKey) {
+      setCachedProjectByDsnKey(parsed.publicKey, {
+        orgSlug,
+        orgName: orgSlug,
+        projectSlug: project.slug,
+        projectName: project.name,
+        projectId: project.id,
+      });
+    }
+  } catch {
+    // Best-effort — cache failure should not break project creation
+  }
+
   return { project, dsn, url };
 }
 

--- a/src/lib/init/local-ops.ts
+++ b/src/lib/init/local-ops.ts
@@ -15,6 +15,8 @@ import {
   listOrganizations,
   tryGetPrimaryDsn,
 } from "../api-client.js";
+import { setCachedDsn } from "../db/dsn-cache.js";
+import { parseDsn } from "../dsn/parser.js";
 import { ApiError } from "../errors.js";
 import { resolveOrCreateTeam } from "../resolve-team.js";
 import { buildProjectUrl } from "../sentry-urls.js";
@@ -1489,6 +1491,7 @@ async function glob(payload: GlobPayload): Promise<LocalOpResult> {
 
 // ── Sentry project + DSN ────────────────────────────────────────────
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: branching for dry-run, existing project, new project, and best-effort cache seeding
 async function createSentryProject(
   payload: CreateSentryProjectPayload,
   options: WizardOptions
@@ -1535,6 +1538,34 @@ async function createSentryProject(
     if (options.org && options.project) {
       const existing = await tryGetExistingProject(orgSlug, slug);
       if (existing) {
+        // Seed dsn_cache so detectDsn() gets a cache hit next time
+        const d = existing.data as {
+          orgSlug: string;
+          projectSlug: string;
+          projectId: string;
+          dsn: string;
+        };
+        if (d.dsn) {
+          try {
+            const parsed = parseDsn(d.dsn);
+            if (parsed) {
+              setCachedDsn(payload.cwd, {
+                dsn: d.dsn,
+                projectId: parsed.projectId,
+                orgId: parsed.orgId,
+                source: "code",
+                resolved: {
+                  orgSlug: d.orgSlug,
+                  orgName: d.orgSlug,
+                  projectSlug: d.projectSlug,
+                  projectName: d.projectSlug,
+                },
+              });
+            }
+          } catch {
+            // Best-effort
+          }
+        }
         return {
           ...existing,
           message: `Using existing project "${slug}" in ${orgSlug}`,
@@ -1555,6 +1586,30 @@ async function createSentryProject(
       team.slug,
       { name, platform }
     );
+
+    // Seed dsn_cache so detectDsn() gets a cache hit next time
+    // (project_cache already seeded by createProjectWithDsn)
+    if (dsn) {
+      try {
+        const parsed = parseDsn(dsn);
+        if (parsed) {
+          setCachedDsn(payload.cwd, {
+            dsn,
+            projectId: parsed.projectId,
+            orgId: parsed.orgId,
+            source: "code",
+            resolved: {
+              orgSlug,
+              orgName: orgSlug,
+              projectSlug: project.slug,
+              projectName: project.name,
+            },
+          });
+        }
+      } catch {
+        // Best-effort
+      }
+    }
 
     return {
       ok: true,

--- a/src/lib/init/local-ops.ts
+++ b/src/lib/init/local-ops.ts
@@ -15,8 +15,6 @@ import {
   listOrganizations,
   tryGetPrimaryDsn,
 } from "../api-client.js";
-import { setCachedDsn } from "../db/dsn-cache.js";
-import { parseDsn } from "../dsn/parser.js";
 import { ApiError } from "../errors.js";
 import { resolveOrCreateTeam } from "../resolve-team.js";
 import { buildProjectUrl } from "../sentry-urls.js";
@@ -1491,7 +1489,6 @@ async function glob(payload: GlobPayload): Promise<LocalOpResult> {
 
 // ── Sentry project + DSN ────────────────────────────────────────────
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: branching for dry-run, existing project, new project, and best-effort cache seeding
 async function createSentryProject(
   payload: CreateSentryProjectPayload,
   options: WizardOptions
@@ -1538,34 +1535,6 @@ async function createSentryProject(
     if (options.org && options.project) {
       const existing = await tryGetExistingProject(orgSlug, slug);
       if (existing) {
-        // Seed dsn_cache so detectDsn() gets a cache hit next time
-        const d = existing.data as {
-          orgSlug: string;
-          projectSlug: string;
-          projectId: string;
-          dsn: string;
-        };
-        if (d.dsn) {
-          try {
-            const parsed = parseDsn(d.dsn);
-            if (parsed) {
-              setCachedDsn(payload.cwd, {
-                dsn: d.dsn,
-                projectId: parsed.projectId,
-                orgId: parsed.orgId,
-                source: "code",
-                resolved: {
-                  orgSlug: d.orgSlug,
-                  orgName: d.orgSlug,
-                  projectSlug: d.projectSlug,
-                  projectName: d.projectSlug,
-                },
-              });
-            }
-          } catch {
-            // Best-effort
-          }
-        }
         return {
           ...existing,
           message: `Using existing project "${slug}" in ${orgSlug}`,
@@ -1586,30 +1555,6 @@ async function createSentryProject(
       team.slug,
       { name, platform }
     );
-
-    // Seed dsn_cache so detectDsn() gets a cache hit next time
-    // (project_cache already seeded by createProjectWithDsn)
-    if (dsn) {
-      try {
-        const parsed = parseDsn(dsn);
-        if (parsed) {
-          setCachedDsn(payload.cwd, {
-            dsn,
-            projectId: parsed.projectId,
-            orgId: parsed.orgId,
-            source: "code",
-            resolved: {
-              orgSlug,
-              orgName: orgSlug,
-              projectSlug: project.slug,
-              projectName: project.name,
-            },
-          });
-        }
-      } catch {
-        // Best-effort
-      }
-    }
 
     return {
       ok: true,

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -728,6 +728,19 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
   }
 
   handleFinalResult(result, spin, spinState);
+
+  // Eagerly populate dsn_cache so the next command doesn't re-scan files.
+  // The DSN is now in source code (written by apply-patchset), so detectDsn
+  // will find it and cache with the correct projectRoot and sourcePath.
+  // project_cache was already seeded by createProjectWithDsn.
+  if (!dryRun) {
+    try {
+      const { detectDsn } = await import("../dsn/index.js");
+      await detectDsn(directory);
+    } catch {
+      // Best-effort — cache seeding failure doesn't affect init result
+    }
+  }
 }
 
 function handleFinalResult(


### PR DESCRIPTION
## Summary

After `sentry init` or `sentry project create`, the resolved project and DSN data wasn't being saved to the local DB. This meant the next command (e.g. `sentry issue list`) had to re-scan files for the DSN and hit the API to resolve the project — even though all that info was just known.

This seeds the same caches that `resolveFromDsn` and `detectDsn` populate on their slow paths, so subsequent commands get cache hits instead.

## Changes

- `createProjectWithDsn` in `projects.ts` now caches in `project_cache` (by orgId:projectId and DSN public key). Covers both `sentry init` and `sentry project create`.
- `createSentryProject` in `local-ops.ts` now caches in `dsn_cache` (keyed by directory) at both success paths — existing project reuse and new project creation.

All inline, matching the existing pattern in `resolve-target.ts` and `detector.ts`. Best-effort with try/catch so cache failures never break the command.

## Test Plan

- Run `sentry project create acme/foo node` → verify `project_cache` has entry
- Run `sentry init acme/my-app` → verify both `dsn_cache` and `project_cache` populated
- Run `sentry issue list` after init → resolves from cache, no extra API call
- Dry-run paths return before caching code, so no writes happen
- Existing tests pass (DB tests, project create tests)