### PR TITLE
ci: skip docs preview deploy on fork PRs

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -81,6 +81,10 @@ jobs:
         run: find docs/dist -name '*.map' -delete
 
       - name: Ensure .nojekyll at gh-pages root
+        # Fork PRs can't push to the base repo (GITHUB_TOKEN is read-only on
+        # pull_request from forks). Skip the deploy but still run the build
+        # above so docs compilation errors surface.
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -112,6 +116,8 @@ jobs:
           fi
 
       - name: Deploy Preview
+        # Same fork-PR guard as the .nojekyll step above.
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: docs/dist/


### PR DESCRIPTION
## Summary
Follow-up to #813. The `Docs Preview` workflow (`docs-preview.yml`) tries to push to the base repo's `gh-pages` branch, but fork PRs get a read-only `GITHUB_TOKEN` and fail with HTTP 403 (`Permission to getsentry/cli.git denied to github-actions[bot]`).

Observed on [PR #806 / run 24776423153](https://github.com/getsentry/cli/actions/runs/24776423153/job/72495750855?pr=806) after rebasing onto main.

## Fix
Gate the `.nojekyll` setup step and the `Deploy Preview` step with `if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'`. The build step still runs unconditionally so docs compilation errors surface on fork PRs — just no live preview published.

## Test plan
- Same-repo PRs / pushes to main: unchanged, preview still deploys.
- Fork PR #806: re-run CI after this merges; `preview` job should succeed (build + skip deploy).