### PR TITLE
fix(ci): scope build-binary and build-docs to production environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,10 @@ jobs:
     name: Build Binary (${{ matrix.target }})
     needs: [changes, lint, test-unit]
     runs-on: ${{ matrix.os }}
+    # SENTRY_AUTH_TOKEN is scoped to the production environment so sourcemap
+    # upload works on main/release branches. Without this, every binary build
+    # skips the upload and Sentry stack traces show minified names (e.g., xE).
+    environment: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 'production' || '' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.changes.outputs.build-targets) }}
@@ -683,6 +687,9 @@ jobs:
     name: Build Docs
     needs: [lint, build-binary]
     runs-on: ubuntu-latest
+    # SENTRY_AUTH_TOKEN is scoped to the production environment. Needed by
+    # the "Inject debug IDs and upload sourcemaps" step below.
+    environment: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 'production' || '' }}
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary

The Bun binary's sourcemaps have **never** been uploaded to Sentry. Every main-branch build logged:

```
SENTRY_AUTH_TOKEN:                          ← empty!
No SENTRY_AUTH_TOKEN, skipping sourcemap upload
```

Root cause: `SENTRY_AUTH_TOKEN` is scoped to the **production** GitHub environment (not a repo secret). Jobs without `environment: production` cannot access it.

- `build-binary` → **missing environment** → token empty → upload skipped
- `build-docs` → **missing environment** → `env.SENTRY_AUTH_TOKEN != ''` gate fails silently
- `build-npm` → had `environment: production` → token available → sourcemaps uploaded ✓

## Verification

Sentry artifact bundles (`sentry api projects/sentry/cli/files/artifact-bundles/`):

| File | Bundle count |
|---|---:|
| `~/index.cjs` (npm) | **100** |
| `~/dist-bin/bin.js` (binary) | **0** |

Every Sentry event from the Bun binary (e.g. `CLI-15H`, `CLI-SS`) shows minified function names like `xE`, `yxe`, `oet` — server-side symbolication has nothing to resolve against.

## Fix

Add `environment: production` to `build-binary` and `build-docs`, matching the pattern already used by `build-npm`.

## Expected impact

- Next build on `main` uploads the Bun binary's sourcemap for the first time
- New binary-originated events resolve to real function names (`viewCommand.func`, `withTelemetry`, …)
- Grouping quality improves — combined with the server-side fingerprint rules from #769, most fragmentation should disappear