### PR TITLE
ci: unblock fork PRs (SENTRY_CLIENT_ID fallback + fork-safe checkout)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ steps.token.outputs.token || github.token }}
-          ref: ${{ github.head_ref || github.ref_name }}
+          # Same-repo PRs (token step succeeded): check out the branch head so
+          # the auto-commit step can push regenerated docs back. Fork PRs leave
+          # `ref` empty so checkout defaults to GITHUB_REF (the pull_request
+          # merge SHA, always fetchable from the base repo with github.token).
+          ref: ${{ steps.token.outcome == 'success' && (github.head_ref || github.ref_name) || '' }}
       - uses: oven-sh/setup-bun@v2
       - uses: actions/cache@v5
         id: cache
@@ -257,7 +261,10 @@ jobs:
           mv package.json.tmp package.json
       - name: Build
         env:
-          SENTRY_CLIENT_ID: ${{ vars.SENTRY_CLIENT_ID }}
+          # Fork PRs can't read repo vars (getsentry org policy); fall back to
+          # a dummy. The resulting binary is only smoke-tested (`--help`) and
+          # never shipped, so any non-empty value works.
+          SENTRY_CLIENT_ID: ${{ vars.SENTRY_CLIENT_ID || 'ci-fork-pr-dummy' }}
           # Sourcemap upload to Sentry (non-fatal, skipped when token is absent)
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           # Set on main/release branches so build.ts runs binpunch + creates .gz
@@ -670,7 +677,10 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Bundle
         env:
-          SENTRY_CLIENT_ID: ${{ vars.SENTRY_CLIENT_ID }}
+          # Fork PRs can't read repo vars (getsentry org policy); fall back to
+          # a dummy. The resulting bundle is only smoke-tested (`--help`) and
+          # never shipped, so any non-empty value works.
+          SENTRY_CLIENT_ID: ${{ vars.SENTRY_CLIENT_ID || 'ci-fork-pr-dummy' }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bun run bundle
       - name: Smoke test (Node.js)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ env:
   # binary is only smoke-tested (--help) and never shipped, so any non-empty
   # value works; tests tolerate the dummy via test/preload.ts.
   SENTRY_CLIENT_ID: ${{ vars.SENTRY_CLIENT_ID || 'ci-fork-pr-dummy' }}
-  # Sourcemap upload to Sentry (non-fatal, skipped when token is absent).
-  # Empty on fork PRs and non-production branches.
-  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
 jobs:
   changes:
@@ -269,6 +266,10 @@ jobs:
           mv package.json.tmp package.json
       - name: Build
         env:
+          # Environment-scoped (production) — must be set at step level to
+          # resolve correctly; workflow-level env evaluates before the job's
+          # environment: is applied.
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           # Set on main/release branches so build.ts runs binpunch + creates .gz
           RELEASE_BUILD: ${{ github.event_name != 'pull_request' && '1' || '' }}
         run: bun run build --target ${{ matrix.target }}
@@ -678,6 +679,9 @@ jobs:
       - if: steps.cache.outputs.cache-hit != 'true'
         run: bun install --frozen-lockfile
       - name: Bundle
+        env:
+          # Environment-scoped (production) — see note in build-binary.
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bun run bundle
       - name: Smoke test (Node.js)
         run: node dist/bin.cjs --help
@@ -696,6 +700,12 @@ jobs:
     # SENTRY_AUTH_TOKEN is scoped to the production environment. Needed by
     # the "Inject debug IDs and upload sourcemaps" step below.
     environment: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && 'production' || '' }}
+    # Hoisted to job level (not step) so the `if: env.SENTRY_AUTH_TOKEN != ''`
+    # guard on the sourcemap-upload step can see it. Job-level env is resolved
+    # after `environment:` is applied, so the production-scoped secret resolves
+    # correctly.
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ env:
   # Commit timestamp used for deterministic nightly version strings.
   # Defined at workflow level so build-binary and publish-nightly always agree.
   COMMIT_TIMESTAMP: ${{ github.event.head_commit.timestamp }}
+  # SENTRY_CLIENT_ID is baked into the binary at build time. Fork PRs can't
+  # read repo vars (getsentry org policy); fall back to a dummy. The resulting
+  # binary is only smoke-tested (--help) and never shipped, so any non-empty
+  # value works; tests tolerate the dummy via test/preload.ts.
+  SENTRY_CLIENT_ID: ${{ vars.SENTRY_CLIENT_ID || 'ci-fork-pr-dummy' }}
+  # Sourcemap upload to Sentry (non-fatal, skipped when token is absent).
+  # Empty on fork PRs and non-production branches.
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
 jobs:
   changes:
@@ -261,12 +269,6 @@ jobs:
           mv package.json.tmp package.json
       - name: Build
         env:
-          # Fork PRs can't read repo vars (getsentry org policy); fall back to
-          # a dummy. The resulting binary is only smoke-tested (`--help`) and
-          # never shipped, so any non-empty value works.
-          SENTRY_CLIENT_ID: ${{ vars.SENTRY_CLIENT_ID || 'ci-fork-pr-dummy' }}
-          # Sourcemap upload to Sentry (non-fatal, skipped when token is absent)
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           # Set on main/release branches so build.ts runs binpunch + creates .gz
           RELEASE_BUILD: ${{ github.event_name != 'pull_request' && '1' || '' }}
         run: bun run build --target ${{ matrix.target }}
@@ -676,12 +678,6 @@ jobs:
       - if: steps.cache.outputs.cache-hit != 'true'
         run: bun install --frozen-lockfile
       - name: Bundle
-        env:
-          # Fork PRs can't read repo vars (getsentry org policy); fall back to
-          # a dummy. The resulting bundle is only smoke-tested (`--help`) and
-          # never shipped, so any non-empty value works.
-          SENTRY_CLIENT_ID: ${{ vars.SENTRY_CLIENT_ID || 'ci-fork-pr-dummy' }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bun run bundle
       - name: Smoke test (Node.js)
         run: node dist/bin.cjs --help
@@ -737,7 +733,6 @@ jobs:
       - name: Inject debug IDs and upload sourcemaps
         if: github.event_name == 'push' && env.SENTRY_AUTH_TOKEN != ''
         env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: sentry
           SENTRY_PROJECT: cli-website
         run: |


### PR DESCRIPTION
## Summary
- Three failures on [PR #806](https://github.com/getsentry/cli/pull/806) / [run 24747631157](https://github.com/getsentry/cli/actions/runs/24747631157) traced to fork-PR restrictions:
  1. `check-generated` checks out `github.head_ref` from the base repo, but that branch only exists on the fork → `git fetch` exits 1.
  2. `build-binary` and `build-npm` hard-fail because `${{ vars.SENTRY_CLIENT_ID }}` isn't reaching fork jobs (likely blocked by the `getsentry` org's "Send variables to fork PR workflows" policy).
  3. `CI Status` fails because of (1) and (2).

## Fix
- **`check-generated` checkout**: condition `ref:` on whether the app token step succeeded. Same-repo PRs keep the branch-head checkout (so auto-commit can `git push` regenerated docs back). Fork PRs leave `ref` empty → `actions/checkout` defaults to `GITHUB_REF` (the PR merge SHA, always fetchable from the base repo with `github.token`).
- **`build-binary` / `build-npm` env**: fall back to a dummy `SENTRY_CLIENT_ID` when `vars.SENTRY_CLIENT_ID` is empty. All tests in the repo already tolerate any non-empty value (see `test/preload.ts` and the `"test-client-id"` defaults in e2e tests); CI smoke tests are `--help` only. PR binaries never ship, so runtime OAuth paths aren't exercised.

## What doesn't change
- Same-repo PRs and `main`/`release/**` pushes still bake the real `vars.SENTRY_CLIENT_ID` into the binary.
- `script/build.ts` and `script/bundle.ts` keep their hard-fail guard — useful dev ergonomic for local builds.
- Security posture: no `pull_request_target`, no new secret exposure, no org-policy change.

## Test plan
- Own-repo CI on this PR must pass (baseline sanity).
- After merge, ask @elucid to rebase #806 to validate the fork path.