### PR TITLE
feat(setup): install agent skills for detected roots

### DIFF
--- a/src/commands/cli/setup.ts
+++ b/src/commands/cli/setup.ts
@@ -280,8 +280,9 @@ async function handleCompletions(
 /**
  * Handle agent skill installation for AI coding assistants.
  *
- * Detects supported agents (currently Claude Code) and installs the
- * version-pinned skill file. Silent when no agent is detected.
+ * Detects supported agent roots (currently `~/.agents` and `~/.claude`)
+ * and installs the version-pinned skill files. Silent when no compatible
+ * agent root is detected.
  *
  * Only produces output when the skill file is freshly created. Subsequent
  * runs (e.g. after upgrade) silently update without printing.
@@ -440,7 +441,7 @@ export const setupCommand = buildCommand({
       "Sets up shell integration for the Sentry CLI:\n\n" +
       "- Adds binary directory to PATH (if not already in PATH)\n" +
       "- Installs shell completions (bash, zsh, fish)\n" +
-      "- Installs agent skills for AI coding assistants (e.g., Claude Code)\n" +
+      "- Installs agent skills for detected AI coding assistants\n" +
       "- Records installation metadata for upgrades\n\n" +
       "With --install, also handles binary placement from a temporary\n" +
       "download location (used by the install script and upgrade command).\n\n" +

--- a/src/lib/agent-skills.ts
+++ b/src/lib/agent-skills.ts
@@ -1,8 +1,8 @@
 /**
  * Agent skill installation for AI coding assistants.
  *
- * Detects supported AI coding agents (currently Claude Code) and installs
- * the Sentry CLI skill files so the agent can use CLI commands effectively.
+ * Detects supported agent roots and installs the embedded Sentry CLI
+ * skill files without creating new top-level agent directories.
  *
  * Skill file contents are embedded at build time (via a generated module
  * produced by script/generate-skill.ts), so no network fetch is needed.
@@ -24,59 +24,65 @@ export type AgentSkillLocation = {
 };
 
 /**
+ * Get the root directory for an agent skill installation target.
+ */
+function getSkillRootPath(
+  homeDir: string,
+  rootDir: ".agents" | ".claude"
+): string {
+  return join(homeDir, rootDir);
+}
+
+/**
  * Check if Claude Code is installed by looking for the ~/.claude directory.
  *
  * Claude Code creates this directory on first use for settings, skills,
  * and other configuration. Its presence is a reliable indicator.
  */
 export function detectClaudeCode(homeDir: string): boolean {
-  return existsSync(join(homeDir, ".claude"));
+  return existsSync(getSkillRootPath(homeDir, ".claude"));
 }
 
 /**
- * Get the installation path for the Sentry CLI skill in Claude Code.
+ * Check if a shared Agent Skills root already exists.
  *
- * Skills are stored under ~/.claude/skills/<skill-name>/SKILL.md,
- * matching the convention used by the `npx skills` tool.
+ * Compatible agents create `~/.agents` when they adopt the shared skills
+ * layout, so its presence is the opt-in signal for installing there.
  */
-export function getSkillInstallPath(homeDir: string): string {
-  return join(homeDir, ".claude", "skills", "sentry-cli", "SKILL.md");
+function detectSharedAgentSkillsRoot(homeDir: string): boolean {
+  return existsSync(getSkillRootPath(homeDir, ".agents"));
 }
 
 /**
- * Install the Sentry CLI agent skill for Claude Code.
+ * Get the installation path for the Sentry CLI skill under a supported
+ * agent root.
  *
- * Checks if Claude Code is installed and writes the embedded skill files
- * to the Claude Code skills directory. Skill content is bundled into the
- * binary at build time, so no network access is required.
- *
- * Returns null (without throwing) if Claude Code isn't detected
- * or any other error occurs.
- *
- * @param homeDir - User's home directory
- * @returns Location info if installed, null otherwise
+ * `~/.claude` remains the default to preserve the existing helper behavior,
+ * while callers can also pass `".agents"` for the shared Agent Skills path.
  */
-export async function installAgentSkills(
-  homeDir: string
+export function getSkillInstallPath(
+  homeDir: string,
+  rootDir: ".agents" | ".claude" = ".claude"
+): string {
+  return join(
+    getSkillRootPath(homeDir, rootDir),
+    "skills",
+    "sentry-cli",
+    "SKILL.md"
+  );
+}
+
+/**
+ * Write embedded skill files beneath an already-detected agent root.
+ *
+ * Callers must ensure the target root exists and is writable before invoking
+ * this helper. Returns null on any filesystem failure.
+ */
+async function writeSkillFiles(
+  skillPath: string
 ): Promise<AgentSkillLocation | null> {
-  if (!detectClaudeCode(homeDir)) {
-    return null;
-  }
-
-  // Verify .claude is writable before attempting file creation.
-  // In sandboxed environments (e.g., Claude Code sandbox), .claude may exist
-  // but be read-only. Some sandboxes terminate the process on write attempts,
-  // bypassing JavaScript error handling — so we must check before writing.
   try {
-    accessSync(join(homeDir, ".claude"), constants.W_OK);
-  } catch {
-    return null;
-  }
-
-  try {
-    const skillPath = getSkillInstallPath(homeDir);
     const skillDir = dirname(skillPath);
-
     const alreadyExists = existsSync(skillPath);
     let referenceCount = 0;
 
@@ -104,4 +110,77 @@ export async function installAgentSkills(
     });
     return null;
   }
+}
+
+/**
+ * Install the embedded skill files for a detected agent root.
+ *
+ * This helper verifies the target root remains present and writable before
+ * attempting to create the nested `skills/sentry-cli` directory tree.
+ */
+async function installDetectedAgentSkill(
+  homeDir: string,
+  rootDir: ".agents" | ".claude"
+): Promise<AgentSkillLocation | null> {
+  const parentDir = getSkillRootPath(homeDir, rootDir);
+  if (!existsSync(parentDir)) {
+    return null;
+  }
+
+  // In sandboxed environments, the agent root may exist but be read-only.
+  // Some sandboxes terminate the process on write attempts, bypassing
+  // JavaScript error handling, so we must check before writing.
+  try {
+    accessSync(parentDir, constants.W_OK);
+  } catch {
+    return null;
+  }
+
+  return await writeSkillFiles(getSkillInstallPath(homeDir, rootDir));
+}
+
+/**
+ * Install the Sentry CLI agent skill for detected AI coding assistants.
+ *
+ * Installs under any supported root that already exists:
+ *
+ * - `~/.agents/skills/sentry-cli/` for compatible agents using the shared
+ *   Agent Skills layout
+ * - `~/.claude/skills/sentry-cli/` when Claude Code is installed
+ *
+ * The installer never creates top-level agent roots. Their presence is the
+ * detection signal that the user already has a compatible agent installed.
+ * Each target is independent, so a failure in one location does not block
+ * the others.
+ *
+ * If any target is freshly created, the returned `path` points to that new
+ * installation so setup output matches the file that was actually added.
+ *
+ * @param homeDir - User's home directory
+ * @returns Location info if installed to at least one detected target, null otherwise
+ */
+export async function installAgentSkills(
+  homeDir: string
+): Promise<AgentSkillLocation | null> {
+  const results: AgentSkillLocation[] = [];
+
+  if (detectSharedAgentSkillsRoot(homeDir)) {
+    const location = await installDetectedAgentSkill(homeDir, ".agents");
+    if (location) {
+      results.push(location);
+    }
+  }
+
+  if (detectClaudeCode(homeDir)) {
+    const location = await installDetectedAgentSkill(homeDir, ".claude");
+    if (location) {
+      results.push(location);
+    }
+  }
+
+  if (results.length === 0) {
+    return null;
+  }
+
+  return results.find((location) => location.created) ?? results[0] ?? null;
 }

--- a/src/lib/agent-skills.ts
+++ b/src/lib/agent-skills.ts
@@ -1,8 +1,9 @@
 /**
  * Agent skill installation for AI coding assistants.
  *
- * Detects supported agent roots and installs the embedded Sentry CLI
- * skill files without creating new top-level agent directories.
+ * Detects supported AI coding agents (currently Claude Code and agents that
+ * use the shared `~/.agents` root) and installs the Sentry CLI skill files
+ * so the agent can use CLI commands effectively.
  *
  * Skill file contents are embedded at build time (via a generated module
  * produced by script/generate-skill.ts), so no network fetch is needed.
@@ -24,38 +25,18 @@ export type AgentSkillLocation = {
 };
 
 /**
- * Get the root directory for an agent skill installation target.
- */
-function getSkillRootPath(
-  homeDir: string,
-  rootDir: ".agents" | ".claude"
-): string {
-  return join(homeDir, rootDir);
-}
-
-/**
  * Check if Claude Code is installed by looking for the ~/.claude directory.
  *
  * Claude Code creates this directory on first use for settings, skills,
  * and other configuration. Its presence is a reliable indicator.
  */
 export function detectClaudeCode(homeDir: string): boolean {
-  return existsSync(getSkillRootPath(homeDir, ".claude"));
+  return existsSync(join(homeDir, ".claude"));
 }
 
 /**
- * Check if a shared Agent Skills root already exists.
- *
- * Compatible agents create `~/.agents` when they adopt the shared skills
- * layout, so its presence is the opt-in signal for installing there.
- */
-function detectSharedAgentSkillsRoot(homeDir: string): boolean {
-  return existsSync(getSkillRootPath(homeDir, ".agents"));
-}
-
-/**
- * Get the installation path for the Sentry CLI skill under a supported
- * agent root.
+ * Get the installation path for the Sentry CLI skill under a supported AI
+ * coding assistant root.
  *
  * `~/.claude` remains the default to preserve the existing helper behavior,
  * while callers can also pass `".agents"` for the shared Agent Skills path.
@@ -64,12 +45,7 @@ export function getSkillInstallPath(
   homeDir: string,
   rootDir: ".agents" | ".claude" = ".claude"
 ): string {
-  return join(
-    getSkillRootPath(homeDir, rootDir),
-    "skills",
-    "sentry-cli",
-    "SKILL.md"
-  );
+  return join(homeDir, rootDir, "skills", "sentry-cli", "SKILL.md");
 }
 
 /**
@@ -113,45 +89,12 @@ async function writeSkillFiles(
 }
 
 /**
- * Install the embedded skill files for a detected agent root.
- *
- * This helper verifies the target root remains present and writable before
- * attempting to create the nested `skills/sentry-cli` directory tree.
- */
-async function installDetectedAgentSkill(
-  homeDir: string,
-  rootDir: ".agents" | ".claude"
-): Promise<AgentSkillLocation | null> {
-  const parentDir = getSkillRootPath(homeDir, rootDir);
-  if (!existsSync(parentDir)) {
-    return null;
-  }
-
-  // In sandboxed environments, the agent root may exist but be read-only.
-  // Some sandboxes terminate the process on write attempts, bypassing
-  // JavaScript error handling, so we must check before writing.
-  try {
-    accessSync(parentDir, constants.W_OK);
-  } catch {
-    return null;
-  }
-
-  return await writeSkillFiles(getSkillInstallPath(homeDir, rootDir));
-}
-
-/**
  * Install the Sentry CLI agent skill for detected AI coding assistants.
  *
- * Installs under any supported root that already exists:
- *
- * - `~/.agents/skills/sentry-cli/` for compatible agents using the shared
- *   Agent Skills layout
- * - `~/.claude/skills/sentry-cli/` when Claude Code is installed
- *
- * The installer never creates top-level agent roots. Their presence is the
- * detection signal that the user already has a compatible agent installed.
- * Each target is independent, so a failure in one location does not block
- * the others.
+ * Checks supported roots and writes the embedded skill files to each detected
+ * location. The installer never creates top-level agent roots. Their presence
+ * is the detection signal that the user already has a compatible agent
+ * installed, matching the original Claude-only skip behavior.
  *
  * If any target is freshly created, the returned `path` points to that new
  * installation so setup output matches the file that was actually added.
@@ -162,17 +105,37 @@ async function installDetectedAgentSkill(
 export async function installAgentSkills(
   homeDir: string
 ): Promise<AgentSkillLocation | null> {
+  const installTargets = [
+    {
+      detected: existsSync(join(homeDir, ".agents")),
+      rootDir: ".agents" as const,
+    },
+    {
+      detected: detectClaudeCode(homeDir),
+      rootDir: ".claude" as const,
+    },
+  ];
   const results: AgentSkillLocation[] = [];
 
-  if (detectSharedAgentSkillsRoot(homeDir)) {
-    const location = await installDetectedAgentSkill(homeDir, ".agents");
-    if (location) {
-      results.push(location);
+  for (const target of installTargets) {
+    if (!target.detected) {
+      continue;
     }
-  }
 
-  if (detectClaudeCode(homeDir)) {
-    const location = await installDetectedAgentSkill(homeDir, ".claude");
+    const parentDir = join(homeDir, target.rootDir);
+
+    // In sandboxed environments, the agent root may exist but be read-only.
+    // Some sandboxes terminate the process on write attempts, bypassing
+    // JavaScript error handling — so we must check before writing.
+    try {
+      accessSync(parentDir, constants.W_OK);
+    } catch {
+      continue;
+    }
+
+    const location = await writeSkillFiles(
+      getSkillInstallPath(homeDir, target.rootDir)
+    );
     if (location) {
       results.push(location);
     }

--- a/test/commands/cli/setup.test.ts
+++ b/test/commands/cli/setup.test.ts
@@ -730,7 +730,7 @@ describe("sentry cli setup", () => {
       expect(existsSync(skillPath)).toBe(true);
     });
 
-    test("silently skips when Claude Code is not detected", async () => {
+    test("silently skips when no supported agent root is detected", async () => {
       const { context, getOutput, restore } = createMockContext({
         homeDir: testDir,
         execPath: join(testDir, "bin", "sentry"),
@@ -748,6 +748,34 @@ describe("sentry cli setup", () => {
       );
 
       expect(getOutput()).not.toContain("Agent skills:");
+    });
+
+    test("installs to ~/.agents/ when the shared agent root is detected", async () => {
+      mkdirSync(join(testDir, ".agents"), { recursive: true });
+
+      const { context, getOutput, restore } = createMockContext({
+        homeDir: testDir,
+        execPath: join(testDir, "bin", "sentry"),
+        env: {
+          PATH: `/usr/bin:${join(testDir, "bin")}:/bin`,
+          SHELL: "/bin/bash",
+        },
+      });
+      restoreStderr = restore;
+
+      await run(
+        app,
+        ["cli", "setup", "--no-modify-path", "--no-completions"],
+        context
+      );
+
+      expect(getOutput()).toContain("Agent skills: Installed to");
+      expect(
+        existsSync(join(testDir, ".agents", "skills", "sentry-cli", "SKILL.md"))
+      ).toBe(true);
+      expect(
+        existsSync(join(testDir, ".claude", "skills", "sentry-cli", "SKILL.md"))
+      ).toBe(false);
     });
 
     test("suppresses agent skills message on subsequent runs (upgrade scenario)", async () => {

--- a/test/lib/agent-skills.test.ts
+++ b/test/lib/agent-skills.test.ts
@@ -1,11 +1,8 @@
 /**
  * Agent Skills Tests
  *
- * Unit tests for Claude Code detection, skill path construction,
- * and embedded skill file installation.
- *
- * Note: URL construction and network fetching tests were removed when
- * skill content was embedded at build time (no more network fetch).
+ * Unit tests for Claude Code detection, shared path construction, and
+ * embedded skill installation across detected agent roots.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -44,9 +41,14 @@ describe("agent-skills", () => {
   });
 
   describe("getSkillInstallPath", () => {
-    test("returns correct path under ~/.claude/skills", () => {
+    test("defaults to the Claude Code path", () => {
       const path = getSkillInstallPath("/home/user");
       expect(path).toBe("/home/user/.claude/skills/sentry-cli/SKILL.md");
+    });
+
+    test("returns correct path under ~/.agents/skills", () => {
+      const path = getSkillInstallPath("/home/user", ".agents");
+      expect(path).toBe("/home/user/.agents/skills/sentry-cli/SKILL.md");
     });
   });
 
@@ -62,53 +64,102 @@ describe("agent-skills", () => {
     });
 
     afterEach(() => {
+      for (const dir of [
+        testDir,
+        join(testDir, ".agents"),
+        join(testDir, ".claude"),
+      ]) {
+        try {
+          if (existsSync(dir)) {
+            chmodSync(dir, 0o755);
+          }
+        } catch {
+          // Ignore cleanup races for directories that never existed.
+        }
+      }
       rmSync(testDir, { recursive: true, force: true });
     });
 
-    test("returns null when Claude Code is not detected", async () => {
+    test("returns null when no supported agent root is detected", async () => {
       const result = await installAgentSkills(testDir);
       expect(result).toBeNull();
     });
 
-    test("installs embedded skill files when Claude Code is detected", async () => {
-      mkdirSync(join(testDir, ".claude"), { recursive: true });
+    test("installs to ~/.agents/ when the shared agent root exists", async () => {
+      mkdirSync(join(testDir, ".agents"), { recursive: true });
 
       const result = await installAgentSkills(testDir);
 
       expect(result).not.toBeNull();
       expect(result!.created).toBe(true);
       expect(result!.path).toBe(
-        join(testDir, ".claude", "skills", "sentry-cli", "SKILL.md")
+        join(testDir, ".agents", "skills", "sentry-cli", "SKILL.md")
       );
       expect(existsSync(result!.path)).toBe(true);
 
       const content = await Bun.file(result!.path).text();
       expect(content).toContain("sentry-cli");
 
-      // Check reference files were created
       expect(result!.referenceCount).toBeGreaterThan(0);
       const refsDir = join(
         testDir,
-        ".claude",
+        ".agents",
         "skills",
         "sentry-cli",
         "references"
       );
       expect(existsSync(refsDir)).toBe(true);
       expect(existsSync(join(refsDir, "issue.md"))).toBe(true);
+
+      expect(
+        existsSync(join(testDir, ".claude", "skills", "sentry-cli", "SKILL.md"))
+      ).toBe(false);
     });
 
-    test("creates intermediate directories", async () => {
+    test("installs to both ~/.agents/ and ~/.claude/ when both roots exist", async () => {
+      mkdirSync(join(testDir, ".agents"), { recursive: true });
       mkdirSync(join(testDir, ".claude"), { recursive: true });
 
       const result = await installAgentSkills(testDir);
 
       expect(result).not.toBeNull();
-      expect(existsSync(result!.path)).toBe(true);
+      expect(result!.path).toBe(
+        join(testDir, ".agents", "skills", "sentry-cli", "SKILL.md")
+      );
+      expect(
+        existsSync(join(testDir, ".agents", "skills", "sentry-cli", "SKILL.md"))
+      ).toBe(true);
+      expect(
+        existsSync(join(testDir, ".claude", "skills", "sentry-cli", "SKILL.md"))
+      ).toBe(true);
+      expect(
+        existsSync(
+          join(
+            testDir,
+            ".agents",
+            "skills",
+            "sentry-cli",
+            "references",
+            "issue.md"
+          )
+        )
+      ).toBe(true);
+      expect(
+        existsSync(
+          join(
+            testDir,
+            ".claude",
+            "skills",
+            "sentry-cli",
+            "references",
+            "issue.md"
+          )
+        )
+      ).toBe(true);
     });
 
     test("reports created: false when updating existing file", async () => {
-      mkdirSync(join(testDir, ".claude"), { recursive: true });
+      mkdirSync(join(testDir, ".agents"), { recursive: true });
 
       const first = await installAgentSkills(testDir);
       expect(first!.created).toBe(true);
@@ -118,31 +169,65 @@ describe("agent-skills", () => {
       expect(second!.path).toBe(first!.path);
     });
 
-    test("returns null on filesystem error without throwing", async () => {
-      // Create .claude as a read-only directory so mkdirSync for the
-      // skills subdirectory fails with EACCES
-      mkdirSync(join(testDir, ".claude"), { recursive: true, mode: 0o444 });
+    test("reports the fresh claude path when shared skills already exist", async () => {
+      mkdirSync(join(testDir, ".agents"), { recursive: true });
 
-      const result = await installAgentSkills(testDir);
-      expect(result).toBeNull();
+      const first = await installAgentSkills(testDir);
+      expect(first!.created).toBe(true);
+      expect(first!.path).toBe(
+        join(testDir, ".agents", "skills", "sentry-cli", "SKILL.md")
+      );
 
-      // Restore write permission so afterEach cleanup can remove it
-      chmodSync(join(testDir, ".claude"), 0o755);
+      mkdirSync(join(testDir, ".claude"), { recursive: true });
+
+      const second = await installAgentSkills(testDir);
+      expect(second).not.toBeNull();
+      expect(second!.created).toBe(true);
+      expect(second!.path).toBe(
+        join(testDir, ".claude", "skills", "sentry-cli", "SKILL.md")
+      );
     });
 
-    test("returns null when .claude exists but is not writable (sandbox)", async () => {
-      // Simulate a sandboxed .claude directory: readable + executable, not writable.
-      // The accessSync(W_OK) pre-check should catch this before any write attempt.
-      mkdirSync(join(testDir, ".claude"), { recursive: true, mode: 0o555 });
+    test("claude install succeeds even if ~/.agents is not writable", async () => {
+      mkdirSync(join(testDir, ".agents"), { recursive: true });
+      chmodSync(join(testDir, ".agents"), 0o444);
+      mkdirSync(join(testDir, ".claude"), { recursive: true });
+
+      const result = await installAgentSkills(testDir);
+      expect(result).not.toBeNull();
+      expect(result!.path).toBe(
+        join(testDir, ".claude", "skills", "sentry-cli", "SKILL.md")
+      );
+      expect(existsSync(result!.path)).toBe(true);
+      expect(
+        existsSync(join(testDir, ".agents", "skills", "sentry-cli", "SKILL.md"))
+      ).toBe(false);
+    });
+
+    test("agents install succeeds even if ~/.claude is not writable", async () => {
+      mkdirSync(join(testDir, ".agents"), { recursive: true });
+      mkdirSync(join(testDir, ".claude"), { recursive: true });
+      chmodSync(join(testDir, ".claude"), 0o444);
+
+      const result = await installAgentSkills(testDir);
+      expect(result).not.toBeNull();
+      expect(result!.path).toBe(
+        join(testDir, ".agents", "skills", "sentry-cli", "SKILL.md")
+      );
+      expect(existsSync(result!.path)).toBe(true);
+      expect(
+        existsSync(join(testDir, ".claude", "skills", "sentry-cli", "SKILL.md"))
+      ).toBe(false);
+    });
+
+    test("returns null when all detected targets are not writable", async () => {
+      mkdirSync(join(testDir, ".agents"), { recursive: true });
+      mkdirSync(join(testDir, ".claude"), { recursive: true });
+      chmodSync(join(testDir, ".agents"), 0o444);
+      chmodSync(join(testDir, ".claude"), 0o444);
 
       const result = await installAgentSkills(testDir);
       expect(result).toBeNull();
-
-      // Verify no write was attempted — skills subdir should not exist
-      expect(existsSync(join(testDir, ".claude", "skills"))).toBe(false);
-
-      // Restore write permission so afterEach cleanup can remove it
-      chmodSync(join(testDir, ".claude"), 0o755);
     });
   });
 });


### PR DESCRIPTION
## Summary

This follows up on #747 with a smaller change built from `main` instead of carrying forward the unconditional `.agents` installer. It keeps the existing Claude-only shape, adds shared `~/.agents` support only when that root already exists, and keeps setup output aligned with the file that was actually created.

## Changes

- detect existing `~/.agents` and `~/.claude` roots instead of creating a top-level shared root
- reuse the existing skill path helper for both targets and keep each install independent
- update setup and unit tests for no-agent silence, detected `~/.agents` installs, and fresh-path reporting

## Test Plan

- [x] `bun test test/lib/agent-skills.test.ts`
- [x] `bun test test/commands/cli/setup.test.ts`
- [x] `bun run typecheck`
- [x] `bun run lint` (passes with an existing unrelated warning in `src/lib/formatters/markdown.ts`)

## References

- Supersedes #747

Made with [Cursor](https://cursor.com)