### PR TITLE
chore(init): trim deprecated --features help entries

### DIFF
--- a/plugins/sentry-cli/skills/sentry-cli/references/init.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/init.md
@@ -18,7 +18,7 @@ Initialize Sentry in your project (experimental)
 **Flags:**
 - `-y, --yes - Non-interactive mode (accept defaults)`
 - `-n, --dry-run - Show what would happen without making changes`
-- `--features <value>... - Features to enable: errors,tracing,logs,replay,metrics,profiling,sourcemaps,crons,ai-monitoring,user-feedback`
+- `--features <value>... - Features to enable: errors,tracing,logs,replay,profiling,ai-monitoring,user-feedback`
 - `-t, --team <value> - Team slug to create the project under`
 
 **Examples:**

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -216,7 +216,7 @@ export const initCommand = buildCommand<
         kind: "parsed",
         parse: String,
         brief:
-          "Features to enable: errors,tracing,logs,replay,metrics,profiling,sourcemaps,crons,ai-monitoring,user-feedback",
+          "Features to enable: errors,tracing,logs,replay,profiling,ai-monitoring,user-feedback",
         variadic: true,
         optional: true,
       },


### PR DESCRIPTION
## Summary
- Remove `metrics`, `sourcemaps`, and `crons` from the `sentry init --features` help description in the command definition.
- Regenerate command skill/reference docs so the generated `init` reference matches the updated CLI help text.

## Test plan
- [x] Run `bun run generate:docs`
- [x] Verify `src/commands/init.ts` shows the updated feature list
- [x] Verify `plugins/sentry-cli/skills/sentry-cli/references/init.md` reflects the same list

Made with [Cursor](https://cursor.com)