### PR TITLE
fix(init): disable MastraClient retries on wizard calls

### DIFF
--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -402,8 +402,13 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
 
   const token = context.authToken;
 
+  // Disable MastraClient's built-in retries. Every wizard call (createRun,
+  // startAsync, resumeAsync) is stateful and non-idempotent; retrying a 5xx
+  // cannot succeed — it only hides the real server error by turning it into
+  // a cascade of "This workflow run was not suspended" responses.
   const client = new MastraClient({
     baseUrl: MASTRA_API_URL,
+    retries: 0,
     headers: token ? { Authorization: `Bearer ${token}` } : {},
     fetch: ((url, init) => {
       const traceData = getTraceData();

--- a/test/lib/init/wizard-runner.test.ts
+++ b/test/lib/init/wizard-runner.test.ts
@@ -388,6 +388,26 @@ describe("runWizard", () => {
     );
   });
 
+  test("constructs MastraClient with retries: 0 so non-idempotent resumes are not retried", async () => {
+    let capturedRetries: unknown;
+    getWorkflowSpy.mockImplementation(function mockGetWorkflow(this: {
+      options?: { retries?: unknown };
+    }) {
+      capturedRetries = this.options?.retries;
+      return {
+        createRun: () =>
+          Promise.resolve({
+            startAsync: mock(() => Promise.resolve({ status: "success" })),
+            resumeAsync: mock(() => Promise.resolve({ status: "success" })),
+          }),
+      } as any;
+    });
+
+    await runWizard(makeOptions());
+
+    expect(capturedRetries).toBe(0);
+  });
+
   test("renders tool result messages via the spinner stop state", async () => {
     mockStartResult = {
       status: "suspended",


### PR DESCRIPTION
## Summary
- Set `retries: 0` on the `MastraClient` used by `runWizard` so a non-idempotent `/resume-async` 5xx is no longer retried 3 times.
- Resume is stateful: once the server starts a resume, the workflow snapshot advances past the suspended state. Retrying hits `"This workflow run was not suspended"` on every attempt and hides the real first-attempt error (for example, the D1 "string or blob too big" we were hitting on tanstack-start-faster).
- Added a unit test that asserts the client is constructed with `retries: 0`.

## Context
Traces `c36da1963c87462f880a5fefc31b81de` and `8067712b70414426a3406c48129e713f` showed four `wizard: *` HTTP server spans per failing resume with exponential-backoff timing - a clean fingerprint of MastraClient's default 3-retry loop on 5xx. The `cli-server` project had zero captured errors for those traces because only the very first 500 carried the real error, and that body was thrown away by the retry path.

This is fix 1 of 3. Follow-ups:
1. Capture server-side 5xx via Sentry + add a `wizard.workflow.errored` metric (separate PR in `cli-init-api`).
2. Stop duplicating `fileCache` / `dirListing` across every step output so snapshots fit in D1 (separate PR in `cli-init-api`; see getsentry/cli-init-api#98).

## Test plan
- [x] `bun test test/lib/init/wizard-runner.test.ts` (13/13 pass).
- [x] `bunx @biomejs/biome check src/lib/init/wizard-runner.ts test/lib/init/wizard-runner.test.ts` clean.
- [ ] Manual: once fix 2 lands and the real D1 error is visible in Sentry, re-run `sentry init` against `/Users/bete/code/sentry-test-projects/tanstack-start-faster` and confirm a single honest error message replaces the "not suspended" cascade.

Made with [Cursor](https://cursor.com)