### PR TITLE
chore(deps): drop Node 20 support, pin CI Node 24 for docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,6 +709,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
+      # Astro 6 requires Node >= 22.12. Pin an explicit version so the docs
+      # build doesn't rely on whatever ships on the runner image.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
       - uses: actions/cache@v5
         id: cache
         with:
@@ -736,9 +741,6 @@ jobs:
           PUBLIC_SENTRY_RELEASE: ${{ steps.version.outputs.version }}
         run: |
           bun install --frozen-lockfile
-          # The `build` script itself invokes `bun --bun astro …` so this
-          # works on Node < 22.12 (CI runners ship Node 20, but Astro 6's
-          # `#!/usr/bin/env node` shebang trips the engine check).
           bun run build
       # Inject debug IDs and upload sourcemaps. The inject step adds
       # //# debugId= and the _sentryDebugIds IIFE to deployed JS files.

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -35,6 +35,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      # Astro 6 requires Node >= 22.12. Pin an explicit version so the docs
+      # build doesn't rely on whatever ships on the runner image.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
       - uses: actions/cache@v5
         id: cache
         with:
@@ -62,9 +68,6 @@ jobs:
           PUBLIC_SENTRY_RELEASE: ${{ steps.version.outputs.version }}
         run: |
           bun install --frozen-lockfile
-          # The `build` script itself invokes `bun --bun astro …` so this
-          # works on Node < 22.12 (CI runners ship Node 20, but Astro 6's
-          # `#!/usr/bin/env node` shebang trips the engine check).
           bun run build
 
       - name: Inject debug IDs and upload sourcemaps

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -34,7 +34,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      # The sentry npm package requires Node.js >= 22 (ubuntu-latest ships 20).
+      # The sentry npm package requires Node.js >= 22.12 — pin an explicit
+      # version so this job doesn't depend on the runner image's default.
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "bun --bun astro dev",
-    "build": "bun --bun astro build",
-    "preview": "bun --bun astro preview"
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
   },
   "dependencies": {
     "@astrojs/starlight": "^0.38.3",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "description": "Sentry CLI - A command-line interface for using Sentry built by robots and humans for robots and humans",
   "engines": {
-    "node": ">=22"
+    "node": ">=22.12"
   },
   "files": [
     "dist/bin.cjs",

--- a/script/bundle.ts
+++ b/script/bundle.ts
@@ -221,9 +221,10 @@ const result = await build({
   plugins,
 });
 
-// Write the CLI bin wrapper (tiny — shebang + version check + dispatch)
+// Write the CLI bin wrapper (tiny — shebang + version check + dispatch).
+// Version floor must track `engines.node` in package.json.
 const BIN_WRAPPER = `#!/usr/bin/env node
-if(parseInt(process.versions.node)<22){console.error("Error: sentry requires Node.js 22 or later (found "+process.version+").\\n\\nEither upgrade Node.js, or install the standalone binary instead:\\n  curl -fsSL https://cli.sentry.dev/install | bash\\n");process.exit(1)}
+{let v=process.versions.node.split(".").map(Number);if(v[0]<22||(v[0]===22&&v[1]<12)){console.error("Error: sentry requires Node.js 22.12 or later (found "+process.version+").\\n\\nEither upgrade Node.js, or install the standalone binary instead:\\n  curl -fsSL https://cli.sentry.dev/install | bash\\n");process.exit(1)}}
 {let e=process.emit;process.emit=function(n,...a){return n==="warning"?!1:e.apply(this,[n,...a])}}
 require('./index.cjs')._cli().catch(()=>{process.exitCode=1});
 `;


### PR DESCRIPTION
## Summary

Node 20 reached EOL in April 2026. This PR drops it from the supported set and cleans up the Astro 6 engine-check workaround that #816 left in place.

## Changes

### `package.json` — tighten engines
- `engines.node`: `>=22` → `>=22.12` (matches Astro 6 and reflects Node 20 EOL).

### `docs/package.json` — revert `bun --bun astro` workaround
- Scripts are back to plain `astro dev / build / preview`.
- #816 prefixed them with `bun --bun` only to route around the GHA runner's Node 20 shipping below Astro 6's `engines.node: ">=22.12"`. With a real Node pin in CI (below) and Node 24 locally, there's no reason to keep it.

### Workflows — pin Node 24 for docs jobs
- `ci.yml` `Build Docs` and `docs-preview.yml` `preview` now both run `actions/setup-node@v6` with `node-version: "24"` before the docs build.
- Dropped the `# works on Node < 22.12 …` comments.

### Unchanged
- `Build npm Package` CI matrix stays at `["22", "24"]`. Node 22 is still LTS (EOL April 2027) and above the new 22.12 minimum.
- Other jobs already pinning `node-version: 22` (release workflows) are fine as-is.

## Verification

```sh
cd docs && rm -rf node_modules && bun install --frozen-lockfile && bun run build
# 29 pages built in ~6s
```