### PR TITLE
fix(init): release /dev/tty handle on all exit paths

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -269,7 +269,9 @@ export const initCommand = buildCommand<
       warmOrgDetection(targetDir);
     }
 
-    // 6. Run the wizard
+    // 6. Run the wizard. It owns the temporary `/dev/tty` forwarding used
+    //    for `curl | bash` flows and tears it down on every exit path, so
+    //    init can return naturally once its own refs are released.
     await runWizard({
       directory: targetDir,
       yes: flags.yes,
@@ -279,12 +281,5 @@ export const initCommand = buildCommand<
       org: explicitOrg,
       project: explicitProject,
     });
-
-    // Force exit after the wizard completes. `sentry init` is a terminal
-    // command, and Bun's global fetch dispatcher (used by MastraClient) can
-    // hold keep-alive sockets open past the wizard, leaving the libuv loop
-    // alive and the shell appearing to hang. `process.exit` flushes stdio
-    // and releases those handles unconditionally.
-    process.exit(process.exitCode ?? 0);
   },
 });

--- a/src/lib/init/stdin-reopen.ts
+++ b/src/lib/init/stdin-reopen.ts
@@ -18,7 +18,36 @@
 import { openSync } from "node:fs";
 import { isatty, ReadStream } from "node:tty";
 
-let installed = false;
+/**
+ * Mutable subset of `process.stdin` that the TTY-forwarding workaround
+ * temporarily patches while the init wizard is running.
+ */
+type StdinHandle = {
+  setRawMode: (mode: boolean) => NodeJS.ReadStream;
+  pause: () => NodeJS.ReadStream;
+  resume: () => NodeJS.ReadStream;
+  _read: (size: number) => void;
+};
+
+/**
+ * State captured when the init wizard installs fresh `/dev/tty` forwarding.
+ * Stored so teardown can release the temporary TTY handle and restore
+ * `process.stdin` to its original behavior.
+ */
+type InstalledState = {
+  fresh: ReadStream;
+  dataListener: (chunk: Buffer) => void;
+  errorListener: () => void;
+  original: {
+    setRawMode: StdinHandle["setRawMode"];
+    pause: StdinHandle["pause"];
+    resume: StdinHandle["resume"];
+    read: StdinHandle["_read"];
+  };
+  backfilledIsTty: boolean;
+};
+
+let installedState: InstalledState | null = null;
 
 /**
  * Open a fresh `/dev/tty` fd and wire it up to feed `process.stdin`'s event
@@ -33,7 +62,7 @@ let installed = false;
  * or leak additional `/dev/tty` fds.
  */
 export function forwardFreshTtyToStdin(): boolean {
-  if (installed) {
+  if (installedState) {
     return true;
   }
   if (!isatty(0)) {
@@ -48,41 +77,46 @@ export function forwardFreshTtyToStdin(): boolean {
   }
 
   const fresh = new ReadStream(fd);
+  const stdinHandle = process.stdin as unknown as StdinHandle;
+  const original = {
+    setRawMode: stdinHandle.setRawMode,
+    pause: stdinHandle.pause,
+    resume: stdinHandle.resume,
+    read: stdinHandle._read,
+  };
 
   // Bun's compiled binary can leave `process.stdin.isTTY === undefined` on
   // inherited-via-redirect fds even when `isatty(0)` is true. Clack gates
   // its internal `setRawMode(true)` call on `input.isTTY`, so without this
   // backfill the patched setRawMode below is never invoked and the fresh
   // fd stays in canonical mode (line-buffered, no keypresses).
+  let backfilledIsTty = false;
   if (process.stdin.isTTY === undefined) {
     (process.stdin as { isTTY?: boolean }).isTTY = true;
+    backfilledIsTty = true;
   }
 
   // Forward keystrokes from the working fd onto process.stdin so any
   // listeners clack attaches (readline's 'data', emitKeypressEvents'
   // 'keypress') fire as expected.
-  fresh.on("data", (chunk: Buffer) => {
+  const dataListener = (chunk: Buffer): void => {
     process.stdin.emit("data", chunk);
-  });
+  };
+  fresh.on("data", dataListener);
 
   // A ReadStream without an `error` listener crashes the process when it
   // emits (e.g. terminal disconnected, SSH dropped). The wizard can't
   // recover from a dead TTY, so silently drop — the next operation that
   // actually needs input will fail with a more meaningful error.
-  fresh.on("error", () => {
+  const errorListener = (): void => {
     // intentionally empty
-  });
+  };
+  fresh.on("error", errorListener);
 
   // setRawMode issues a TCSETS ioctl on the underlying TTY device. The device
   // is shared between the broken fd 0 and the fresh fd, but the broken fd's
   // ioctl path may be the root cause — so route raw-mode toggles through the
   // fresh fd, which we know works.
-  const stdinHandle = process.stdin as unknown as {
-    setRawMode: (mode: boolean) => NodeJS.ReadStream;
-    pause: () => NodeJS.ReadStream;
-    resume: () => NodeJS.ReadStream;
-    _read: (size: number) => void;
-  };
   stdinHandle.setRawMode = (mode: boolean): NodeJS.ReadStream => {
     fresh.setRawMode(mode);
     return process.stdin;
@@ -105,12 +139,48 @@ export function forwardFreshTtyToStdin(): boolean {
   // our 'data' handler fires.
   fresh.resume();
 
-  // `unref()` detaches the TTY handle from the event loop's lifetime so the
-  // process can exit when the wizard finishes. Without this, the still-flowing
-  // fresh stream keeps the event loop alive indefinitely (process.stdin.pause
-  // is a no-op now, so clack's own cleanup can't stop it either).
-  fresh.unref();
+  installedState = {
+    fresh,
+    dataListener,
+    errorListener,
+    original,
+    backfilledIsTty,
+  };
 
-  installed = true;
   return true;
+}
+
+/**
+ * Tear down the fresh `/dev/tty` forwarding installed by
+ * {@link forwardFreshTtyToStdin}.
+ *
+ * Must be safe on every wizard exit path, including when forwarding was never
+ * installed. Destroying the temporary `ReadStream` releases the TTY handle so
+ * the process can exit naturally once the wizard is done.
+ */
+export function closeFreshTtyForwarding(): void {
+  if (!installedState) {
+    return;
+  }
+
+  const { fresh, dataListener, errorListener, original, backfilledIsTty } =
+    installedState;
+  installedState = null;
+
+  fresh.off("data", dataListener);
+  fresh.off("error", errorListener);
+  // Pause before destroy so no queued read callback tries to deliver bytes
+  // after the stream has been torn down.
+  fresh.pause();
+  fresh.destroy();
+
+  const stdinHandle = process.stdin as unknown as StdinHandle;
+  stdinHandle.setRawMode = original.setRawMode;
+  stdinHandle.pause = original.pause;
+  stdinHandle.resume = original.resume;
+  stdinHandle._read = original.read;
+
+  if (backfilledIsTty) {
+    (process.stdin as { isTTY?: boolean }).isTTY = undefined;
+  }
 }

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -38,7 +38,10 @@ import { checkGitStatus } from "./git.js";
 import { handleInteractive } from "./interactive.js";
 import { resolveInitContext } from "./preflight.js";
 import { createWizardSpinner } from "./spinner.js";
-import { forwardFreshTtyToStdin } from "./stdin-reopen.js";
+import {
+  closeFreshTtyForwarding,
+  forwardFreshTtyToStdin,
+} from "./stdin-reopen.js";
 import { describeTool, executeTool } from "./tools/registry.js";
 import type {
   ResolvedInitContext,
@@ -367,8 +370,18 @@ async function preamble(
   return true;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: sequential wizard orchestration with error handling branches
 export async function runWizard(initialOptions: WizardOptions): Promise<void> {
+  try {
+    await runWizardInner(initialOptions);
+  } finally {
+    // The wizard owns the temporary `/dev/tty` forwarding installed in
+    // preamble(), so teardown must run on every exit path.
+    closeFreshTtyForwarding();
+  }
+}
+
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: sequential wizard orchestration with error handling branches
+async function runWizardInner(initialOptions: WizardOptions): Promise<void> {
   const { directory, yes, dryRun, features } = initialOptions;
 
   if (!(await preamble(directory, yes, dryRun))) {
@@ -514,6 +527,16 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
       );
     }
   } catch (err) {
+    // A running spinner owns a live interval, so stop it before any early
+    // return or rethrow to avoid leaving the event loop artificially busy.
+    if (spinState.running) {
+      const [label, code] =
+        err instanceof WizardCancelledError
+          ? (["Cancelled", 0] as const)
+          : (["Error", 1] as const);
+      spin.stop(label, code);
+      spinState.running = false;
+    }
     if (err instanceof WizardCancelledError) {
       captureException(err);
       process.exitCode = 0;
@@ -521,10 +544,6 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     }
     if (err instanceof WizardError) {
       throw err;
-    }
-    if (spinState.running) {
-      spin.stop("Error", 1);
-      spinState.running = false;
     }
     log.error(errorMessage(err));
     cancel("Setup failed");

--- a/src/lib/version-check.ts
+++ b/src/lib/version-check.ts
@@ -49,9 +49,8 @@ const SUPPRESSED_ARGS = new Set([
   "-V",
   "--json",
   "token",
-  // `init` force-exits after the wizard (src/commands/init.ts) to release
-  // Bun's fetch keep-alive sockets that keep the loop alive. That bypasses
-  // this check anyway — suppress explicitly so the intent is documented.
+  // `init` runs an interactive wizard with its own terminal UI, so suppress
+  // update notifications explicitly to avoid unrelated banners mid-flow.
   "init",
 ]);
 

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -30,7 +30,6 @@ let capturedArgs: Record<string, unknown> | undefined;
 let runWizardSpy: ReturnType<typeof spyOn>;
 let findProjectsSpy: ReturnType<typeof spyOn>;
 let warmSpy: ReturnType<typeof spyOn>;
-let exitSpy: ReturnType<typeof spyOn>;
 
 const func = (await initCommand.loader()) as unknown as (
   this: {
@@ -77,20 +76,12 @@ beforeEach(() => {
     // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op mock
     () => {}
   );
-  // The init command force-exits after the wizard to release Bun's fetch
-  // keep-alive sockets (src/commands/init.ts). Tests call `func` directly,
-  // so without this stub `process.exit` would terminate the test runner
-  // mid-suite.
-  exitSpy = spyOn(process, "exit").mockImplementation((() => {
-    // intentionally no-op — see comment above
-  }) as never);
 });
 
 afterEach(() => {
   runWizardSpy.mockRestore();
   findProjectsSpy.mockRestore();
   warmSpy.mockRestore();
-  exitSpy.mockRestore();
   resetPrefetch();
 });
 

--- a/test/lib/init/stdin-reopen.test.ts
+++ b/test/lib/init/stdin-reopen.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { closeFreshTtyForwarding } from "../../../src/lib/init/stdin-reopen.js";
+
+describe("closeFreshTtyForwarding", () => {
+  test("is a no-op when forwarding was never installed", () => {
+    expect(() => closeFreshTtyForwarding()).not.toThrow();
+  });
+
+  test("is idempotent across repeated calls", () => {
+    expect(() => {
+      closeFreshTtyForwarding();
+      closeFreshTtyForwarding();
+      closeFreshTtyForwarding();
+    }).not.toThrow();
+  });
+});

--- a/test/lib/init/wizard-runner.test.ts
+++ b/test/lib/init/wizard-runner.test.ts
@@ -13,6 +13,7 @@ import { MastraClient } from "@mastra/client-js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as banner from "../../../src/lib/banner.js";
 import { WizardError } from "../../../src/lib/errors.js";
+import { WizardCancelledError } from "../../../src/lib/init/clack-utils.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as fmt from "../../../src/lib/init/formatters.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
@@ -23,6 +24,8 @@ import * as inter from "../../../src/lib/init/interactive.js";
 import * as preflight from "../../../src/lib/init/preflight.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as initSpinner from "../../../src/lib/init/spinner.js";
+// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
+import * as stdinReopen from "../../../src/lib/init/stdin-reopen.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as registry from "../../../src/lib/init/tools/registry.js";
 import type {
@@ -92,6 +95,7 @@ let executeToolSpy: ReturnType<typeof spyOn>;
 let precomputeDirListingSpy: ReturnType<typeof spyOn>;
 let preReadCommonFilesSpy: ReturnType<typeof spyOn>;
 let precomputeSentryDetectionSpy: ReturnType<typeof spyOn>;
+let closeFreshTtyForwardingSpy: ReturnType<typeof spyOn>;
 let getWorkflowSpy: ReturnType<typeof spyOn>;
 let stderrSpy: ReturnType<typeof spyOn>;
 
@@ -148,6 +152,7 @@ beforeEach(() => {
     ok: true,
     data: { status: "none", signals: [] },
   });
+  closeFreshTtyForwardingSpy = spyOn(stdinReopen, "closeFreshTtyForwarding");
   stderrSpy = spyOn(process.stderr, "write").mockImplementation(
     () => true as any
   );
@@ -191,6 +196,7 @@ afterEach(() => {
   precomputeDirListingSpy.mockRestore();
   preReadCommonFilesSpy.mockRestore();
   precomputeSentryDetectionSpy.mockRestore();
+  closeFreshTtyForwardingSpy.mockRestore();
   getWorkflowSpy.mockRestore();
   stderrSpy.mockRestore();
 
@@ -204,6 +210,7 @@ describe("runWizard", () => {
     expect(formatResultSpy).toHaveBeenCalled();
     expect(formatErrorSpy).not.toHaveBeenCalled();
     expect(spinnerMock.stop).toHaveBeenCalledWith("Done");
+    expect(closeFreshTtyForwardingSpy).toHaveBeenCalledTimes(1);
   });
 
   test("throws when stdin is not a TTY without --yes", async () => {
@@ -352,6 +359,52 @@ describe("runWizard", () => {
     };
 
     await expect(runWizard(makeOptions())).rejects.toThrow(WizardError);
+  });
+
+  test("tears down forwarding and stops the spinner on tool errors", async () => {
+    const payload: ToolPayload = {
+      type: "tool",
+      operation: "run-commands",
+      cwd: "/tmp/test",
+      params: { commands: ["npm install @sentry/node"] },
+    };
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["install-deps"]],
+      steps: {
+        "install-deps": { suspendPayload: payload },
+      },
+    };
+    executeToolSpy.mockRejectedValue(new Error("boom"));
+
+    await expect(runWizard(makeOptions())).rejects.toThrow(WizardError);
+
+    expect(spinnerMock.stop).toHaveBeenCalledWith("Error", 1);
+    expect(cancelSpy).toHaveBeenCalledWith("Setup failed");
+    expect(closeFreshTtyForwardingSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("tears down forwarding and stops the spinner on cancellation", async () => {
+    const payload: ToolPayload = {
+      type: "tool",
+      operation: "run-commands",
+      cwd: "/tmp/test",
+      params: { commands: ["npm install @sentry/node"] },
+    };
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["install-deps"]],
+      steps: {
+        "install-deps": { suspendPayload: payload },
+      },
+    };
+    executeToolSpy.mockRejectedValue(new WizardCancelledError());
+
+    await runWizard(makeOptions());
+
+    expect(process.exitCode).toBe(0);
+    expect(spinnerMock.stop).toHaveBeenCalledWith("Cancelled", 0);
+    expect(closeFreshTtyForwardingSpy).toHaveBeenCalledTimes(1);
   });
 
   test("shows a multiline tree while reading files and then analyzing them", async () => {


### PR DESCRIPTION
## Summary
- The root cause of the post-wizard shell hang isn't the install script or a generic stdin close problem. It's the fresh `/dev/tty` `ReadStream` opened by `forwardFreshTtyToStdin`, which `sentry init` owned but never explicitly tore down.
- The old `process.exit` workaround only covered the success path. This change centralizes teardown in the wizard runtime so success, cancel, and error all release the same init-owned refs.
- The fix also stops the wizard spinner on cancellation and error paths so its interval does not keep the event loop alive.

## Changes
- `src/lib/init/stdin-reopen.ts`: replace the boolean install flag with stored forwarding state and add `closeFreshTtyForwarding()` to remove listeners, destroy the fresh `/dev/tty` stream, restore patched `process.stdin` methods, and clear the temporary `isTTY` backfill.
- `src/lib/init/wizard-runner.ts`: wrap the wizard in `try/finally`, call `closeFreshTtyForwarding()` on every exit path, and stop the spinner before early returns/rethrows on cancel and error paths.
- `src/commands/init.ts`: remove the success-only `process.exit(process.exitCode ?? 0)` workaround and update the comment to reflect wizard-owned teardown.
- `src/lib/version-check.ts` and `test/commands/init.test.ts`: remove the stale fetch-keepalive rationale.
- Tests: add `test/lib/init/stdin-reopen.test.ts` and extend wizard-runner coverage for success, cancellation, and tool-error teardown behavior.

## Test plan
- [x] `bun test test/lib/init/stdin-reopen.test.ts test/lib/init/wizard-runner.test.ts test/commands/init.test.ts`
- [x] `bunx @biomejs/biome check src/commands/init.ts src/lib/init/stdin-reopen.ts src/lib/init/wizard-runner.ts src/lib/version-check.ts test/commands/init.test.ts test/lib/init/wizard-runner.test.ts test/lib/init/stdin-reopen.test.ts`
- [ ] `bun run typecheck` (currently blocked in this worktree because `generate:command-docs` fails before TS with missing `src/generated/api-schema.json`)
- [ ] Manual: `curl -fsSL https://cli.sentry.dev/install | SENTRY_INIT=1 bash -s`
- [ ] Manual: force an init failure path and confirm the shell returns immediately

Fixes #798.
