### PR TITLE
refactor(scan): transport grep worker line pool as bytes

### DIFF
--- a/src/lib/scan/grep-worker.js
+++ b/src/lib/scan/grep-worker.js
@@ -13,24 +13,29 @@
  *
  * Worker → Main:
  * - `{ type: "ready" }` once on startup.
- * - `{ type: "result", ints: Uint32Array, linePool: string }` per
- *   request. `ints.buffer` is transferred (zero-copy); `linePool`
- *   is cloned.
+ * - `{ type: "result", ints: Uint32Array, linePoolBytes: Uint8Array }`
+ *   per request. Both buffers are transferred (zero-copy).
  *
  * ## Match encoding
  *
  * Each match is 4 consecutive `u32`s in `ints`:
  *   [0] pathIdx     index into the input `paths` array
  *   [1] lineNum     1-based line number
- *   [2] lineOffset  character offset into `linePool`
+ *   [2] lineOffset  character offset into the decoded line pool
  *   [3] lineLength  character length of the line (post-truncation)
  *
- * Structured-clone of `GrepMatch[]` for 215k matches costs ~200ms.
- * Binary-packed form + shared `linePool` string drops that to
- * ~2–3ms.
+ * The line pool is built as a JS string on the worker, UTF-8 encoded
+ * just before `postMessage`, and decoded back on the main side.
+ * Offsets stay in UTF-16 code-unit space; the encode/decode round
+ * trip preserves `.length` for all valid code points. Shipping the
+ * pool as a transferable `Uint8Array` keeps both buffers on
+ * `postMessage`'s zero-copy path — mixing a string with a
+ * transferable falls back to the slow structured-clone path in Bun.
  */
 
 const { readFileSync } = require("node:fs");
+
+const textEncoder = new TextEncoder();
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: hot regex loop with literal gate + line counter + line-bound extraction + per-file cap is inherently branchy
 self.onmessage = (event) => {
@@ -85,7 +90,15 @@ self.onmessage = (event) => {
       const lineEnd = lineEndRaw === -1 ? content.length : lineEndRaw;
       let line = content.slice(lineStart, lineEnd);
       if (line.length > maxLineLength) {
-        line = `${line.slice(0, maxLineLength - 1)}\u2026`;
+        // Back off if the cut lands on a high surrogate — splitting
+        // a pair leaves a lone half that `TextEncoder.encode`
+        // replaces with U+FFFD on the wire.
+        let cut = maxLineLength - 1;
+        const lastCode = line.charCodeAt(cut - 1);
+        if (lastCode >= 0xd8_00 && lastCode <= 0xdb_ff) {
+          cut -= 1;
+        }
+        line = `${line.slice(0, cut)}\u2026`;
       }
 
       const lineOffset = linePool.length;
@@ -105,9 +118,10 @@ self.onmessage = (event) => {
   }
 
   const packed = new Uint32Array(ints);
+  const linePoolBytes = textEncoder.encode(linePool);
   self.postMessage(
-    { type: "result", ints: packed, linePool },
-    { transfer: [packed.buffer] }
+    { type: "result", ints: packed, linePoolBytes },
+    { transfer: [packed.buffer, linePoolBytes.buffer] }
   );
 };
 

--- a/src/lib/scan/worker-pool.ts
+++ b/src/lib/scan/worker-pool.ts
@@ -34,8 +34,11 @@ export type WorkerGrepRequest = {
 export type WorkerGrepResult = {
   /** Packed 4-u32-per-match (pathIdx, lineNum, lineOffset, lineLength). */
   ints: Uint32Array;
-  /** Concatenated line text, indexed by `ints[i*4 + 2]` and `+3`. */
-  linePool: string;
+  /**
+   * Concatenated line text as UTF-8 bytes. Decoded on the main side;
+   * `ints[i*4 + 2]` / `+3` index into the decoded string.
+   */
+  linePoolBytes: Uint8Array;
 };
 
 /**
@@ -169,7 +172,7 @@ export function getWorkerPool(): WorkerPool {
       if (pw.inflight === 0) {
         unrefWorker(pw.worker);
       }
-      next.resolve({ ints: data.ints, linePool: data.linePool });
+      next.resolve({ ints: data.ints, linePoolBytes: data.linePoolBytes });
     });
     w.addEventListener("error", (err) => {
       pw.alive = false;
@@ -271,8 +274,18 @@ export function terminatePool(): void {
   }
 }
 
+// `ignoreBOM: true` is load-bearing: without it the decoder silently
+// strips a leading U+FEFF, which desynchronises every `lineOffset` /
+// `lineLength` index the worker stored against the pre-encode pool
+// length. A BOM-prefixed source file lands a U+FEFF at pool index 0,
+// and with default (BOM-eating) decode the whole batch's lines would
+// shift left by one code unit. `fatal: false` (default) keeps
+// replacement-char behavior intact for any invalid sequences — the
+// worker's round-trip can't produce them, but it's the safer default.
+const LINE_POOL_DECODER = new TextDecoder("utf-8", { ignoreBOM: true });
+
 /**
- * Decode a worker's packed `{ints, linePool}` into `GrepMatch[]`,
+ * Decode a worker's packed `{ints, linePoolBytes}` into `GrepMatch[]`,
  * reconstructing path fields from the caller's `paths` / `relPaths`.
  *
  * Optional `mtimes` is a parallel per-path array; when provided,
@@ -285,7 +298,8 @@ export function decodeWorkerMatches(
   relPaths: readonly string[],
   mtimes: readonly number[] | null = null
 ): GrepMatch[] {
-  const { ints, linePool } = result;
+  const { ints, linePoolBytes } = result;
+  const linePool = LINE_POOL_DECODER.decode(linePoolBytes);
   const matches: GrepMatch[] = [];
   const count = Math.floor(ints.length / 4);
   for (let i = 0; i < count; i += 1) {

--- a/test/lib/scan/grep.test.ts
+++ b/test/lib/scan/grep.test.ts
@@ -80,6 +80,78 @@ describe("collectGrep — basic matching", () => {
       cleanup();
     }
   });
+
+  test("preserves non-ASCII / multi-byte UTF-8 in matched lines", async () => {
+    const { cwd, cleanup } = makeSandbox({
+      "a.txt": "héllo wörld TARGET here\npréfix TARGET 你好世界\n",
+      "b.txt": "emoji 🙂 TARGET 🎉 end\nmath ∑ ∞ TARGET ∂\n",
+      "c.txt": "astral 𝒜 TARGET 𝕏 𝔸\n",
+    });
+    try {
+      const { matches } = await collectGrep({ cwd, pattern: "TARGET" });
+      expect(matches.map((m) => m.line).sort()).toEqual([
+        "astral 𝒜 TARGET 𝕏 𝔸",
+        "emoji 🙂 TARGET 🎉 end",
+        "héllo wörld TARGET here",
+        "math ∑ ∞ TARGET ∂",
+        "préfix TARGET 你好世界",
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("truncation at a surrogate-pair boundary doesn't leak U+FFFD", async () => {
+    // Regression: `maxLineLength` truncation used to slice on a
+    // code-unit boundary, which could split a pair and leave a lone
+    // high surrogate that `TextEncoder` replaces with U+FFFD.
+    const { cwd, cleanup } = makeSandbox({
+      "a.txt": "TARGET🙂trailing content beyond the cutoff\n",
+    });
+    try {
+      const { matches } = await collectGrep({
+        cwd,
+        pattern: "TARGET",
+        maxLineLength: 8,
+      });
+      expect(matches).toHaveLength(1);
+      const line = matches[0]?.line ?? "";
+      expect(line.startsWith("TARGET")).toBe(true);
+      expect(line.endsWith("\u2026")).toBe(true);
+      expect(line.includes("\uFFFD")).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("UTF-8 BOM at the start of a file preserves line offsets", async () => {
+    // Regression: the decoder defaults to `ignoreBOM: false`, which
+    // silently strips a leading U+FEFF. A BOM-prefixed source file
+    // would put U+FEFF at pool index 0 on the worker side; without
+    // `ignoreBOM: true` on the main-side decoder, the decoded pool is
+    // one code unit shorter than the worker's offsets assume, and
+    // every line in that batch shifts left by one character.
+    const { cwd, cleanup } = makeSandbox({});
+    try {
+      const body = "TARGET first\nTARGET second\nTARGET third\n";
+      const bytes = new Uint8Array(3 + body.length);
+      bytes[0] = 0xef;
+      bytes[1] = 0xbb;
+      bytes[2] = 0xbf;
+      bytes.set(new TextEncoder().encode(body), 3);
+      writeFileSync(join(cwd, "bom.txt"), bytes);
+      const { matches } = await collectGrep({ cwd, pattern: "TARGET" });
+      // The first line keeps the BOM (that's what's in the source
+      // file); lines 2 and 3 are intact — no bleed-through.
+      expect(matches.map((m) => m.line)).toEqual([
+        "\uFEFFTARGET first",
+        "TARGET second",
+        "TARGET third",
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 describe("collectGrep — case sensitivity", () => {


### PR DESCRIPTION
## Summary

Changes the grep worker's result protocol from `{type, ints: Uint32Array, linePool: string}` to `{type, ints, linePoolBytes: Uint8Array}`, encoding the pool to UTF-8 on the worker side and decoding it once on the main side. **Both** buffers now ride `postMessage`'s zero-copy transfer path.

## Why

Bun's [fast-path `postMessage`](https://bun.com/blog/how-we-made-postMessage-string-500x-faster) for strings fires for bare strings and string-only plain objects, but not when a string is sent alongside a transferable. Our mixed message `{ints: transferable, linePool: string}` was on the slow structured-clone path for the string portion on every batch.

Packing the pool as a transferable `Uint8Array` lets both pieces go zero-copy. **In a worker-messaging microbench this is ~8× faster per round-trip at realistic match densities.**

## Not a perf PR

**End-to-end wall-clock on typical grep workloads is within ±2% of the previous protocol** because messaging happens concurrently with walker I/O and worker regex work — it was never on the critical path. Measured multiple rounds of 50-run benches across zero-match, rare, common, and very-common grep patterns; the microbench-visible savings don't surface as user-visible speed.

Landing anyway for:

- **Memory pressure**: the pool is no longer duplicated across the thread boundary on every batch.
- **Protocol correctness**: the old string path silently papered over two protocol-level hazards that the bytes path surfaces and fixes (see below).
- **Future-proofing**: if Bun later extends the fast path to mixed messages, or the pipeline becomes less overlapped, the zero-copy path delivers automatically.

## Correctness fixes surfaced by the new transport

Both bugs were latent on the string protocol — structured-clone silently preserved surrogates and BOMs, so the bugs never manifested. Forcing `TextEncoder.encode` / `TextDecoder.decode` for the round-trip made them visible, and both are now tested:

### 1. `maxLineLength` truncation splitting a surrogate pair

`grep-worker.js` truncates long lines via `line.slice(0, maxLineLength - 1) + "…"`. `slice()` is code-unit-based, so it can split a UTF-16 surrogate pair and leave a lone high surrogate at the boundary. `TextEncoder.encode` then replaces the lone half with U+FFFD — silent data loss.

**Fix**: before cutting, if the character at `cut - 1` is a high surrogate (its low-surrogate partner is at `cut`, which we're about to exclude), back off one code unit. Drops both halves of the orphaned pair. Safe under all observable inputs — `readFileSync("utf-8")` can't produce lone surrogates on its own, so truncation is the only path that could create one.

### 2. `TextDecoder` BOM stripping (caught by Cursor Bugbot in review)

`new TextDecoder("utf-8")` defaults to `ignoreBOM: false`, which silently drops a leading U+FEFF. For a BOM-prefixed source file, the worker puts U+FEFF at pool index 0 and stores offsets against the pre-encode pool length; without `ignoreBOM: true` on the main-side decoder, the decoded pool is one code unit shorter than the worker expected and every `lineOffset`/`lineLength` in the batch shifts left by one — lines bleed into each other.

**Fix**: pass `{ ignoreBOM: true }` to the `LINE_POOL_DECODER` constructor. Verified end-to-end with `collectGrep` on a real BOM-prefixed file: without the fix, matched lines came back as `"TARGET firstT"`, `"ARGET secondT"`, `"ARGET third"`; with the fix, they're intact.

## Bench

Measured on the `fx-large` synthetic fixture (10k files), 50 runs × 5 warmup × 3 repeated rounds each side. p50:

| op | main | PR | Δ |
|---|---:|---:|---:|
| `collectGrep` zero-match uncapped | 302ms | 298ms | ~ |
| `collectGrep` rare uncapped (SENTRY_DSN) | 316ms | 303ms | −4% |
| `collectGrep` common uncapped (`import.*from`) | 631ms | 636ms | +1% |
| `collectGrep` very-common uncapped (`function\s+\w+`) | 636ms | 629ms | −1% |

All deltas within ±4%, consistent with noise floor.

## Tests

Three new tests in `test/lib/scan/grep.test.ts`:

- `preserves non-ASCII / multi-byte UTF-8 in matched lines` — emoji, CJK, accented chars, astral-plane codepoints through the encode/decode round-trip.
- `truncation at a surrogate-pair boundary doesn't leak U+FFFD` — regression for fix #1; verified to fail when the backoff is reverted.
- `UTF-8 BOM at the start of a file preserves line offsets` — regression for fix #2; verified to fail when `ignoreBOM: true` is removed.

All 41 grep tests pass; 5729 full-suite + 138 isolated pass. Typecheck + lint clean.

## Review

- Round 1 (subagent): caught the lone-surrogate correctness issue in the pre-existing truncation code.
- Round 2 (subagent): verified the surrogate fix and blessed for ship.
- Cursor Bugbot on force-push: caught the BOM-stripping bug on `LINE_POOL_DECODER`. Fixed with `{ ignoreBOM: true }` + regression test.
- Round 3 (subagent, pre-merge): verified both fixes hold, no other latent issues, ready to merge.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint` — clean
- [x] `bun test test/lib/scan/grep.test.ts` — 41 pass
- [x] `bun test test/lib test/commands test/types` — 5729 pass
- [x] `bun test test/isolated` — 138 pass
- [x] Negative-verified both correctness regression tests catch the bugs they guard against