### PR TITLE
fix(arg-parsing): normalize spaces in slugs and trim whitespace in issue IDs (CLI-14M, CLI-16M)

### DIFF
--- a/src/lib/arg-parsing.ts
+++ b/src/lib/arg-parsing.ts
@@ -66,11 +66,9 @@ export function normalizeSlug(slug: string): {
     result = result.toLowerCase();
   }
 
-  // Replace underscores and spaces with dashes
-  result = result.replace(/[_ ]/g, "-");
-
-  // Collapse consecutive dashes (from "My  Project" or "a__b")
-  result = result.replace(/-{2,}/g, "-");
+  // Replace runs of underscores/spaces with a single dash.
+  // Using [_ ]+ collapses "My  Project" and "a__b" in one pass.
+  result = result.replace(/[_ ]+/g, "-");
 
   // Trim leading/trailing dashes (from " My Project " → "-my-project-")
   result = result.replace(/^-+|-+$/g, "");

--- a/src/lib/arg-parsing.ts
+++ b/src/lib/arg-parsing.ts
@@ -18,34 +18,96 @@ import { isAllDigits } from "./utils.js";
 // Slug normalization
 // ---------------------------------------------------------------------------
 
+/** Describes what was normalized in a slug — used for targeted warning messages. */
+export type NormalizeReason = "underscores" | "spaces" | "both";
+
 /**
- * Normalize a Sentry slug by replacing underscores with dashes.
+ * Normalize a Sentry slug by replacing underscores and spaces with dashes.
  *
- * Sentry enforces that organization and project slugs use dashes, never
- * underscores. Users frequently type underscores by mistake (e.g.,
- * `selfbase_admin_backend` instead of `selfbase-admin-backend`).
+ * Sentry enforces that slugs use lowercase letters, numbers, and dashes.
+ * Users frequently type underscores by mistake or paste display names
+ * (e.g., `"My Project"` instead of `"my-project"`).
+ *
+ * Normalization rules:
+ * 1. Underscores → dashes (existing)
+ * 2. Spaces → dashes, with lowercase (spaces imply a display name)
+ * 3. Consecutive dashes collapsed (`"My  Project"` → `"my-project"`)
+ * 4. Leading/trailing dashes trimmed
+ *
+ * Lowercasing is only applied when spaces are present. Pure underscore
+ * normalization preserves casing for backward compatibility.
  *
  * @param slug - Raw slug string from CLI input
- * @returns Normalized slug and whether normalization was applied
+ * @returns Normalized slug, whether normalization was applied, and reason
  *
  * @example
- * normalizeSlug("selfbase_admin_backend")  // { slug: "selfbase-admin-backend", normalized: true }
+ * normalizeSlug("selfbase_admin_backend")  // { slug: "selfbase-admin-backend", normalized: true, reason: "underscores" }
+ * normalizeSlug("My Project")              // { slug: "my-project", normalized: true, reason: "spaces" }
+ * normalizeSlug("My_Project Name")         // { slug: "my-project-name", normalized: true, reason: "both" }
  * normalizeSlug("my-project")              // { slug: "my-project", normalized: false }
  */
 export function normalizeSlug(slug: string): {
   slug: string;
   normalized: boolean;
+  reason?: NormalizeReason;
 } {
-  if (slug.includes("_")) {
-    return { slug: slug.replace(/_/g, "-"), normalized: true };
+  const hasUnderscores = slug.includes("_");
+  const hasSpaces = slug.includes(" ");
+
+  if (!(hasUnderscores || hasSpaces)) {
+    return { slug, normalized: false };
   }
-  return { slug, normalized: false };
+
+  let result = slug;
+
+  // When spaces are present, lowercase the entire slug.
+  // Spaces imply a display name like "My Project" — slugs are always lowercase.
+  if (hasSpaces) {
+    result = result.toLowerCase();
+  }
+
+  // Replace underscores and spaces with dashes
+  result = result.replace(/[_ ]/g, "-");
+
+  // Collapse consecutive dashes (from "My  Project" or "a__b")
+  result = result.replace(/-{2,}/g, "-");
+
+  // Trim leading/trailing dashes (from " My Project " → "-my-project-")
+  result = result.replace(/^-+|-+$/g, "");
+
+  let reason: NormalizeReason;
+  if (hasUnderscores && hasSpaces) {
+    reason = "both";
+  } else if (hasSpaces) {
+    reason = "spaces";
+  } else {
+    reason = "underscores";
+  }
+
+  return { slug: result, normalized: true, reason };
 }
 
 const log = logger.withTag("arg-parsing");
 
 /**
- * Emit a warning when slug normalization replaced underscores with dashes.
+ * Combine two normalization reasons into the most descriptive one.
+ * Used when org and project slugs have different normalizations.
+ */
+function combineReasons(
+  a?: NormalizeReason,
+  b?: NormalizeReason
+): NormalizeReason {
+  if (a === "both" || b === "both") {
+    return "both";
+  }
+  if (a && b && a !== b) {
+    return "both";
+  }
+  return a ?? b ?? "underscores";
+}
+
+/**
+ * Emit a warning when slug normalization changed the input.
  * Called internally by {@link parseOrgProjectArg} — callers do not need to
  * check `parsed.normalized` themselves.
  */
@@ -67,9 +129,21 @@ function warnNormalized(
       return;
   }
 
-  log.warn(
-    `Normalized slug to '${slug}' (Sentry slugs use dashes, never underscores)`
-  );
+  let explanation: string;
+  switch (parsed.reason) {
+    case "spaces":
+      explanation = "Sentry slugs use lowercase with dashes, not spaces";
+      break;
+    case "both":
+      explanation =
+        "Sentry slugs use lowercase with dashes, not spaces or underscores";
+      break;
+    default:
+      explanation = "Sentry slugs use dashes, never underscores";
+      break;
+  }
+
+  log.warn(`Normalized slug to '${slug}' (${explanation})`);
 }
 
 // ---------------------------------------------------------------------------
@@ -366,28 +440,34 @@ export const ProjectSpecificationType = {
  * Parsed result from an org/project positional argument.
  * Discriminated union based on the `type` field.
  *
- * When `normalized` is true, the slug contained underscores that were
- * auto-corrected to dashes. Callers should emit a warning via `log.warn()`.
+ * When `normalized` is true, the slug was auto-corrected (underscores → dashes,
+ * spaces → dashes with lowercasing). `reason` describes what was normalized.
  */
 export type ParsedOrgProject =
   | {
       type: typeof ProjectSpecificationType.Explicit;
       org: string;
       project: string;
-      /** True if any slug was normalized (underscores → dashes) */
+      /** True if any slug was normalized */
       normalized?: boolean;
+      /** What was normalized — used for targeted warning messages */
+      reason?: NormalizeReason;
     }
   | {
       type: typeof ProjectSpecificationType.OrgAll;
       org: string;
-      /** True if org slug was normalized (underscores → dashes) */
+      /** True if org slug was normalized */
       normalized?: boolean;
+      /** What was normalized — used for targeted warning messages */
+      reason?: NormalizeReason;
     }
   | {
       type: typeof ProjectSpecificationType.ProjectSearch;
       projectSlug: string;
-      /** True if project slug was normalized (underscores → dashes) */
+      /** True if project slug was normalized */
       normalized?: boolean;
+      /** What was normalized — used for targeted warning messages */
+      reason?: NormalizeReason;
     }
   | { type: typeof ProjectSpecificationType.AutoDetect };
 
@@ -516,38 +596,39 @@ function parseSlashOrgProject(input: string): ParsedOrgProject {
       );
     }
     rejectAtSelector(rawProject, "project slug");
-    validateResourceId(rawProject, "project slug");
     const np = normalizeSlug(rawProject);
+    validateResourceId(np.slug, "project slug");
     return {
       type: "project-search",
       projectSlug: np.slug,
-      ...(np.normalized && { normalized: true }),
+      ...(np.normalized && { normalized: true, reason: np.reason }),
     };
   }
 
   rejectAtSelector(rawOrg, "organization slug");
-  validateResourceId(rawOrg, "organization slug");
   const no = normalizeSlug(rawOrg);
+  validateResourceId(no.slug, "organization slug");
 
   if (!rawProject) {
     // "sentry/" → list all projects in org
     return {
       type: "org-all",
       org: no.slug,
-      ...(no.normalized && { normalized: true }),
+      ...(no.normalized && { normalized: true, reason: no.reason }),
     };
   }
 
   // "sentry/cli" → explicit org and project
   rejectAtSelector(rawProject, "project slug");
-  validateResourceId(rawProject, "project slug");
   const np = normalizeSlug(rawProject);
+  validateResourceId(np.slug, "project slug");
   const normalized = no.normalized || np.normalized;
+  const reason = normalized ? combineReasons(no.reason, np.reason) : undefined;
   return {
     type: "explicit",
     org: no.slug,
     project: np.slug,
-    ...(normalized && { normalized: true }),
+    ...(normalized && { normalized: true, reason }),
   };
 }
 
@@ -592,12 +673,12 @@ export function parseOrgProjectArg(arg: string | undefined): ParsedOrgProject {
   } else {
     // No slash → search for project across all orgs
     rejectAtSelector(trimmed, "project slug");
-    validateResourceId(trimmed, "project slug");
     const np = normalizeSlug(trimmed);
+    validateResourceId(np.slug, "project slug");
     parsed = {
       type: "project-search",
       projectSlug: np.slug,
-      ...(np.normalized && { normalized: true }),
+      ...(np.normalized && { normalized: true, reason: np.reason }),
     };
   }
 
@@ -883,19 +964,26 @@ export function parseSlashSeparatedArg(
   idLabel: string,
   usageHint: string
 ): { id: string; targetArg: string | undefined } {
-  const slashIdx = arg.indexOf("/");
+  // Trim whitespace — agents may pass trailing newlines
+  const trimmed = arg.trim();
+
+  if (!trimmed) {
+    throw new ContextError(idLabel, usageHint, []);
+  }
+
+  const slashIdx = trimmed.indexOf("/");
 
   if (slashIdx === -1) {
     // No slashes — plain ID. Skip validation here because callers may
     // do further processing (e.g., splitting newline-separated IDs).
     // Downstream validators like validateHexId or validateTraceId provide
     // format-specific validation.
-    return { id: arg, targetArg: undefined };
+    return { id: trimmed, targetArg: undefined };
   }
 
   // IDs are hex and never contain "/" — this must be a structured
   // "org/project/id" or "org/project" (missing ID)
-  const lastSlashIdx = arg.lastIndexOf("/");
+  const lastSlashIdx = trimmed.lastIndexOf("/");
 
   if (slashIdx === lastSlashIdx) {
     // Exactly one slash: "org/project" without ID
@@ -903,8 +991,8 @@ export function parseSlashSeparatedArg(
   }
 
   // Two+ slashes: split on last "/" → target + id
-  const targetArg = arg.slice(0, lastSlashIdx);
-  const id = arg.slice(lastSlashIdx + 1);
+  const targetArg = trimmed.slice(0, lastSlashIdx);
+  const id = trimmed.slice(lastSlashIdx + 1);
 
   if (!id) {
     throw new ContextError(idLabel, usageHint, []);
@@ -918,8 +1006,18 @@ export function parseSlashSeparatedArg(
 }
 
 export function parseIssueArg(arg: string): ParsedIssueArg {
+  // Trim whitespace — agents may pass trailing newlines (CLI-16M)
+  const input = arg.trim();
+
+  if (!input) {
+    throw new ValidationError(
+      "Issue identifier is empty after trimming whitespace.",
+      "issue identifier"
+    );
+  }
+
   // 0. URL detection — extract issue ID from Sentry web URLs
-  const urlParsed = parseSentryUrl(arg);
+  const urlParsed = parseSentryUrl(input);
   if (urlParsed) {
     applySentryUrlContext(urlParsed.baseUrl);
     const result = issueArgFromUrl(urlParsed);
@@ -935,13 +1033,13 @@ export function parseIssueArg(arg: string): ParsedIssueArg {
 
   // 1. Magic @ selectors — detect before any other parsing.
   // Supports bare `@latest` and org-prefixed `sentry/@latest`.
-  if (arg.includes("@")) {
-    const slashIdx = arg.indexOf("/");
-    const selectorPart = slashIdx === -1 ? arg : arg.slice(slashIdx + 1);
+  if (input.includes("@")) {
+    const slashIdx = input.indexOf("/");
+    const selectorPart = slashIdx === -1 ? input : input.slice(slashIdx + 1);
     const selector = parseSelector(selectorPart);
     if (selector) {
       if (slashIdx !== -1) {
-        const org = normalizeSlug(arg.slice(0, slashIdx)).slug;
+        const org = normalizeSlug(input.slice(0, slashIdx)).slug;
         validateResourceId(org, "organization slug");
         return { type: "selector", selector, org };
       }
@@ -954,26 +1052,26 @@ export function parseIssueArg(arg: string): ParsedIssueArg {
   // Validate raw input against injection characters before parsing.
   // Slashes are allowed (they're structural separators), but ?, #, %, whitespace,
   // and control characters are never valid in issue identifiers.
-  validateResourceId(arg.replace(/\//g, ""), "issue identifier");
+  validateResourceId(input.replace(/\//g, ""), "issue identifier");
 
   // 2. Pure numeric → direct fetch by ID
-  if (isAllDigits(arg)) {
-    return { type: "numeric", id: arg };
+  if (isAllDigits(input)) {
+    return { type: "numeric", id: input };
   }
 
   // 3. Has slash → check slash FIRST (takes precedence over dashes)
   // This ensures "my-org/123" parses as org="my-org", not project="my"
-  if (arg.includes("/")) {
-    return parseWithSlash(arg);
+  if (input.includes("/")) {
+    return parseWithSlash(input);
   }
 
   // 4. Has dash but no slash → split on last "-" for project-suffix
-  if (arg.includes("-")) {
-    return parseWithDash(arg);
+  if (input.includes("-")) {
+    return parseWithDash(input);
   }
 
   // 5. No dash, no slash → suffix only (needs DSN context)
-  return { type: "suffix-only", suffix: arg.toUpperCase() };
+  return { type: "suffix-only", suffix: input.toUpperCase() };
 }
 
 // ---------------------------------------------------------------------------

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -349,9 +349,11 @@ describe("init command func", () => {
       );
     });
 
-    test("invalid org slug (whitespace) throws", async () => {
+    test("org slug with whitespace is normalized (not rejected)", async () => {
+      // Spaces in slugs are normalized to dashes (like underscore normalization)
       const ctx = makeContext();
-      expect(func.call(ctx, DEFAULT_FLAGS, "acme corp/")).rejects.toThrow();
+      await func.call(ctx, DEFAULT_FLAGS, "acme corp/");
+      expect(capturedArgs?.org).toBe("acme-corp");
     });
   });
 

--- a/test/lib/arg-parsing.property.test.ts
+++ b/test/lib/arg-parsing.property.test.ts
@@ -366,11 +366,6 @@ describe("parseIssueArg and parseOrgProjectArg consistency", () => {
   });
 });
 
-// Arbitrary for strings that may contain underscores (slug-like with underscores)
-const slugLikeWithUnderscoresArb = stringMatching(
-  /^[a-z][a-z0-9_-]{0,20}[a-z0-9]$/
-);
-
 /** Generates all-lowercase slug-like strings with at least one dash */
 const lowercaseSlugWithDashArb = stringMatching(
   /^[a-z][a-z0-9]*(-[a-z][a-z0-9]*)+$/
@@ -385,10 +380,16 @@ const withSlashArb = stringMatching(/^[a-zA-Z0-9]+\/[a-zA-Z0-9]+$/);
 /** Generates strings without slashes */
 const noSlashArb = stringMatching(/^[a-zA-Z0-9-]{1,20}$/);
 
+/** Generates display-name-like strings with spaces (e.g., "My Project") */
+const displayNameLikeArb = stringMatching(/^[A-Za-z][A-Za-z0-9 _-]{0,20}$/);
+
+/** Generates strings that always have at least one space */
+const withSpaceArb = stringMatching(/^[A-Za-z]+ [A-Za-z0-9]+$/);
+
 describe("normalizeSlug properties", () => {
   test("idempotent: normalizing twice yields same slug as normalizing once", async () => {
     await fcAssert(
-      property(slugLikeWithUnderscoresArb, (input) => {
+      property(displayNameLikeArb, (input) => {
         const first = normalizeSlug(input);
         const second = normalizeSlug(first.slug);
         expect(second.slug).toBe(first.slug);
@@ -397,31 +398,56 @@ describe("normalizeSlug properties", () => {
     );
   });
 
-  test("normalized is true iff input contained underscores", async () => {
+  test("normalized is true iff input contained underscores or spaces", async () => {
     await fcAssert(
-      property(slugLikeWithUnderscoresArb, (input) => {
+      property(displayNameLikeArb, (input) => {
         const result = normalizeSlug(input);
-        expect(result.normalized).toBe(input.includes("_"));
+        expect(result.normalized).toBe(
+          input.includes("_") || input.includes(" ")
+        );
       }),
       { numRuns: DEFAULT_NUM_RUNS }
     );
   });
 
-  test("result slug never contains underscores", async () => {
+  test("result slug never contains underscores or spaces", async () => {
     await fcAssert(
-      property(slugLikeWithUnderscoresArb, (input) => {
+      property(displayNameLikeArb, (input) => {
         const result = normalizeSlug(input);
         expect(result.slug.includes("_")).toBe(false);
+        expect(result.slug.includes(" ")).toBe(false);
       }),
       { numRuns: DEFAULT_NUM_RUNS }
     );
   });
 
-  test("length is preserved (underscore and dash are both 1 char)", async () => {
+  test("result slug length is <= input length", async () => {
     await fcAssert(
-      property(slugLikeWithUnderscoresArb, (input) => {
+      property(displayNameLikeArb, (input) => {
         const result = normalizeSlug(input);
-        expect(result.slug.length).toBe(input.length);
+        expect(result.slug.length).toBeLessThanOrEqual(input.length);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("normalized slug never contains consecutive dashes", async () => {
+    await fcAssert(
+      property(withSpaceArb, (input) => {
+        const result = normalizeSlug(input);
+        // When normalization actually happens, consecutive dashes are collapsed
+        expect(result.slug.includes("--")).toBe(false);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("result slug is lowercase when spaces were present", async () => {
+    await fcAssert(
+      property(withSpaceArb, (input) => {
+        const result = normalizeSlug(input);
+        expect(result.slug).toBe(result.slug.toLowerCase());
+        expect(result.reason).toMatch(/^(spaces|both)$/);
       }),
       { numRuns: DEFAULT_NUM_RUNS }
     );

--- a/test/lib/arg-parsing.test.ts
+++ b/test/lib/arg-parsing.test.ts
@@ -14,6 +14,7 @@ import {
   normalizeSlug,
   parseIssueArg,
   parseOrgProjectArg,
+  parseSlashSeparatedArg,
 } from "../../src/lib/arg-parsing.js";
 import { stripDsnOrgPrefix } from "../../src/lib/dsn/index.js";
 import { ValidationError } from "../../src/lib/errors.js";
@@ -202,6 +203,7 @@ describe("parseOrgProjectArg", () => {
         type: "project-search",
         projectSlug: "my-project",
         normalized: true,
+        reason: "underscores",
       });
       expect(stderrOutput).toContain("Normalized slug to 'my-project'");
       expect(stderrOutput).toContain(
@@ -216,6 +218,7 @@ describe("parseOrgProjectArg", () => {
         org: "my-org",
         project: "cli",
         normalized: true,
+        reason: "underscores",
       });
       expect(stderrOutput).toContain("Normalized slug to 'my-org/cli'");
     });
@@ -227,6 +230,7 @@ describe("parseOrgProjectArg", () => {
         org: "sentry",
         project: "my-project",
         normalized: true,
+        reason: "underscores",
       });
       expect(stderrOutput).toContain("Normalized slug to 'sentry/my-project'");
     });
@@ -237,8 +241,36 @@ describe("parseOrgProjectArg", () => {
         type: "org-all",
         org: "my-org",
         normalized: true,
+        reason: "underscores",
       });
       expect(stderrOutput).toContain("Normalized slug to 'my-org/'");
+    });
+
+    test("emits space-specific warning for project with spaces", () => {
+      const result = parseOrgProjectArg("My Project");
+      expect(result).toEqual({
+        type: "project-search",
+        projectSlug: "my-project",
+        normalized: true,
+        reason: "spaces",
+      });
+      expect(stderrOutput).toContain("Normalized slug to 'my-project'");
+      expect(stderrOutput).toContain(
+        "Sentry slugs use lowercase with dashes, not spaces"
+      );
+    });
+
+    test("emits combined warning for mixed spaces and underscores", () => {
+      const result = parseOrgProjectArg("my_org/My Project");
+      expect(result).toEqual({
+        type: "explicit",
+        org: "my-org",
+        project: "my-project",
+        normalized: true,
+        reason: "both",
+      });
+      expect(stderrOutput).toContain("Normalized slug to 'my-org/my-project'");
+      expect(stderrOutput).toContain("not spaces or underscores");
     });
 
     test("does not emit warning for auto-detect", () => {
@@ -746,6 +778,7 @@ describe("normalizeSlug", () => {
     expect(normalizeSlug("selfbase_admin_backend")).toEqual({
       slug: "selfbase-admin-backend",
       normalized: true,
+      reason: "underscores",
     });
   });
 
@@ -760,20 +793,23 @@ describe("normalizeSlug", () => {
     expect(normalizeSlug("a_b_c_d")).toEqual({
       slug: "a-b-c-d",
       normalized: true,
+      reason: "underscores",
     });
   });
 
   test("handles leading underscore", () => {
     expect(normalizeSlug("_leading")).toEqual({
-      slug: "-leading",
+      slug: "leading",
       normalized: true,
+      reason: "underscores",
     });
   });
 
   test("handles trailing underscore", () => {
     expect(normalizeSlug("trailing_")).toEqual({
-      slug: "trailing-",
+      slug: "trailing",
       normalized: true,
+      reason: "underscores",
     });
   });
 
@@ -781,6 +817,46 @@ describe("normalizeSlug", () => {
     expect(normalizeSlug("")).toEqual({
       slug: "",
       normalized: false,
+    });
+  });
+
+  test("replaces spaces with dashes and lowercases", () => {
+    expect(normalizeSlug("My Project")).toEqual({
+      slug: "my-project",
+      normalized: true,
+      reason: "spaces",
+    });
+  });
+
+  test("collapses consecutive spaces into single dash", () => {
+    expect(normalizeSlug("My  Project")).toEqual({
+      slug: "my-project",
+      normalized: true,
+      reason: "spaces",
+    });
+  });
+
+  test("trims leading/trailing dashes from space conversion", () => {
+    expect(normalizeSlug(" My Project ")).toEqual({
+      slug: "my-project",
+      normalized: true,
+      reason: "spaces",
+    });
+  });
+
+  test("handles mixed underscores and spaces", () => {
+    expect(normalizeSlug("My_Project Name")).toEqual({
+      slug: "my-project-name",
+      normalized: true,
+      reason: "both",
+    });
+  });
+
+  test("does not lowercase when only underscores (backward compat)", () => {
+    expect(normalizeSlug("My_Project")).toEqual({
+      slug: "My-Project",
+      normalized: true,
+      reason: "underscores",
     });
   });
 });
@@ -898,6 +974,7 @@ describe("parseOrgProjectArg underscore normalization", () => {
       org: "org-name",
       project: "project",
       normalized: true,
+      reason: "underscores",
     });
   });
 
@@ -907,6 +984,7 @@ describe("parseOrgProjectArg underscore normalization", () => {
       org: "org",
       project: "project-name",
       normalized: true,
+      reason: "underscores",
     });
   });
 
@@ -916,6 +994,7 @@ describe("parseOrgProjectArg underscore normalization", () => {
       org: "org-name",
       project: "project-name",
       normalized: true,
+      reason: "underscores",
     });
   });
 
@@ -924,6 +1003,7 @@ describe("parseOrgProjectArg underscore normalization", () => {
       type: "project-search",
       projectSlug: "selfbase-admin-backend",
       normalized: true,
+      reason: "underscores",
     });
   });
 
@@ -944,6 +1024,65 @@ describe("parseOrgProjectArg underscore normalization", () => {
       type: "org-all",
       org: "org-name",
       normalized: true,
+      reason: "underscores",
+    });
+  });
+});
+
+describe("parseOrgProjectArg space normalization", () => {
+  test("normalizes bare project with spaces and lowercases", () => {
+    expect(parseOrgProjectArg("My Project")).toEqual({
+      type: "project-search",
+      projectSlug: "my-project",
+      normalized: true,
+      reason: "spaces",
+    });
+  });
+
+  test("normalizes org/project with spaces", () => {
+    expect(parseOrgProjectArg("My Org/My Project")).toEqual({
+      type: "explicit",
+      org: "my-org",
+      project: "my-project",
+      normalized: true,
+      reason: "spaces",
+    });
+  });
+
+  test("collapses consecutive spaces into single dash", () => {
+    expect(parseOrgProjectArg("My  Project")).toEqual({
+      type: "project-search",
+      projectSlug: "my-project",
+      normalized: true,
+      reason: "spaces",
+    });
+  });
+
+  test("normalizes org-all with spaces", () => {
+    expect(parseOrgProjectArg("My Org/")).toEqual({
+      type: "org-all",
+      org: "my-org",
+      normalized: true,
+      reason: "spaces",
+    });
+  });
+
+  test("normalizes leading-slash with spaces", () => {
+    expect(parseOrgProjectArg("/My Project")).toEqual({
+      type: "project-search",
+      projectSlug: "my-project",
+      normalized: true,
+      reason: "spaces",
+    });
+  });
+
+  test("normalizes mixed underscores and spaces", () => {
+    expect(parseOrgProjectArg("my_org/My Project")).toEqual({
+      type: "explicit",
+      org: "my-org",
+      project: "my-project",
+      normalized: true,
+      reason: "both",
     });
   });
 });
@@ -983,8 +1122,14 @@ describe("parseOrgProjectArg: injection hardening", () => {
     );
   });
 
-  test("rejects space in bare project slug", () => {
-    expect(() => parseOrgProjectArg("my project")).toThrow(ValidationError);
+  test("normalizes space in bare project slug instead of rejecting", () => {
+    // Spaces are normalized to dashes (like underscore normalization)
+    expect(parseOrgProjectArg("my project")).toEqual({
+      type: "project-search",
+      projectSlug: "my-project",
+      normalized: true,
+      reason: "spaces",
+    });
   });
 
   test("rejects tab character in org slug", () => {
@@ -1013,7 +1158,8 @@ describe("parseIssueArg: injection hardening", () => {
 
   test("rejects control characters in issue arg", () => {
     expect(() => parseIssueArg("CLI-G\x00")).toThrow(ValidationError);
-    expect(() => parseIssueArg("CLI-G\t")).toThrow(ValidationError);
+    // Tab in the middle is still rejected (trailing tab is trimmed like newlines)
+    expect(() => parseIssueArg("CLI\tG")).toThrow(ValidationError);
   });
 
   test("rejects space in numeric ID", () => {
@@ -1022,5 +1168,84 @@ describe("parseIssueArg: injection hardening", () => {
 
   test("rejects query string in org/issue format", () => {
     expect(() => parseIssueArg("sentry/CLI-G?extra")).toThrow(ValidationError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Whitespace trimming for agent-injected newlines (CLI-16M)
+// ---------------------------------------------------------------------------
+
+describe("parseIssueArg: whitespace trimming", () => {
+  test("trims trailing newline from issue short ID", () => {
+    expect(parseIssueArg("CLI-G5\n")).toEqual({
+      type: "project-search",
+      projectSlug: "cli",
+      suffix: "G5",
+    });
+  });
+
+  test("trims trailing space from issue short ID", () => {
+    expect(parseIssueArg("CLI-G5 ")).toEqual({
+      type: "project-search",
+      projectSlug: "cli",
+      suffix: "G5",
+    });
+  });
+
+  test("trims leading/trailing whitespace from numeric ID", () => {
+    expect(parseIssueArg(" 123456789 ")).toEqual({
+      type: "numeric",
+      id: "123456789",
+    });
+  });
+
+  test("trims carriage return + newline", () => {
+    expect(parseIssueArg("CLI-G5\r\n")).toEqual({
+      type: "project-search",
+      projectSlug: "cli",
+      suffix: "G5",
+    });
+  });
+
+  test("trims trailing newline from org/issue format", () => {
+    expect(parseIssueArg("sentry/CLI-G5\n")).toEqual({
+      type: "explicit",
+      org: "sentry",
+      project: "cli",
+      suffix: "G5",
+    });
+  });
+
+  test("empty string after trimming throws", () => {
+    expect(() => parseIssueArg("  \n  ")).toThrow(ValidationError);
+  });
+});
+
+describe("parseSlashSeparatedArg: whitespace trimming", () => {
+  test("trims trailing newline from plain ID", () => {
+    const result = parseSlashSeparatedArg(
+      "a9b4ad2c\n",
+      "Event ID",
+      "sentry event view <id>"
+    );
+    expect(result).toEqual({ id: "a9b4ad2c", targetArg: undefined });
+  });
+
+  test("trims trailing newline from structured arg", () => {
+    const result = parseSlashSeparatedArg(
+      "sentry/cli/a9b4ad2c\n",
+      "Event ID",
+      "sentry event view <id>"
+    );
+    expect(result).toEqual({ id: "a9b4ad2c", targetArg: "sentry/cli" });
+  });
+
+  test("trims leading/trailing whitespace from plain ID", () => {
+    const result = parseSlashSeparatedArg(
+      "  a9b4ad2c  ",
+      "Event ID",
+      "sentry event view <id>"
+    );
+    expect(result).toEqual({ id: "a9b4ad2c", targetArg: undefined });
   });
 });


### PR DESCRIPTION
## Summary

- Extend `normalizeSlug()` to convert spaces → dashes with lowercasing and consecutive dash collapsing, matching how Sentry generates slugs from display names (e.g., `"My Project"` → `"my-project"`)
- Reorder parsing flow so normalization runs before `validateResourceId()` — spaces become dashes before the forbidden-character check can reject them
- Add `.trim()` to `parseIssueArg()` and `parseSlashSeparatedArg()` to strip trailing whitespace/newlines from AI agent inputs

## Motivation

Two related `ValidationError` issues from the input validation layer:

- **CLI-14M**: `Invalid project slug: contains a space.` — User passed a display name like `"My Project"` instead of slug `"my-project"`
- **CLI-16M**: `Invalid issue identifier: contains a newline.` — AI agent (Claude) passed an issue ID with a trailing `\n`

The validation itself is correct (agent hallucination hardening), but the parsing layer should normalize recoverable inputs before validation — just like it already normalizes underscores → dashes.

## Key Design Decisions

- **Lowercase only when spaces are present** — `"my_project"` stays `"my-project"` (preserves casing for backward compat), but `"My Project"` → `"my-project"` since spaces imply a display name
- **`validateResourceId()` unchanged** — Still rejects spaces as defense-in-depth for any code path that skips `normalizeSlug`
- **No space normalization in issue IDs** — `parseIssueArg` only trims, since issue identifiers like `"CLI-G5"` should never have internal spaces silently converted
- **Reason-aware warning messages** — `"spaces"` → "use lowercase with dashes, not spaces"; `"both"` → "not spaces or underscores"