### PR TITLE
fix(upgrade): retry spawn on EBUSY for Windows Defender file locking (CLI-16E)

### DIFF
--- a/src/commands/cli/upgrade.ts
+++ b/src/commands/cli/upgrade.ts
@@ -367,11 +367,8 @@ function buildCheckResult(opts: {
  */
 const SPAWN_MAX_ATTEMPTS = 5;
 
-/**
- * Backoff delays (ms) between spawn retry attempts.
- * Index 0 = delay before retry #1, etc. Total budget: ~5s.
- */
-const SPAWN_RETRY_DELAYS_MS = [500, 1000, 1500, 2000];
+/** Base delay (ms) between spawn retry attempts. Delay = attempt * base. */
+const SPAWN_RETRY_BASE_MS = 500;
 
 /**
  * Check whether an error is an EBUSY system error from spawn.
@@ -417,7 +414,7 @@ async function spawnWithRetry(
       if (!isEbusyError(error) || attempt === SPAWN_MAX_ATTEMPTS) {
         throw error;
       }
-      const delay = SPAWN_RETRY_DELAYS_MS[attempt - 1] ?? 2000;
+      const delay = attempt * SPAWN_RETRY_BASE_MS;
       log.warn(
         `Binary is locked (antivirus scan?), retrying in ${delay}ms... (attempt ${attempt}/${SPAWN_MAX_ATTEMPTS})`
       );

--- a/src/commands/cli/upgrade.ts
+++ b/src/commands/cli/upgrade.ts
@@ -359,6 +359,76 @@ function buildCheckResult(opts: {
 }
 
 /**
+ * Maximum number of spawn attempts for the new binary.
+ *
+ * On Windows, Defender/SmartScreen may lock a newly-written executable for
+ * antivirus scanning after the file handle is closed. This causes EBUSY from
+ * uv_spawn. Retrying with backoff lets the scan complete without a fixed sleep.
+ */
+const SPAWN_MAX_ATTEMPTS = 5;
+
+/**
+ * Backoff delays (ms) between spawn retry attempts.
+ * Index 0 = delay before retry #1, etc. Total budget: ~5s.
+ */
+const SPAWN_RETRY_DELAYS_MS = [500, 1000, 1500, 2000];
+
+/**
+ * Check whether an error is an EBUSY system error from spawn.
+ *
+ * On Windows, Defender/SmartScreen locks newly-written executables for
+ * scanning. libuv's uv_spawn fails with EBUSY until the lock is released.
+ */
+export function isEbusyError(error: unknown): boolean {
+  return (
+    error instanceof Error && (error as NodeJS.ErrnoException).code === "EBUSY"
+  );
+}
+
+/**
+ * Spawn a binary with retry on EBUSY errors.
+ *
+ * On Windows, Defender/SmartScreen asynchronously scans newly-written
+ * executables after the file handle is closed. If the CLI spawns the
+ * binary before the scan completes, uv_spawn fails with EBUSY.
+ * This function retries with backoff to let the scan finish.
+ *
+ * On non-Windows platforms (or when Defender isn't active), the first
+ * attempt succeeds immediately with zero overhead.
+ *
+ * @returns Process exit code from the successful spawn
+ * @throws The last EBUSY error if all attempts are exhausted
+ * @throws Immediately on non-EBUSY errors (ENOENT, EACCES, etc.)
+ */
+async function spawnWithRetry(
+  binaryPath: string,
+  args: string[],
+  env: NodeJS.ProcessEnv | undefined
+): Promise<number> {
+  for (let attempt = 1; attempt <= SPAWN_MAX_ATTEMPTS; attempt++) {
+    try {
+      const proc = Bun.spawn([binaryPath, ...args], {
+        stdout: "inherit",
+        stderr: "inherit",
+        env,
+      });
+      return await proc.exited;
+    } catch (error) {
+      if (!isEbusyError(error) || attempt === SPAWN_MAX_ATTEMPTS) {
+        throw error;
+      }
+      const delay = SPAWN_RETRY_DELAYS_MS[attempt - 1] ?? 2000;
+      log.warn(
+        `Binary is locked (antivirus scan?), retrying in ${delay}ms... (attempt ${attempt}/${SPAWN_MAX_ATTEMPTS})`
+      );
+      await Bun.sleep(delay);
+    }
+  }
+  // Unreachable — the loop either returns or throws
+  throw new UpgradeError("execution_failed", "Spawn retry loop exhausted");
+}
+
+/**
  * Spawn the new binary with `cli setup` to update completions, agent skills,
  * and record installation metadata.
  */
@@ -404,12 +474,7 @@ async function runSetupOnNewBinary(opts: SetupOptions): Promise<void> {
     ? { ...process.env, SENTRY_INSTALL_DIR: installDir }
     : undefined;
 
-  const proc = Bun.spawn([binaryPath, ...args], {
-    stdout: "inherit",
-    stderr: "inherit",
-    env,
-  });
-  const exitCode = await proc.exited;
+  const exitCode = await spawnWithRetry(binaryPath, args, env);
   if (exitCode !== 0) {
     throw new UpgradeError(
       "execution_failed",

--- a/test/commands/cli/upgrade.test.ts
+++ b/test/commands/cli/upgrade.test.ts
@@ -15,6 +15,7 @@ import { unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { run } from "@stricli/core";
 import { app } from "../../../src/app.js";
+import { isEbusyError } from "../../../src/commands/cli/upgrade.js";
 import type { SentryContext } from "../../../src/context.js";
 import { CLI_VERSION } from "../../../src/lib/constants.js";
 import {
@@ -993,5 +994,36 @@ describe("sentry cli upgrade — migrateToStandaloneForNightly (Bun.spawn spy)",
       "npm-installed sentry may still appear earlier in PATH"
     );
     expect(combined).toContain("npm uninstall -g sentry");
+  });
+});
+
+describe("isEbusyError", () => {
+  test("returns true for EBUSY errno error", () => {
+    const err = new Error("EBUSY: resource busy or locked, uv_spawn");
+    (err as NodeJS.ErrnoException).code = "EBUSY";
+    expect(isEbusyError(err)).toBe(true);
+  });
+
+  test("returns false for ENOENT", () => {
+    const err = new Error("ENOENT: no such file or directory");
+    (err as NodeJS.ErrnoException).code = "ENOENT";
+    expect(isEbusyError(err)).toBe(false);
+  });
+
+  test("returns false for EACCES", () => {
+    const err = new Error("EACCES: permission denied");
+    (err as NodeJS.ErrnoException).code = "EACCES";
+    expect(isEbusyError(err)).toBe(false);
+  });
+
+  test("returns false for non-Error values", () => {
+    expect(isEbusyError("EBUSY")).toBe(false);
+    expect(isEbusyError(null)).toBe(false);
+    expect(isEbusyError(undefined)).toBe(false);
+    expect(isEbusyError(42)).toBe(false);
+  });
+
+  test("returns false for Error without code", () => {
+    expect(isEbusyError(new Error("some error"))).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes [CLI-16E](https://sentry.sentry.io/issues/7413492046/): `EBUSY: resource busy or locked, uv_spawn` on Windows during `sentry cli upgrade`
- On Windows, Defender/SmartScreen locks newly-written executables for antivirus scanning after the file handle is closed, causing `Bun.spawn()` to fail with EBUSY
- Adds `spawnWithRetry()` that retries up to 5 times with backoff (500ms-2s, ~5s total) when EBUSY is detected
- Zero overhead on non-Windows platforms since the first spawn attempt succeeds immediately
- Retry over pre-emptive sleep because Defender scan time varies widely (SSD vs HDD) — retry is self-calibrating

## Changes

- `src/commands/cli/upgrade.ts`: Add `isEbusyError()`, `spawnWithRetry()`, refactor `runSetupOnNewBinary()` to use retry wrapper
- `test/commands/cli/upgrade.test.ts`: Add unit tests for `isEbusyError()` detection