### PR TITLE
fix(init): force process exit after wizard completes

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -279,5 +279,12 @@ export const initCommand = buildCommand<
       org: explicitOrg,
       project: explicitProject,
     });
+
+    // Force exit after the wizard completes. `sentry init` is a terminal
+    // command, and Bun's global fetch dispatcher (used by MastraClient) can
+    // hold keep-alive sockets open past the wizard, leaving the libuv loop
+    // alive and the shell appearing to hang. `process.exit` flushes stdio
+    // and releases those handles unconditionally.
+    process.exit(process.exitCode ?? 0);
   },
 });

--- a/src/lib/version-check.ts
+++ b/src/lib/version-check.ts
@@ -37,6 +37,10 @@ const SUPPRESSED_ARGS = new Set([
   "-V",
   "--json",
   "token",
+  // `init` force-exits after the wizard (src/commands/init.ts) to release
+  // Bun's fetch keep-alive sockets that keep the loop alive. That bypasses
+  // this check anyway — suppress explicitly so the intent is documented.
+  "init",
 ]);
 
 /**

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -30,6 +30,7 @@ let capturedArgs: Record<string, unknown> | undefined;
 let runWizardSpy: ReturnType<typeof spyOn>;
 let findProjectsSpy: ReturnType<typeof spyOn>;
 let warmSpy: ReturnType<typeof spyOn>;
+let exitSpy: ReturnType<typeof spyOn>;
 
 const func = (await initCommand.loader()) as unknown as (
   this: {
@@ -76,12 +77,20 @@ beforeEach(() => {
     // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op mock
     () => {}
   );
+  // The init command force-exits after the wizard to release Bun's fetch
+  // keep-alive sockets (src/commands/init.ts). Tests call `func` directly,
+  // so without this stub `process.exit` would terminate the test runner
+  // mid-suite.
+  exitSpy = spyOn(process, "exit").mockImplementation((() => {
+    // intentionally no-op — see comment above
+  }) as never);
 });
 
 afterEach(() => {
   runWizardSpy.mockRestore();
   findProjectsSpy.mockRestore();
   warmSpy.mockRestore();
+  exitSpy.mockRestore();
   resetPrefetch();
 });
 


### PR DESCRIPTION
## Summary

- `sentry init` hangs after the wizard finishes, requiring Ctrl+C (or, with the partial fix from this branch's earlier iteration, one Enter) to recover the shell prompt
- Root cause: Bun's global fetch dispatcher (used by `MastraClient`) holds keep-alive sockets open after requests return, keeping the libuv loop alive past the wizard. There's no clean programmatic close for it.
- Fix: explicit \`process.exit(process.exitCode ?? 0)\` at the end of \`init\` command's \`func\`. \`init\` is a terminal command, \`process.exit\` flushes stdio before exiting, and the OS releases the lingering handles unconditionally.

Fixes #780.

## Test plan

- [x] \`cat /tmp/install-local | SENTRY_INIT=1 bash\` (curl|bash repro) — shell prompt returns immediately, no Enter or Ctrl+C
- [x] Wizard cancel path (Ctrl-C at confirm prompt) — exits cleanly
- [x] \`bun run lint\` — clean (only pre-existing warning in markdown.ts)
- [x] \`bun run typecheck\` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)