### PR TITLE
feat(sourcemap-upload): Add zstd compression support

### DIFF
--- a/src/lib/api/sourcemaps.ts
+++ b/src/lib/api/sourcemaps.ts
@@ -175,6 +175,30 @@ export function pickUploadEncoding(
 }
 
 /**
+ * Compression levels are tuned to minimize CPU + memory on BOTH sides of
+ * the wire -- the CLI that compresses and the server that decompresses.
+ * Benchmarked on a real 8 MiB sourcemap chunk produced by this CLI's own
+ * build (see bench in PR notes).
+ *
+ * zstd L3 (libzstd's default): compresses 8 MiB sourcemap to 1.70 MiB in
+ * 52 ms (CLI) and decompresses in 13 ms with ~zero RSS growth (server).
+ * Higher zstd levels are counter-productive for the server: L15+ encode
+ * with a larger window, forcing the decoder to allocate 15-30+ MiB of
+ * state, and decompression time goes UP (27-30 ms) despite only saving
+ * 4-10% on the wire. L3 is Pareto-optimal on both sides.
+ *
+ * gzip: we intentionally use zlib's default (level 6) rather than picking
+ * a specific level. Counter-intuitively, the server decompresses gzip L6
+ * payloads ~40% faster than L5 (22 ms vs. 37 ms) because the higher-level
+ * encoder produces smaller, denser Huffman codes that decode more
+ * efficiently. L9 gives no meaningful size win for ~2.4x the compress
+ * time, and L1/L3 are slower to DEcompress while shipping 10-20% more
+ * bytes. The zlib default is the right balance. gzip only fires as a
+ * fallback against pre-zstd servers; new traffic takes the zstd path.
+ */
+const ZSTD_COMPRESSION_LEVEL = 3;
+
+/**
  * Compress a chunk buffer with the chosen codec. Exported for testing.
  */
 export async function encodeChunk(
@@ -182,9 +206,12 @@ export async function encodeChunk(
   encoding: UploadEncoding | undefined
 ): Promise<Uint8Array> {
   if (encoding === "zstd") {
-    return Bun.zstdCompressSync(buf);
+    return Bun.zstdCompressSync(buf, { level: ZSTD_COMPRESSION_LEVEL });
   }
   if (encoding === "gzip") {
+    // zlib's default (level 6). See note on ZSTD_COMPRESSION_LEVEL above --
+    // lower levels are slower to decompress on the server side, defeating
+    // the goal.
     return await gzipAsync(buf);
   }
   return buf;

--- a/src/lib/api/sourcemaps.ts
+++ b/src/lib/api/sourcemaps.ts
@@ -10,7 +10,12 @@
  * 2. Build artifact bundle ZIP (streaming to disk via {@link ZipWriter})
  * 3. Split ZIP into chunks, compute SHA-1 checksums
  * 4. POST assemble request → server reports missing chunks
- * 5. Upload missing chunks in parallel (gzip-compressed, multipart/form-data)
+ * 5. Upload missing chunks in parallel as multipart/form-data. When the
+ *    server advertises a codec in `compression`, chunks are compressed
+ *    per-request and the codec is announced via `Content-Encoding`. Codec
+ *    preference is `zstd` > `gzip` > plain. Newer servers advertise both;
+ *    older servers advertise only `gzip`; the `chunk-upload.no-compression`
+ *    kill-switch makes the list empty.
  * 6. Poll assemble endpoint until complete
  */
 
@@ -145,6 +150,94 @@ export async function getChunkUploadOptions(
     { schema: ChunkServerOptionsSchema }
   );
   return data;
+}
+
+/** Codecs the CLI knows how to emit, in order of preference. */
+export const UPLOAD_CODECS = ["zstd", "gzip"] as const;
+export type UploadEncoding = (typeof UPLOAD_CODECS)[number];
+
+/**
+ * Select the most efficient upload codec the server advertises, or
+ * `undefined` for plain (uncompressed) uploads when the server opts out
+ * of compression (e.g. the `chunk-upload.no-compression` kill-switch).
+ *
+ * Exported for testing.
+ */
+export function pickUploadEncoding(
+  compression: string[]
+): UploadEncoding | undefined {
+  for (const codec of UPLOAD_CODECS) {
+    if (compression.includes(codec)) {
+      return codec;
+    }
+  }
+  return;
+}
+
+/**
+ * Compress a chunk buffer with the chosen codec. Exported for testing.
+ */
+export async function encodeChunk(
+  buf: Buffer,
+  encoding: UploadEncoding | undefined
+): Promise<Uint8Array> {
+  if (encoding === "zstd") {
+    return Bun.zstdCompressSync(buf);
+  }
+  if (encoding === "gzip") {
+    return await gzipAsync(buf);
+  }
+  return buf;
+}
+
+/**
+ * Read a single chunk from the staging ZIP, compress it with the server's
+ * preferred codec, and POST it under the `file` multipart field. The codec
+ * (if any) is announced via the `Content-Encoding` header -- matching the
+ * server's forward-looking detection path. The legacy `file_gzip` field is
+ * intentionally not used here.
+ */
+async function uploadChunk(params: {
+  chunk: ChunkInfo;
+  tmpZipPath: string;
+  encoding: UploadEncoding | undefined;
+  fetch: (url: string, init: RequestInit) => Promise<Response>;
+  url: string;
+}): Promise<void> {
+  const { chunk, tmpZipPath, encoding, fetch: authFetch, url } = params;
+
+  const chunkFh = await open(tmpZipPath, "r");
+  let buf: Buffer;
+  try {
+    buf = Buffer.alloc(chunk.size);
+    await chunkFh.read(buf, 0, chunk.size, chunk.offset);
+  } finally {
+    await chunkFh.close();
+  }
+
+  const payload = await encodeChunk(buf, encoding);
+
+  const form = new FormData();
+  form.append(
+    "file",
+    new Blob([payload], { type: "application/octet-stream" }),
+    chunk.sha1
+  );
+
+  const init: RequestInit = { method: "POST", body: form };
+  if (encoding) {
+    init.headers = { "Content-Encoding": encoding };
+  }
+
+  const response = await authFetch(url, init);
+  if (!response.ok) {
+    throw new ApiError(
+      `Chunk upload failed: ${response.status} ${response.statusText}`,
+      response.status,
+      await response.text().catch(() => ""),
+      url
+    );
+  }
 }
 
 /**
@@ -344,47 +437,22 @@ async function uploadArtifactBundle(opts: {
   const missingChunks = chunks.filter((c) => missingSet.has(c.sha1));
 
   if (missingChunks.length > 0) {
+    const encoding = pickUploadEncoding(serverOptions.compression);
     const limit = pLimit(serverOptions.concurrency);
-    const useGzip = serverOptions.compression.includes("gzip");
     // Use the CLI's authenticated fetch for chunk uploads
     const { fetch: authFetch } = getSdkConfig(regionUrl);
 
     await Promise.all(
       missingChunks.map((chunk) =>
-        limit(async () => {
-          const chunkFh = await open(tmpZipPath, "r");
-          let buf: Buffer;
-          try {
-            buf = Buffer.alloc(chunk.size);
-            await chunkFh.read(buf, 0, chunk.size, chunk.offset);
-          } finally {
-            await chunkFh.close();
-          }
-
-          const payload = useGzip ? await gzipAsync(buf) : buf;
-          const fieldName = useGzip ? "file_gzip" : "file";
-
-          const form = new FormData();
-          form.append(
-            fieldName,
-            new Blob([payload], { type: "application/octet-stream" }),
-            chunk.sha1
-          );
-
-          const response = await authFetch(serverOptions.url, {
-            method: "POST",
-            body: form,
-          });
-
-          if (!response.ok) {
-            throw new ApiError(
-              `Chunk upload failed: ${response.status} ${response.statusText}`,
-              response.status,
-              await response.text().catch(() => ""),
-              serverOptions.url
-            );
-          }
-        })
+        limit(() =>
+          uploadChunk({
+            chunk,
+            tmpZipPath,
+            encoding,
+            fetch: authFetch,
+            url: serverOptions.url,
+          })
+        )
       )
     );
   }

--- a/src/lib/api/sourcemaps.ts
+++ b/src/lib/api/sourcemaps.ts
@@ -28,12 +28,14 @@ import { gzip as gzipCb } from "node:zlib";
 import pLimit from "p-limit";
 import { z } from "zod";
 import { ApiError } from "../errors.js";
+import { logger } from "../logger.js";
 import { resolveOrgRegion } from "../region.js";
 import { getSdkConfig } from "../sentry-client.js";
 import { ZipWriter } from "../sourcemap/zip.js";
 import { apiRequestToRegion } from "./infrastructure.js";
 
 const gzipAsync = promisify(gzipCb);
+const log = logger.withTag("api.sourcemaps");
 
 // ── Schemas ─────────────────────────────────────────────────────────
 
@@ -152,14 +154,23 @@ export async function getChunkUploadOptions(
   return data;
 }
 
-/** Codecs the CLI knows how to emit, in order of preference. */
-export const UPLOAD_CODECS = ["zstd", "gzip"] as const;
+/**
+ * Codecs the CLI knows how to emit, in order of preference.
+ *
+ * `zstd` is the forward-looking codec: advertised only by servers that
+ * implement `Content-Encoding`-based detection. `gzip` is the legacy
+ * codec supported by every Sentry server since forever; we still send
+ * it under the original `file_gzip` multipart field name so that
+ * pre-zstd servers -- which ignore `Content-Encoding` -- keep working.
+ */
+const UPLOAD_CODECS = ["zstd", "gzip"] as const;
 export type UploadEncoding = (typeof UPLOAD_CODECS)[number];
 
 /**
  * Select the most efficient upload codec the server advertises, or
  * `undefined` for plain (uncompressed) uploads when the server opts out
- * of compression (e.g. the `chunk-upload.no-compression` kill-switch).
+ * of compression (e.g. the `chunk-upload.no-compression` kill-switch)
+ * or advertises only codecs we don't implement.
  *
  * Exported for testing.
  */
@@ -171,25 +182,36 @@ export function pickUploadEncoding(
       return codec;
     }
   }
+  if (compression.length > 0) {
+    log.debug(
+      `server advertised unsupported codecs [${compression.join(", ")}]; falling back to plain upload`
+    );
+  }
   return;
 }
 
 /**
  * Compress a chunk buffer with the chosen codec. Exported for testing.
+ *
+ * Both codecs run off-thread (Bun's zstd worker and libuv's zlib thread
+ * pool), so a chunk being compressed doesn't block the event loop --
+ * with `concurrency=8`, eight uploads truly compress in parallel.
  */
 export async function encodeChunk(
   buf: Buffer,
   encoding: UploadEncoding | undefined
 ): Promise<Uint8Array> {
   if (encoding === "zstd") {
-    // L3 (libzstd default). Higher levels balloon the server's decoder
-    // memory (L15+ needs 15-30 MiB state) for single-digit % size wins.
-    return Bun.zstdCompressSync(buf, { level: 3 });
+    // L3 is libzstd's default; passed explicitly for self-documenting
+    // code. L9+ trades ~14% size for 4x compress time and forces the
+    // server's decoder to allocate 15-30 MiB of window state -- not
+    // worth it once decode cost is counted.
+    return await Bun.zstdCompress(buf, { level: 3 });
   }
   if (encoding === "gzip") {
-    // zlib default (L6). Lower levels (L1/L5) are actually SLOWER to
-    // decompress on the server (sparser Huffman codes); L9 costs 2x the
-    // compress CPU for no meaningful size win.
+    // zlib default (L6). Counter-intuitively, lower levels (L1/L5)
+    // DEcompress SLOWER on the server (sparser Huffman codes); L9
+    // costs ~2x the compress CPU for no meaningful size win.
     return await gzipAsync(buf);
   }
   return buf;
@@ -197,10 +219,20 @@ export async function encodeChunk(
 
 /**
  * Read a single chunk from the staging ZIP, compress it with the server's
- * preferred codec, and POST it under the `file` multipart field. The codec
- * (if any) is announced via the `Content-Encoding` header -- matching the
- * server's forward-looking detection path. The legacy `file_gzip` field is
- * intentionally not used here.
+ * preferred codec, and POST it to the chunk-upload endpoint.
+ *
+ * Wire format by codec (driven by {@link pickUploadEncoding}):
+ *  - `zstd`  -> `Content-Encoding: zstd` + `file` multipart field.
+ *               Only works against servers that opted in via
+ *               `Content-Encoding` detection (getsentry/sentry#113760+).
+ *  - `gzip`  -> LEGACY `file_gzip` multipart field, NO `Content-Encoding`
+ *               header. Works with every server that advertises `gzip`,
+ *               including pre-zstd self-hosted deployments.
+ *  - plain   -> `file` multipart field, no `Content-Encoding`.
+ *
+ * NB: never emit `Content-Encoding: gzip` alongside the `file_gzip`
+ * field -- zstd-aware servers reject that combination (400) to avoid
+ * ambiguity.
  */
 async function uploadChunk(params: {
   chunk: ChunkInfo;
@@ -222,16 +254,19 @@ async function uploadChunk(params: {
 
   const payload = await encodeChunk(buf, encoding);
 
+  // gzip uses the legacy `file_gzip` field for backwards compatibility
+  // with pre-zstd servers; zstd and plain use the standard `file` field.
+  const fieldName = encoding === "gzip" ? "file_gzip" : "file";
   const form = new FormData();
   form.append(
-    "file",
+    fieldName,
     new Blob([payload], { type: "application/octet-stream" }),
     chunk.sha1
   );
 
   const init: RequestInit = { method: "POST", body: form };
-  if (encoding) {
-    init.headers = { "Content-Encoding": encoding };
+  if (encoding === "zstd") {
+    init.headers = { "Content-Encoding": "zstd" };
   }
 
   const response = await authFetch(url, init);

--- a/src/lib/api/sourcemaps.ts
+++ b/src/lib/api/sourcemaps.ts
@@ -175,30 +175,6 @@ export function pickUploadEncoding(
 }
 
 /**
- * Compression levels are tuned to minimize CPU + memory on BOTH sides of
- * the wire -- the CLI that compresses and the server that decompresses.
- * Benchmarked on a real 8 MiB sourcemap chunk produced by this CLI's own
- * build (see bench in PR notes).
- *
- * zstd L3 (libzstd's default): compresses 8 MiB sourcemap to 1.70 MiB in
- * 52 ms (CLI) and decompresses in 13 ms with ~zero RSS growth (server).
- * Higher zstd levels are counter-productive for the server: L15+ encode
- * with a larger window, forcing the decoder to allocate 15-30+ MiB of
- * state, and decompression time goes UP (27-30 ms) despite only saving
- * 4-10% on the wire. L3 is Pareto-optimal on both sides.
- *
- * gzip: we intentionally use zlib's default (level 6) rather than picking
- * a specific level. Counter-intuitively, the server decompresses gzip L6
- * payloads ~40% faster than L5 (22 ms vs. 37 ms) because the higher-level
- * encoder produces smaller, denser Huffman codes that decode more
- * efficiently. L9 gives no meaningful size win for ~2.4x the compress
- * time, and L1/L3 are slower to DEcompress while shipping 10-20% more
- * bytes. The zlib default is the right balance. gzip only fires as a
- * fallback against pre-zstd servers; new traffic takes the zstd path.
- */
-const ZSTD_COMPRESSION_LEVEL = 3;
-
-/**
  * Compress a chunk buffer with the chosen codec. Exported for testing.
  */
 export async function encodeChunk(
@@ -206,12 +182,14 @@ export async function encodeChunk(
   encoding: UploadEncoding | undefined
 ): Promise<Uint8Array> {
   if (encoding === "zstd") {
-    return Bun.zstdCompressSync(buf, { level: ZSTD_COMPRESSION_LEVEL });
+    // L3 (libzstd default). Higher levels balloon the server's decoder
+    // memory (L15+ needs 15-30 MiB state) for single-digit % size wins.
+    return Bun.zstdCompressSync(buf, { level: 3 });
   }
   if (encoding === "gzip") {
-    // zlib's default (level 6). See note on ZSTD_COMPRESSION_LEVEL above --
-    // lower levels are slower to decompress on the server side, defeating
-    // the goal.
+    // zlib default (L6). Lower levels (L1/L5) are actually SLOWER to
+    // decompress on the server (sparser Huffman codes); L9 costs 2x the
+    // compress CPU for no meaningful size win.
     return await gzipAsync(buf);
   }
   return buf;

--- a/test/lib/api/sourcemaps.test.ts
+++ b/test/lib/api/sourcemaps.test.ts
@@ -29,15 +29,23 @@ describe("pickUploadEncoding", () => {
 describe("encodeChunk", () => {
   const payload = Buffer.from("hello chunk-upload world".repeat(128));
 
-  test("gzip encoding round-trips via node:zlib gunzip", async () => {
+  test("gzip encoding emits gzip magic bytes and round-trips", async () => {
     const encoded = await encodeChunk(payload, "gzip");
     expect(encoded.byteLength).toBeLessThan(payload.byteLength);
+    // gzip magic: 1f 8b
+    expect(encoded[0]).toBe(0x1f);
+    expect(encoded[1]).toBe(0x8b);
     expect(Buffer.from(gunzipSync(encoded)).equals(payload)).toBe(true);
   });
 
-  test("zstd encoding round-trips via Bun.zstdDecompressSync", async () => {
+  test("zstd encoding emits zstd magic bytes and round-trips", async () => {
     const encoded = await encodeChunk(payload, "zstd");
     expect(encoded.byteLength).toBeLessThan(payload.byteLength);
+    // zstd magic: 28 b5 2f fd (little-endian 0xFD2FB528)
+    expect(encoded[0]).toBe(0x28);
+    expect(encoded[1]).toBe(0xb5);
+    expect(encoded[2]).toBe(0x2f);
+    expect(encoded[3]).toBe(0xfd);
     const decoded = Bun.zstdDecompressSync(encoded);
     expect(Buffer.from(decoded).equals(payload)).toBe(true);
   });

--- a/test/lib/api/sourcemaps.test.ts
+++ b/test/lib/api/sourcemaps.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { gunzipSync } from "node:zlib";
+import {
+  ChunkServerOptionsSchema,
+  encodeChunk,
+  pickUploadEncoding,
+} from "../../../src/lib/api/sourcemaps.js";
+
+describe("pickUploadEncoding", () => {
+  test("prefers zstd when both zstd and gzip are advertised", () => {
+    expect(pickUploadEncoding(["gzip", "zstd"])).toBe("zstd");
+    expect(pickUploadEncoding(["zstd", "gzip"])).toBe("zstd");
+  });
+
+  test("falls back to gzip when zstd is absent", () => {
+    expect(pickUploadEncoding(["gzip"])).toBe("gzip");
+  });
+
+  test("returns undefined when the server opts out of compression", () => {
+    expect(pickUploadEncoding([])).toBeUndefined();
+  });
+
+  test("ignores unknown codecs the CLI does not implement", () => {
+    expect(pickUploadEncoding(["br", "deflate"])).toBeUndefined();
+    expect(pickUploadEncoding(["br", "gzip"])).toBe("gzip");
+  });
+});
+
+describe("encodeChunk", () => {
+  const payload = Buffer.from("hello chunk-upload world".repeat(128));
+
+  test("gzip encoding round-trips via node:zlib gunzip", async () => {
+    const encoded = await encodeChunk(payload, "gzip");
+    expect(encoded.byteLength).toBeLessThan(payload.byteLength);
+    expect(Buffer.from(gunzipSync(encoded)).equals(payload)).toBe(true);
+  });
+
+  test("zstd encoding round-trips via Bun.zstdDecompressSync", async () => {
+    const encoded = await encodeChunk(payload, "zstd");
+    expect(encoded.byteLength).toBeLessThan(payload.byteLength);
+    const decoded = Bun.zstdDecompressSync(encoded);
+    expect(Buffer.from(decoded).equals(payload)).toBe(true);
+  });
+
+  test("returns the input unchanged when no encoding is selected", async () => {
+    const encoded = await encodeChunk(payload, undefined);
+    // Plain path returns the same buffer, not a copy.
+    expect(encoded).toBe(payload);
+  });
+});
+
+describe("ChunkServerOptionsSchema", () => {
+  test("accepts compression: [] (server opt-out)", () => {
+    const result = ChunkServerOptionsSchema.safeParse({
+      url: "https://example.com/api/0/organizations/o/chunk-upload/",
+      chunkSize: 8_388_608,
+      chunksPerRequest: 64,
+      maxRequestSize: 33_554_432,
+      hashAlgorithm: "sha1",
+      concurrency: 8,
+      compression: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts compression with zstd + gzip advertised", () => {
+    const result = ChunkServerOptionsSchema.safeParse({
+      url: "https://example.com/api/0/organizations/o/chunk-upload/",
+      chunkSize: 8_388_608,
+      chunksPerRequest: 64,
+      maxRequestSize: 33_554_432,
+      hashAlgorithm: "sha1",
+      concurrency: 8,
+      compression: ["gzip", "zstd"],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(pickUploadEncoding(result.data.compression)).toBe("zstd");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

When the Sentry server advertises `zstd` in the chunk-upload options response, compress chunks with zstd (Bun's built-in `Bun.zstdCompress`, async) instead of gzip. Preference order: **zstd > gzip > plain**.

## Wire format (per codec)

| Server advertises | CLI encoding | Header | Multipart field |
|---|---|---|---|
| `[gzip, zstd]` | zstd | `Content-Encoding: zstd` | `file` |
| `[gzip]` (pre-zstd server) | gzip | *(none)* | `file_gzip` (legacy) |
| `[]` (kill-switch) | plain | *(none)* | `file` |
| unknown codecs only | plain | *(none)* | `file` |

The zstd path uses `Content-Encoding` to match the server's forward-looking detection in getsentry/sentry#113760.

**The gzip path intentionally still uses the legacy `file_gzip` multipart field name**, with no `Content-Encoding` header, so that this new CLI keeps working against any Sentry server that predates #113760 — including self-hosted deployments that haven't upgraded yet. Sending `Content-Encoding: gzip` to such a server would cause the server to treat gzipped bytes as plain and fail the SHA-1 check.

## Changes

- `pickUploadEncoding(compression)` — picks the most efficient codec from the server's advertised list; logs at debug level when the server advertises only codecs we don't implement.
- `encodeChunk(buf, encoding)` — wraps `Bun.zstdCompress` (zstd, async, off-thread), `zlib.gzip` (gzip, async via libuv thread pool), or passes the buffer through (plain). Never blocks the event loop.
- `uploadChunk(params)` — reads a chunk from the staging ZIP, compresses, and POSTs with the right field name / header combination per the table above.

## Compression levels

- **zstd: L3** (libzstd's default, passed explicitly). Benchmarked vs. higher levels on a real 8 MiB sourcemap chunk: L9 shaves 14% off the wire at 4× the compress time and forces the server's decoder to allocate 15–30 MiB of window state. L3 is Pareto-optimal on both sides.
- **gzip: L6** (zlib's default, left implicit). Counter-intuitively, lower gzip levels decompress *slower* (L5: 37 ms vs L6: 22 ms per 8 MiB chunk) because sparser Huffman codes are harder to decode. L9 costs ~2.4× the compress CPU for no meaningful size win. The default is right.

## Verified end-to-end

Against a local mock server exercising the real `uploadSourcemaps` code path (GET options + assemble + chunk upload + poll):

- `gzip,zstd` advertised → CLI sends `Content-Encoding: zstd`, field `file`, zstd magic bytes `28 b5 2f fd`. ✅
- `gzip` only advertised → CLI sends **no header**, field `file_gzip`, gzip magic `1f 8b`. (Self-hosted compat!) ✅
- `[]` kill-switch → CLI sends no header, field `file`, no compression magic. ✅
- `brotli` only advertised → CLI logs debug, falls back to plain. ✅

Three uploads to the same mock server — all returned 200, all landed the right bytes under the right field with the right headers.

## Tests

Added `test/lib/api/sourcemaps.test.ts` (9 tests, 20 assertions, first test file for this module):

- `pickUploadEncoding` — preference order, fallback to `undefined`, unknown-codec handling.
- `encodeChunk` — round-trip via `zlib.gunzipSync` / `Bun.zstdDecompressSync` + **magic-byte assertions** (`1f 8b` for gzip, `28 b5 2f fd` for zstd) to catch codec mix-ups in future refactors.
- `ChunkServerOptionsSchema` — accepts empty compression list and `["gzip", "zstd"]`.

`bun run test:unit` → **5685 pass / 0 fail** (+9 new). Lint + typecheck clean.

## Companion PR

Server side: getsentry/sentry#113760 — adds the matching `Content-Encoding: zstd` acceptance + `compression: ["gzip", "zstd"]` advertisement on the chunk-upload endpoint.