### PR TITLE
fix(init): reuse detected existing project data

### DIFF
--- a/src/lib/init/preflight.ts
+++ b/src/lib/init/preflight.ts
@@ -141,6 +141,7 @@ async function resolveProjectSelection(
   const resolved = await resolveExistingProjectChoice({
     org,
     project: seed.project,
+    existingProject: seed.existingProject,
     yes: initial.yes,
     promptOnExisting: Boolean(initial.project && !initial.org),
   });
@@ -231,6 +232,7 @@ async function resolveDetectedProject(initial: WizardOptions): Promise<{
 async function resolveExistingProjectChoice(opts: {
   org: string;
   project: string;
+  existingProject?: ExistingProjectData;
   yes: boolean;
   promptOnExisting: boolean;
 }): Promise<ExistingProjectChoice> {
@@ -239,9 +241,12 @@ async function resolveExistingProjectChoice(opts: {
     return { project: opts.project };
   }
 
-  const existingProject = await tryGetExistingProjectData(opts.org, slug).catch(
-    () => null
-  );
+  const existingProject =
+    opts.existingProject &&
+    opts.existingProject.orgSlug === opts.org &&
+    opts.existingProject.projectSlug === slug
+      ? opts.existingProject
+      : await tryGetExistingProjectData(opts.org, slug).catch(() => null);
   if (!existingProject) {
     return { project: opts.project };
   }

--- a/test/lib/init/preflight.test.ts
+++ b/test/lib/init/preflight.test.ts
@@ -129,6 +129,8 @@ describe("resolveInitContext", () => {
         }),
       })
     );
+    expect(getProjectSpy).toHaveBeenCalledTimes(1);
+    expect(tryGetPrimaryDsnSpy).toHaveBeenCalledTimes(1);
   });
 
   test("keeps a detected DSN project even when project enrichment fails", async () => {
@@ -156,6 +158,41 @@ describe("resolveInitContext", () => {
       })
     );
     expect(context?.existingProject).toBeUndefined();
+  });
+
+  test("retries detected project enrichment during project selection when the first lookup yields no metadata", async () => {
+    detectDsnSpy.mockResolvedValue({
+      publicKey: "abc",
+      protocol: "https",
+      host: "o1.ingest.sentry.io",
+      projectId: "42",
+      raw: "https://abc@o1.ingest.sentry.io/42",
+      source: "env_file" as const,
+    });
+    resolveDsnByPublicKeySpy.mockResolvedValue({
+      org: "acme",
+      project: "my-app",
+    });
+    getProjectSpy
+      .mockRejectedValueOnce(new ApiError("not found", 404))
+      .mockResolvedValue({
+        id: "42",
+        slug: "my-app",
+        name: "my-app",
+        platform: "javascript-react",
+        dateCreated: "2026-04-16T00:00:00Z",
+      } as any);
+
+    const context = await resolveInitContext(makeOptions());
+
+    expect(context?.existingProject).toEqual(
+      expect.objectContaining({
+        orgSlug: "acme",
+        projectSlug: "my-app",
+      })
+    );
+    expect(getProjectSpy).toHaveBeenCalledTimes(2);
+    expect(tryGetPrimaryDsnSpy).toHaveBeenCalledTimes(1);
   });
 
   test("falls back to listing organizations when prefetch misses", async () => {


### PR DESCRIPTION
## Summary
- reuse hydrated existing-project data during init preflight when the detected project has already been enriched
- keep the later lookup as a fallback only when the first best-effort enrichment did not return metadata
- add preflight coverage for the single-fetch path and the fallback retry path

## Testing
- bun test test/lib/init/preflight.test.ts