### PR TITLE
perf(scan): fast-path known-binary extensions in classifyByExtension

### DIFF
--- a/src/lib/scan/binary.ts
+++ b/src/lib/scan/binary.ts
@@ -9,9 +9,10 @@
  *
  * Two entry points:
  *
- * - `classifyByExtension` — O(1) fast path. Returns `{ isBinary: false }`
- *   for known text extensions; returns null otherwise so the caller knows
- *   to fall through to the sniff path.
+ * - `classifyByExtension` — O(1) fast path. Classifies known text
+ *   and known-binary extensions without a disk read. Returns `null`
+ *   when the extension is ambiguous so the caller falls through to
+ *   the NUL-sniff path.
  * - `readHeadAndSniff` — opens the file, reads the first 8 KB via
  *   `fs.promises.open` + `handle.read`, runs the sniff, returns the head
  *   buffer alongside the classification.
@@ -20,6 +21,101 @@
 import { open } from "node:fs/promises";
 import { extname } from "node:path";
 import { BINARY_SNIFF_BYTES } from "./constants.js";
+
+/**
+ * Extensions that are unambiguously binary. Listed extensions
+ * return `{ isBinary: true }` from `classifyByExtension` with no
+ * disk read — a 60-80ms win on fixtures rich in binary blobs
+ * (`.bin`, build outputs full of `.png`/`.woff2`/`.pdf`, etc.).
+ *
+ * Inclusion rule: only extensions whose file-format specification
+ * mandates non-text content. Ambiguous cases (`.log`, `.lock`,
+ * `.map`) fall through to the NUL-sniff — treating them as binary
+ * would silently drop text matches they may contain. `.svg` is XML
+ * text, NOT included. `.json` and `.yaml` are text, NOT included.
+ */
+export const BINARY_EXTENSIONS: ReadonlySet<string> = new Set([
+  // Images (raster/bitmap)
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".ico",
+  ".bmp",
+  ".tiff",
+  ".tif",
+  ".avif",
+  ".heic",
+  ".heif",
+  // Fonts
+  ".woff",
+  ".woff2",
+  ".ttf",
+  ".otf",
+  ".eot",
+  // Archives
+  ".zip",
+  ".gz",
+  ".bz2",
+  ".xz",
+  ".7z",
+  ".rar",
+  ".tar",
+  ".tgz",
+  ".tbz2",
+  ".txz",
+  // Media
+  ".mp3",
+  ".mp4",
+  ".wav",
+  ".ogg",
+  ".oga",
+  ".ogv",
+  ".webm",
+  ".flac",
+  ".m4a",
+  ".m4v",
+  ".avi",
+  ".mov",
+  ".mkv",
+  ".opus",
+  // Documents (binary office formats)
+  ".pdf",
+  ".doc",
+  ".docx",
+  ".xls",
+  ".xlsx",
+  ".ppt",
+  ".pptx",
+  ".odt",
+  ".ods",
+  ".odp",
+  // Executables and compiled artifacts
+  ".exe",
+  ".dll",
+  ".so",
+  ".dylib",
+  ".wasm",
+  ".class",
+  ".o",
+  ".a",
+  ".obj",
+  ".pyc",
+  ".pyo",
+  ".node",
+  // Databases (binary)
+  ".db",
+  ".sqlite",
+  ".sqlite3",
+  ".mdb",
+  // Generic binary
+  ".bin",
+  ".dat",
+  ".dump",
+  ".iso",
+  ".img",
+]);
 
 /**
  * Inspect up to 8 KB of `head` for a NUL byte.
@@ -40,23 +136,29 @@ export function isLikelyBinary(head: Uint8Array): boolean {
 /**
  * Extension-based classification for the fast path.
  *
- * Returns `{ isBinary: false }` when the path's extension is a known
- * text extension — no disk read needed. Returns `null` when the
- * extension is unknown and the caller must read the file head.
+ * Returns `{ isBinary: false }` when the extension is a known text
+ * type, `{ isBinary: true }` when it is unambiguously binary (see
+ * `BINARY_EXTENSIONS`). Returns `null` for the ambiguous middle
+ * ground — the caller falls through to `readHeadAndSniff`.
  *
- * This intentionally does not try to classify "known binary" extensions
- * (.png, .zip, .woff…). A NUL-byte sniff is fast and more reliable than
- * maintaining a binary-extension allowlist; most text files without a
- * TEXT_EXTENSIONS membership (e.g., `.sentryclirc`, `.editorconfig`,
- * `Makefile`) would be misclassified by a naive binary-ext list.
+ * This is a performance hint, not a safety guarantee: even known-
+ * text extensions could in principle hold NUL bytes, and files
+ * without any extension (`.sentryclirc`, `Makefile`, `README`) or
+ * with unusual extensions always fall through to the NUL-sniff.
  */
 export function classifyByExtension(
   absPath: string,
   textExtensions: ReadonlySet<string>
-): { isBinary: false } | null {
+): { isBinary: boolean } | null {
   const ext = extname(absPath).toLowerCase();
-  if (ext && textExtensions.has(ext)) {
+  if (!ext) {
+    return null;
+  }
+  if (textExtensions.has(ext)) {
     return { isBinary: false };
+  }
+  if (BINARY_EXTENSIONS.has(ext)) {
+    return { isBinary: true };
   }
   return null;
 }

--- a/src/lib/scan/binary.ts
+++ b/src/lib/scan/binary.ts
@@ -92,6 +92,10 @@ export const BINARY_EXTENSIONS: ReadonlySet<string> = new Set([
   ".ods",
   ".odp",
   // Executables and compiled artifacts
+  // NOTE: `.obj` is deliberately EXCLUDED — it's shared with the
+  // Wavefront OBJ 3D model format (plain-text ASCII), common in
+  // game-dev / AR / 3D-printing repos. MSVC `.obj` outputs land in
+  // `build/`/`target/` dirs which DEFAULT_SKIP_DIRS prunes anyway.
   ".exe",
   ".dll",
   ".so",
@@ -100,19 +104,23 @@ export const BINARY_EXTENSIONS: ReadonlySet<string> = new Set([
   ".class",
   ".o",
   ".a",
-  ".obj",
   ".pyc",
   ".pyo",
   ".node",
-  // Databases (binary)
+  // Databases (binary-format SQLite / Access)
   ".db",
   ".sqlite",
   ".sqlite3",
   ".mdb",
-  // Generic binary
-  ".bin",
-  ".dat",
-  ".dump",
+  // Unambiguously-binary disk images.
+  // NOTE: generic blob extensions are deliberately EXCLUDED:
+  //   - `.bin`  — used for both firmware/raw data AND arbitrary
+  //     text dumps; no format spec.
+  //   - `.dat`  — countless text data formats use this.
+  //   - `.dump` — frequently plain-text SQL (`pg_dump`, `mysqldump`
+  //     default to text).
+  // All three fall back to the NUL-sniff, which classifies them
+  // correctly by content.
   ".iso",
   ".img",
 ]);

--- a/test/fixtures/bench/generate.ts
+++ b/test/fixtures/bench/generate.ts
@@ -28,6 +28,14 @@ export type FixtureSpec = {
   filesPerPackage: number;
   /** Text file extensions. Picked round-robin; DSN sprinkling works across all. */
   fileExtensions: string[];
+  /**
+   * Binary file extensions — picked for each binary blob. Defaults
+   * to `[".bin"]` for backward compat with pre-existing fixture
+   * hashes. Real-world shapes use a mix (`.png`, `.woff2`, `.mp3`,
+   * `.pdf`, etc.) to exercise the `BINARY_EXTENSIONS` fast-path in
+   * `src/lib/scan/binary.ts`.
+   */
+  binaryExtensions?: string[];
   /** Fraction [0,1] of files that are random binary blobs (NUL-byte-containing). */
   binaryRatio: number;
   /** Fraction [0,1] of text files that include a DSN somewhere in the body. */
@@ -272,10 +280,17 @@ function populatePackage(
     }
   }
 
+  // `assets/` is intentionally a sibling of `src/` so the binary
+  // blobs stay inside the walked tree (outside `src/` means the
+  // walker still reaches them via the package root). Extension
+  // picked from `spec.binaryExtensions` (defaults to `.bin` when
+  // unspecified).
+  const binaryExts = spec.binaryExtensions ?? [".bin"];
   for (let i = 0; i < binaryCount; i += 1) {
     const subdir = join(baseDir, "assets");
     mkdirSync(subdir, { recursive: true });
-    const filename = `blob-${i.toString().padStart(4, "0")}.bin`;
+    const ext = rng.pick(binaryExts);
+    const filename = `blob-${i.toString().padStart(4, "0")}${ext}`;
     writeFileSync(join(subdir, filename), buildBinaryBlob(spec.avgFileKB, rng));
     fileCount += 1;
   }
@@ -362,6 +377,9 @@ export function hashSpec(spec: FixtureMeta["spec"]): string {
   const canonical = JSON.stringify({
     ...spec,
     fileExtensions: [...spec.fileExtensions].sort(),
+    binaryExtensions: spec.binaryExtensions
+      ? [...spec.binaryExtensions].sort()
+      : undefined,
   });
   return createHash("sha256").update(canonical).digest("hex").slice(0, 16);
 }

--- a/test/fixtures/bench/presets.ts
+++ b/test/fixtures/bench/presets.ts
@@ -21,6 +21,8 @@ export const SMALL: Omit<FixtureSpec, "rootDir" | "seed"> = {
   packages: 0,
   filesPerPackage: 100,
   fileExtensions: [".ts", ".tsx", ".js", ".json", ".yml", ".md"],
+  // See `LARGE` for the rationale.
+  binaryExtensions: [".png", ".jpg", ".woff2", ".mp3", ".pdf", ".bin"],
   binaryRatio: 0.05,
   dsnRatio: 0.1,
   gitignoreDepth: "root",
@@ -33,6 +35,8 @@ export const MEDIUM: Omit<FixtureSpec, "rootDir" | "seed"> = {
   packages: 10,
   filesPerPackage: 100,
   fileExtensions: [".ts", ".tsx", ".js", ".json", ".yml", ".py", ".md"],
+  // See `LARGE` for the rationale.
+  binaryExtensions: [".png", ".jpg", ".woff2", ".mp3", ".pdf", ".bin"],
   binaryRatio: 0.08,
   dsnRatio: 0.12,
   gitignoreDepth: "nested",
@@ -55,6 +59,12 @@ export const LARGE: Omit<FixtureSpec, "rootDir" | "seed"> = {
     ".go",
     ".md",
   ],
+  // Mix of realistic webapp binary extensions that hit the
+  // `BINARY_EXTENSIONS` fast-path in `src/lib/scan/binary.ts`. `.bin`
+  // is NOT in BINARY_EXTENSIONS (generic — falls through to
+  // NUL-sniff), so including it lets the walker exercise both paths
+  // proportionally.
+  binaryExtensions: [".png", ".jpg", ".woff2", ".mp3", ".pdf", ".bin"],
   binaryRatio: 0.1,
   dsnRatio: 0.08,
   gitignoreDepth: "nested",

--- a/test/lib/scan/binary.test.ts
+++ b/test/lib/scan/binary.test.ts
@@ -77,10 +77,31 @@ describe("classifyByExtension", () => {
     });
   });
 
-  test("unknown extensions return null (caller must sniff)", () => {
-    expect(classifyByExtension("/a/b/c.png", TEXT_EXTENSIONS)).toBeNull();
-    expect(classifyByExtension("/a/b/c.bin", TEXT_EXTENSIONS)).toBeNull();
-    expect(classifyByExtension("/a/b/c.woff", TEXT_EXTENSIONS)).toBeNull();
+  test("known-binary extensions return isBinary:true (no sniff)", () => {
+    expect(classifyByExtension("/a/b/c.png", TEXT_EXTENSIONS)).toEqual({
+      isBinary: true,
+    });
+    expect(classifyByExtension("/a/b/c.bin", TEXT_EXTENSIONS)).toEqual({
+      isBinary: true,
+    });
+    expect(classifyByExtension("/a/b/c.woff", TEXT_EXTENSIONS)).toEqual({
+      isBinary: true,
+    });
+    // Case-insensitive — common for screenshot exports etc.
+    expect(classifyByExtension("/a/b/c.PNG", TEXT_EXTENSIONS)).toEqual({
+      isBinary: true,
+    });
+  });
+
+  test("ambiguous extensions return null (caller must sniff)", () => {
+    // `.svg` is XML text, NOT in BINARY_EXTENSIONS.
+    expect(classifyByExtension("/a/b/c.svg", TEXT_EXTENSIONS)).toBeNull();
+    // `.log` / `.lock` / `.map` — usually text, unsafe to presume.
+    expect(classifyByExtension("/a/b/c.log", TEXT_EXTENSIONS)).toBeNull();
+    expect(classifyByExtension("/a/b/c.lock", TEXT_EXTENSIONS)).toBeNull();
+    expect(classifyByExtension("/a/b/c.map", TEXT_EXTENSIONS)).toBeNull();
+    // Wholly unknown extension.
+    expect(classifyByExtension("/a/b/c.xyz", TEXT_EXTENSIONS)).toBeNull();
   });
 
   test("no-extension files return null", () => {

--- a/test/lib/scan/binary.test.ts
+++ b/test/lib/scan/binary.test.ts
@@ -81,10 +81,13 @@ describe("classifyByExtension", () => {
     expect(classifyByExtension("/a/b/c.png", TEXT_EXTENSIONS)).toEqual({
       isBinary: true,
     });
-    expect(classifyByExtension("/a/b/c.bin", TEXT_EXTENSIONS)).toEqual({
+    expect(classifyByExtension("/a/b/c.woff", TEXT_EXTENSIONS)).toEqual({
       isBinary: true,
     });
-    expect(classifyByExtension("/a/b/c.woff", TEXT_EXTENSIONS)).toEqual({
+    expect(classifyByExtension("/a/b/c.pdf", TEXT_EXTENSIONS)).toEqual({
+      isBinary: true,
+    });
+    expect(classifyByExtension("/a/b/c.wasm", TEXT_EXTENSIONS)).toEqual({
       isBinary: true,
     });
     // Case-insensitive — common for screenshot exports etc.
@@ -100,6 +103,13 @@ describe("classifyByExtension", () => {
     expect(classifyByExtension("/a/b/c.log", TEXT_EXTENSIONS)).toBeNull();
     expect(classifyByExtension("/a/b/c.lock", TEXT_EXTENSIONS)).toBeNull();
     expect(classifyByExtension("/a/b/c.map", TEXT_EXTENSIONS)).toBeNull();
+    // Generic binary-ish extensions that are often text — we rely
+    // on the NUL-sniff for these.
+    expect(classifyByExtension("/a/b/c.bin", TEXT_EXTENSIONS)).toBeNull();
+    expect(classifyByExtension("/a/b/c.dat", TEXT_EXTENSIONS)).toBeNull();
+    expect(classifyByExtension("/a/b/c.dump", TEXT_EXTENSIONS)).toBeNull();
+    // `.obj` is shared with Wavefront OBJ (text 3D model format).
+    expect(classifyByExtension("/a/b/c.obj", TEXT_EXTENSIONS)).toBeNull();
     // Wholly unknown extension.
     expect(classifyByExtension("/a/b/c.xyz", TEXT_EXTENSIONS)).toBeNull();
   });


### PR DESCRIPTION
## Summary

Extends `classifyByExtension` with a `BINARY_EXTENSIONS` set (images, fonts, archives, media, binary office formats, native executables, binary-format databases, disk images). Files whose extension is unambiguously binary return `{ isBinary: true }` without a disk read, skipping the 8 KB NUL-sniff.

Follow-up to #821 (parallel walker).

## Scope

Only helps callers that don't set `extensions` — the walker's `classifyFile` short-circuits to `{ isBinary: false }` when an extensions allowlist is provided, and `processEntry` filters binary-extension files out BEFORE `classifyFile` runs. Production callers with explicit `extensions` (`scanCodeForDsns`, `sourcemap/inject::discoverFilePairs`) see zero change.

The primary beneficiary is the init-wizard grep path (`collectGrep` called without `extensions`), which the Mastra agent uses to find user-supplied patterns across a project tree. Real-world repos commonly contain images, fonts, and compiled binaries that previously paid an 8 KB head read to be classified binary.

## Correctness

The inclusion rule: **only extensions whose file-format specification mandates non-text content AND where no common text-format shares the extension.**

Cursor caught three initial violations — fixed:

- `.obj` is shared with the **Wavefront OBJ** 3D model format (plain-text ASCII). MSVC compiler outputs use `.obj` but live in `build/`/`target/` dirs that `DEFAULT_SKIP_DIRS` already prunes. Dropped.
- `.dump` has no format spec. `pg_dump` / `mysqldump` default to **plain-text SQL**. Dropped.
- `.dat` has no format spec — used for countless text data formats. Dropped.
- `.bin` — also generic, often used for text firmware-config dumps. Dropped for the same reason.

The conservative rule applies for the rest: any extension that could plausibly hold text (`.log`, `.lock`, `.map`, `.svg`, `.yaml`, `.xml`, `.toml`, `.json`, …) is NOT in `BINARY_EXTENSIONS` and falls through to the NUL-sniff which classifies by actual content.

Final included list:

```
Images:   .png .jpg .jpeg .gif .webp .ico .bmp .tiff .tif .avif .heic .heif
Fonts:    .woff .woff2 .ttf .otf .eot
Archives: .zip .gz .bz2 .xz .7z .rar .tar .tgz .tbz2 .txz
Media:    .mp3 .mp4 .wav .ogg .oga .ogv .webm .flac .m4a .m4v .avi .mov .mkv .opus
Docs:     .pdf .doc .docx .xls .xlsx .ppt .pptx .odt .ods .odp
Native:   .exe .dll .so .dylib .wasm .class .o .a .pyc .pyo .node
DB:       .db .sqlite .sqlite3 .mdb
Disk:     .iso .img
```

## Bench fixture update (3rd commit on this PR)

The original `fx-large` fixture wrote every binary blob as `.bin`, which after the correctness fixes above no longer hits the new fast-path. To measure the real-world benefit honestly, the fixture generator now distributes blobs across a realistic webapp mix: `.png .jpg .woff2 .mp3 .pdf .bin` (five out of six hit the fast-path; `.bin` still falls through to the NUL-sniff, so both code paths are exercised).

## Measured impact

On the regenerated `fx-large` fixture (10k files, ~1000 binary blobs across 6 extensions — ~850 hit the fast-path, ~150 `.bin` fall through):

| op | baseline (main) | with PR | Δ |
|---|---:|---:|---:|
| `walkFiles` no-ext **parallel** (concurrency=4) | 290.4ms | 273.7ms | **−6%** |
| `walkFiles` no-ext **serial** (concurrency=1) | 446.5ms | 383.1ms | **−14%** |
| `collectGrep` zero-match uncapped | 312.3ms | 295.9ms | **−5%** |
| `collectGrep` zero-match cap=100 (Mastra default) | 316.9ms | 304.2ms | **−4%** |
| `collectGrep` rare-match cap=100 | 43.7ms | 43.1ms | ~ |
| `collectGrep` common-match cap=100 | 23.9ms | 22.7ms | ~ |

Each bench: 20 runs + 5 warmup, p50 reported.

**Why serial benefits 4× more than parallel**: serial walker blocks on each `readHeadAndSniff` call; parallel walker overlaps the sniff I/O with peer workers' `readdir`. The per-file CPU savings (~40µs) is the same either way, but the wall-clock win is smaller when the walker is already parallel. Callers that need the serial walker (`scanCodeForFirstDsn`) all set `extensions`, so they don't benefit from this PR — but the savings is there for any future caller that doesn't.

**Why DSN-scan-type benchmarks are unaffected**: `scanCodeForDsns` sets `extensions: TEXT_EXTENSIONS`, which short-circuits the ext-filter in `processEntry` BEFORE `classifyFile` runs. Binary extensions never reach the sniff path there.

## Review

- Cursor flagged 2 Medium correctness issues on the initial extension list (`.obj` shared with Wavefront OBJ text format; `.dat`/`.dump` generic blob extensions). Both addressed by removing the ambiguous entries; also removed `.bin` on the same grounds.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean (1 pre-existing markdown.ts warning)
- [x] `bun test test/lib/scan/binary` — 19 pass, 0 fail
- [x] `bun test test/lib test/commands test/types` — 5705 pass
- [x] `bun run bench --size large --runs 20 --warmup 5` — measurements above