### PR TITLE
chore(scan,dsn): trim session cruft from comment-heavy files

### DIFF
--- a/script/text-import-plugin.ts
+++ b/script/text-import-plugin.ts
@@ -1,23 +1,13 @@
 /**
  * esbuild plugin that polyfills Bun's `with { type: "text" }` import
- * attribute.
+ * attribute (esbuild only supports `json`). Intercepts matching
+ * imports, reads the file, and default-exports its contents as a
+ * string. Runtime behavior matches Bun's native handling.
  *
- * esbuild doesn't natively support the `text` import attribute (only
- * `json`), but Bun does. Our CLI code uses it to load the grep worker
- * source as a string at bundle time (see
- * `src/lib/scan/worker-pool.ts`). Without this plugin, esbuild errors
- * with `Importing with a type attribute of "text" is not supported`
- * on any file that imports a sibling `.js` as text.
- *
- * The plugin intercepts imports whose `with` attribute matches
- * `{ type: "text" }`, reads the file from disk, and emits it as a JS
- * module that default-exports the file's contents as a string.
- * Runtime behavior matches Bun's native handling, so the same source
- * works in dev (via `bun run`) and in compiled binaries (esbuild +
- * `bun build --compile` two-step).
- *
- * Used by both `script/build.ts` (single-file executable) and
- * `script/bundle.ts` (CJS library bundle for npm).
+ * Used by `script/build.ts` (single-file executable) and
+ * `script/bundle.ts` (CJS library bundle) so the grep-worker source
+ * in `src/lib/scan/worker-pool.ts` loads correctly in both dev and
+ * compiled builds.
  */
 
 import { readFileSync } from "node:fs";
@@ -25,7 +15,6 @@ import { resolve as resolvePath } from "node:path";
 import type { Plugin } from "esbuild";
 
 const TEXT_IMPORT_NS = "text-import";
-/** Match-any filter for esbuild's plugin API. Hoisted for top-level-regex lint. */
 const ANY_FILTER = /.*/;
 
 export const textImportPlugin: Plugin = {

--- a/src/lib/dsn/code-scanner.ts
+++ b/src/lib/dsn/code-scanner.ts
@@ -1,51 +1,29 @@
 /**
- * Language-Agnostic DSN Code Scanner (policy layer).
+ * Language-agnostic DSN code scanner.
  *
- * This module owns the DSN-specific policy (URL regex, comment-line
- * filtering, host validation, package-path inference, stop-on-first
- * semantics). All file walking, `.gitignore` handling, extension
- * filtering, bounded concurrency, AND worker-pool dispatch are
- * delegated to the shared `src/lib/scan/` module via `collectGrep`.
+ * Owns the DSN-specific policy (URL regex, comment-line filtering,
+ * host validation, package-path inference). File walking, gitignore
+ * handling, extension filtering, bounded concurrency, and worker-pool
+ * dispatch are delegated to `src/lib/scan/`.
  *
- * Flow:
- *   1. `scanDirectory(cwd, stopOnFirst)` calls `collectGrep` with the
- *      DSN pattern and preset (`dsnScanOptions()`), plus
- *      `recordMtimes: true` and an `onDirectoryVisit` hook so the
- *      cache-invalidation maps are populated in one traversal.
- *   2. `collectGrep` dispatches per-file work to the worker pool (when
- *      available) or a concurrent-async fallback. Each yielded
- *      `GrepMatch` represents one line containing a DSN URL; the
- *      grep engine handles the file-level literal gate (`http`) for
- *      free, so we skip files that can't possibly match before any
- *      regex runs.
- *   3. Main thread post-filters each match:
- *      - Skip commented lines (language-aware comment prefixes)
- *      - Re-run `DSN_PATTERN` on `match.line` to recover all DSNs
- *        (grep emits one match per line regardless of how many
- *        hits the line contains — rare for DSNs but the contract
- *        predates this refactor)
- *      - Validate host (`isValidDsnHost`)
- *      - Dedup on raw DSN string
- *      - Early-exit on first unique DSN when `stopOnFirst: true`
- *      - Build `DetectedDsn` with inferred package path
- *   4. `sourceMtimes` records mtime per file that contributed a
- *      validated DSN; `dirMtimes` records mtime per visited dir via
- *      the hook. Both are used by `src/lib/db/dsn-cache.ts` for
- *      cache invalidation.
+ * ### Flow
  *
- * Behavior change landed in PR 3: the walker's `nestedGitignore: true`
- * default (via `dsnScanOptions()`) means nested `.gitignore` files are
- * now honored. Pre-PR-3 code only read the project-root `.gitignore`.
- * This is a correctness improvement matching git's cumulative semantics;
- * DSNs in files covered by a subdir `.gitignore` are no longer detected.
+ * `scanCodeForDsns` routes through `collectGrep(DSN_PATTERN, ...)`.
+ * Each emitted `GrepMatch` is one line containing a DSN-like URL;
+ * the scanner post-filters matches on the main thread (comment-line
+ * check, host validation, dedup). `sourceMtimes` / `dirMtimes` are
+ * populated via `recordMtimes: true` + the `onDirectoryVisit` hook
+ * in a single traversal.
  *
- * Behavior change landed in PR 6 (this one): the DSN scanner now shares
- * the grep pipeline and gets worker-pool parallelism for free.
- * End-to-end time on the 10k-file fixture drops from ~330ms → ~200ms.
- * Correctness is unchanged — `extractDsnsFromContent` is still
- * exported for `src/lib/dsn/detector.ts::isDsnStillPresent` (the
- * cache-verify fast path for a single file) and internally we still
- * go through the same comment/host-validation filter.
+ * `scanCodeForFirstDsn` deliberately avoids the worker pool — the
+ * pool's ~20ms startup cost dwarfs the work for a stop-on-first scan
+ * that typically finds its target in the first few files. Uses a
+ * direct `walkFiles` loop instead.
+ *
+ * Both the `CodeScanResult` shape and the result-map semantics are
+ * cache-contract-stable — `src/lib/db/dsn-cache.ts` verifies entries
+ * against the filesystem, so changing keys/values requires bumping
+ * the cache schema.
  */
 
 import path from "node:path";
@@ -58,152 +36,94 @@ import { createDetectedDsn, inferPackagePath, parseDsn } from "./parser.js";
 import { DSN_MAX_DEPTH, dsnScanOptions } from "./scan-options.js";
 import type { DetectedDsn } from "./types.js";
 
-/** Scoped logger for DSN code scanning. */
 const log = logger.withTag("dsn-scan");
 
 /**
- * Result of scanning code for DSNs, including mtimes for caching.
- *
- * Shape is stable — `src/lib/db/dsn-cache.ts` stores this via
- * `setCachedDetection` and verifies `sourceMtimes` / `dirMtimes`
- * against the filesystem. Do NOT change keys/values without also
- * bumping the cache schema.
+ * Result of scanning code for DSNs. Shape is cache-contract-stable
+ * — `src/lib/db/dsn-cache.ts` uses it directly.
  */
 export type CodeScanResult = {
-  /** All detected DSNs */
   dsns: DetectedDsn[];
   /**
-   * Map of source file paths (POSIX, relative to cwd) to their mtimes.
-   * Only files that contained at least one DSN are present — the cache
+   * Map of source file paths (POSIX, relative to cwd) → mtime.
+   * Only files containing at least one validated DSN. The cache
    * verifier uses this to detect "source file touched since last scan".
    */
   sourceMtimes: Record<string, number>;
   /**
    * Map of scanned directories (POSIX, relative to cwd; `.` for the
-   * root) to their floored `stat.mtimeMs`. The verifier uses this to
-   * detect "files added to a scanned dir since last scan".
+   * root) → floored `stat.mtimeMs`. The verifier uses this to detect
+   * "files added to a scanned dir since last scan".
    */
   dirMtimes: Record<string, number>;
 };
 
-/**
- * Common comment prefixes to detect commented-out DSNs.
- * Lines starting with these (after trimming whitespace) are ignored.
- */
+/** Comment prefixes — lines starting with any of these are ignored. */
 const COMMENT_PREFIXES = ["//", "#", "--", "<!--", "/*", "*", "'''", '"""'];
 
 /**
- * Pattern to match Sentry DSN URLs.
- * Captures the full DSN including protocol, public key, optional secret key, host, and project ID.
+ * Sentry DSN URL pattern. Supports both formats:
+ * - `https://{PUBLIC_KEY}@{HOST}/{PROJECT_ID}`
+ * - `https://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PROJECT_ID}`
  *
- * Formats supported:
- * - https://{PUBLIC_KEY}@{HOST}/{PROJECT_ID}
- * - https://{PUBLIC_KEY}:{SECRET_KEY}@{HOST}/{PROJECT_ID}
- *
- * Examples:
- * - https://abc123def456@o123456.ingest.us.sentry.io/4507654321
- * - https://abc123def456:secret789@sentry.example.com/123
- *
- * The public key is typically a 32-character hex string, but we accept any
- * alphanumeric string to support test fixtures and edge cases.
- *
- * Note: Uses 'g' and 'i' flags. When used with String.matchAll(), the iterator
- * always starts from the beginning regardless of lastIndex, so no reset needed.
+ * Used with `String.matchAll`, which always iterates from the start
+ * regardless of `lastIndex`.
  */
 const DSN_PATTERN =
   /https?:\/\/[a-z0-9]+(?::[a-z0-9]+)?@[a-z0-9.-]+(?:\.[a-z]+|:[0-9]+)\/\d+/gi;
 
 /**
- * Case-insensitive probe for the DSN scheme prefix. `DSN_PATTERN`
- * starts with `https?` under the `/i` flag, so any match's first 4
- * chars are some casing of `http`. The literal-prefix fast path uses
- * this probe to skip `matchAll` on files with no `http` substring —
- * the common case on large walks.
- *
- * Must be `/i` for correctness: a previous version used two
- * case-sensitive `indexOf` calls covering only all-lower and
- * all-upper, which silently missed mixed-case URLs like `Https://…`
- * or `hTtP://…`. Regressed detection on any source file with
- * unusual scheme casing.
+ * Case-insensitive probe for the DSN scheme prefix. Every DSN starts
+ * with some casing of `http`, so a file without the substring has
+ * zero candidates and can skip the `matchAll` scan entirely. `/i` is
+ * required for correctness: mixed-case schemes like `Https://` or
+ * `hTtP://` would slip through a two-indexOf (lowercase + uppercase)
+ * probe.
  */
 const HTTP_SCHEME_PROBE = /http/i;
 
 /**
- * Extract DSN URLs from file content, filtering out those in commented lines.
+ * Extract DSN URLs from file content, filtering out commented lines
+ * and hosts that don't match the configured Sentry instance.
  *
- * Algorithm:
- * 1. Find all DSN matches in the content using regex
- * 2. For each match, find the line it appears on
- * 3. Check if that line is commented out
- * 4. Validate the DSN host is acceptable
- *
- * @param content - File content to scan
- * @param limit - Maximum number of DSNs to return (undefined = no limit)
- * @returns Array of unique DSN strings found in non-commented lines
+ * @param content - File content to scan.
+ * @param limit - Stop after this many unique DSNs. Unbounded when omitted.
+ * @returns Unique DSN strings in file order.
  */
 export function extractDsnsFromContent(
   content: string,
   limit?: number
 ): string[] {
-  // Literal-prefix fast path: every DSN starts with `http://` or
-  // `https://` (case-insensitive). When the scheme doesn't appear
-  // anywhere in the file, we know there are zero candidates and can
-  // skip the `matchAll` scan entirely. On large walks (10k+ files),
-  // ~99% of files contain no `http` substring in any casing, so the
-  // probe is effectively free.
-  //
-  // Correctness note: the probe must be case-insensitive. An earlier
-  // version used two `indexOf` calls covering only all-lowercase and
-  // all-uppercase, which regressed detection on mixed-case schemes
-  // like `Https://` or `hTtP://`. `/http/i.test()` is ~5µs per file
-  // in V8 — ~16ms slower than the two-indexOf version on a 10k-file
-  // scan, a trade we accept for correctness.
   if (!HTTP_SCHEME_PROBE.test(content)) {
     return [];
   }
 
   const dsns = new Set<string>();
-
-  // Find all potential DSN matches
   for (const match of content.matchAll(DSN_PATTERN)) {
     const dsn = match[0];
-    const matchIndex = match.index;
-
-    // Skip if we've already found this DSN
     if (dsns.has(dsn)) {
       continue;
     }
-
-    // Find the line this match appears on by looking backwards for newline
+    const matchIndex = match.index;
     const lineStart = content.lastIndexOf("\n", matchIndex) + 1;
     const lineEnd = content.indexOf("\n", matchIndex);
     const line = content.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
-
-    // Skip if the line is commented
     if (isCommentedLine(line.trim())) {
       continue;
     }
-
-    // Validate it's a DSN with an acceptable host
     if (isValidDsnHost(dsn)) {
       dsns.add(dsn);
-
-      // Early exit if we've reached the limit
       if (limit !== undefined && dsns.size >= limit) {
         break;
       }
     }
   }
-
   return [...dsns];
 }
 
 /**
- * Extract the first DSN from file content.
- * Used by cache verification to check if a DSN is still present in a file.
- *
- * @param content - File content
- * @returns First DSN found or null
+ * Extract the first DSN from file content. Used by cache verification
+ * to check if a DSN is still present in a file.
  */
 export function extractFirstDsnFromContent(content: string): string | null {
   const dsns = extractDsnsFromContent(content, 1);
@@ -211,32 +131,19 @@ export function extractFirstDsnFromContent(content: string): string | null {
 }
 
 /**
- * Scan a directory for all DSNs in source code files.
- *
- * Respects .gitignore (including nested), skips large files, and
- * limits depth via `dsnScanOptions()`. Returns all unique DSNs plus
- * mtimes for cache invalidation.
+ * Scan a directory for all DSNs in source code files. Respects nested
+ * `.gitignore`, skips large files, and limits depth via
+ * `dsnScanOptions()`. Returns unique DSNs plus mtime maps for cache
+ * invalidation.
  */
 export function scanCodeForDsns(cwd: string): Promise<CodeScanResult> {
   return scanDirectory(cwd);
 }
 
 /**
- * Scan a directory and return the first DSN found.
- *
- * Optimized for the common case of single-project repositories.
- * This path deliberately avoids the worker pool — spawning workers
- * for a stopOnFirst scan adds ~20ms of startup cost that dwarfs the
- * actual work (most scans find the DSN in the first few files).
- *
- * Walks files one at a time on the main thread, reading each with
- * `Bun.file().text()` and passing through `extractFirstDsnFromContent`
- * which benefits from the `/http/i` literal fast path — ~99% of
- * files skip the full regex entirely.
- *
- * The full-scan variant `scanCodeForDsns` takes the opposite
- * tradeoff: it uses workers + parallel file reads, which is a net
- * win when we need to inspect every file.
+ * Scan a directory and return the first DSN found. Optimized for
+ * single-project repositories — deliberately avoids the worker pool
+ * (pool startup dwarfs the work on a stop-on-first scan).
  */
 export function scanCodeForFirstDsn(cwd: string): Promise<DetectedDsn | null> {
   return withTracingSpan(
@@ -293,9 +200,6 @@ export function scanCodeForFirstDsn(cwd: string): Promise<DetectedDsn | null> {
   );
 }
 
-/**
- * Check if a line is commented out based on common comment prefixes.
- */
 function isCommentedLine(trimmedLine: string): boolean {
   return COMMENT_PREFIXES.some((prefix) => trimmedLine.startsWith(prefix));
 }
@@ -303,22 +207,19 @@ function isCommentedLine(trimmedLine: string): boolean {
 /**
  * Get the expected Sentry host for DSN validation.
  *
- * When SENTRY_URL is set (self-hosted), only DSNs matching that host are valid.
- * When not set (SaaS), only *.sentry.io DSNs are valid.
+ * Self-hosted (SENTRY_URL set): only DSNs matching the configured
+ * host are valid. SaaS: only `*.sentry.io` DSNs are valid.
  *
- * @throws {ConfigError} If SENTRY_URL is set but not a valid URL
- * @returns The expected host domain for DSN validation
+ * @throws {ConfigError} If SENTRY_URL is set but not a valid URL.
  */
 function getExpectedHost(): string {
   const sentryUrl = getConfiguredSentryUrl();
 
   if (sentryUrl) {
-    // Self-hosted: only accept DSNs matching the configured host
     try {
       const url = new URL(sentryUrl);
       return url.host;
     } catch {
-      // Invalid SENTRY_HOST/SENTRY_URL - throw immediately since nothing will work
       throw new ConfigError(
         `SENTRY_HOST/SENTRY_URL "${sentryUrl}" is not a valid URL`,
         "Set SENTRY_HOST/SENTRY_URL to a valid URL (e.g., https://sentry.example.com) or unset it to use sentry.io"
@@ -326,50 +227,29 @@ function getExpectedHost(): string {
     }
   }
 
-  // SaaS: only accept *.sentry.io
   return DEFAULT_SENTRY_HOST;
 }
 
 /**
- * Validate that a DSN has an acceptable Sentry host.
- *
- * When SENTRY_URL is set (self-hosted): DSNs matching host or any subdomain are valid
- * When SENTRY_URL is not set (SaaS): only *.sentry.io DSNs are valid
- *
- * This ensures we don't detect SaaS DSNs when configured for self-hosted
- * (they can't be queried against a self-hosted instance) and vice versa.
+ * Validate that a DSN has an acceptable Sentry host. Accepts exact
+ * match or any subdomain. Prevents SaaS DSNs from being detected on
+ * self-hosted instances (and vice versa).
  */
 function isValidDsnHost(dsn: string): boolean {
   const parsed = parseDsn(dsn);
   if (!parsed) {
     return false;
   }
-
   const expectedHost = getExpectedHost();
-
-  // Accept exact match or any subdomain for both SaaS and self-hosted
-  // e.g., for sentry.io: accept sentry.io or o123.ingest.us.sentry.io
-  // e.g., for sentry.example.com: accept sentry.example.com or ingest.sentry.example.com
   return (
     parsed.host === expectedHost || parsed.host.endsWith(`.${expectedHost}`)
   );
 }
 
 /**
- * Main scan implementation. Wraps the pipeline in a traced span so
- * production dashboards + the `scanCodeForDsns` bench op stay in
- * sync. Attribute names match the pre-PR-3 scanner byte-for-byte.
- *
- * Delegates the heavy lifting to `collectGrep`:
- * - Walker config (depth, gitignore, skip dirs) from `dsnScanOptions()`.
- * - `DSN_PATTERN` as the grep pattern — the engine's literal
- *   prefilter uses `http` as a file-level gate, identical to the
- *   pre-refactor `HTTP_SCHEME_PROBE` regex.
- * - `recordMtimes: true` + `onDirectoryVisit` populate the two
- *   cache-invalidation maps in one traversal.
- * - Worker pool handles per-file read + regex in parallel; main
- *   thread post-filters each `GrepMatch` for comments and host
- *   validation.
+ * Main full-scan implementation. Delegates the walker + grep work to
+ * `collectGrep`; post-filters matches for comments and host validation
+ * on the main thread.
  */
 function scanDirectory(cwd: string): Promise<CodeScanResult> {
   return withTracingSpan(
@@ -379,12 +259,9 @@ function scanDirectory(cwd: string): Promise<CodeScanResult> {
       const sourceMtimes: Record<string, number> = {};
       const dirMtimes: Record<string, number> = {};
       const seen = new Map<string, DetectedDsn>();
-      // Dedup set for mtime recording: one entry per file that
-      // contributed a validated DSN. Used to skip redundant mtime
-      // writes in `processMatch` — `grepFiles` emits one match per
-      // matching line, so a file with 3 DSN-containing lines would
-      // otherwise trigger 3 mtime writes for the same path. NOT
-      // used for telemetry (see `stats.filesRead` below).
+      // Dedup set for mtime recording. `grepFiles` emits one match
+      // per line, so a file with 3 DSN-containing lines would trigger
+      // 3 redundant writes to `sourceMtimes` without this gate.
       const filesSeenForMtime = new Set<string>();
 
       try {
@@ -397,55 +274,33 @@ function scanDirectory(cwd: string): Promise<CodeScanResult> {
             const rel = normalizePath(path.relative(cwd, absDir)) || ".";
             dirMtimes[rel] = mtimeMs;
           },
-          // Disable line-text truncation. The default (2000 chars) is
-          // fine for interactive grep output, but would silently drop
-          // DSNs that appear past column ~1900 on long minified lines.
-          // `processMatch` re-runs `DSN_PATTERN` on `match.line`, so
-          // a `…` suffix introduced by truncation would make the
-          // regex fail at the pattern-terminating `/\d+`. The
-          // per-DSN memory cost is bounded by the walker's
-          // `maxFileSize` (256 KB) and the `seen` dedup map.
+          // Disable line truncation — the default (2000 chars) would
+          // silently drop DSNs past column ~1900 on long minified
+          // lines because `processMatch` re-runs `DSN_PATTERN` on
+          // `match.line` and the pattern-terminating `/\d+` can't
+          // survive a `…` suffix. Memory is bounded by the walker's
+          // 256 KB `maxFileSize`.
           maxLineLength: Number.POSITIVE_INFINITY,
         });
 
         for (const match of matches) {
-          processMatch(match, {
-            seen,
-            sourceMtimes,
-            filesSeenForMtime,
-          });
+          processMatch(match, { seen, sourceMtimes, filesSeenForMtime });
         }
 
-        // `stats.filesRead` is the count of files actually read and
-        // tested by the grep pipeline — matches the walker-yielded
-        // file count after the walker's own filters (extension,
-        // gitignore, etc.). Consistent with `scanCodeForFirstDsn`
-        // which counts every file it walks. `files_collected` is a
-        // legacy attribute: alias to the same count so telemetry
-        // consumers don't need to know about the historical
-        // distinction.
         span.setAttribute("dsn.files_collected", stats.filesRead);
         span.setAttributes({
           "dsn.files_scanned": stats.filesRead,
           "dsn.dsns_found": seen.size,
         });
 
-        return {
-          dsns: [...seen.values()],
-          sourceMtimes,
-          dirMtimes,
-        };
+        return { dsns: [...seen.values()], sourceMtimes, dirMtimes };
       } catch (error) {
         if (error instanceof ConfigError) {
           throw error;
         }
-        // Anything else is an unexpected walk failure. Return all
-        // three maps empty to match the pre-PR-3 scanner's error-path
-        // behavior AND avoid a cache-invalidation hole: a partial
-        // `dirMtimes` would cause the cache verifier to only check
-        // the dirs we happened to reach before the error, silently
-        // blessing the cache for dirs the walker never visited.
-        // Empty `dirMtimes` forces a full rescan on the next attempt.
+        // Unexpected walk failure: return empty maps so the cache
+        // verifier forces a full rescan on next attempt. A partial
+        // `dirMtimes` would silently bless unvisited dirs.
         span.setStatus({ code: 2, message: "Directory scan failed" });
         return { dsns: [], sourceMtimes: {}, dirMtimes: {} };
       }
@@ -458,12 +313,6 @@ function scanDirectory(cwd: string): Promise<CodeScanResult> {
   );
 }
 
-/**
- * Per-match processing context. Collected into one record so the
- * hot loop's callback stays under Biome's cognitive-complexity
- * ceiling and the caller can mutate `seen` / `sourceMtimes` /
- * `filesSeenForMtime` by reference.
- */
 type MatchProcessingContext = {
   seen: Map<string, DetectedDsn>;
   sourceMtimes: Record<string, number>;
@@ -471,16 +320,9 @@ type MatchProcessingContext = {
 };
 
 /**
- * Process one `GrepMatch` from the DSN scan:
- *
- * 1. Skip commented lines.
- * 2. Extract all DSNs on the line via `extractDsnsOnLine` (rare
- *    multi-DSN lines preserved from pre-refactor behavior).
- * 3. For each DSN: validate via `createDetectedDsn`, record
- *    `fileHadValidDsn` for mtime tracking, dedup into `seen`.
- * 4. If this file contributed at least one validated DSN, record
- *    its mtime in `sourceMtimes` (first match wins since subsequent
- *    matches on the same file have the same mtime).
+ * Process one `GrepMatch`: skip commented lines, extract all DSNs on
+ * the line, validate hosts, dedup into `seen`, and record the file's
+ * mtime in `sourceMtimes` on first-match-per-file.
  */
 function processMatch(
   match: {
@@ -519,15 +361,9 @@ function processMatch(
 }
 
 /**
- * Extract DSN URLs from a single line's text. Called by
- * `scanDirectory` on each matching line yielded by `grepFiles`.
- * Runs the full `DSN_PATTERN` match + host validation, mirroring
- * `extractDsnsFromContent` but without the whole-file literal gate
+ * Extract DSN URLs from a single line's text. Mirrors
+ * `extractDsnsFromContent` but without the file-level scheme probe
  * (grep already handles that).
- *
- * Most lines have zero or one DSN; this loop handles the rare case
- * of two URLs on one line (a preserved behavior of the pre-refactor
- * scanner's `content.matchAll`).
  */
 function extractDsnsOnLine(line: string): string[] {
   const dsns: string[] = [];

--- a/src/lib/dsn/scan-options.ts
+++ b/src/lib/dsn/scan-options.ts
@@ -1,16 +1,13 @@
 /**
- * DSN scanner preset for `src/lib/scan/walkFiles`.
+ * DSN scanner preset for `walkFiles`.
  *
- * Expresses the policy the current DSN scanner
- * (`src/lib/dsn/code-scanner.ts`) applies today: a depth-3 cap, full
+ * Expresses the policy the DSN scanner applies: a depth-3 cap, full
  * DSN skip list (including test/fixture dirs), monorepo-boundary
- * depth reset, and the `TEXT_EXTENSIONS` allowlist. PR 3 will consume
- * this to replace `collectFiles` / `processFile` with a walker-backed
- * implementation.
+ * depth reset, and the `TEXT_EXTENSIONS` allowlist.
  *
- * Isolated in the `dsn/` package — not `scan/` — so the core scanner
- * module stays policy-free. Other callers (the init wizard, future
- * features) will bring their own presets.
+ * Lives in `dsn/` rather than `scan/` so the core scanner module
+ * stays policy-free. Other callers (the init wizard, future features)
+ * bring their own presets.
  */
 
 import type { WalkOptions } from "../scan/index.js";
@@ -22,29 +19,17 @@ import {
 } from "../scan/index.js";
 
 /**
- * The DSN scanner's depth limit. Matches
- * `src/lib/dsn/code-scanner.ts::MAX_SCAN_DEPTH` (pre-PR-3).
- *
- * `maxDepth` in the scan module caps **directory descent** — files
- * inside the last-entered directory are still yielded regardless.
- * So with `maxDepth: 3` and the monorepo descent hook, the deepest
- * files yielded inside a package look like
- * `packages/foo/a/b/c/file.ts` — three directory levels past the
- * package boundary.
+ * DSN scanner depth limit. `maxDepth` caps directory descent; files
+ * inside the last-entered directory are still yielded regardless. So
+ * with `maxDepth: 3` + the monorepo descent hook, the deepest yielded
+ * files look like `packages/foo/a/b/c/file.ts` — three directory
+ * levels past the package boundary.
  */
 export const DSN_MAX_DEPTH = 3;
 
 /**
  * Build a `WalkOptions` recipe that produces DSN-scanner-equivalent
- * behavior. Callers provide `cwd` (and optionally `signal`); this
- * helper fills in the rest.
- *
- * Notable choices vs. the current DSN scanner:
- *   - `nestedGitignore: true` — the existing scanner only reads the
- *     root `.gitignore`. Honoring nested ones is a correctness
- *     upgrade; PR 1.5's walker optimization makes the cost tolerable.
- *   - `extensions: TEXT_EXTENSIONS` — matches the existing scanner's
- *     filter; files outside this set are never considered.
+ * behavior. Callers provide `cwd`; this helper fills in the rest.
  */
 export function dsnScanOptions(): Omit<WalkOptions, "cwd"> {
   return {
@@ -59,12 +44,9 @@ export function dsnScanOptions(): Omit<WalkOptions, "cwd"> {
 }
 
 /**
- * Exported so tests can exercise the hook in isolation without
- * reaching into the options object.
+ * Entering a monorepo package dir resets the depth counter, giving
+ * each package its own depth-3 budget. Exported for isolated tests.
  */
 export function dsnDescentHook(relPath: string, currentDepth: number): number {
-  // Entering a monorepo package dir resets the depth counter, giving
-  // each package its own depth-3 budget (mirrors the existing DSN
-  // scanner's isMonorepoPackageDir-driven reset in code-scanner.ts).
   return isMonorepoPackageDir(relPath) ? 0 : currentDepth + 1;
 }

--- a/src/lib/init/tools/glob.ts
+++ b/src/lib/init/tools/glob.ts
@@ -1,18 +1,8 @@
 /**
- * Init-wizard `glob` tool adapter.
- *
- * Thin wrapper over `collectGlob` from `src/lib/scan/`. Historically
- * this file contained a `rg --files → git ls-files → fs walk` fallback
- * chain with ~150 LOC of subprocess plumbing; all replaced by the
- * pure-TS scanner from PR #791. This adapter:
- *
- * 1. Sandboxes the user-supplied `params.path` via `safePath` (once,
- *    since it's shared across all patterns).
- * 2. Runs each pattern as a separate `collectGlob` call — the wire
- *    contract returns one result row per pattern, with its own
- *    `truncated` flag. `collectGlob` accepts a `patterns` array but
- *    unions them, which would lose per-pattern attribution.
- * 3. Passes each pattern's `files` + `truncated` straight through.
+ * Init-wizard `glob` tool adapter. Thin wrapper over `collectGlob`:
+ * sandboxes `params.path`, runs each pattern as a separate call
+ * (the wire contract returns one row per pattern with its own
+ * `truncated` flag), and passes `files` + `truncated` through.
  */
 
 import { collectGlob } from "../../scan/index.js";
@@ -28,18 +18,13 @@ type PatternResult = {
   truncated: boolean;
 };
 
-/**
- * Find files matching one or more glob patterns.
- *
- * Patterns run in parallel via `Promise.all` — preserves the
- * concurrency shape of the pre-PR implementation.
- */
+/** Find files matching one or more glob patterns in parallel. */
 export async function glob(payload: GlobPayload): Promise<ToolResult> {
   const maxResults = payload.params.maxResults ?? MAX_GLOB_RESULTS;
 
-  // Validate the optional subpath once before spawning per-pattern
-  // calls — a single throw aborts the whole payload, which matches
-  // the registry's sandbox-reject contract.
+  // Validate once before spawning per-pattern calls — a single
+  // throw aborts the whole payload, matching the registry's
+  // sandbox-reject contract.
   if (payload.params.path !== undefined) {
     safePath(payload.cwd, payload.params.path);
   }

--- a/src/lib/init/tools/grep.ts
+++ b/src/lib/init/tools/grep.ts
@@ -1,19 +1,9 @@
 /**
- * Init-wizard `grep` tool adapter.
- *
- * Thin wrapper over `collectGrep` from `src/lib/scan/`. Historically
- * this file contained a `rg → git grep → fs walk` fallback chain with
- * ~300 LOC of subprocess-spawn plumbing; that was all replaced by the
- * pure-TS scanner shipped in PR #791. This adapter now just:
- *
- * 1. Sandboxes the user-supplied `search.path` via `safePath`.
- * 2. Forwards each `GrepSearch` to `collectGrep` with the wire-level
- *    constants (`maxResults`, `maxLineLength`) plumbed through.
- * 3. Strips the `absolutePath` field from each `GrepMatch` before
- *    returning — the Mastra wire contract has never included it.
- * 4. Catches `ValidationError` from `compilePattern` so a bad regex
- *    from the agent surfaces as an empty result for that search
- *    (rather than taking down the whole payload).
+ * Init-wizard `grep` tool adapter. Thin wrapper over `collectGrep`:
+ * sandboxes `search.path`, forwards the wire-level constants,
+ * strips `absolutePath` from each match (not part of the wire
+ * contract), and catches `ValidationError` from a bad regex so the
+ * agent can retry without the whole payload aborting.
  */
 
 import { ValidationError } from "../../errors.js";
@@ -34,21 +24,15 @@ type SearchResult = {
   truncated: boolean;
 };
 
-/**
- * Run one `GrepSearch`. Throws if `safePath` rejects `search.path`;
- * caller (`grep`) hoists the throw to the registry's error path.
- */
 async function runOneSearch(
   cwd: string,
   search: GrepSearch,
   maxResults: number
 ): Promise<SearchResult> {
-  // Validate the subpath against the sandbox. `safePath` throws on
-  // escape attempts — the scan engine explicitly trusts its `path`
-  // input (see `src/lib/scan/types.ts::GrepOptions.path`), so the
-  // adapter is the correct place to enforce sandboxing. We only need
-  // the validation side effect; `collectGrep` takes a cwd-relative
-  // subpath, so we pass `search.path` through unchanged afterward.
+  // The scan engine trusts its `path` input (see
+  // `GrepOptions.path`) — sandbox enforcement lives here. We only
+  // need the validation side effect; `collectGrep` takes a
+  // cwd-relative subpath, so we forward `search.path` unchanged.
   if (search.path !== undefined) {
     safePath(cwd, search.path);
   }
@@ -59,10 +43,9 @@ async function runOneSearch(
       pattern: search.pattern,
       include: search.include,
       path: search.path,
-      // `caseInsensitive` is the wire shape; the scan engine exposes
-      // the inverse (`caseSensitive`). Pass `undefined` when the
-      // caller didn't set it so the engine's default (rg-like,
-      // case-sensitive) takes effect.
+      // Wire shape uses `caseInsensitive`; scan engine uses the
+      // inverse. Leave undefined when unset so the engine's default
+      // (case-sensitive, rg-like) applies.
       caseSensitive: search.caseInsensitive === true ? false : undefined,
       multiline: search.multiline,
       maxResults,
@@ -70,7 +53,6 @@ async function runOneSearch(
     });
     return {
       pattern: search.pattern,
-      // Strip `absolutePath` — not part of the Mastra wire contract.
       matches: matches.map((m) => ({
         path: m.path,
         lineNum: m.lineNum,
@@ -80,21 +62,15 @@ async function runOneSearch(
     };
   } catch (error) {
     if (error instanceof ValidationError) {
-      // Malformed regex from the agent. Surface as an empty row for
-      // this search rather than aborting the whole payload — lets the
-      // agent retry with a corrected pattern.
+      // Malformed regex from the agent. Empty row lets the agent
+      // retry with a fix instead of aborting the whole payload.
       return { pattern: search.pattern, matches: [], truncated: false };
     }
     throw error;
   }
 }
 
-/**
- * Search project files for one or more regex patterns.
- *
- * Searches run in parallel via `Promise.all` — preserves the
- * concurrency shape of the pre-PR implementation.
- */
+/** Search project files for one or more regex patterns in parallel. */
 export async function grep(payload: GrepPayload): Promise<ToolResult> {
   const maxResults =
     payload.params.maxResultsPerSearch ?? MAX_GREP_RESULTS_PER_SEARCH;

--- a/src/lib/scan/glob.ts
+++ b/src/lib/scan/glob.ts
@@ -17,11 +17,8 @@
  *   walker's default `hidden: true`.
  * - `**` spans directory boundaries.
  *
- * The semantics match the init wizard's pre-PR-791 FS-fallback
- * glob (a hand-rolled `matchGlob` in the now-deleted
- * `src/lib/init/tools/search-utils.ts`) but use picomatch's full
- * grammar — extglobs (`+(a|b)`), braces (`{a,b}`), negation
- * (`!pattern`), etc.
+ * Uses picomatch's full grammar: extglobs (`+(a|b)`), braces
+ * (`{a,b}`), negation (`!pattern`), etc.
  *
  * ### Cost model
  *

--- a/src/lib/scan/grep-worker.js
+++ b/src/lib/scan/grep-worker.js
@@ -1,56 +1,21 @@
 /**
  * Grep worker body. Imported as raw text (`with { type: "text" }`)
- * by `worker-pool.ts` and handed to a `Blob` / `URL.createObjectURL`
- * at runtime to spawn workers.
+ * by `worker-pool.ts` and spawned via `Blob` + `URL.createObjectURL`.
  *
- * ## Why a plain `.js` file, not a `.ts` one
- *
- * This file is NEVER executed as a module via `import` — it's always
- * loaded as the body of a `new Worker()`. So we need its contents to
- * be valid JS verbatim (no TS syntax). Keeping it `.js` avoids a
- * transpile step and makes the flow obvious: the file you see is
- * exactly what the worker engine parses.
- *
- * ## Why a separate file and not a string in TS
- *
- * Linting, syntax validation, and IDE tooling all work on real files.
- * A previous iteration inlined this as a template literal inside a
- * TS source — but the string was invisible to lint/format/search.
- * `with { type: "text" }` gives us the best of both: the worker is a
- * first-class file at dev time, and a string constant at runtime.
- *
- * ## Why not `new Worker(url)` with a TS file entrypoint
- *
- * Bun's `bun build --compile` docs describe passing the worker TS
- * file as an additional entrypoint. We tested that with our
- * esbuild→Bun compile two-step and all three documented forms
- * (`new Worker("./path.ts")`, `new Worker(new URL(...))`,
- * `new Worker(URL.href)`). The URL forms fail in compiled binaries
- * because `import.meta.url` resolves to the binary path — the
- * bundler doesn't rewrite URLs at compile time. The plain-string
- * form resolves relative to the project root that `bun build` ran
- * from, which works in compiled mode but requires `bun run` / `bun
- * test` to also be invoked from the project root — brittle.
- *
- * The Blob-URL + text-import approach has no such fragility and
- * works identically in dev, `bun test`, and compiled binaries.
- *
- * ## Self-contained
- *
- * - No imports from local modules (they wouldn't be available in
- *   the worker's module registry anyway).
- * - Uses `require("node:fs")` (CJS-style) which Bun exposes to
- *   workers; avoids the top-level await concerns of ESM imports.
+ * Kept as plain `.js` (no TS) so it's valid Worker input verbatim
+ * with no transpile step. Self-contained: no imports from local
+ * modules (the worker's module registry wouldn't have them).
  *
  * ## Protocol
  *
  * Main → Worker: `{ paths, patternSource, flags, maxLineLength,
- * maxMatchesPerFile, literal }`
+ *   maxMatchesPerFile, literal }`.
  *
  * Worker → Main:
- * - Once on startup: `{ type: "ready" }`
- * - Per request: `{ type: "result", ints: Uint32Array, linePool: string }`
- *   — `ints.buffer` is transferred (zero-copy); `linePool` is cloned.
+ * - `{ type: "ready" }` once on startup.
+ * - `{ type: "result", ints: Uint32Array, linePool: string }` per
+ *   request. `ints.buffer` is transferred (zero-copy); `linePool`
+ *   is cloned.
  *
  * ## Match encoding
  *
@@ -60,10 +25,9 @@
  *   [2] lineOffset  character offset into `linePool`
  *   [3] lineLength  character length of the line (post-truncation)
  *
- * Structured-clone of `GrepMatch[]` for 215k-match workloads costs
- * ~200ms because the per-match path/line strings get deep-copied.
- * The binary-packed form + single shared `linePool` string drops
- * that to ~2-3ms.
+ * Structured-clone of `GrepMatch[]` for 215k matches costs ~200ms.
+ * Binary-packed form + shared `linePool` string drops that to
+ * ~2–3ms.
  */
 
 const { readFileSync } = require("node:fs");
@@ -79,7 +43,6 @@ self.onmessage = (event) => {
     literal,
   } = event.data;
   const regex = new RegExp(patternSource, flags);
-  // Packed match data: 4 u32s per match — [pathIdx, lineNum, lineOffset, lineLength]
   const ints = [];
   let linePool = "";
 
@@ -92,10 +55,10 @@ self.onmessage = (event) => {
       continue;
     }
 
-    // File-level literal gate (matches main-thread readAndGrep behavior).
     if (literal !== null) {
-      const isCaseInsensitive = regex.flags.includes("i");
-      const haystack = isCaseInsensitive ? content.toLowerCase() : content;
+      const haystack = regex.flags.includes("i")
+        ? content.toLowerCase()
+        : content;
       if (haystack.indexOf(literal) === -1) {
         continue;
       }
@@ -109,7 +72,7 @@ self.onmessage = (event) => {
 
     while (m !== null) {
       const matchIndex = m.index;
-      // Advance line counter to match position via indexOf hops.
+      // Advance line counter to the match position via indexOf hops.
       let nl = content.indexOf("\n", cursor);
       while (nl !== -1 && nl < matchIndex) {
         lineNum += 1;
@@ -125,7 +88,6 @@ self.onmessage = (event) => {
         line = `${line.slice(0, maxLineLength - 1)}\u2026`;
       }
 
-      // Append line text to pool, record offset+length
       const lineOffset = linePool.length;
       linePool += line;
       ints.push(pathIdx, lineNum, lineOffset, line.length);
@@ -142,7 +104,6 @@ self.onmessage = (event) => {
     }
   }
 
-  // Pack into Uint32Array with transferable backing buffer.
   const packed = new Uint32Array(ints);
   self.postMessage(
     { type: "result", ints: packed, linePool },

--- a/src/lib/scan/grep.ts
+++ b/src/lib/scan/grep.ts
@@ -4,41 +4,28 @@
  * Layers regex matching onto `walkFiles`:
  *   1. Walk cwd with the caller's filters (extensions, depth, gitignore).
  *   2. Post-filter yields by `isBinary` + include/exclude globs.
- *   3. Read each surviving file's content, optionally gate via the
- *      extracted literal, run the regex across the full buffer.
- *   4. Emit `GrepMatch` entries as they arrive.
+ *   3. Read each surviving file, optionally gate via an extracted
+ *      literal, run the regex across the full buffer.
+ *   4. Emit one `GrepMatch` per matching line.
  *
- * ### Primary API
+ * The public entry points are `grepFiles` (streaming) and
+ * `collectGrep` (drained + sorted). Both share `setupGrepPipeline`
+ * so defaults/compilation/matching are configured in one place.
  *
- * `grepFiles(opts)` returns an `AsyncIterable<GrepMatch>` that streams
- * matches as they're discovered. Consumer-initiated `break` halts
- * in-flight work via the shared early-exit flag inside
- * `mapFilesConcurrentStream`.
+ * File reads use `Bun.file(path).text()`; the walker's `maxFileSize`
+ * (default 256 KB) caps the blast radius. CRLF is preserved verbatim.
  *
- * `collectGrep(opts)` drains the iterable into a sorted array +
- * aggregate stats — the Promise-returning variant init-wizard style
- * callers want.
+ * Matching uses whole-buffer `regex.exec` iteration with the per-file
+ * regex cloned so `lastIndex` is local. A literal extracted from the
+ * compiled regex source (via `extractInnerLiteral`) is used as a
+ * cheap `indexOf` file-level gate before the regex runs. Inline flags
+ * (`(?i)` / `(?im)` / `(?i:...)`) are translated to JS flags by
+ * `compilePattern`.
  *
- * ### File-reading strategy
- *
- * Full slurp via `Bun.file(path).text()`. The walker's
- * `maxFileSize` (default 256 KB) caps the blast radius; minified
- * bundles bigger than that never reach us. CRLF line endings are
- * preserved verbatim in the emitted match text.
- *
- * ### Matching strategy
- *
- * Before matching, `setupGrepPipeline` extracts a literal prefix
- * from the compiled regex (when possible). If the file doesn't
- * contain that literal, it can't possibly match — skip via cheap
- * `indexOf`. Files that pass the gate, or patterns with no
- * extractable literal, go through `grepByWholeBuffer`, which clones
- * the compiled regex per file (`/g`-augmented, plus `/m` when
- * `multiline` is true), iterates via `regex.exec(content)` on the
- * full buffer, and emits one `GrepMatch` per matching line
- * (advancing `lastIndex` past the line's newline so the next match
- * starts on a fresh line). Inline flags `(?i)` / `(?im)` / `(?i:...)`
- * are translated to JS flags by `compilePattern`.
+ * When the runtime supports `new Worker(url)`, batches of file paths
+ * are dispatched to a worker pool; otherwise the pipeline falls back
+ * to main-thread `mapFilesConcurrent`. Disable workers for tests or
+ * debugging via `SENTRY_SCAN_DISABLE_WORKERS=1`.
  */
 
 import { handleFileError } from "../dsn/fs-utils.js";
@@ -78,10 +65,6 @@ import {
 /** Default line-truncation length for the init-wizard wire shape. */
 const DEFAULT_MAX_LINE_LENGTH = 2000;
 
-/**
- * Build a stats object seeded with zeros. Separated so both iterable
- * and collector paths share the init logic.
- */
 function createStats(): GrepStats {
   return {
     filesConsidered: 0,
@@ -92,11 +75,6 @@ function createStats(): GrepStats {
   };
 }
 
-/**
- * Wrap an async iterable to count each yielded entry into `stats`.
- * Lets `grepFiles`' internal pipeline observe the walker's output
- * without re-iterating it.
- */
 async function* tapWalkerStats<T extends WalkEntry>(
   source: AsyncIterable<T>,
   stats: GrepStats
@@ -107,11 +85,6 @@ async function* tapWalkerStats<T extends WalkEntry>(
   }
 }
 
-/**
- * Filter walker entries by the grep-specific criteria (binary +
- * include/exclude). Files that fail the filter are swallowed; the
- * downstream per-file worker never sees them.
- */
 async function* applyGrepFilters(
   source: AsyncIterable<WalkEntry>,
   opts: {
@@ -143,17 +116,6 @@ async function* applyGrepFilters(
   }
 }
 
-/**
- * Options bundle for `readAndGrep` — collecting into one param keeps
- * Biome's `useMaxParams` rule happy.
- *
- * The regex is cloned per file at the top of `readAndGrep` so each
- * worker gets its own `lastIndex`. The `multiline` flag controls
- * whether `/m` is applied (line-boundary anchoring on) or not
- * (buffer-boundary anchoring); we can't infer this from `regex.flags`
- * because the caller's intent matters independent of whatever flags
- * `compilePattern` already set.
- */
 type PerFileOptions = {
   regex: RegExp;
   multiline: boolean;
@@ -161,51 +123,24 @@ type PerFileOptions = {
   maxMatchesPerFile: number;
   pathPrefix: string;
   /**
-   * Optional literal prefilter — when set, the per-file path runs
-   * a cheap `indexOf(literal)` gate before invoking the regex
-   * engine. Files that don't contain the literal are skipped
-   * entirely. Computed once per `collectGrep`/`grepFiles` call via
-   * `extractInnerLiteral`.
+   * Pre-extracted literal for the file-level prefilter. Null when
+   * the pattern has no safe extractable literal (top-level
+   * alternation, all-metachar, etc.).
    *
-   * NOTE: the gate is file-level only. We intentionally do NOT use
-   * the literal to locate individual matches — patterns that can
-   * span newlines (e.g., `foo\sbar` where `\s` matches `\n`) and
-   * patterns whose literal differs from the compiled form (e.g.,
-   * `\x41foo` matches `Afoo`, not `\x41foo`) would both produce
-   * silent misses under per-line verify.
+   * The gate is file-level only — we never use the literal to
+   * locate individual matches. Patterns that can match across
+   * newlines or whose literal differs from the compiled form would
+   * both produce silent misses under a per-line verify.
    */
   literal: string | null;
-  /**
-   * When true, each emitted `GrepMatch` carries `mtime` (the
-   * source file's floored `mtimeMs`). The walker produces it; the
-   * grep path just forwards it. Incurs one extra stat per file at
-   * the walker layer.
-   */
+  /** When true, emitted `GrepMatch` entries carry `mtime`. */
   recordMtimes: boolean;
 };
 
 /**
- * Read one file's content and emit one `GrepMatch` per matching line.
- *
- * ### Implementation note
- *
- * We iterate matches via `content.matchAll(regex)` on the whole
- * buffer rather than `content.split("\n")` + per-line `regex.test`.
- * The split approach allocates one string per line (millions on
- * large repos), which dominates CPU on grep's hot path; whole-buffer
- * matchAll does the same work 10-12× faster because the regex engine
- * already understands `^`/`$`/`\n` and doesn't need a TS-side split.
- *
- * Line numbers are computed by incrementally counting `\n` up to
- * each match's offset with a running cursor — O(content_length) total
- * per file, amortized across all matches. For files with zero matches
- * the line-count work is O(0).
- *
- * Per-line emission: to match the init-wizard / rg contract (one
- * `GrepMatch` per matching line, not per in-line match), we advance
- * the regex's `lastIndex` past the end of the matched line before
- * the next `matchAll` iteration. Without this skip, a regex like
- * `/foo/g` on `"foo foo"` would emit two matches on the same line.
+ * Read one file and emit one `GrepMatch` per matching line.
+ * Applies the literal-prefilter gate when available, then runs the
+ * whole-buffer regex.
  */
 async function readAndGrep(
   entry: WalkEntry,
@@ -222,80 +157,33 @@ async function readAndGrep(
     return null;
   }
 
-  // File-level prefilter gate. If the pattern has an extractable
-  // literal, skip the regex engine entirely on files that don't
-  // contain the literal — ripgrep's central optimization, adapted.
-  //
-  // Important: this is a FILE-level gate only. We deliberately do
-  // NOT attempt to use the literal to find/verify matches line-by-
-  // line. That approach has subtle correctness failures for patterns
-  // that can match across newlines (e.g., `foo\sbar` where `\s`
-  // matches `\n`) and for patterns whose literal isn't what the
-  // regex engine actually matches (e.g., `\x41foo` matches `Afoo`,
-  // not the literal string `\x41foo`; and `(?i:foo|bar)baz` compiles
-  // to `foo|barbaz` with different alternation structure).
-  //
-  // Keeping the gate at file-level sidesteps all of that: we only
-  // use `indexOf(literal)` to quickly reject files that can't match,
-  // and let V8's regex engine handle the actual matching. The perf
-  // win is still substantial because most files in a large tree
-  // contain zero instances of the literal, and `indexOf` is much
-  // cheaper than constructing the regex engine's NFA state.
-  //
-  // Preconditions for the gate:
-  // - Literal must be extractable AND not case-sensitivity-altered
-  //   in a way that breaks indexOf (so: either case-sensitive search,
-  //   OR content.toLowerCase() preserves length).
-  // - The literal must actually be something the compiled regex MUST
-  //   match — guaranteed by `extractInnerLiteral` operating on the
-  //   compiled regex source (see `setupGrepPipeline`).
   if (opts.literal !== null) {
-    const isCaseInsensitive = opts.regex.flags.includes("i");
-    // Note: for case-insensitive search, `content.toLowerCase()` may
-    // be LONGER than `content` (e.g., Turkish `İ` → `i` + U+0307).
-    // That's fine because we only use the result as a boolean gate:
-    // "does the literal exist anywhere in this file?" The returned
-    // position is never used as a `content` offset — the whole-buffer
-    // regex engine does the actual match localization.
-    const haystack = isCaseInsensitive ? content.toLowerCase() : content;
+    // Case-insensitive search: lowercase the haystack for the gate.
+    // This may change string length (e.g., Turkish `İ` → `i` + U+0307),
+    // but we only use the result as a boolean "does the literal exist?"
+    // — the returned position is never used as a content offset.
+    const haystack = opts.regex.flags.includes("i")
+      ? content.toLowerCase()
+      : content;
     if (haystack.indexOf(opts.literal) === -1) {
       return [];
     }
-    // File contains the literal — fall through to the whole-buffer
-    // matcher. The regex engine handles the actual matching; the
-    // literal gate only ruled out files that can't possibly match.
   }
 
   return grepByWholeBuffer(content, entry, opts);
 }
 
 /**
- * Whole-buffer grep — runs the compiled regex across the full file
- * content, emitting one `GrepMatch` per match's enclosing line.
- *
- * This is the primary matching implementation. The file-level
- * literal gate in `readAndGrep` may skip files that have no chance
- * of matching, but once a file reaches this function the regex
- * engine does the actual work.
+ * Whole-buffer regex iteration. Clones the compiled regex so each
+ * invocation has its own `lastIndex`. `/g` is always applied;
+ * `/m` is applied when the caller opted into line-boundary
+ * anchoring (the default — see `GrepOptions.multiline`).
  */
 function grepByWholeBuffer(
   content: string,
   entry: WalkEntry,
   opts: PerFileOptions
 ): GrepMatch[] {
-  // Whole-buffer iteration requires `/g`. `/m` (line-boundary
-  // anchoring) is applied when the caller opts into grep-like
-  // semantics via `opts.multiline` (the default — see `GrepOptions`
-  // docstring). If the caller explicitly set `multiline: false`,
-  // anchor `^/$` to the buffer boundaries like raw JS semantics.
-  //
-  // We clone the regex per file so each invocation has its own
-  // `lastIndex`. Today the exec/loop block runs synchronously with
-  // no `await`, so concurrent `readAndGrep` workers can't actually
-  // observe each other's `lastIndex` mutations (JS is single-threaded;
-  // microtasks only yield at `await`). But the clone is still worth
-  // paying — ~1µs per file — to eliminate the foot-gun if anyone
-  // ever introduces an `await` inside the match loop.
   const ensured = opts.multiline
     ? ensureGlobalMultilineFlags(opts.regex)
     : ensureGlobalFlag(opts.regex);
@@ -303,10 +191,8 @@ function grepByWholeBuffer(
   const ctx: MatchContext = { entry, opts, content };
 
   const matches: GrepMatch[] = [];
-  // Advance `cursor` to each match index using `indexOf("\n", cursor)`
-  // in a loop — skipping newline-to-newline instead of walking char-
-  // by-char via `charCodeAt`. 2-5× faster because V8 implements
-  // `indexOf` in optimized C++ with no per-iteration JS interop.
+  // Track line numbers by jumping newline-to-newline with `indexOf`
+  // — faster than a `charCodeAt` walk (V8 optimizes `indexOf` in C++).
   let lineNum = 1;
   let cursor = 0;
   let match = regex.exec(content);
@@ -328,18 +214,13 @@ function grepByWholeBuffer(
     if (lineEndRaw === -1) {
       break;
     }
+    // Advance past the line so we emit at most one match per line.
     regex.lastIndex = lineEnd + 1;
     match = regex.exec(content);
   }
   return matches;
 }
 
-/**
- * Per-call context for `buildMatch` — bundles args that stay
- * constant for the duration of a file's scan (entry, opts, content)
- * separately from args that change per match (lineNum, lineStart,
- * lineEnd). Keeps Biome's useMaxParams under the 4-param ceiling.
- */
 type MatchContext = {
   entry: WalkEntry;
   opts: PerFileOptions;
@@ -352,7 +233,6 @@ type LineBounds = {
   lineEnd: number;
 };
 
-/** Build a `GrepMatch` record for one line. Shared by all grep paths. */
 function buildMatch(ctx: MatchContext, bounds: LineBounds): GrepMatch {
   const rawLine = ctx.content.slice(bounds.lineStart, bounds.lineEnd);
   const line =
@@ -373,10 +253,6 @@ function buildMatch(ctx: MatchContext, bounds: LineBounds): GrepMatch {
   return match;
 }
 
-/**
- * Build walker options from grep options — the set that `walkFiles`
- * actually consumes. Anything grep-specific stays in grep.
- */
 function buildWalkOptions(opts: GrepOptions, root: string): WalkOptions {
   return {
     cwd: root,
@@ -397,9 +273,6 @@ function buildWalkOptions(opts: GrepOptions, root: string): WalkOptions {
   };
 }
 
-/**
- * Options for `grepFilesInternal` — keeps arity down for Biome.
- */
 type GrepPipelineOptions = {
   regex: RegExp;
   perFile: PerFileOptions;
@@ -411,38 +284,14 @@ type GrepPipelineOptions = {
 };
 
 /**
- * Batch size for worker dispatch. Each batch is a chunk of N file
- * paths the worker will read + grep in one go. Benched on
- * synthetic/large (10k files): 100 = 420ms, 200 = 275ms (streamed),
- * 400 = 290ms. The plateau is around 200 — too small and postMessage
- * overhead dominates; too large and we lose per-worker parallelism
- * because the walker finishes yielding before the first worker
- * returns.
+ * Batch size for worker dispatch. Bench (synthetic/large, 10k files):
+ * 100 → 420ms, 200 → 275ms (plateau), 400 → 290ms. Too small and
+ * `postMessage` overhead dominates; too large and we lose parallelism
+ * because the walker finishes before workers return.
  */
 const WORKER_BATCH_SIZE = 200;
 
-/**
- * The internal pipeline. Separated from the public entry points so
- * `grepFiles` and `collectGrep` share it.
- *
- * Two execution strategies:
- *
- * 1. **Worker pool** (default when the runtime supports `new Worker`
- *    + `Blob` + `URL.createObjectURL`): walker streams paths on the
- *    main thread, paths are batched into chunks of
- *    `WORKER_BATCH_SIZE`, each batch is dispatched round-robin to
- *    a lazy-initialized pool of workers. Workers return matches
- *    packed as `Uint32Array` + a shared string pool (transferable,
- *    zero-copy). Main thread decodes and yields.
- *
- * 2. **Async fallback** (when workers aren't available — e.g. some
- *    Node library embeddings): falls back to `mapFilesConcurrent`
- *    on the main thread. Same result, ~4× slower on large workloads.
- *
- * Worker disablement for tests or debugging: set
- * `SENTRY_SCAN_DISABLE_WORKERS=1`.
- */
-// biome-ignore lint/suspicious/useAwait: async generator that dispatches to one of two sub-generators via `yield*`; no `await` needed in the dispatcher itself
+// biome-ignore lint/suspicious/useAwait: yield* delegates to sub-generators
 async function* grepFilesInternal(
   opts: GrepPipelineOptions
 ): AsyncGenerator<GrepMatch> {
@@ -453,11 +302,6 @@ async function* grepFilesInternal(
   yield* grepViaAsyncMain(opts);
 }
 
-/**
- * Returns true when the worker path should be used. Gated on the
- * runtime capability check (`isWorkerSupported`) and the
- * `SENTRY_SCAN_DISABLE_WORKERS` env var (for tests + debugging).
- */
 function shouldUseWorkers(): boolean {
   if (process.env.SENTRY_SCAN_DISABLE_WORKERS === "1") {
     return false;
@@ -466,10 +310,8 @@ function shouldUseWorkers(): boolean {
 }
 
 /**
- * Fallback pipeline: `mapFilesConcurrentStream` on the main thread.
- * Used when the worker pool is unavailable or explicitly disabled.
- * Identical semantics to the worker path; ~4× slower on 10k-file
- * many-match workloads.
+ * Main-thread fallback. Identical semantics to the worker path;
+ * ~4× slower on 10k-file many-match workloads.
  */
 async function* grepViaAsyncMain(
   opts: GrepPipelineOptions
@@ -478,10 +320,8 @@ async function* grepViaAsyncMain(
     opts.walkSource,
     async (entry) => {
       const matches = await readAndGrep(entry, opts.perFile);
-      // `filesRead` is documented as "files whose content was read
-      // and tested against the pattern" — only increment when
-      // `readAndGrep` actually succeeded (returned a non-null array).
-      // A null return means the open failed; we don't count those.
+      // Only count `filesRead` on successful read — a null return
+      // means the open failed.
       if (matches !== null) {
         opts.stats.filesRead += 1;
       }
@@ -503,28 +343,10 @@ async function* grepViaAsyncMain(
 }
 
 /**
- * Worker-based pipeline. Streams paths from the walker, batches
- * them, dispatches to workers, decodes results, yields matches in
- * worker-completion order (not walker order).
- *
- * ### Streaming + early-exit
- *
- * Walker runs on main thread. As paths arrive, we accumulate into a
- * `batch: string[]`. When the batch reaches `WORKER_BATCH_SIZE` we
- * dispatch it and start a new batch. Each dispatch returns a
- * promise; we race the set of in-flight dispatches so the first
- * batch to finish yields its matches first (workers may complete
- * out of order).
- *
- * On `maxResults`/`stopOnFirst`, we stop dispatching new batches.
- * In-flight batches keep running (no cancellation API on workers)
- * but their results are discarded once we've exited.
- *
- * `filesRead` counts all paths dispatched to workers — we don't
- * distinguish "read successfully" from "open failed" at the worker
- * boundary (the worker swallows the error and produces zero matches
- * for that path). For the main-thread fallback the stat is more
- * precise.
+ * Worker pipeline. Walker streams paths on the main thread; paths
+ * are batched, each batch dispatches round-robin to the pool,
+ * workers return packed results via transferable `Uint32Array`.
+ * Main thread decodes and yields in worker-completion order.
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: producer/consumer pattern with early exit, batch dispatch, and abort-signal propagation is inherently branchy
 async function* grepViaWorkers(
@@ -532,13 +354,10 @@ async function* grepViaWorkers(
 ): AsyncGenerator<GrepMatch> {
   const pool = getWorkerPool();
 
-  // Queue of completed batches ready to emit. Filled by dispatched
-  // worker promises as they resolve; drained by this generator.
   const pending: GrepMatch[][] = [];
-  // Consumer wait state: `pendingNotify` is a one-shot resolver set
-  // by the consumer when it's about to wait; `notifyPending` tracks
-  // a notification that arrived while no one was waiting, so the
-  // consumer picks it up on next loop iteration.
+  // Consumer wait state. `notifyPending` is set when `wakeConsumer`
+  // fires before the consumer is waiting, so the consumer picks it
+  // up on the next loop iteration instead of missing the wakeup.
   let pendingNotify: (() => void) | null = null;
   let notifyPending = false;
   const wakeConsumer = () => {
@@ -555,22 +374,12 @@ async function* grepViaWorkers(
   let walkerDone = false;
   let inflightCount = 0;
 
-  // Tracks batches that failed at dispatch time (worker error,
-  // "all workers dead", etc.) so we can surface silent-failure
-  // scenarios to the caller. A single failed batch is not fatal
-  // (its results are dropped — per-file errors are already expected
-  // to be swallowed inside the worker), but if every batch fails
-  // we throw so callers aren't handed a false-negative empty result
-  // that could poison downstream caches.
+  // Track dispatch outcomes so the consumer's `finally` can detect
+  // a pipeline-wide failure. `dispatchPromises` is awaited to ensure
+  // `failedBatches` is final before we check it (otherwise an
+  // early-exit could race the in-flight `.catch()` handlers).
   let dispatchedBatches = 0;
   let failedBatches = 0;
-  // Track dispatch promises so the consumer's `finally` can await
-  // them before checking the failure counters. Without this, an
-  // early exit (e.g., AbortError, maxResults = 0) could race the
-  // final failure assessment: the consumer's finally runs before
-  // in-flight dispatch `.catch()` handlers have bumped
-  // `failedBatches`, causing a legitimate all-failure scenario to
-  // silently pass through as "no matches found."
   const dispatchPromises: Promise<unknown>[] = [];
 
   const dispatchBatch = (
@@ -594,16 +403,9 @@ async function* grepViaWorkers(
       })
       .then(
         (result) => {
-          // `decodeWorkerMatches` attaches per-file mtime by pathIdx
-          // when `mtimes` is non-null. Mtime comes from the walker
-          // (main thread) — worker doesn't need to stat again.
           pending.push(decodeWorkerMatches(result, paths, rels, mtimes));
         },
         () => {
-          // Worker error — drop this batch's results. Per-file errors
-          // are already swallowed inside the worker itself. Counted so
-          // the consumer can surface total-pipeline failure if every
-          // batch failed.
           failedBatches += 1;
         }
       )
@@ -614,18 +416,14 @@ async function* grepViaWorkers(
     dispatchPromises.push(dispatchP);
   };
 
-  // Producer: walk paths, batch them, dispatch each full batch.
-  // Errors thrown by the walker (e.g. `AbortError` when the caller
-  // signals abort) propagate to the consumer via `producerError`.
   let producerError: unknown = null;
   const recordMtimes = opts.perFile.recordMtimes;
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: walker drain + path-prefix handling + batch flush + error capture is inherently branchy
   const producer = (async () => {
     let batch: string[] = [];
     let batchRel: string[] = [];
-    // Per-batch mtime array (parallel to `batch`). Only allocated
-    // when the caller opts in via `recordMtimes`; otherwise stays
-    // null and the decoder skips the `mtime` field entirely.
+    // Per-batch mtime array, parallel to `batch`. Allocated only
+    // when the caller opted into `recordMtimes`.
     let batchMtimes: number[] | null = recordMtimes ? [] : null;
     try {
       for await (const entry of opts.walkSource) {
@@ -648,7 +446,6 @@ async function* grepViaWorkers(
           batchMtimes = recordMtimes ? [] : null;
         }
       }
-      // Final partial batch.
       if (batch.length > 0) {
         dispatchBatch(batch, batchRel, batchMtimes);
       }
@@ -660,9 +457,8 @@ async function* grepViaWorkers(
     }
   })();
 
-  // Helper to check + throw on aborted signal. Matches the behavior
-  // of `walkFiles` which throws `DOMException("AbortError")` on the
-  // next yield when the signal fires mid-iteration.
+  // `walkFiles` throws `DOMException("AbortError")` on the next
+  // yield after the signal fires; mirror that in the consumer.
   const checkAborted = (): void => {
     const signal = opts.concurrent.signal;
     if (signal?.aborted) {
@@ -670,13 +466,9 @@ async function* grepViaWorkers(
     }
   };
 
-  // Consumer: drain `pending` as batches complete, yielding matches
-  // and respecting `maxResults`/`stopOnFirst`. Wait for `notify`
-  // when there's nothing to emit and more work is in flight.
   try {
     while (!earlyExit) {
       checkAborted();
-      // Emit everything currently pending.
       while (pending.length > 0) {
         checkAborted();
         const matches = pending.shift();
@@ -705,14 +497,12 @@ async function* grepViaWorkers(
       if (earlyExit) {
         break;
       }
-      // Nothing pending. If the walker is done AND no in-flight
-      // batches remain, we're finished.
       if (walkerDone && inflightCount === 0) {
         break;
       }
-      // Otherwise, wait for something to happen. Check for a
-      // pre-arrived notification first to avoid missing wakeups
-      // that happened while we were iterating `pending`.
+      // Wait for something to happen. Check for a pre-arrived
+      // notification first to avoid missing wakeups that fired while
+      // we were draining `pending`.
       if (notifyPending) {
         notifyPending = false;
         continue;
@@ -727,36 +517,25 @@ async function* grepViaWorkers(
       });
     }
   } finally {
-    // Ensure the producer settles even on early exit so errors
-    // surface in the next run (pool promises stay alive otherwise).
     earlyExit = true;
     wakeConsumer();
     await producer;
     // Await every dispatched batch so `failedBatches` is final
-    // before we inspect it. Without this, an early exit could run
-    // the failure check before in-flight `.catch()` handlers
-    // bumped the counter — collapsing an all-failure scenario into
-    // a silent "no matches" return. `allSettled` because we don't
-    // care about individual rejections here (each was already
-    // counted via the dispatch's `.catch()` handler).
+    // before the pipeline-failure check. Without this the failure
+    // check can race in-flight `.catch()` handlers on early exit.
     if (dispatchPromises.length > 0) {
       await Promise.allSettled(dispatchPromises);
     }
-    // If the walker threw (typically `AbortError`), re-throw so the
-    // caller sees the same behavior as the async-fallback path.
     if (producerError !== null) {
-      // biome-ignore lint/correctness/noUnsafeFinally: intentional — re-raising walker error (e.g., AbortError) so callers see it
+      // biome-ignore lint/correctness/noUnsafeFinally: re-raising walker error (e.g. AbortError) so callers see it
       throw producerError;
     }
-    // Worker-pipeline failure detector: if at least one batch was
-    // dispatched AND every dispatched batch failed, the pipeline
-    // returned zero matches due to worker failures — NOT due to the
-    // regex not matching. We must surface this so callers (notably
-    // the DSN cache layer) don't persist a false-negative empty
-    // result. A partial failure (some batches succeeded) is
-    // acceptable — we've at least reported the matches we did find.
+    // If every dispatched batch failed, the "no matches" result is
+    // a pipeline failure, not a genuine zero-match. Surface it so
+    // callers (notably the DSN cache layer) don't persist a
+    // false-negative empty result.
     if (dispatchedBatches > 0 && failedBatches === dispatchedBatches) {
-      // biome-ignore lint/correctness/noUnsafeFinally: intentional — surfacing pipeline-wide failure so false-negative empty result doesn't leak upstream
+      // biome-ignore lint/correctness/noUnsafeFinally: surfacing pipeline-wide failure so false-negative empty result doesn't leak upstream
       throw new Error(
         `worker pipeline: all ${dispatchedBatches} dispatched batch(es) failed`
       );
@@ -764,12 +543,6 @@ async function* grepViaWorkers(
   }
 }
 
-/**
- * Resolve the regex flags to send to the worker. Matches the logic
- * in `grepByWholeBuffer` — always `/g` (required for iteration),
- * plus `/m` when the caller opted into line-boundary semantics (the
- * default).
- */
 function resolveWorkerFlags(opts: PerFileOptions): string {
   const ensured = opts.multiline
     ? ensureGlobalMultilineFlags(opts.regex)
@@ -777,25 +550,10 @@ function resolveWorkerFlags(opts: PerFileOptions): string {
   return ensured.flags;
 }
 
-/**
- * Resolved pipeline inputs shared by `grepFiles` and `collectGrep`.
- * Extracted so both entry points get the same default-resolution,
- * pattern compilation, matcher compilation, walker construction, and
- * filter wiring — a divergence between the two would be a silent
- * correctness bug.
- */
 type GrepPipelineSetup = {
   regex: RegExp;
   multiline: boolean;
-  /**
-   * Pre-extracted literal prefilter (see `extractInnerLiteral`). Null
-   * when the pattern has no safe extractable literal (top-level
-   * alternation, all-metachar, etc.). When set, `readAndGrep` uses
-   * it as a file-level gate via `indexOf` — files without the literal
-   * are skipped entirely.
-   */
   literal: string | null;
-  /** Mirrors `GrepOptions.recordMtimes`. Threaded into PerFileOptions. */
   recordMtimes: boolean;
   stats: GrepStats;
   walkSource: AsyncIterable<WalkEntry>;
@@ -809,38 +567,23 @@ type GrepPipelineSetup = {
 };
 
 /**
- * Resolve all defaults + compile + wire the walker. Both `grepFiles`
- * and `collectGrep` consume this — keeps defaults in one place.
+ * Resolve defaults, compile the regex, extract a literal prefilter,
+ * compile include/exclude matchers, and wire the walker. Shared by
+ * `grepFiles` and `collectGrep` — divergence between the two would
+ * be a silent correctness bug.
  *
- * Extracts a literal prefix/substring from the compiled regex (if
- * possible) so the per-file path can use `indexOf` as a file-level
- * gate. The gate is conservative: we only use it to skip files that
- * can't possibly contain a match; the whole-buffer matcher handles
- * the actual matching.
+ * Literal extraction runs on `regex.source` (the compiled form), not
+ * the raw user pattern. `compilePattern` rewrites scoped inline flags
+ * like `(?i:foo|bar)baz` into `foo|barbaz` + `i` flag — extracting
+ * from the original would miss the top-level alternation and pick a
+ * bogus required literal, silently dropping one branch of matches.
  */
 function setupGrepPipeline(opts: GrepOptions): GrepPipelineSetup {
-  // Default `multiline: true` — matches grep/rg's line-boundary
-  // anchoring semantics. Callers opt out with `multiline: false` for
-  // buffer-boundary JS semantics.
   const multiline = opts.multiline ?? true;
   const regex = compilePattern(opts.pattern, {
     caseSensitive: opts.caseSensitive,
     multiline,
   });
-
-  // Literal extraction runs on the COMPILED regex's source, not the
-  // raw user input. `compilePattern` rewrites scoped inline flags
-  // like `(?i:foo|bar)baz` — strip the group and widen the flag,
-  // which yields `foo|barbaz` (source) + `i` (flag). The rewritten
-  // source has top-level alternation the original lacked. If we
-  // extracted from the original, `hasTopLevelAlternation` would miss
-  // it and we'd extract `"baz"` as a "required" literal — but the
-  // compiled regex can match `foo` alone, silently dropping lines
-  // that match the first branch of the alternation.
-  //
-  // Always extract from `regex.source` so the extractor sees what
-  // the regex engine will actually run. `regex.flags` is authoritative
-  // for case-sensitivity either way.
   const literal = extractInnerLiteral(regex.source, regex.flags);
 
   const includes = compileMatchers(opts.include);
@@ -874,16 +617,9 @@ function setupGrepPipeline(opts: GrepOptions): GrepPipelineSetup {
 }
 
 /**
- * Public entry point — yield one `GrepMatch` per matching line under
- * `opts.cwd`. Consumer `break` halts in-flight work (via the
- * concurrent-stream's internal early-exit flag).
- *
- * Throws `ValidationError` on bad regex input; propagates
- * `AbortError` from the `signal`.
- *
- * The `yield*` delegates to the internal pipeline, which does the
- * actual async work — `async *` is required so callers get an
- * `AsyncGenerator<GrepMatch>`.
+ * Stream one `GrepMatch` per matching line under `opts.cwd`.
+ * Consumer `break` halts in-flight work. Throws `ValidationError`
+ * on bad regex input; propagates `AbortError` from `opts.signal`.
  */
 // biome-ignore lint/suspicious/useAwait: yield* delegates to async generator
 export async function* grepFiles(opts: GrepOptions): AsyncGenerator<GrepMatch> {
@@ -912,23 +648,18 @@ export async function* grepFiles(opts: GrepOptions): AsyncGenerator<GrepMatch> {
 }
 
 /**
- * Drain `grepFiles` into a sorted-by-[path, lineNum] array alongside
+ * Drain `grepFiles` into a sorted-by-[path, lineNum] array plus
  * aggregate stats. Primary entry point for Promise-returning callers
  * (init wizard, diagnostic scripts).
- *
- * Sort order is stable across runs: byte-lexicographic on `path`,
- * numeric ascending on `lineNum` within a path.
  */
 export async function collectGrep(opts: GrepOptions): Promise<GrepResult> {
   const setup = setupGrepPipeline(opts);
 
-  // Ask the iterator for one extra match past `maxResults` so we can
-  // distinguish "exactly maxResults matches existed" from "more
-  // existed but we stopped". Without this +1 probe, the iterator
-  // would flip `stats.truncated = true` the moment it emits the
-  // N-th match, regardless of whether an (N+1)-th was available.
-  // Same pattern as `collectGlob`; see the lore entry on
-  // `collectGlob/collectGrep truncation flag`.
+  // Probe for one extra match past `maxResults` so we can distinguish
+  // "exactly N matches existed" from "more existed but we stopped."
+  // Without the +1 probe the iterator flips `truncated = true` the
+  // moment it emits the N-th match, regardless of whether an (N+1)-th
+  // was available.
   const probeLimit = Number.isFinite(setup.maxResults)
     ? Math.min(Number.MAX_SAFE_INTEGER, setup.maxResults + 1)
     : Number.POSITIVE_INFINITY;
@@ -956,24 +687,20 @@ export async function collectGrep(opts: GrepOptions): Promise<GrepResult> {
     stopOnFirst: setup.stopOnFirst,
   })) {
     if (matches.length >= setup.maxResults) {
-      // We've got the overshoot match — there ARE more results than
-      // the caller asked for. Stop draining, flag truncation.
       truncated = true;
       break;
     }
     matches.push(match);
   }
   matches.sort(compareMatches);
-  // Reflect the collector-level truncation in the stats bag the
-  // iterator populated. Preserves stopOnFirst-path flag (stats.truncated
-  // is already set by the iterator in that case).
+  // Preserve stopOnFirst-path flag (iterator already set it in that
+  // case); otherwise reflect the collector-level truncation.
   if (truncated) {
     setup.stats.truncated = true;
   }
   return { matches, stats: setup.stats };
 }
 
-/** [path, lineNum] lexicographic comparator for stable collectGrep output. */
 function compareMatches(a: GrepMatch, b: GrepMatch): number {
   if (a.path < b.path) {
     return -1;

--- a/src/lib/scan/path-utils.ts
+++ b/src/lib/scan/path-utils.ts
@@ -1,9 +1,7 @@
 /**
  * Internal path + pattern utilities shared by the grep and glob
- * engines in `src/lib/scan/`. Not part of the public barrel — these
- * are implementation details we factored out to stop two very similar
- * copies of the same logic drifting apart over time (flagged in PR
- * 791 review).
+ * engines. Not part of the public barrel — implementation details
+ * factored out to prevent drift between the two engines.
  */
 
 import path from "node:path";

--- a/src/lib/scan/types.ts
+++ b/src/lib/scan/types.ts
@@ -301,12 +301,10 @@ export type GrepOptions = {
    *   and `$` to the buffer end. Only useful for patterns that
    *   explicitly want to match on the whole file as a single unit.
    *
-   * Note: the pre-PR-3.5 grep engine iterated line-by-line (via
-   * `content.split("\n")`), so each line was its own string and
-   * `^/$` anchored naturally. After the switch to whole-buffer
-   * `regex.exec`, the engine needs the `m` flag to recover the same
-   * anchoring semantics — which is why the default is `true` here
-   * despite `compilePattern`'s lower-level default being `false`.
+   * The default differs from `compilePattern`'s lower-level default
+   * (`false`): whole-buffer iteration needs the `m` flag to recover
+   * the line-boundary anchoring that a line-by-line engine would
+   * get for free.
    */
   multiline?: boolean;
   /**

--- a/src/lib/scan/walker.ts
+++ b/src/lib/scan/walker.ts
@@ -250,11 +250,9 @@ async function processEntry(
   if (!isFile) {
     return null;
   }
-  // maxDepth controls directory *descent*, not file yield. Files sit
-  // inside the last-entered dir; once the walker has entered that dir,
-  // every file in it is eligible for yield. This matches the classic
-  // Unix `find -maxdepth` semantics and the pre-PR-3 DSN scanner's
-  // MAX_SCAN_DEPTH behavior.
+  // `maxDepth` controls directory descent, not file yield. Once the
+  // walker has entered a dir, every file inside it is eligible —
+  // matches Unix `find -maxdepth` semantics.
   const fileDepth = frame.depth + 1;
   if (matcher.isIgnored(rel, false)) {
     return null;
@@ -491,9 +489,8 @@ function listDirEntries(dir: string): Dirent[] {
  * the walk.
  *
  * Uses `node:fs.stat` because `Bun.file()` doesn't support
- * directories (see the pre-PR-3 `getDirMtime` helper for the same
- * rationale). Flooring matches `src/lib/db/dsn-cache.ts`'s verifier
- * — see `validateDirMtime`.
+ * directories. Flooring matches `src/lib/db/dsn-cache.ts`'s
+ * `validateDirMtime`.
  */
 async function notifyDirectoryVisit(
   absDir: string,

--- a/src/lib/scan/worker-pool.ts
+++ b/src/lib/scan/worker-pool.ts
@@ -1,65 +1,26 @@
 /**
  * Worker pool for parallel file-grep work.
  *
- * Lazy-initialized singleton: the first call to `getWorkerPool()`
- * spawns N workers via a Blob URL (for compatibility with
- * `bun build --compile`'s single-file binary — see
- * `grep-worker.js` for the worker body + rationale). Subsequent
- * calls reuse the pool.
+ * Lazy-initialized singleton. Workers are spawned unref'd and ref'd
+ * per-dispatch so the process exits cleanly once all dispatches
+ * settle — no explicit shutdown is required from callers.
  *
- * ### Lifetime
- *
- * Workers are kept ref'd — they hold the event loop open. The CLI
- * relies on `process.exit()` at the end of command execution to
- * tear them down; no explicit shutdown is required from callers.
- *
- * An earlier iteration `.unref()`'d each worker for "clean" exit,
- * but that caused a deadlock: when the main thread's only pending
- * work was a promise awaiting a worker result, unref'd workers
- * didn't process messages on idle ticks and the pipeline hung with
- * in-flight batches never settling.
- *
- * `terminatePool()` is provided for tests that need to reset the
- * singleton between cases; it's not part of the CLI shutdown path.
- *
- * ### Feature-gate
- *
- * `isWorkerSupported()` returns true only when `Worker`, `Blob`,
- * and `URL.createObjectURL` are available. The Bun runtime and
- * Bun-compiled binaries always pass this check; the Node library
- * bundle (`dist/index.cjs`) may or may not depending on the
- * consumer's Node version. We avoid depending on `bun:*` or
- * `Bun.*` APIs so the same code works in both runtimes.
- *
- * When unsupported, callers fall back to the async
- * `mapFilesConcurrent` path.
+ * Feature-gated on `isWorkerSupported()`. On runtimes without
+ * `Worker` / `Blob` / `URL.createObjectURL` (older Node), callers
+ * fall back to the async `mapFilesConcurrent` path.
  */
 
 import { availableParallelism } from "node:os";
-// Raw-text import: Bun reads the file's contents at bundle time and
-// exposes them as the module's default export (a string). The file
-// is a real `.js` file (`grep-worker.js`) so it's lintable,
-// syntax-checked, and easy to edit. At runtime we feed the string
-// to a `Blob` + `URL.createObjectURL` to spawn workers. See
-// `grep-worker.js` for full rationale.
-//
-// TypeScript's type system doesn't model Bun's `with { type: "text" }`
-// attribute (the default export gets typed as the module's shape),
-// so we cast through unknown. Guarded at startup by the runtime
-// Blob constructor which would throw if given a non-string.
+// Raw-text import of the worker body. Bun handles the
+// `with { type: "text" }` attribute natively; the esbuild build
+// uses `script/text-import-plugin.ts` to polyfill it. TypeScript
+// doesn't model the attribute, hence the cast.
 import grepWorkerSource from "./grep-worker.js" with { type: "text" };
+import type { GrepMatch } from "./types.js";
 
 const GREP_WORKER_SOURCE = grepWorkerSource as unknown as string;
 
-import type { GrepMatch } from "./types.js";
-
-/**
- * Batch dispatched to a worker. `paths` are absolute filesystem
- * paths the worker will `readFileSync`. `pathsBase` is the
- * relative-path prefix (usually the walker's `cwd + "/"`) that the
- * caller uses to reconstruct `GrepMatch.path` from
- * `pathsBase + absolutePath.slice(pathsBase.length)`.
- */
+/** Batch dispatched to a worker. */
 export type WorkerGrepRequest = {
   paths: string[];
   patternSource: string;
@@ -69,10 +30,7 @@ export type WorkerGrepRequest = {
   literal: string | null;
 };
 
-/**
- * Packed result from a single worker batch. Rehydrate via
- * `decodeWorkerMatches`.
- */
+/** Packed result from a single worker batch. Rehydrate via `decodeWorkerMatches`. */
 export type WorkerGrepResult = {
   /** Packed 4-u32-per-match (pathIdx, lineNum, lineOffset, lineLength). */
   ints: Uint32Array;
@@ -81,71 +39,38 @@ export type WorkerGrepResult = {
 };
 
 /**
- * Per-worker state. Dispatch queues requests FIFO per worker — we
- * can't use `addEventListener` per request because multiple
- * concurrent dispatches to the same worker would make their handlers
- * all fire on the first `result` message (they each match the
- * shape), resulting in the wrong `resolve()` getting called with
- * the wrong batch's data.
+ * Per-worker state.
  *
- * Instead: one `onmessage` per worker, `pending` queue of resolvers,
- * shift the head on each `result` message.
+ * Each worker has one `onmessage` handler and a FIFO `pending`
+ * queue of result resolvers. `addEventListener`-per-dispatch would
+ * cause every listener to fire on every `result` message — FIFO
+ * shifting matches the order in which the worker processes requests.
  */
 type PooledWorker = {
   worker: Worker;
-  /** Promise that resolves once the worker signals `"ready"`. */
   ready: Promise<void>;
-  /** Number of batches currently dispatched to this worker. */
+  /** Number of dispatches currently in flight to this worker. */
   inflight: number;
-  /**
-   * Queue of pending result resolvers. Populated by `dispatch`,
-   * drained in FIFO order by `worker.onmessage` as `result` messages
-   * arrive. Workers process messages sequentially so FIFO matching
-   * is sound.
-   */
   pending: Array<{
     resolve: (r: WorkerGrepResult) => void;
     reject: (e: unknown) => void;
   }>;
-  /**
-   * False once the worker has emitted an `error` event. Dispatchers
-   * skip dead workers — without this, the least-loaded selection
-   * would favor a dead worker (its `inflight` gets reset to 0 in
-   * the error handler), new dispatches would post to a worker that
-   * can't respond, and the calling `grepViaWorkers` would deadlock
-   * waiting for results that never arrive.
-   */
+  /** Flipped to false on the first `error` event; dispatch skips dead workers. */
   alive: boolean;
 };
 
 type WorkerPool = {
   workers: PooledWorker[];
-  /**
-   * Dispatch `request` to the least-loaded worker, returning a
-   * promise that resolves when the worker posts its `"result"`.
-   */
   dispatch(request: WorkerGrepRequest): Promise<WorkerGrepResult>;
-  /**
-   * Terminate all workers in the pool. Used by tests and on process
-   * teardown. Safe to call multiple times.
-   */
   terminate(): void;
 };
 
-/**
- * Module-level pool singleton. Lazily initialized on first
- * `getWorkerPool()` call. Cleared by `terminatePool()` (used by
- * tests).
- */
 let pool: WorkerPool | null = null;
 
 /**
- * True when the runtime supports Web-Workers-style `new Worker(url)`
- * with a Blob-URL source. Covers:
- *   - Bun (dev mode and single-file compiled binary)
- *   - Node 22+ when the library bundle is consumed (Node exposes
- *     `Worker` via the DOM shim in newer versions; older Node lacks
- *     it, so we fall back).
+ * True when the runtime supports `new Worker(url)` with a Blob-URL
+ * source. Covers Bun (dev + single-file binary) and Node 22+ with
+ * the DOM Worker shim.
  */
 export function isWorkerSupported(): boolean {
   return (
@@ -157,38 +82,32 @@ export function isWorkerSupported(): boolean {
 }
 
 /**
- * Default pool size: clamped to [2, 8] based on `availableParallelism()`.
- * Bench (synthetic/large, 10k files, `import.*from`): 4 workers hits
- * the knee (183ms p50 vs 171ms for 8 workers; 316ms for 2). Most
- * CLI hosts are 4–16 core, so clamping at 8 prevents over-spawn on
- * high-core boxes where per-worker stat/read contention dominates.
+ * Default pool size: `availableParallelism()` clamped to `[2, 8]`.
+ * Bench (10k files, `import.*from`): 4 workers hits the knee
+ * (~180ms p50 vs 316ms for 2; 8 workers saves ~10ms). Clamping
+ * prevents over-spawn on high-core boxes where stat/read
+ * contention dominates.
  */
 export function getPoolSize(): number {
   return Math.max(2, Math.min(8, availableParallelism()));
 }
 
 /**
- * Call `worker.ref()` if the runtime exposes it. Both Bun's native
- * `Worker` and Node's `worker_threads.Worker` have `.ref()` / `.unref()`;
- * DOM Worker shims may not. Guarded.
+ * `.ref()` / `.unref()` on a Bun/Node worker if available. DOM
+ * Worker shims may not expose them — guarded.
+ *
+ * Both calls are **idempotent booleans, not reference-counted** —
+ * one `.unref()` releases the event-loop hold regardless of how
+ * many `.ref()` calls preceded it. Call sites must guard on
+ * `inflight === 0` to avoid premature unref.
  */
 function refWorker(w: Worker): void {
-  if (typeof (w as unknown as { ref?: () => void }).ref === "function") {
-    (w as unknown as { ref: () => void }).ref();
-  }
+  (w as unknown as { ref?: () => void }).ref?.();
 }
-
-/** Counterpart to {@link refWorker}. */
 function unrefWorker(w: Worker): void {
-  if (typeof (w as unknown as { unref?: () => void }).unref === "function") {
-    (w as unknown as { unref: () => void }).unref();
-  }
+  (w as unknown as { unref?: () => void }).unref?.();
 }
 
-/**
- * Build the worker's Blob-URL source once per pool. Cached so
- * repeated pool recreation (in tests) doesn't leak URLs.
- */
 let cachedBlobUrl: string | null = null;
 function getWorkerBlobUrl(): string {
   if (cachedBlobUrl !== null) {
@@ -203,8 +122,7 @@ function getWorkerBlobUrl(): string {
 
 /**
  * Get or lazily create the worker pool. Throws if
- * `isWorkerSupported()` is false — callers should feature-gate
- * on that first.
+ * `isWorkerSupported()` is false.
  */
 export function getWorkerPool(): WorkerPool {
   if (pool !== null) {
@@ -222,32 +140,10 @@ export function getWorkerPool(): WorkerPool {
 
   for (let i = 0; i < size; i += 1) {
     const w = new Worker(url);
-    // Workers are unref'd at spawn so an idle pool doesn't hold the
-    // event loop open. On each `dispatch()` we `ref()` the worker
-    // before posting work; when inflight drops to zero (i.e., the
-    // worker goes idle), we `unref()` it again. This gives us:
-    //
-    //   - Clean CLI exit: once all pending dispatches settle,
-    //     workers are idle + unref'd, the loop drains, and the
-    //     process exits naturally — no `beforeExit` / explicit
-    //     `terminatePool()` required on the CLI happy path.
-    //   - No mid-pipeline deadlock: ref'd workers during active
-    //     work means their `message` events fire on the main
-    //     thread's next tick, not starved by idle-tick bypass.
-    //
-    // IMPORTANT: `Worker.ref()` / `.unref()` are idempotent booleans,
-    // NOT reference-counted. Calling `unref()` on a worker that has
-    // multiple dispatches in flight unrefs it entirely (subsequent
-    // `ref()` calls are no-ops until the worker becomes idle again).
-    // Hence the inflight-zero guard in every unref site — we only
-    // unref when the LAST dispatch for this worker completes.
     unrefWorker(w);
     const pw: PooledWorker = {
       worker: w,
       ready: new Promise<void>((resolve) => {
-        // Single readiness listener; removed when the ready signal
-        // arrives. Subsequent messages are handled by `onmessage`
-        // set below (which takes over after ready).
         const readyHandler = (event: MessageEvent) => {
           if (event.data?.type === "ready") {
             w.removeEventListener("message", readyHandler);
@@ -260,11 +156,6 @@ export function getWorkerPool(): WorkerPool {
       pending: [],
       alive: true,
     };
-    // Single onmessage handler per worker. Matches `result` messages
-    // to the oldest pending dispatch via FIFO shift. Messages from
-    // the worker arrive in the same order as `postMessage` calls,
-    // and the worker processes requests sequentially (single-thread
-    // inside), so FIFO matching is sound.
     w.addEventListener("message", (event) => {
       const data = event.data as { type?: string } & WorkerGrepResult;
       if (data.type !== "result") {
@@ -275,25 +166,14 @@ export function getWorkerPool(): WorkerPool {
         return;
       }
       pw.inflight -= 1;
-      // `ref()` / `unref()` are idempotent booleans, NOT reference-
-      // counted. Only unref when the worker's own inflight drops to
-      // zero — unrefing while other dispatches are still in flight
-      // would let the event loop exit and drop their results.
       if (pw.inflight === 0) {
         unrefWorker(pw.worker);
       }
       next.resolve({ ints: data.ints, linePool: data.linePool });
     });
     w.addEventListener("error", (err) => {
-      // Mark the worker dead before rejecting pending dispatches —
-      // `dispatch` consults `alive` under the least-loaded picker to
-      // avoid routing new work to a worker that can't respond.
       pw.alive = false;
       const errMsg = err.message ?? String(err);
-      // Drain the pending queue: reject each dispatch. Then unref
-      // the worker ONCE at the end (ref/unref are idempotent; one
-      // unref is sufficient to release the event-loop hold even if
-      // there were multiple pending dispatches).
       let slot = pw.pending.shift();
       while (slot !== undefined) {
         slot.reject(new Error(`worker error: ${errMsg}`));
@@ -308,12 +188,10 @@ export function getWorkerPool(): WorkerPool {
   pool = {
     workers,
     dispatch(request: WorkerGrepRequest): Promise<WorkerGrepResult> {
-      // Pick least-loaded LIVE worker. Dead workers (those that
-      // emitted an `error` event) are skipped entirely — dispatching
-      // to them would hang because they can't respond. Their
-      // `inflight` gets reset to 0 in the error handler, which
-      // would otherwise make them the "least loaded" and silently
-      // capture all subsequent dispatches.
+      // Pick least-loaded live worker. Dead workers (error event fired)
+      // are skipped — their `inflight` was reset to 0, which would
+      // otherwise make them look "least loaded" and silently capture
+      // all new dispatches.
       let best: PooledWorker | null = null;
       for (const pw of workers) {
         if (!pw.alive) {
@@ -328,43 +206,21 @@ export function getWorkerPool(): WorkerPool {
       }
       const chosen = best;
       chosen.inflight += 1;
-      // Ref the worker while this dispatch is in flight. Matched by
-      // the `unref()` call in the `message` result handler (or the
-      // mass-unref in the `error` handler / `terminate()` path).
       refWorker(chosen.worker);
 
-      // Enqueue a pending slot for this request. The worker's
-      // `onmessage` handler will resolve it when the corresponding
-      // `result` message arrives (FIFO).
-      //
-      // We hold a direct reference to `ourSlot` so the readiness-
-      // failure path can remove and reject THIS dispatch's entry
-      // specifically — not whatever happens to be at the front or
-      // back of the pending queue when the failure fires. With
-      // concurrent dispatches to the same worker, `pop()` or
-      // `shift()` could reject a sibling dispatch's promise with
-      // this dispatch's error.
+      // `ourSlot` is held by the closure so a readiness-failure
+      // can remove THIS dispatch's slot by identity, not `pop()` /
+      // `shift()` which would misassign errors to siblings.
       let ourSlot: PooledWorker["pending"][number];
       const result = new Promise<WorkerGrepResult>((resolve, reject) => {
         ourSlot = { resolve, reject };
         chosen.pending.push(ourSlot);
       });
-      // Wait for readiness (first dispatch only), then post the
-      // request. Subsequent dispatches skip the await (the ready
-      // promise is already settled).
       chosen.ready.then(
         () => {
           chosen.worker.postMessage(request);
         },
         (err) => {
-          // Readiness failed — fail THIS dispatch's resolver and
-          // remove ITS slot from the pending queue. Identity-based
-          // removal preserves the FIFO invariant for any sibling
-          // dispatches still in flight. Only unref if no other
-          // dispatches remain in flight (same reasoning as the
-          // `message` handler: `unref()` is idempotent, and
-          // unrefing while others are in flight would let the
-          // loop exit prematurely).
           const idx = chosen.pending.indexOf(ourSlot);
           if (idx !== -1) {
             chosen.pending.splice(idx, 1);
@@ -381,10 +237,6 @@ export function getWorkerPool(): WorkerPool {
     terminate(): void {
       for (const pw of workers) {
         pw.alive = false;
-        // Drain pending: reject every dispatch. `ref`/`unref` are
-        // idempotent booleans — one unref at the end is sufficient
-        // to release the event-loop hold even if the worker had
-        // multiple pending dispatches.
         let slot = pw.pending.shift();
         while (slot !== undefined) {
           slot.reject(new Error("worker pool terminated"));
@@ -395,8 +247,7 @@ export function getWorkerPool(): WorkerPool {
         try {
           pw.worker.terminate();
         } catch {
-          // Ignore — terminate is experimental in Bun and may throw
-          // on already-terminated workers.
+          // Already-terminated workers throw in Bun — ignore.
         }
       }
     },
@@ -406,8 +257,8 @@ export function getWorkerPool(): WorkerPool {
 }
 
 /**
- * Tear down the singleton pool. Primarily for tests — the
- * singleton is otherwise kept alive for the process lifetime.
+ * Tear down the singleton pool. Primarily for tests; the singleton
+ * is otherwise kept alive for the process lifetime.
  */
 export function terminatePool(): void {
   if (pool !== null) {
@@ -415,22 +266,18 @@ export function terminatePool(): void {
     pool = null;
   }
   if (cachedBlobUrl !== null) {
-    // URL.revokeObjectURL is safe to call on Node + Bun.
     URL.revokeObjectURL(cachedBlobUrl);
     cachedBlobUrl = null;
   }
 }
 
 /**
- * Decode a worker's packed `{ints, linePool}` into an array of
- * `GrepMatch`es, using the caller's `paths` and `relPaths` to
- * reconstruct path fields.
+ * Decode a worker's packed `{ints, linePool}` into `GrepMatch[]`,
+ * reconstructing path fields from the caller's `paths` / `relPaths`.
  *
- * Optional `mtimes` is a parallel per-path array: when provided,
- * each emitted `GrepMatch` gets an `mtime` field indexed by the
- * match's `pathIdx`. Populated by callers that set
- * `recordMtimes: true` — the mtime is known on the main thread
- * from the walker, not from the worker.
+ * Optional `mtimes` is a parallel per-path array; when provided,
+ * each match gets `mtime` attached via its `pathIdx`. Walker-side
+ * knowledge, not worker-side.
  */
 export function decodeWorkerMatches(
   result: WorkerGrepResult,
@@ -440,7 +287,6 @@ export function decodeWorkerMatches(
 ): GrepMatch[] {
   const { ints, linePool } = result;
   const matches: GrepMatch[] = [];
-  // 4 u32s per match (pathIdx, lineNum, lineOffset, lineLength).
   const count = Math.floor(ints.length / 4);
   for (let i = 0; i < count; i += 1) {
     const base = i * 4;


### PR DESCRIPTION
## Summary

Cleanup pass over the `scan/` and `dsn/` modules after the grep + worker-pool stack (#791, #804, #805, #807, #797) landed. Removed comment bloat accumulated across the 6+ review cycles those PRs went through — redundant bug-history narration, repeated explanations of `ref/unref` boolean semantics, "pre-PR-N" references, and other scars that wouldn't survive a fresh-eyes read.

**Net −708 LOC across 12 files. No behavior changes.**

## Per-file reductions

| File | Before | After | Δ |
|---|---:|---:|---:|
| `src/lib/scan/worker-pool.ts` | 466 | 312 | −33% |
| `src/lib/scan/grep.ts` | 985 | 712 | −28% |
| `src/lib/dsn/code-scanner.ts` | 541 | 377 | −30% |
| `src/lib/scan/grep-worker.js` | 153 | 114 | −25% |
| `src/lib/dsn/scan-options.ts` | 70 | 52 | −26% |
| `src/lib/init/tools/grep.ts` | 122 | 98 | −20% |
| `src/lib/init/tools/glob.ts` | 74 | 59 | −20% |

Plus minor trims in `types.ts`, `walker.ts`, `path-utils.ts`, `scan/glob.ts`, and `script/text-import-plugin.ts`.

## What was removed

- Redundant explanations of `Worker.ref()` / `.unref()` boolean semantics (stated 3× in `worker-pool.ts` — kept once, on the primary ref/unref helper pair).
- Multi-paragraph "earlier iteration did X, deadlocked, so we now do Y" histories — kept in git log where they belong.
- "pre-PR-3" / "pre-refactor" / "previous version" narration that explained how code used to look before the current session's work.
- File-header docstrings that repeated what the module structure and exports already told you.
- Rationale comments for `biome-ignore`s that were already justified by adjacent context.

## What was kept

- Every `biome-ignore` comment (all still justified).
- Every "why" comment tied to a real gotcha (e.g., the length-change warning on case-insensitive literal prefilters, the `/g` flag cloning rationale, the pipeline-failure detector explanation).
- Every JSDoc on exported functions and types.
- All inline comments that explain non-obvious constraints (sandbox enforcement, cache-contract stability, etc.).

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean (1 pre-existing markdown warning)
- [x] `bun test --timeout 15000 test/lib test/commands test/types` — **5641 pass, 0 fail**
- [x] `bun test test/isolated` — 138 pass
- [x] `bun run bench --size large --runs 3` — no perf regression (`scan.grepFiles` 167ms, `scanCodeForDsns` 232ms — matching pre-trim numbers)
- [x] `bun run build --single` — binary builds and exits cleanly on `sentry project view` from empty dir (3 consecutive runs, all exit=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>