### PR TITLE
fix(init): treat no-op edits as passthrough instead of throwing

### DIFF
--- a/src/lib/init/replacers.ts
+++ b/src/lib/init/replacers.ts
@@ -488,9 +488,7 @@ export function replace(
   replaceAll = false
 ): string {
   if (oldString === newString) {
-    throw new Error(
-      "No changes to apply: oldString and newString are identical."
-    );
+    return content;
   }
 
   let notFound = true;

--- a/test/lib/init/replacers.test.ts
+++ b/test/lib/init/replacers.test.ts
@@ -19,10 +19,9 @@ describe("replace", () => {
     );
   });
 
-  test("throws when oldString equals newString", () => {
-    expect(() => replace("hello", "hello", "hello")).toThrow(
-      "No changes to apply"
-    );
+  test("returns content unchanged when oldString equals newString", () => {
+    const result = replace("hello world", "hello", "hello");
+    expect(result).toBe("hello world");
   });
 
   test("throws on ambiguous match (multiple occurrences)", () => {


### PR DESCRIPTION
## Summary

When the AI agent generates an edit where `oldString === newString`, return the content unchanged instead of throwing. The agent sometimes produces redundant no-op edits (e.g., package.json already has the right content), and crashing on those triggered 4 retries followed by "Codemod recovery produced no modifications."

This is a deliberate deviation from opencode's `replace()` which throws on identical strings — their context is interactive editing where it's a user mistake. In our agent context, no-op edits are benign.

## Test plan

- [x] Updated test: expects passthrough instead of throw
- [x] All 15 replacer tests pass

Made with [Cursor](https://cursor.com)