### PR TITLE
fix(ux): rate-limit update banner and silence /api/0/ auto-fix (#785)

### DIFF
--- a/src/commands/api.ts
+++ b/src/commands/api.ts
@@ -1216,8 +1216,12 @@ export const apiCommand = buildCommand({
       ? cleaned.length - 1
       : cleaned.length;
     if (normalizedEndpoint.length < baseLen) {
-      log.warn(
-        "Endpoint includes the /api/0/ prefix which is added automatically — stripping it to avoid a doubled path"
+      // Silent auto-fix — not a warning. Users commonly copy/paste URLs
+      // that include the /api/0/ prefix; we strip it transparently and
+      // only surface the detail at debug level for troubleshooting
+      // (getsentry/cli#785 item #11).
+      log.debug(
+        "Stripped /api/0/ prefix from endpoint (auto-added by the API client)"
       );
     }
     const { body, params } = await resolveBody(flags, stdin);

--- a/src/lib/db/version-check.ts
+++ b/src/lib/db/version-check.ts
@@ -10,14 +10,23 @@ import { clearMetadata, getMetadata, setMetadata } from "./utils.js";
 
 const KEY_LAST_CHECKED = "version_check.last_checked";
 const KEY_LATEST_VERSION = "version_check.latest_version";
+/**
+ * Timestamp (ms) when we last printed the "new version available"
+ * notification to stderr. Separate from `last_checked` so the cached
+ * latest-version can stay hot for faster subsequent checks while the
+ * notification itself is rate-limited to once per day.
+ */
+const KEY_LAST_NOTIFIED = "version_check.last_notified";
 
-const ALL_KEYS = [KEY_LAST_CHECKED, KEY_LATEST_VERSION];
+const ALL_KEYS = [KEY_LAST_CHECKED, KEY_LATEST_VERSION, KEY_LAST_NOTIFIED];
 
 export type VersionCheckInfo = {
   /** Unix timestamp (ms) of last check, or null if never checked */
   lastChecked: number | null;
   /** Latest version string from GitHub, or null if never fetched */
   latestVersion: string | null;
+  /** Unix timestamp (ms) when we last printed the update notification, or null */
+  lastNotified: number | null;
 };
 
 /**
@@ -29,11 +38,24 @@ export function getVersionCheckInfo(): VersionCheckInfo {
 
   const lastChecked = m.get(KEY_LAST_CHECKED);
   const latestVersion = m.get(KEY_LATEST_VERSION);
+  const lastNotified = m.get(KEY_LAST_NOTIFIED);
 
   return {
     lastChecked: lastChecked ? Number(lastChecked) : null,
     latestVersion: latestVersion ?? null,
+    lastNotified: lastNotified ? Number(lastNotified) : null,
   };
+}
+
+/**
+ * Record that we just displayed the update notification.
+ *
+ * Called from `getUpdateNotification()` so repeat CLI invocations within
+ * the rate-limit window don't keep re-printing the same banner.
+ */
+export function markUpdateNotified(): void {
+  const db = getDatabase();
+  setMetadata(db, { [KEY_LAST_NOTIFIED]: String(Date.now()) });
 }
 
 /**

--- a/src/lib/version-check.ts
+++ b/src/lib/version-check.ts
@@ -13,6 +13,7 @@ import { CLI_VERSION } from "./constants.js";
 import { getReleaseChannel } from "./db/release-channel.js";
 import {
   getVersionCheckInfo,
+  markUpdateNotified,
   setVersionCheckInfo,
 } from "./db/version-check.js";
 import {
@@ -26,6 +27,17 @@ import { fetchLatestFromGitHub, fetchLatestNightlyVersion } from "./upgrade.js";
 
 /** Target check interval: ~24 hours */
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Minimum time between successive "new version available" notifications.
+ *
+ * Rate-limits the banner to once per 24h regardless of how many commands
+ * run in that window. Previously the banner fired on every invocation as
+ * long as the cached latest-version was ahead of CLI_VERSION, cluttering
+ * scripts, CI output, and screen-sharing sessions (see CLI UX feedback
+ * getsentry/cli#785 item #10).
+ */
+const NOTIFICATION_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 /** Jitter factor for probabilistic checking (±20%) */
 const JITTER_FACTOR = 0.2;
@@ -195,13 +207,62 @@ function checkForUpdateInBackgroundImpl(): void {
 }
 
 /**
+ * Check whether stderr is attached to a TTY.
+ *
+ * Non-TTY output covers scripts piping into other commands, CI logs, and
+ * editors capturing CLI output. The update banner is human-only signal —
+ * suppress it when no human will read it. Matches `gh` CLI behavior.
+ */
+function isStderrTTY(): boolean {
+  return Boolean(process.stderr.isTTY);
+}
+
+/**
+ * Whether we've already returned an update notification this process.
+ *
+ * A single process (e.g. `sentry help` piped into `less`) may read the
+ * notification twice — once for the banner render, once by other code
+ * paths — but we only want to count as "notified" once.
+ */
+let notifiedThisProcess = false;
+
+/**
+ * Check whether enough time has passed since the last notification.
+ *
+ * Uses the DB-backed `last_notified` timestamp so the rate limit survives
+ * across CLI invocations. Returns `true` on first-ever notification
+ * (`lastNotified === null`).
+ */
+function canNotifyAgain(lastNotified: number | null): boolean {
+  if (lastNotified === null) {
+    return true;
+  }
+  return Date.now() - lastNotified >= NOTIFICATION_INTERVAL_MS;
+}
+
+/**
  * Get the update notification message if a new version is available.
- * Returns null if up-to-date, no cached version info, or on error.
- * Never throws - errors are caught and reported to Sentry.
+ * Returns null if up-to-date, no cached version info, rate-limited, on a
+ * non-TTY stderr, or on error. Never throws — errors are caught and
+ * reported to Sentry.
+ *
+ * Side effects: when a non-null message is returned, the function also
+ * persists `last_notified = now` via {@link markUpdateNotified} so
+ * subsequent invocations within the rate-limit window return null.
  */
 function getUpdateNotificationImpl(): string | null {
+  // Gate 1: non-TTY stderr (scripts, CI, pipes).
+  if (!isStderrTTY()) {
+    return null;
+  }
+
+  // Gate 2: don't double-emit within the same process.
+  if (notifiedThisProcess) {
+    return null;
+  }
+
   try {
-    const { latestVersion } = getVersionCheckInfo();
+    const { latestVersion, lastNotified } = getVersionCheckInfo();
 
     if (!latestVersion) {
       return null;
@@ -213,15 +274,45 @@ function getUpdateNotificationImpl(): string | null {
       return null;
     }
 
+    // Gate 3: daily rate limit across CLI invocations.
+    if (!canNotifyAgain(lastNotified)) {
+      return null;
+    }
+
     const channel = getReleaseChannel();
     const label =
       channel === "nightly" ? "New nightly available:" : "Update available:";
+
+    // Record that we're about to print the banner so repeat invocations
+    // within the rate-limit window stay silent. Failures here are
+    // non-fatal: the banner still prints, it just won't be rate-limited
+    // on the next run. That's strictly better than swallowing the notice.
+    try {
+      markUpdateNotified();
+    } catch (error) {
+      Sentry.captureException(error);
+    }
+    notifiedThisProcess = true;
+
     return `\n${muted(label)} ${cyan(CLI_VERSION)} -> ${cyan(latestVersion)}  Run ${cyan('"sentry cli upgrade"')} to update.\n`;
   } catch (error) {
     // DB access failed - report to Sentry but don't crash CLI
     Sentry.captureException(error);
     return null;
   }
+}
+
+/**
+ * Reset the in-process "already notified" latch.
+ *
+ * Tests call this between scenarios to re-exercise the first-notification
+ * path without spinning up a new process. Not part of the public API and
+ * should not be called from production code.
+ *
+ * @internal
+ */
+export function resetUpdateNotificationState(): void {
+  notifiedThisProcess = false;
 }
 
 /**

--- a/test/lib/version-check.test.ts
+++ b/test/lib/version-check.test.ts
@@ -12,9 +12,29 @@ import {
   abortPendingVersionCheck,
   getUpdateNotification,
   maybeCheckForUpdateInBackground,
+  resetUpdateNotificationState,
   shouldSuppressNotification,
 } from "../../src/lib/version-check.js";
 import { mockFetch, useTestConfigDir } from "../helpers.js";
+
+/**
+ * Force `process.stderr.isTTY` for the duration of a test.
+ *
+ * `getUpdateNotification` suppresses output when stderr is not a TTY
+ * (scripts, CI, pipes) so tests that assert a non-null notification
+ * must simulate a TTY first. Restores the previous value on cleanup.
+ */
+function withStderrTTY(value: boolean): () => void {
+  const original = process.stderr.isTTY;
+  (process.stderr as { isTTY?: boolean }).isTTY = value;
+  return () => {
+    if (original === undefined) {
+      delete (process.stderr as { isTTY?: boolean }).isTTY;
+    } else {
+      (process.stderr as { isTTY?: boolean }).isTTY = original;
+    }
+  };
+}
 
 describe("shouldSuppressNotification", () => {
   test("suppresses for upgrade command", () => {
@@ -76,11 +96,17 @@ describe("shouldSuppressNotification", () => {
 describe("getUpdateNotification", () => {
   useTestConfigDir("test-version-notif-");
   let savedNoUpdateCheck: string | undefined;
+  let restoreTTY: (() => void) | undefined;
 
   beforeEach(() => {
     // Save and clear the env var to test real implementation
     savedNoUpdateCheck = process.env.SENTRY_CLI_NO_UPDATE_CHECK;
     delete process.env.SENTRY_CLI_NO_UPDATE_CHECK;
+    // Reset the in-process "already notified" latch so each test starts fresh.
+    resetUpdateNotificationState();
+    // Default to TTY so the human-facing banner path is exercised. Tests
+    // that specifically check non-TTY suppression override this.
+    restoreTTY = withStderrTTY(true);
   });
 
   afterEach(() => {
@@ -88,6 +114,8 @@ describe("getUpdateNotification", () => {
     if (savedNoUpdateCheck !== undefined) {
       process.env.SENTRY_CLI_NO_UPDATE_CHECK = savedNoUpdateCheck;
     }
+    restoreTTY?.();
+    restoreTTY = undefined;
   });
 
   test("returns null when no version info is cached", () => {
@@ -140,6 +168,45 @@ describe("getUpdateNotification", () => {
     expect(notification).not.toBeNull();
     expect(notification).toContain("Update available:");
     expect(notification).not.toContain("New nightly available:");
+  });
+
+  test("returns null when stderr is not a TTY (scripts, CI, pipes)", () => {
+    // Override the TTY shim set in beforeEach with a non-TTY stderr.
+    restoreTTY?.();
+    restoreTTY = withStderrTTY(false);
+
+    setVersionCheckInfo("99.0.0");
+    const notification = getUpdateNotification();
+    expect(notification).toBeNull();
+  });
+
+  test("only notifies once per process even with a newer version", () => {
+    setVersionCheckInfo("99.0.0");
+
+    const first = getUpdateNotification();
+    const second = getUpdateNotification();
+    const third = getUpdateNotification();
+
+    expect(first).not.toBeNull();
+    // Subsequent calls in the same process must be silent — the banner
+    // is printed once at the end of the command run, not per API call.
+    expect(second).toBeNull();
+    expect(third).toBeNull();
+  });
+
+  test("rate-limits across CLI invocations to once per day", () => {
+    setVersionCheckInfo("99.0.0");
+
+    // First invocation emits the banner and stamps last_notified.
+    const first = getUpdateNotification();
+    expect(first).not.toBeNull();
+
+    // Simulate a fresh CLI invocation.
+    resetUpdateNotificationState();
+
+    // Still within the 24h window → no banner.
+    const second = getUpdateNotification();
+    expect(second).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Two small output-noise fixes from the UX feedback issue:

**Update banner (item #10).** The "New version available" banner previously printed on every CLI invocation as long as the cached latest-version was ahead of `CLI_VERSION`. Scripts, CI logs, and screen-sharing sessions all saw it repeatedly. It now:

- Rate-limits to once per 24h across CLI invocations via a new `last_notified` metadata key in the `version_check` table.
- Suppresses itself when stderr is not a TTY (pipes, CI, captures) — matches `gh` CLI.
- Only emits once per process even if called multiple times.

The semver-compare + cached-version fetch logic is unchanged; only the display gate is new. `sentry cli upgrade` still always shows the current cached version.

**`sentry api` /api/0/ prefix (item #11).** The CLI silently strips an accidental `/api/0/` prefix because the API client adds it automatically. Previously it emitted a `log.warn` about this — but there was nothing for the user to fix: the strip is transparent auto-correction. Demoted to `log.debug` so it's only visible with `--log-level debug`.

## Test plan

- `bun test test/lib/version-check.test.ts` — added coverage for non-TTY suppression, once-per-process latch, and 24h rate-limit.
- `bun run typecheck`, `bun run lint` — clean.
- Full unit suite: 5263 passing.

Part of #785 (addresses items #10 and #11).