### PR TITLE
fix(init): cancel in-flight Mastra requests on teardown

### DIFF
--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -415,11 +415,32 @@ async function runWizardInner(initialOptions: WizardOptions): Promise<void> {
 
   const token = context.authToken;
 
+  // AbortController bound to the MastraClient lifecycle. Aborting on
+  // teardown (success OR failure, via `using` below) cancels any in-flight
+  // fetches — releasing keep-alive sockets so the event loop drains and
+  // `sentry init` returns to the shell promptly. Without this, a stuck or
+  // idle socket in Bun's fetch dispatcher can hold the process alive past
+  // the wizard's natural exit.
+  const abortController = new AbortController();
+  using _mastraCleanup = {
+    [Symbol.dispose]: (): void => {
+      // Guard against double-abort — calling abort() on an already-aborted
+      // signal is a no-op in Node/Bun, but explicit check documents intent.
+      if (!abortController.signal.aborted) {
+        abortController.abort();
+      }
+    },
+  };
+
   const client = new MastraClient({
     baseUrl: MASTRA_API_URL,
     headers: token ? { Authorization: `Bearer ${token}` } : {},
+    abortSignal: abortController.signal,
     fetch: ((url, init) => {
       const traceData = getTraceData();
+      // Preserve `init.signal` via the spread — MastraClient may pass its
+      // own per-request signal, and the client-level `abortSignal` is
+      // forwarded through the same channel.
       return fetch(url, {
         ...init,
         headers: {

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -424,11 +424,8 @@ async function runWizardInner(initialOptions: WizardOptions): Promise<void> {
   const abortController = new AbortController();
   using _mastraCleanup = {
     [Symbol.dispose]: (): void => {
-      // Guard against double-abort — calling abort() on an already-aborted
-      // signal is a no-op in Node/Bun, but explicit check documents intent.
-      if (!abortController.signal.aborted) {
-        abortController.abort();
-      }
+      // AbortController.abort() is spec-idempotent, so no guard needed.
+      abortController.abort();
     },
   };
 

--- a/test/lib/init/wizard-runner.test.ts
+++ b/test/lib/init/wizard-runner.test.ts
@@ -582,39 +582,34 @@ describe("runWizard — MastraClient lifecycle", () => {
     expect((signal as AbortSignal).aborted).toBe(true);
   });
 
-  test("forwards a live abortSignal to MastraClient at construction", async () => {
-    // Before the wizard exits, the signal MUST NOT yet be aborted — the
-    // MastraClient is using it for in-flight fetches throughout the run.
-    // We observe this by checking the signal state inside the workflow
-    // handler (which executes while the wizard's `using` scope is active).
-    let signalDuringRun: AbortSignal | undefined;
-    startAsyncMock = mock(() => {
-      signalDuringRun = capturedClientOptions[0]?.abortSignal;
-      return Promise.resolve(mockStartResult);
-    });
-    // Re-rig the workflow mock to use the new startAsyncMock.
-    const workflow = {
-      createRun: mock(() =>
-        Promise.resolve({
-          startAsync: startAsyncMock,
-          resumeAsync: mock(() => Promise.resolve({ status: "success" })),
-        })
-      ),
-    };
+  test("signal is live (not pre-aborted) while the wizard is running", async () => {
+    // `getWorkflow` runs BEFORE `startAsync` (client.getWorkflow is called
+    // synchronously right after `new MastraClient(...)`), so the signal
+    // observed at that time is the same instance that in-flight fetches
+    // would see during the wizard. If the signal were somehow pre-aborted
+    // at construction, it would be aborted here too. This proves the
+    // `using _mastraCleanup` disposable does NOT fire until teardown.
+    let abortedAtConstruction: boolean | undefined;
     getWorkflowSpy.mockImplementation(function (this: MastraClient) {
-      capturedClientOptions.push(
-        (this as unknown as { options: { abortSignal?: AbortSignal } }).options
-      );
-      return workflow as any;
+      const opts = (
+        this as unknown as { options: { abortSignal?: AbortSignal } }
+      ).options;
+      capturedClientOptions.push(opts);
+      abortedAtConstruction = opts.abortSignal?.aborted;
+      return {
+        createRun: mock(() =>
+          Promise.resolve({
+            startAsync: startAsyncMock,
+            resumeAsync: mock(() => Promise.resolve({ status: "success" })),
+          })
+        ),
+      } as any;
     });
 
     await runWizard(makeOptions());
 
-    expect(signalDuringRun).toBeInstanceOf(AbortSignal);
-    // Signal was live at time of fetch dispatch. Post-run assertion in
-    // other tests proves it's aborted by teardown.
-    // (The .aborted state at capture time can race with the synchronous
-    // wizard completion path in tests that resolve instantly, so we only
-    // assert the signal identity is correct here.)
+    expect(abortedAtConstruction).toBe(false);
+    // And teardown aborted it by the time the wizard returned.
+    expect(capturedClientOptions[0]?.abortSignal?.aborted).toBe(true);
   });
 });

--- a/test/lib/init/wizard-runner.test.ts
+++ b/test/lib/init/wizard-runner.test.ts
@@ -98,6 +98,12 @@ let precomputeSentryDetectionSpy: ReturnType<typeof spyOn>;
 let closeFreshTtyForwardingSpy: ReturnType<typeof spyOn>;
 let getWorkflowSpy: ReturnType<typeof spyOn>;
 let stderrSpy: ReturnType<typeof spyOn>;
+/**
+ * ClientOptions captured from each MastraClient instance constructed by
+ * runWizard. Used by the MastraClient lifecycle suite to assert that the
+ * `abortSignal` passed at construction time is aborted on teardown.
+ */
+let capturedClientOptions: { abortSignal?: AbortSignal }[] = [];
 
 beforeEach(() => {
   mockStartResult = { status: "success", result: { platform: "React" } };
@@ -171,9 +177,18 @@ beforeEach(() => {
   const workflow = {
     createRun: mock(() => Promise.resolve(run)),
   };
-  getWorkflowSpy = spyOn(MastraClient.prototype, "getWorkflow").mockReturnValue(
-    workflow as any
-  );
+  capturedClientOptions = [];
+  getWorkflowSpy = spyOn(
+    MastraClient.prototype,
+    "getWorkflow"
+  ).mockImplementation(function (this: MastraClient) {
+    // `this` is the MastraClient instance. `BaseResource.options` holds the
+    // full ClientOptions passed to the constructor — including abortSignal.
+    capturedClientOptions.push(
+      (this as unknown as { options: { abortSignal?: AbortSignal } }).options
+    );
+    return workflow as any;
+  });
 });
 
 afterEach(() => {
@@ -505,5 +520,101 @@ describe("runWizard", () => {
     await runWizard(makeOptions());
 
     expect(spinnerMock.stop).toHaveBeenCalledWith("Using existing project");
+  });
+});
+
+describe("runWizard — MastraClient lifecycle", () => {
+  test("aborts the MastraClient signal after a successful run", async () => {
+    await runWizard(makeOptions());
+
+    expect(capturedClientOptions).toHaveLength(1);
+    const signal = capturedClientOptions[0]?.abortSignal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    // Using the non-null assertion safely — we asserted toBeInstanceOf above.
+    expect((signal as AbortSignal).aborted).toBe(true);
+  });
+
+  test("aborts the MastraClient signal when a tool throws", async () => {
+    const payload: ToolPayload = {
+      type: "tool",
+      operation: "run-commands",
+      cwd: "/tmp/test",
+      params: { commands: ["npm install @sentry/node"] },
+    };
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["install-deps"]],
+      steps: {
+        "install-deps": { suspendPayload: payload },
+      },
+    };
+    executeToolSpy.mockRejectedValue(new Error("tool blew up"));
+
+    await expect(runWizard(makeOptions())).rejects.toThrow(WizardError);
+
+    expect(capturedClientOptions).toHaveLength(1);
+    const signal = capturedClientOptions[0]?.abortSignal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect((signal as AbortSignal).aborted).toBe(true);
+  });
+
+  test("aborts the MastraClient signal on cancellation", async () => {
+    const payload: ToolPayload = {
+      type: "tool",
+      operation: "run-commands",
+      cwd: "/tmp/test",
+      params: { commands: ["npm install @sentry/node"] },
+    };
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["install-deps"]],
+      steps: {
+        "install-deps": { suspendPayload: payload },
+      },
+    };
+    executeToolSpy.mockRejectedValue(new WizardCancelledError());
+
+    await runWizard(makeOptions());
+
+    expect(capturedClientOptions).toHaveLength(1);
+    const signal = capturedClientOptions[0]?.abortSignal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect((signal as AbortSignal).aborted).toBe(true);
+  });
+
+  test("forwards a live abortSignal to MastraClient at construction", async () => {
+    // Before the wizard exits, the signal MUST NOT yet be aborted — the
+    // MastraClient is using it for in-flight fetches throughout the run.
+    // We observe this by checking the signal state inside the workflow
+    // handler (which executes while the wizard's `using` scope is active).
+    let signalDuringRun: AbortSignal | undefined;
+    startAsyncMock = mock(() => {
+      signalDuringRun = capturedClientOptions[0]?.abortSignal;
+      return Promise.resolve(mockStartResult);
+    });
+    // Re-rig the workflow mock to use the new startAsyncMock.
+    const workflow = {
+      createRun: mock(() =>
+        Promise.resolve({
+          startAsync: startAsyncMock,
+          resumeAsync: mock(() => Promise.resolve({ status: "success" })),
+        })
+      ),
+    };
+    getWorkflowSpy.mockImplementation(function (this: MastraClient) {
+      capturedClientOptions.push(
+        (this as unknown as { options: { abortSignal?: AbortSignal } }).options
+      );
+      return workflow as any;
+    });
+
+    await runWizard(makeOptions());
+
+    expect(signalDuringRun).toBeInstanceOf(AbortSignal);
+    // Signal was live at time of fetch dispatch. Post-run assertion in
+    // other tests proves it's aborted by teardown.
+    // (The .aborted state at capture time can race with the synchronous
+    // wizard completion path in tests that resolve instantly, so we only
+    // assert the signal identity is correct here.)
   });
 });


### PR DESCRIPTION
## Summary

Create an `AbortController` alongside the `MastraClient` in `runWizard`, pass its signal via `abortSignal` in `ClientOptions`, and abort it from a `using` disposable so any in-flight fetches are canceled on every exit path (success, error, cancellation).

Companion PR to #824 — both are independent follow-ups to #802 and can land in either order.

## Why

`MastraClient` has no `close()`/`dispose()` API (verified in `node_modules/@mastra/client-js/dist/client.d.ts`). Without an explicit abort, keep-alive sockets in Bun's fetch dispatcher can hold the event loop alive past the wizard's natural exit, causing the shell to appear stuck. The original `process.exit(0)` workaround (removed in #802) papered over this symptom by forcing exit; this PR addresses the root cause so `sentry init` releases cleanly under any runtime.

Explicit cancellation also removes the implicit dependency on Bun's fetch dispatcher auto-unref'ing idle sockets, making the fix robust across future Bun versions and alternative runtimes.

## Implementation

- `AbortController` created per-`runWizard` call. Scope matches the `MastraClient`.
- `using _mastraCleanup` disposable calls `abortController.abort()` on every exit path. Idempotent — guarded by `signal.aborted` to avoid double-abort diagnostics.
- Custom `fetch` wrapper preserves `init.signal` via the existing object spread — MastraClient's per-request signals still reach the underlying `fetch` call.
- **No `run.cancel()`.** The server observes the dropped fetch connection and cancels the run server-side. Avoids an extra HTTP round-trip during teardown, which could be slow if the server is why we're erroring.

## Tests

- Capture `ClientOptions` from each `MastraClient` instance via a prototype `getWorkflow` hook that reads `this.options` (exposed via `BaseResource`).
- Assert `abortSignal` is aborted after success, tool-error, and `WizardCancelledError` paths.
- Assert the signal is forwarded live to `MastraClient` at construction (not pre-aborted) so in-flight fetches during the run are actually gated on it.

## Test plan

- [x] `bun test test/lib/init/wizard-runner.test.ts` — 19 pass, 0 fail
- [x] `bun test test/lib/init/ test/commands/init.test.ts` — green
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (only pre-existing markdown.ts warning)

## Notes

- Uses `using` (TS 5 / Bun native) in exactly one place — matches the pattern adopted in #824 for `/dev/tty` teardown. `tsconfig.json` already has `target: "ESNext"` so no build-config change needed.
- If #824 lands first, this PR's `using` declaration is the second one in `wizard-runner.ts` — idiomatically consistent. If this lands first, it's the first one.