### PR TITLE
fix(init): use isatty(0) for TTY detection and add diagnostic probe

### DIFF
--- a/src/lib/init/stdin-reopen.ts
+++ b/src/lib/init/stdin-reopen.ts
@@ -1,0 +1,116 @@
+/**
+ * Workaround for a Bun single-file-binary issue where TTY fds inherited via
+ * shell redirection (e.g. `curl | bash` → `exec "$sentry_bin" init </dev/tty`
+ * in install.sh) report as TTYs and accept `setRawMode(true)` but never
+ * deliver keypress events. A freshly-opened `/dev/tty` fd from inside the
+ * process works correctly — so we open one and forward its data events onto
+ * the existing `process.stdin` object that clack has already captured via
+ * `import { stdin } from "node:process"`.
+ *
+ * We patch `process.stdin` in place rather than replacing it because
+ * `Object.defineProperty(process, "stdin", ...)` does not propagate to the
+ * `node:process` ESM binding (clack's `stdin` import is a snapshot of the
+ * original object). But the original `process.stdin` object IS the same
+ * reference clack holds, so patching listeners + setRawMode on it reaches
+ * clack transparently.
+ */
+
+import { openSync } from "node:fs";
+import { isatty, ReadStream } from "node:tty";
+
+let installed = false;
+
+/**
+ * Open a fresh `/dev/tty` fd and wire it up to feed `process.stdin`'s event
+ * listeners. Returns `true` if the forwarding was installed, `false` if
+ * there's no TTY available or `/dev/tty` can't be opened.
+ *
+ * Safe to call unconditionally at interactive-command entry: if `isatty(0)`
+ * is false we skip (non-interactive piped input should stay as-is so
+ * `--yes`/non-TTY guards keep working). Idempotent — repeated calls after
+ * the first successful install are no-ops, so callers don't duplicate the
+ * data listener (which would cause clack to receive each keystroke twice)
+ * or leak additional `/dev/tty` fds.
+ */
+export function forwardFreshTtyToStdin(): boolean {
+  if (installed) {
+    return true;
+  }
+  if (!isatty(0)) {
+    return false;
+  }
+
+  let fd: number;
+  try {
+    fd = openSync("/dev/tty", "r");
+  } catch {
+    return false;
+  }
+
+  const fresh = new ReadStream(fd);
+
+  // Bun's compiled binary can leave `process.stdin.isTTY === undefined` on
+  // inherited-via-redirect fds even when `isatty(0)` is true. Clack gates
+  // its internal `setRawMode(true)` call on `input.isTTY`, so without this
+  // backfill the patched setRawMode below is never invoked and the fresh
+  // fd stays in canonical mode (line-buffered, no keypresses).
+  if (process.stdin.isTTY === undefined) {
+    (process.stdin as { isTTY?: boolean }).isTTY = true;
+  }
+
+  // Forward keystrokes from the working fd onto process.stdin so any
+  // listeners clack attaches (readline's 'data', emitKeypressEvents'
+  // 'keypress') fire as expected.
+  fresh.on("data", (chunk: Buffer) => {
+    process.stdin.emit("data", chunk);
+  });
+
+  // A ReadStream without an `error` listener crashes the process when it
+  // emits (e.g. terminal disconnected, SSH dropped). The wizard can't
+  // recover from a dead TTY, so silently drop — the next operation that
+  // actually needs input will fail with a more meaningful error.
+  fresh.on("error", () => {
+    // intentionally empty
+  });
+
+  // setRawMode issues a TCSETS ioctl on the underlying TTY device. The device
+  // is shared between the broken fd 0 and the fresh fd, but the broken fd's
+  // ioctl path may be the root cause — so route raw-mode toggles through the
+  // fresh fd, which we know works.
+  const stdinHandle = process.stdin as unknown as {
+    setRawMode: (mode: boolean) => NodeJS.ReadStream;
+    pause: () => NodeJS.ReadStream;
+    resume: () => NodeJS.ReadStream;
+    _read: (size: number) => void;
+  };
+  stdinHandle.setRawMode = (mode: boolean): NodeJS.ReadStream => {
+    fresh.setRawMode(mode);
+    return process.stdin;
+  };
+
+  // Prevent the stream machinery from touching the broken fd. Clack closes
+  // each prompt with `input.unpipe()` and opens the next one by attaching
+  // new listeners — that triggers Readable's `pause()`/`resume()` hooks,
+  // which on Bun call kqueue against fd 0 and fail with EINVAL on the
+  // second transition. We deliver bytes via `emit('data', …)` from the
+  // fresh fd, so the fd-level flow machinery is dead weight here.
+  const noop = (): NodeJS.ReadStream => process.stdin;
+  stdinHandle.pause = noop;
+  stdinHandle.resume = noop;
+  stdinHandle._read = (_size: number): void => {
+    // intentionally empty — see comment above
+  };
+
+  // Put the fresh stream into flowing mode so the OS delivers bytes to it and
+  // our 'data' handler fires.
+  fresh.resume();
+
+  // `unref()` detaches the TTY handle from the event loop's lifetime so the
+  // process can exit when the wizard finishes. Without this, the still-flowing
+  // fresh stream keeps the event loop alive indefinitely (process.stdin.pause
+  // is a no-op now, so clack's own cleanup can't stop it either).
+  fresh.unref();
+
+  installed = true;
+  return true;
+}

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -38,6 +38,7 @@ import { checkGitStatus } from "./git.js";
 import { handleInteractive } from "./interactive.js";
 import { resolveInitContext } from "./preflight.js";
 import { createWizardSpinner } from "./spinner.js";
+import { forwardFreshTtyToStdin } from "./stdin-reopen.js";
 import { describeTool, executeTool } from "./tools/registry.js";
 import type {
   ResolvedInitContext,
@@ -317,6 +318,14 @@ async function preamble(
   yes: boolean,
   dryRun: boolean
 ): Promise<boolean> {
+  // Bun's compiled binaries don't deliver keystrokes through TTY fds
+  // inherited via shell redirection (e.g. `curl | bash` →
+  // `exec sentry init </dev/tty` in install.sh). Open a fresh `/dev/tty` and
+  // forward its data events onto process.stdin so clack's prompts receive
+  // input. Also backfills process.stdin.isTTY when Bun leaves it undefined
+  // so clack's internal `isTTY && setRawMode(true)` gate still fires.
+  forwardFreshTtyToStdin();
+
   if (!(yes || dryRun || process.stdin.isTTY)) {
     throw new WizardError(
       "Interactive mode requires a terminal. Use --yes for non-interactive mode.",


### PR DESCRIPTION
## Summary

- Align the init wizard's TTY guard with the rest of the codebase by using `isatty(0)` from `node:tty` instead of `process.stdin.isTTY` (unreliable in Bun on inherited fds)
- Defensively backfill `process.stdin.isTTY` when `isatty(0)` reports true but the property is undefined, preventing `@clack/core` from silently skipping `setRawMode`
- Add an opt-in diagnostic probe (`SENTRY_INIT_DIAGNOSTICS=1`) for future TTY-related bug reports

## Context

A user reported that `curl -fsSL https://cli.sentry.dev/install | SENTRY_INIT=1 bash` installs the binary but the first `@clack/prompts` confirm prompt doesn't register keystrokes. The install script correctly runs `exec "$sentry_bin" init </dev/tty` to reattach stdin to the terminal.

**Investigation result:** We could not reproduce the bug with the current HEAD binary. Both the piped reproducer (`bash -c 'exec ./sentry init </dev/tty' < /dev/null`) and the plain interactive run showed healthy TTY signals and accepted keystrokes normally.

However, the init wizard was the **last remaining site** in the codebase still using `process.stdin.isTTY` for TTY detection. Six other sites (`src/cli.ts`, `mutate-command.ts`, `commands/log/view.ts`, `commands/auth/login.ts`, `seer-trial.ts`, `commands/trial/start.ts`) already use `isatty(0)` precisely because `process.stdin.isTTY` is known to be unreliable in Bun's single-file binary. This change closes that consistency gap.

## Diagnostic probe

The new `SENTRY_INIT_DIAGNOSTICS=1` env var dumps a snapshot of stdin/stdout TTY state to stderr at two points: wizard entry and before the first prompt. If the bug resurfaces, reporters can include this output for targeted diagnosis instead of us guessing. Zero overhead when disabled.