### PR TITLE
fix(init): send dirListing/fileCache/existingSentry via initialState

### DIFF
--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -437,6 +437,13 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     const fileCache = await preReadCommonFiles(directory, dirListing);
     spin.message("Connecting to wizard...");
     run = await workflow.createRun();
+    // Large shared context (dirListing, fileCache, existingSentry)
+    // travels via Mastra's workflow `initialState` instead of `inputData`.
+    // Keeping it on state means the server stores it exactly once per run
+    // rather than duplicating it across every step's output in the D1
+    // snapshot — which used to overflow the per-row size limit on big
+    // projects and surface as a cascading "workflow run was not suspended"
+    // error. See getsentry/cli-init-api#98.
     result = assertWorkflowResult(
       await withTimeout(
         run.startAsync({
@@ -445,6 +452,8 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
             yes,
             dryRun,
             features,
+          },
+          initialState: {
             dirListing,
             fileCache,
             existingSentry: existingSentry?.data,

--- a/test/lib/init/wizard-runner.test.ts
+++ b/test/lib/init/wizard-runner.test.ts
@@ -71,6 +71,7 @@ function makeContext(
 let mockStartResult: WorkflowRunResult;
 let mockResumeResults: WorkflowRunResult[];
 let resumeCallCount = 0;
+let startAsyncMock: ReturnType<typeof mock>;
 
 let introSpy: ReturnType<typeof spyOn>;
 let confirmSpy: ReturnType<typeof spyOn>;
@@ -151,8 +152,9 @@ beforeEach(() => {
     () => true as any
   );
 
+  startAsyncMock = mock(() => Promise.resolve(mockStartResult));
   const run = {
-    startAsync: mock(() => Promise.resolve(mockStartResult)),
+    startAsync: startAsyncMock,
     resumeAsync: mock(() => {
       const result = mockResumeResults[resumeCallCount] ?? {
         status: "success",
@@ -386,6 +388,43 @@ describe("runWizard", () => {
     expect(messages).toContain(
       "Analyzing files...\n├─ ✓ settings.py\n└─ ✓ urls.py"
     );
+  });
+
+  test("passes precomputed dirListing/fileCache/existingSentry via initialState, not inputData", async () => {
+    const dirListing = [
+      { name: "package.json", path: "package.json", type: "file" as const },
+    ];
+    const fileCache = { "package.json": '{"name":"app"}' };
+    const detectedSentry = { status: "none" as const, signals: [] };
+
+    precomputeDirListingSpy.mockResolvedValue(dirListing);
+    preReadCommonFilesSpy.mockResolvedValue(fileCache);
+    precomputeSentryDetectionSpy.mockResolvedValue({
+      ok: true,
+      data: detectedSentry,
+    });
+
+    await runWizard(makeOptions());
+
+    expect(startAsyncMock).toHaveBeenCalledTimes(1);
+    const call = startAsyncMock.mock.calls[0] as
+      | [
+          {
+            inputData?: Record<string, unknown>;
+            initialState?: Record<string, unknown>;
+          },
+        ]
+      | undefined;
+    expect(call).toBeDefined();
+    const args = call?.[0] ?? {};
+
+    // Large shared context lives on state, not on inputData.
+    expect(args.inputData).not.toHaveProperty("dirListing");
+    expect(args.inputData).not.toHaveProperty("fileCache");
+    expect(args.inputData).not.toHaveProperty("existingSentry");
+    expect(args.initialState?.dirListing).toEqual(dirListing);
+    expect(args.initialState?.fileCache).toEqual(fileCache);
+    expect(args.initialState?.existingSentry).toEqual(detectedSentry);
   });
 
   test("renders tool result messages via the spinner stop state", async () => {


### PR DESCRIPTION
## Summary
- Move large shared context (`dirListing`, `fileCache`, `existingSentry`) out of `inputData` and into `initialState` on `run.startAsync`. `inputData` now carries only the small parameters (`directory`, `yes`, `dryRun`, `features`).
- Added a test that asserts the client no longer packs these fields into `inputData` and that `initialState` carries them verbatim.

## Context
Companion to [getsentry/cli-init-api#108](https://github.com/getsentry/cli-init-api/pull/108). The server-side refactor drops `dirListing` / `fileCache` / `existingSentry` from `wizardInputSchema` and every `afterXxxFields` composite — they now live on `wizardStateSchema` so the D1 snapshot stores them exactly once per run instead of duplicating them across every step's output. This CLI change is what populates that state.

Together with:
- [#795](https://github.com/getsentry/cli/pull/795): `retries: 0` on `MastraClient` so real server errors surface instead of retry cascade.
- getsentry/cli-init-api#107: capture server-side handler exceptions + new `wizard.workflow.errored` funnel metric.

Relates to [getsentry/cli-init-api#98](https://github.com/getsentry/cli-init-api/issues/98).

## Migration
No shim. Land order: server #108 → this CLI PR. In-flight runs at server-deploy time (if any) will fail on next resume and users re-run; runs are short-lived (single CLI session) so blast radius is small.

## Test plan
- [x] `bun test test/lib/init/wizard-runner.test.ts` (13/13 pass; new test for `initialState` wiring).
- [x] `bunx @biomejs/biome check` clean.
- [ ] After server #108 is deployed: run `sentry init` against `/Users/bete/code/sentry-test-projects/tanstack-start-faster` and confirm the wizard completes successfully.

Made with [Cursor](https://cursor.com)