### PR TITLE
fix(upgrade): verify downloaded binary exists before spawn (CLI-1D3)

### DIFF
--- a/src/commands/cli/upgrade.ts
+++ b/src/commands/cli/upgrade.ts
@@ -383,6 +383,23 @@ export function isEbusyError(error: unknown): boolean {
 }
 
 /**
+ * Check whether an error indicates the spawn target was not found.
+ *
+ * Bun surfaces a missing executable as `Executable not found in $PATH: "..."`
+ * without a standard `code` field on the Error, so we fall back to message
+ * matching. Node's `child_process.spawn` would use `code: "ENOENT"`.
+ */
+export function isEnoentSpawnError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+    return true;
+  }
+  return error.message.includes("Executable not found in $PATH");
+}
+
+/**
  * Spawn a binary with retry on EBUSY errors.
  *
  * On Windows, Defender/SmartScreen asynchronously scans newly-written
@@ -394,8 +411,11 @@ export function isEbusyError(error: unknown): boolean {
  * attempt succeeds immediately with zero overhead.
  *
  * @returns Process exit code from the successful spawn
+ * @throws {UpgradeError} Reason `execution_failed` when the binary path
+ *   doesn't exist (Bun "Executable not found" or ENOENT), with an
+ *   actionable message instructing the user to rerun the upgrade.
  * @throws The last EBUSY error if all attempts are exhausted
- * @throws Immediately on non-EBUSY errors (ENOENT, EACCES, etc.)
+ * @throws Immediately on other non-EBUSY errors (EACCES, etc.)
  */
 async function spawnWithRetry(
   binaryPath: string,
@@ -411,6 +431,21 @@ async function spawnWithRetry(
       });
       return await proc.exited;
     } catch (error) {
+      // Translate the opaque Bun "Executable not found" error into an
+      // actionable UpgradeError. This path triggers when the binary at
+      // `binaryPath` doesn't exist on disk when spawn is attempted (see
+      // CLI-1D3). `downloadBinaryToTemp`'s visibility-race retry loop
+      // normally catches this earlier, but this is a safety net for the
+      // `.download` file being removed between verification and spawn
+      // (e.g. manual cleanup by the user) or for future callers that
+      // pass a path not backed by the download pipeline.
+      if (isEnoentSpawnError(error)) {
+        throw new UpgradeError(
+          "execution_failed",
+          `Downloaded binary not found at ${binaryPath}. ` +
+            "The download may have been interrupted — rerun `sentry cli upgrade`."
+        );
+      }
       if (!isEbusyError(error) || attempt === SPAWN_MAX_ATTEMPTS) {
         throw error;
       }

--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -7,7 +7,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { chmodSync, realpathSync, unlinkSync } from "node:fs";
+import { chmodSync, realpathSync, statSync, unlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, sep } from "node:path";
 import {
@@ -661,6 +661,79 @@ async function downloadStableToPath(
 }
 
 /**
+ * Max probe attempts before giving up. Six probes run with five sleeps
+ * in between, yielding ~3.1s total wall-clock budget (see backoff table
+ * on {@link waitForBinaryVisible}).
+ */
+const VERIFY_MAX_ATTEMPTS = 6;
+
+/** Base delay (ms) between verify attempts. Doubles each retry. */
+const VERIFY_BASE_DELAY_MS = 100;
+
+/**
+ * Stat the downloaded file, tolerating absence.
+ *
+ * Returns the file size when the path is present, a regular file, and
+ * has non-zero size. Returns `null` otherwise so the caller can poll.
+ */
+function probeBinaryFile(path: string): number | null {
+  const stats = statSync(path, { throwIfNoEntry: false });
+  if (stats?.isFile() && stats.size > 0) {
+    return stats.size;
+  }
+  return null;
+}
+
+/**
+ * Wait for a freshly written binary to become visible by path.
+ *
+ * On Windows + Bun 1.3.9 (CLI-1D3), streaming writes via `Bun.file().writer()`
+ * can return from `writer.end()` before the OS surfaces the file by path.
+ * A subsequent `Bun.spawn` then fails with `Executable not found in $PATH`.
+ * Polling with exponential backoff lets the transient visibility race
+ * self-heal without prompting the user to manually retry.
+ *
+ * Backoff table (6 probes, 5 sleeps, cumulative worst case 3.1s):
+ *
+ * | Attempt | Probe at | Sleep after |
+ * |---------|----------|-------------|
+ * | 1       | 0 ms     | 100 ms      |
+ * | 2       | 100 ms   | 200 ms      |
+ * | 3       | 300 ms   | 400 ms      |
+ * | 4       | 700 ms   | 800 ms      |
+ * | 5       | 1500 ms  | 1600 ms     |
+ * | 6       | 3100 ms  | —           |
+ *
+ * @param path - Absolute path to the downloaded binary
+ * @returns Size of the verified file in bytes
+ * @throws {UpgradeError} When the file never becomes visible or stays empty
+ */
+async function waitForBinaryVisible(path: string): Promise<number> {
+  for (let attempt = 1; attempt <= VERIFY_MAX_ATTEMPTS; attempt++) {
+    const size = probeBinaryFile(path);
+    if (size !== null) {
+      if (attempt > 1) {
+        log.debug(`Binary became visible after ${attempt} attempts`);
+      }
+      return size;
+    }
+    if (attempt === VERIFY_MAX_ATTEMPTS) {
+      break;
+    }
+    const delay = VERIFY_BASE_DELAY_MS * 2 ** (attempt - 1);
+    log.debug(
+      `Downloaded binary not yet visible at ${path}, retrying in ${delay}ms (attempt ${attempt}/${VERIFY_MAX_ATTEMPTS})`
+    );
+    await Bun.sleep(delay);
+  }
+  throw new UpgradeError(
+    "execution_failed",
+    `Downloaded binary is missing or empty at ${path}. ` +
+      "This is usually transient — rerun `sentry cli upgrade` to retry."
+  );
+}
+
+/**
  * Download the new binary to a temporary path and return its location.
  * Used by the upgrade command to download before spawning setup --install.
  *
@@ -722,6 +795,16 @@ export async function downloadBinaryToTemp(
       log.debug("Downloading full binary");
       await downloadFullBinary(version, downloadTag, tempPath);
     }
+
+    // Verify the download produced a real, non-empty file before the caller
+    // spawns it. Seen on Windows + Bun 1.3.9 (CLI-1D3): streaming writes via
+    // `Bun.file(path).writer()` can return without surfacing the file by
+    // path, leaving `Bun.spawn` to fail with an opaque
+    // `Executable not found in $PATH: "...sentry.exe.download"`. Poll with
+    // exponential backoff so a transient filesystem-visibility race
+    // self-heals without asking the user to rerun.
+    const verifiedSize = await waitForBinaryVisible(tempPath);
+    log.debug(`Downloaded binary verified (${verifiedSize} bytes)`);
 
     // Clear consumed patch cache — patches for the old version are useless
     // after the binary has been updated (whether via delta or full download).

--- a/test/lib/upgrade.test.ts
+++ b/test/lib/upgrade.test.ts
@@ -9,7 +9,7 @@ import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
-
+import { isEnoentSpawnError } from "../../src/commands/cli/upgrade.js";
 import {
   acquireLock,
   getBinaryDownloadUrl,
@@ -1539,5 +1539,167 @@ describe("downloadBinaryToTemp offline errors", () => {
       expect(upgradeError.message).toContain("Check your internet connection");
       expect(upgradeError.message).not.toContain("cached patches");
     }
+  });
+});
+
+// Regression coverage for CLI-1D3: when the full download silently produces
+// a missing or empty file, `downloadBinaryToTemp` polls with exponential
+// backoff (letting a Windows filesystem-visibility race self-heal), then
+// fails with an actionable `UpgradeError` if the file never appears.
+describe("downloadBinaryToTemp verifies download integrity (CLI-1D3)", () => {
+  const verifyBinDir = join(TEST_TMP_DIR, "upgrade-verify-test");
+  const verifyInstallPath = join(verifyBinDir, "sentry");
+
+  beforeEach(() => {
+    clearInstallInfo();
+    mkdirSync(verifyBinDir, { recursive: true });
+    setInstallInfo({
+      method: "curl",
+      path: verifyInstallPath,
+      version: "0.0.0",
+    });
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    const paths = getCurlInstallPaths();
+    for (const p of [
+      paths.installPath,
+      paths.tempPath,
+      paths.oldPath,
+      paths.lockPath,
+    ]) {
+      try {
+        await unlink(p);
+      } catch {
+        // Ignore
+      }
+    }
+    clearInstallInfo();
+  });
+
+  test("throws execution_failed UpgradeError after retry budget is exhausted", async () => {
+    // Serve an empty gzip payload. The outer stream completes cleanly, so
+    // neither fetchWithUpgradeError nor streamDecompressToFile throws —
+    // but `destPath` ends up with zero bytes. The verification loop polls
+    // 5 times (~3.1s cumulative) before giving up with an actionable
+    // error; without it the caller would spawn the empty file and fail
+    // with "Executable not found in $PATH" (the CLI-1D3 symptom).
+    const emptyGzip = Bun.gzipSync(new Uint8Array(0));
+    mockFetch(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.endsWith(".gz")) {
+        return new Response(emptyGzip, { status: 200 });
+      }
+      return new Response("Not Found", { status: 404 });
+    });
+
+    try {
+      await downloadBinaryToTemp("0.26.1");
+      expect.unreachable("Should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(UpgradeError);
+      const upgradeError = error as UpgradeError;
+      expect(upgradeError.reason).toBe("execution_failed");
+      expect(upgradeError.message).toContain("missing or empty");
+      expect(upgradeError.message).toContain("sentry cli upgrade");
+    }
+  }, 10_000);
+
+  test("releases the download lock when verification fails", async () => {
+    const emptyGzip = Bun.gzipSync(new Uint8Array(0));
+    mockFetch(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.endsWith(".gz")) {
+        return new Response(emptyGzip, { status: 200 });
+      }
+      return new Response("Not Found", { status: 404 });
+    });
+
+    await expect(downloadBinaryToTemp("0.26.1")).rejects.toThrow(UpgradeError);
+
+    // The lock must be released so a subsequent retry can acquire it.
+    // acquireLock throws UpgradeError("Another upgrade is already in progress")
+    // when a live lock exists; if the previous failure released it correctly
+    // this call succeeds silently.
+    const { lockPath } = getCurlInstallPaths();
+    expect(() => acquireLock(lockPath)).not.toThrow();
+    releaseLock(lockPath);
+  }, 10_000);
+
+  test("recovers when the binary becomes visible during the retry window", async () => {
+    // Simulate a Windows filesystem-visibility race: the download writes
+    // an empty file, but good bytes become visible a short time later.
+    // The polling loop's exponential backoff observes the non-empty file
+    // on a subsequent attempt and returns without throwing.
+    //
+    // To keep the ordering deterministic under CI load, the "delayed
+    // writer" first waits until the empty download file is visible on
+    // disk (proving streamDecompressToFile has finished) before writing
+    // the good bytes. Otherwise a slow CI could let our Bun.write land
+    // before the download completes and get clobbered by the empty write.
+    const mockBinaryContent = new Uint8Array([0x7f, 0x45, 0x4c, 0x46]); // ELF
+    const emptyGzip = Bun.gzipSync(new Uint8Array(0));
+    mockFetch(async (url) => {
+      const urlStr = String(url);
+      if (urlStr.endsWith(".gz")) {
+        return new Response(emptyGzip, { status: 200 });
+      }
+      return new Response("Not Found", { status: 404 });
+    });
+
+    const { tempPath } = getCurlInstallPaths();
+    const delayedWrite = (async () => {
+      // Wait for the empty download to land on disk first, so we
+      // overwrite it instead of racing it.
+      for (let i = 0; i < 200; i++) {
+        if (await Bun.file(tempPath).exists()) {
+          break;
+        }
+        await Bun.sleep(10);
+      }
+      // Give the probe loop at least one zero-byte observation so the
+      // recovery branch (attempt > 1) actually fires.
+      await Bun.sleep(150);
+      await Bun.write(tempPath, mockBinaryContent);
+    })();
+
+    const result = await downloadBinaryToTemp("0.26.1");
+    expect(result.tempBinaryPath).toBe(tempPath);
+    await delayedWrite;
+
+    // Verify the good bytes survived — catches the regression where a
+    // late download completion clobbers the delayed write.
+    const onDisk = new Uint8Array(await Bun.file(tempPath).arrayBuffer());
+    expect(onDisk).toEqual(mockBinaryContent);
+
+    // Release the lock so afterEach cleanup runs cleanly.
+    releaseLock(result.lockPath);
+  }, 10_000);
+});
+
+// CLI-1D3 tail: even if the verification in downloadBinaryToTemp is
+// somehow bypassed (e.g. manual `rm` of .download between verification
+// and spawn), `spawnWithRetry` translates the opaque "Executable not
+// found in $PATH" into an actionable UpgradeError.
+describe("isEnoentSpawnError", () => {
+  test("detects Bun's 'Executable not found in $PATH' error", () => {
+    const err = new Error(
+      `Executable not found in $PATH: "C:\\Users\\x\\.local\\bin\\sentry.exe.download"`
+    );
+    expect(isEnoentSpawnError(err)).toBe(true);
+  });
+
+  test("detects Node's ENOENT errno code", () => {
+    const err: NodeJS.ErrnoException = new Error("spawn ENOENT");
+    err.code = "ENOENT";
+    expect(isEnoentSpawnError(err)).toBe(true);
+  });
+
+  test("returns false for unrelated errors", () => {
+    expect(isEnoentSpawnError(new Error("EBUSY: file locked"))).toBe(false);
+    expect(isEnoentSpawnError(new Error("permission denied"))).toBe(false);
+    expect(isEnoentSpawnError("string error")).toBe(false);
+    expect(isEnoentSpawnError(null)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes [CLI-1D3](https://sentry.sentry.io/issues/7432324852/): `sentry cli upgrade` fails on Windows with an opaque `Executable not found in $PATH: "C:\Users\...\sentry.exe.download"` when the downloaded binary never actually materializes on disk.

### Root cause

On Windows + Bun 1.3.9, streaming writes via `Bun.file(path).writer()` can return from `writer.end()` before the OS has made the file visible by its path. The parent `sentry cli upgrade` process then directly spawns the `.download` temp path to run `cli setup --install` (which does the atomic rename to the final binary name), and `Bun.spawn` fails with ENOENT — surfaced as the opaque "Executable not found in $PATH" error with no clue that the download itself was the problem.

Contributing factors:

- `downloadBinaryToTemp` returned without verifying the temp file existed or had non-zero size.
- `chmodSync` — which would have incidentally surfaced a missing file — is skipped on Windows.
- The full-download stable path has no SHA-256 verification (unlike the delta path, which already verifies).

### Fix

Two defense-in-depth guards:

1. **Primary** — `downloadBinaryToTemp` now polls the temp path with exponential backoff immediately after download completes:

   | Attempt | Probe at | Sleep after |
   |---------|----------|-------------|
   | 1       | 0 ms     | 100 ms      |
   | 2       | 100 ms   | 200 ms      |
   | 3       | 300 ms   | 400 ms      |
   | 4       | 700 ms   | 800 ms      |
   | 5       | 1500 ms  | 1600 ms     |
   | 6       | 3100 ms  | —           |

   Six probes with five sleeps = ~3.1s wall-clock budget. If the file appears with non-zero size on any attempt we proceed normally — so a transient Windows filesystem-visibility race self-heals without bothering the user. If the file is still missing or empty after the final probe we throw `UpgradeError("execution_failed", ...)` with an actionable "rerun `sentry cli upgrade`" message. The outer catch releases the download lock so manual retries work.

   Covers both the full-download and delta-upgrade paths: the delta path also writes to `destPath` via `Bun.file(destPath).writer()` in the final patch iteration, so it's vulnerable to the same visibility race.

2. **Secondary** — `spawnWithRetry` now translates Bun's `Executable not found in $PATH` error (and Node's `ENOENT`) into the same actionable `UpgradeError`, as a safety net for the `.download` file being removed between verification and spawn (e.g. manual cleanup by the user). A new `isEnoentSpawnError` helper handles both error shapes since Bun surfaces its "not found" error with only a message, no `code` property. ENOENT check runs before the existing EBUSY retry branch — no conflict since the error messages are distinct.

### Follow-up

SHA-256 verification of full-download stable/nightly binaries (matching what the delta path already does) would close the "silent truncated download" class for good. Tracking separately — not required for this fix.

## Test Plan

- New `downloadBinaryToTemp verifies download integrity (CLI-1D3)` describe block with three tests:
  - Retry budget exhausted → rejects with `execution_failed` / "missing or empty".
  - Lock released on verification failure so subsequent retries can acquire it.
  - **Recovery path**: file becomes visible mid-retry → succeeds without throwing. The test is race-hardened — the delayed writer first waits for the empty download file to land on disk before overwriting, so the ordering is deterministic under CI load.
- New `isEnoentSpawnError` describe block with three tests covering Bun's message format, Node's `ENOENT` errno code, and negative cases.
- Verified: `bun run typecheck`, `bun run lint`, and `bun test test/lib/upgrade.test.ts test/commands/cli/upgrade.test.ts test/lib/delta-upgrade.test.ts test/lib/binary.test.ts test/lib/bspatch.test.ts` (268 pass, 0 fail).