### PR TITLE
fix(api): clone request body per retry + classify timeouts (CLI-1D6)

### DIFF
--- a/src/lib/sentry-client.ts
+++ b/src/lib/sentry-client.ts
@@ -6,6 +6,22 @@
  *
  * Instead of managing client instances, we pass configuration per-request
  * through the SDK function options (baseUrl, fetch, headers).
+ *
+ * ## Retry safety (CLI-1D6)
+ *
+ * The retry loop must feed `fetch` a fresh `(input, init)` pair per attempt
+ * because fetch consumes the request body on attempt 1. Reusing a consumed
+ * `Request` (or a streamed `init.body`) on retry throws
+ * `TypeError: Request body already used`, which used to surface as
+ * "Unable to reach Sentry API. Cause: Request body already used" after a
+ * timeout followed by retry. `buildAttemptFactory` materializes the body
+ * once so every retry sees a readable copy.
+ *
+ * ## Per-endpoint timeouts
+ *
+ * Known-slow endpoints (e.g. Seer autofix) can exceed the default 30 s
+ * per-request timeout. `ENDPOINT_TIMEOUT_OVERRIDES` lets us raise the
+ * ceiling for specific paths without touching call sites.
  */
 
 import { getTraceData } from "@sentry/node-core/light";
@@ -18,6 +34,7 @@ import {
 } from "./constants.js";
 import { applyCustomHeaders } from "./custom-headers.js";
 import { getAuthToken, refreshToken } from "./db/auth.js";
+import { TimeoutError } from "./errors.js";
 import { logger } from "./logger.js";
 import {
   getCachedResponse,
@@ -28,8 +45,41 @@ import { withTracingSpan } from "./telemetry.js";
 
 const log = logger.withTag("http");
 
-/** Request timeout in milliseconds */
+/** Default request timeout in milliseconds */
 const REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Per-endpoint timeout overrides.
+ *
+ * Known-slow Sentry endpoints whose server-side processing can exceed
+ * the default 30 s request timeout. Matched against the request URL's
+ * pathname; the first matching pattern wins, falling back to
+ * {@link REQUEST_TIMEOUT_MS}.
+ *
+ * Seer autofix POSTs trigger root-cause analysis / solution planning on
+ * the server and can take up to ~2 minutes before returning the run_id
+ * (see CLI-1D6). Subsequent polling of the same endpoint is short-lived
+ * and fits easily under the 30 s default, but the initial POST must be
+ * given room to breathe.
+ *
+ * To add a new entry: append `{ pattern, timeoutMs, reason }`. Keep the
+ * pattern conservative (match only the exact slow endpoint, not broad
+ * prefixes) so unrelated endpoints don't accidentally inherit a long
+ * timeout.
+ */
+type TimeoutOverride = {
+  pattern: RegExp;
+  timeoutMs: number;
+  reason: string;
+};
+
+const ENDPOINT_TIMEOUT_OVERRIDES: TimeoutOverride[] = [
+  {
+    pattern: /\/autofix\/?(?:\?|$)/,
+    timeoutMs: 120_000,
+    reason: "Seer autofix trigger/plan",
+  },
+];
 
 /** Maximum retry attempts for failed requests */
 const MAX_RETRIES = 2;
@@ -42,6 +92,14 @@ const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
 
 /** Header to mark requests as retries, preventing infinite token refresh loops */
 const RETRY_MARKER_HEADER = "x-sentry-cli-retry";
+
+/**
+ * Symbol marker for aborts caused by our own per-request timeout (as opposed
+ * to the caller's external abort signal). Stamped onto the thrown error so
+ * the retry loop can classify it and surface a {@link TimeoutError} with a
+ * clear message instead of the opaque "Network error" envelope.
+ */
+const INTERNAL_TIMEOUT_MARKER = Symbol("sentry-cli:internal-timeout");
 
 /** Calculate exponential backoff delay, capped at MAX_BACKOFF_MS */
 function backoffDelay(attempt: number): number {
@@ -151,27 +209,96 @@ function linkAbortSignal(
 }
 
 /**
+ * Resolve the effective timeout for a request.
+ *
+ * Consults {@link ENDPOINT_TIMEOUT_OVERRIDES} using the URL's pathname;
+ * falls back to {@link REQUEST_TIMEOUT_MS}. If the URL string cannot be
+ * parsed (shouldn't happen in practice — our callers always pass absolute
+ * URLs), the raw string is used for matching so overrides still apply.
+ */
+function resolveTimeoutMs(fullUrl: string): number {
+  let pathname = fullUrl;
+  try {
+    pathname = new URL(fullUrl).pathname;
+  } catch {
+    // Fall through: match against the raw input.
+  }
+  for (const entry of ENDPOINT_TIMEOUT_OVERRIDES) {
+    if (entry.pattern.test(pathname)) {
+      return entry.timeoutMs;
+    }
+  }
+  return REQUEST_TIMEOUT_MS;
+}
+
+/**
+ * True if the error was caused by our internal per-request timeout
+ * (as opposed to a user-initiated abort or another network error).
+ */
+function isInternalTimeout(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as Record<PropertyKey, unknown>)[INTERNAL_TIMEOUT_MARKER] === true
+  );
+}
+
+/**
  * Execute a single fetch attempt with timeout.
+ *
+ * If the per-request timeout fires before the response arrives, the
+ * resulting `AbortError` is tagged with {@link INTERNAL_TIMEOUT_MARKER}
+ * and the effective `timeoutMs` so the retry loop can distinguish it
+ * from a user abort or generic network error.
  *
  * @returns The Response, or throws on network/timeout errors
  */
-async function fetchWithTimeout(
-  input: Request | string | URL,
-  init: RequestInit | undefined,
-  headers: Headers,
-  externalSignal?: AbortSignal | null
-): Promise<Response> {
+type FetchWithTimeoutArgs = {
+  input: Request | string | URL;
+  init: RequestInit | undefined;
+  headers: Headers;
+  externalSignal: AbortSignal | undefined | null;
+  timeoutMs: number;
+};
+
+async function fetchWithTimeout({
+  input,
+  init,
+  headers,
+  externalSignal,
+  timeoutMs,
+}: FetchWithTimeoutArgs): Promise<Response> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
   linkAbortSignal(externalSignal, controller);
 
   try {
-    const response = await fetch(input, {
+    return await fetch(input, {
       ...init,
       headers,
       signal: controller.signal,
     });
-    return response;
+  } catch (error) {
+    if (timedOut) {
+      // Tag the error so handleFetchError can classify it. We attach the
+      // marker onto the caught error directly when possible so downstream
+      // consumers can still inspect the original stack trace.
+      const tagged = error instanceof Error ? error : new Error(String(error));
+      Object.defineProperty(tagged, INTERNAL_TIMEOUT_MARKER, {
+        value: true,
+        enumerable: false,
+      });
+      Object.defineProperty(tagged, "timeoutMs", {
+        value: timeoutMs,
+        enumerable: false,
+      });
+      throw tagged;
+    }
+    throw error;
   } finally {
     clearTimeout(timeout);
   }
@@ -206,8 +333,13 @@ async function handleResponse(
 
 /**
  * Decide what to do with a fetch error.
- * Throws immediately for user-initiated aborts or last attempt;
- * returns 'retry' otherwise.
+ *
+ * - User aborts propagate immediately (unchanged original error).
+ * - Internal timeouts are retryable for non-last attempts; on the last
+ *   attempt we surface a {@link TimeoutError} with a friendly message so
+ *   callers see "Request timed out after Ns." instead of the generic
+ *   "Network error" wrapper.
+ * - Other errors retry until the last attempt, then propagate.
  */
 function handleFetchError(
   error: unknown,
@@ -216,6 +348,18 @@ function handleFetchError(
 ): AttemptResult {
   if (isUserAbort(error, signal)) {
     return { action: "throw", error };
+  }
+  if (isInternalTimeout(error) && isLastAttempt) {
+    const timeoutMs =
+      (error as { timeoutMs?: number }).timeoutMs ?? REQUEST_TIMEOUT_MS;
+    const seconds = Math.round(timeoutMs / 1000);
+    return {
+      action: "throw",
+      error: new TimeoutError(
+        `Request timed out after ${seconds}s.`,
+        "The Sentry API did not respond in time. Try again; if the problem persists, check https://status.sentry.io."
+      ),
+    };
   }
   if (isLastAttempt) {
     return { action: "throw", error };
@@ -324,6 +468,69 @@ function authHeaders(token: string | undefined): Record<string, string> {
 }
 
 /**
+ * Per-attempt `(input, init)` factory.
+ *
+ * Returns a fresh pair on every invocation so retries never reuse a
+ * consumed request body. See the file header comment (CLI-1D6).
+ */
+type AttemptInputFactory = () => {
+  input: Request | string | URL;
+  init: RequestInit | undefined;
+};
+
+/**
+ * Build an attempt factory that yields a fresh, body-readable `(input, init)`
+ * pair per retry.
+ *
+ * The SDK calls our authenticated fetch with a `Request` object whose body
+ * is a stream that fetch consumes on the first attempt; our own
+ * `apiRequestToRegion`/`rawApiRequest` call it with a string URL and a
+ * primitive `init.body` (typically a JSON string). Both shapes need
+ * different treatment:
+ *
+ * - **Request input**: clone per attempt. `Request.clone()` tees the body
+ *   stream so each retry gets an independent readable copy.
+ * - **String/URL input + primitive body** (string, ArrayBuffer, TypedArray,
+ *   or no body): already re-usable; pass through unchanged. This is the
+ *   hot path for all of our non-SDK call sites — no allocation on retry.
+ * - **Stream/Blob/FormData body**: materialize once to an ArrayBuffer so
+ *   subsequent attempts read the same bytes. Defensive path; currently
+ *   unused by our call sites but keeps the invariant airtight.
+ */
+async function buildAttemptFactory(
+  input: Request | string | URL,
+  init: RequestInit | undefined
+): Promise<AttemptInputFactory> {
+  if (input instanceof Request) {
+    // Cast mirrors the cacheResponse pattern: Bun's `Request` adds
+    // toJSON/count/getAll that the DOM lib's Request type doesn't carry
+    // through `.clone()`, but at runtime the clone is a fully-usable Request.
+    return () => ({ input: input.clone() as unknown as Request, init });
+  }
+
+  const body = init?.body;
+  if (
+    body === undefined ||
+    body === null ||
+    typeof body === "string" ||
+    body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body)
+  ) {
+    return () => ({ input, init });
+  }
+
+  // Stream / Blob / FormData / URLSearchParams — drain once to an ArrayBuffer
+  // so every retry attempt can reuse the same bytes. `new Response(body)`
+  // accepts every valid BodyInit and normalizes to an ArrayBuffer. The cast
+  // is needed because `BodyInit` isn't globally available without the DOM
+  // lib, but at runtime any valid `RequestInit.body` is a valid `BodyInit`.
+  const snapshot = await new Response(
+    body as ConstructorParameters<typeof Response>[0]
+  ).arrayBuffer();
+  return () => ({ input, init: { ...init, body: snapshot } });
+}
+
+/**
  * Authenticate and execute a request with retry logic.
  *
  * Refreshes the auth token, then retries the request up to `MAX_RETRIES` times
@@ -337,10 +544,19 @@ async function fetchWithRetry(
 ): Promise<Response> {
   const { token } = await refreshToken();
   const headers = prepareHeaders(input, init, token);
+  const attemptFactory = await buildAttemptFactory(input, init);
+  const timeoutMs = resolveTimeoutMs(fullUrl);
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     const isLastAttempt = attempt === MAX_RETRIES;
-    const result = await executeAttempt(input, init, headers, isLastAttempt);
+    const { input: attemptInput, init: attemptInit } = attemptFactory();
+    const result = await executeAttempt({
+      input: attemptInput,
+      init: attemptInit,
+      headers,
+      isLastAttempt,
+      timeoutMs,
+    });
 
     if (result.action === "done") {
       // Use getAuthToken() instead of captured `token` — after a 401 refresh,
@@ -447,14 +663,29 @@ function createAuthenticatedFetch(): (
 /**
  * Execute a single fetch attempt and classify the outcome.
  */
-async function executeAttempt(
-  input: Request | string | URL,
-  init: RequestInit | undefined,
-  headers: Headers,
-  isLastAttempt: boolean
-): Promise<AttemptResult> {
+type ExecuteAttemptArgs = {
+  input: Request | string | URL;
+  init: RequestInit | undefined;
+  headers: Headers;
+  isLastAttempt: boolean;
+  timeoutMs: number;
+};
+
+async function executeAttempt({
+  input,
+  init,
+  headers,
+  isLastAttempt,
+  timeoutMs,
+}: ExecuteAttemptArgs): Promise<AttemptResult> {
   try {
-    const response = await fetchWithTimeout(input, init, headers, init?.signal);
+    const response = await fetchWithTimeout({
+      input,
+      init,
+      headers,
+      externalSignal: init?.signal,
+      timeoutMs,
+    });
     return handleResponse(response, headers, isLastAttempt);
   } catch (error) {
     return handleFetchError(error, init?.signal, isLastAttempt);
@@ -546,4 +777,36 @@ export function getControlSdkConfig() {
  */
 export function resetAuthenticatedFetch(): void {
   cachedFetch = null;
+}
+
+/**
+ * Resolve the effective per-request timeout for a URL.
+ *
+ * Exported for tests and for introspection. The 30 s default is returned
+ * unless the URL matches an {@link ENDPOINT_TIMEOUT_OVERRIDES} pattern.
+ */
+export function getRequestTimeoutMs(fullUrl: string): number {
+  return resolveTimeoutMs(fullUrl);
+}
+
+/**
+ * Test-only helper: temporarily prepend a timeout override and return a
+ * disposer that restores the original list.
+ *
+ * Lets tests exercise the real timeout → `TimeoutError` path without
+ * having to wait 30 s for the default timeout to fire. Prepended (not
+ * appended) so the injected pattern always wins over existing entries.
+ *
+ * @internal
+ */
+export function __injectTimeoutOverrideForTests(
+  override: TimeoutOverride
+): () => void {
+  ENDPOINT_TIMEOUT_OVERRIDES.unshift(override);
+  return () => {
+    const idx = ENDPOINT_TIMEOUT_OVERRIDES.indexOf(override);
+    if (idx >= 0) {
+      ENDPOINT_TIMEOUT_OVERRIDES.splice(idx, 1);
+    }
+  };
 }

--- a/src/lib/sentry-client.ts
+++ b/src/lib/sentry-client.ts
@@ -6,22 +6,6 @@
  *
  * Instead of managing client instances, we pass configuration per-request
  * through the SDK function options (baseUrl, fetch, headers).
- *
- * ## Retry safety (CLI-1D6)
- *
- * The retry loop must feed `fetch` a fresh `(input, init)` pair per attempt
- * because fetch consumes the request body on attempt 1. Reusing a consumed
- * `Request` (or a streamed `init.body`) on retry throws
- * `TypeError: Request body already used`, which used to surface as
- * "Unable to reach Sentry API. Cause: Request body already used" after a
- * timeout followed by retry. `buildAttemptFactory` materializes the body
- * once so every retry sees a readable copy.
- *
- * ## Per-endpoint timeouts
- *
- * Known-slow endpoints (e.g. Seer autofix) can exceed the default 30 s
- * per-request timeout. `ENDPOINT_TIMEOUT_OVERRIDES` lets us raise the
- * ceiling for specific paths without touching call sites.
  */
 
 import { getTraceData } from "@sentry/node-core/light";
@@ -49,36 +33,18 @@ const log = logger.withTag("http");
 const REQUEST_TIMEOUT_MS = 30_000;
 
 /**
- * Per-endpoint timeout overrides.
- *
- * Known-slow Sentry endpoints whose server-side processing can exceed
- * the default 30 s request timeout. Matched against the request URL's
- * pathname; the first matching pattern wins, falling back to
- * {@link REQUEST_TIMEOUT_MS}.
- *
- * Seer autofix POSTs trigger root-cause analysis / solution planning on
- * the server and can take up to ~2 minutes before returning the run_id
- * (see CLI-1D6). Subsequent polling of the same endpoint is short-lived
- * and fits easily under the 30 s default, but the initial POST must be
- * given room to breathe.
- *
- * To add a new entry: append `{ pattern, timeoutMs, reason }`. Keep the
- * pattern conservative (match only the exact slow endpoint, not broad
- * prefixes) so unrelated endpoints don't accidentally inherit a long
- * timeout.
+ * Per-endpoint timeout overrides, matched against the request URL's
+ * pathname (first match wins, otherwise {@link REQUEST_TIMEOUT_MS}).
  */
 type TimeoutOverride = {
   pattern: RegExp;
   timeoutMs: number;
-  reason: string;
 };
 
 const ENDPOINT_TIMEOUT_OVERRIDES: TimeoutOverride[] = [
-  {
-    pattern: /\/autofix\/?(?:\?|$)/,
-    timeoutMs: 120_000,
-    reason: "Seer autofix trigger/plan",
-  },
+  // Seer autofix POSTs trigger server-side root-cause analysis /
+  // solution planning and can take up to ~2 minutes (see CLI-1D6).
+  { pattern: /\/autofix\/?(?:\?|$)/, timeoutMs: 120_000 },
 ];
 
 /** Maximum retry attempts for failed requests */
@@ -93,12 +59,7 @@ const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
 /** Header to mark requests as retries, preventing infinite token refresh loops */
 const RETRY_MARKER_HEADER = "x-sentry-cli-retry";
 
-/**
- * Symbol marker for aborts caused by our own per-request timeout (as opposed
- * to the caller's external abort signal). Stamped onto the thrown error so
- * the retry loop can classify it and surface a {@link TimeoutError} with a
- * clear message instead of the opaque "Network error" envelope.
- */
+/** Stamped on thrown errors caused by our own per-request timeout. */
 const INTERNAL_TIMEOUT_MARKER = Symbol("sentry-cli:internal-timeout");
 
 /** Calculate exponential backoff delay, capped at MAX_BACKOFF_MS */
@@ -208,21 +169,9 @@ function linkAbortSignal(
   signal.addEventListener("abort", () => controller.abort(), { once: true });
 }
 
-/**
- * Resolve the effective timeout for a request.
- *
- * Consults {@link ENDPOINT_TIMEOUT_OVERRIDES} using the URL's pathname;
- * falls back to {@link REQUEST_TIMEOUT_MS}. If the URL string cannot be
- * parsed (shouldn't happen in practice — our callers always pass absolute
- * URLs), the raw string is used for matching so overrides still apply.
- */
+/** Resolve the per-request timeout for a URL via {@link ENDPOINT_TIMEOUT_OVERRIDES}. */
 function resolveTimeoutMs(fullUrl: string): number {
-  let pathname = fullUrl;
-  try {
-    pathname = new URL(fullUrl).pathname;
-  } catch {
-    // Fall through: match against the raw input.
-  }
+  const pathname = extractUrlPath(fullUrl);
   for (const entry of ENDPOINT_TIMEOUT_OVERRIDES) {
     if (entry.pattern.test(pathname)) {
       return entry.timeoutMs;
@@ -231,10 +180,6 @@ function resolveTimeoutMs(fullUrl: string): number {
   return REQUEST_TIMEOUT_MS;
 }
 
-/**
- * True if the error was caused by our internal per-request timeout
- * (as opposed to a user-initiated abort or another network error).
- */
 function isInternalTimeout(error: unknown): boolean {
   return (
     typeof error === "object" &&
@@ -243,16 +188,6 @@ function isInternalTimeout(error: unknown): boolean {
   );
 }
 
-/**
- * Execute a single fetch attempt with timeout.
- *
- * If the per-request timeout fires before the response arrives, the
- * resulting `AbortError` is tagged with {@link INTERNAL_TIMEOUT_MARKER}
- * and the effective `timeoutMs` so the retry loop can distinguish it
- * from a user abort or generic network error.
- *
- * @returns The Response, or throws on network/timeout errors
- */
 type FetchWithTimeoutArgs = {
   input: Request | string | URL;
   init: RequestInit | undefined;
@@ -261,6 +196,11 @@ type FetchWithTimeoutArgs = {
   timeoutMs: number;
 };
 
+/**
+ * Execute a single fetch attempt with timeout. If the timeout fires, the
+ * thrown error is tagged with {@link INTERNAL_TIMEOUT_MARKER} so the retry
+ * loop can distinguish it from a user abort or network error.
+ */
 async function fetchWithTimeout({
   input,
   init,
@@ -284,18 +224,11 @@ async function fetchWithTimeout({
     });
   } catch (error) {
     if (timedOut) {
-      // Tag the error so handleFetchError can classify it. We attach the
-      // marker onto the caught error directly when possible so downstream
-      // consumers can still inspect the original stack trace.
-      const tagged = error instanceof Error ? error : new Error(String(error));
-      Object.defineProperty(tagged, INTERNAL_TIMEOUT_MARKER, {
-        value: true,
-        enumerable: false,
-      });
-      Object.defineProperty(tagged, "timeoutMs", {
-        value: timeoutMs,
-        enumerable: false,
-      });
+      const tagged = (
+        error instanceof Error ? error : new Error(String(error))
+      ) as Error & { [INTERNAL_TIMEOUT_MARKER]?: true; timeoutMs?: number };
+      tagged[INTERNAL_TIMEOUT_MARKER] = true;
+      tagged.timeoutMs = timeoutMs;
       throw tagged;
     }
     throw error;
@@ -332,14 +265,9 @@ async function handleResponse(
 }
 
 /**
- * Decide what to do with a fetch error.
- *
- * - User aborts propagate immediately (unchanged original error).
- * - Internal timeouts are retryable for non-last attempts; on the last
- *   attempt we surface a {@link TimeoutError} with a friendly message so
- *   callers see "Request timed out after Ns." instead of the generic
- *   "Network error" wrapper.
- * - Other errors retry until the last attempt, then propagate.
+ * Decide what to do with a fetch error. User aborts and an internal
+ * timeout on the last attempt throw immediately; other errors retry
+ * until the last attempt, then propagate.
  */
 function handleFetchError(
   error: unknown,
@@ -467,44 +395,29 @@ function authHeaders(token: string | undefined): Record<string, string> {
   return token ? { authorization: `Bearer ${token}` } : {};
 }
 
-/**
- * Per-attempt `(input, init)` factory.
- *
- * Returns a fresh pair on every invocation so retries never reuse a
- * consumed request body. See the file header comment (CLI-1D6).
- */
 type AttemptInputFactory = () => {
   input: Request | string | URL;
   init: RequestInit | undefined;
 };
 
 /**
- * Build an attempt factory that yields a fresh, body-readable `(input, init)`
- * pair per retry.
+ * Build an attempt factory that yields a fresh, body-readable
+ * `(input, init)` pair per retry. `fetch` consumes a request body on
+ * attempt 1; without this cloning every retry after a timeout / 5xx /
+ * 401-refresh would throw `TypeError: Request body already used` (CLI-1D6).
  *
- * The SDK calls our authenticated fetch with a `Request` object whose body
- * is a stream that fetch consumes on the first attempt; our own
- * `apiRequestToRegion`/`rawApiRequest` call it with a string URL and a
- * primitive `init.body` (typically a JSON string). Both shapes need
- * different treatment:
- *
- * - **Request input**: clone per attempt. `Request.clone()` tees the body
- *   stream so each retry gets an independent readable copy.
- * - **String/URL input + primitive body** (string, ArrayBuffer, TypedArray,
- *   or no body): already re-usable; pass through unchanged. This is the
- *   hot path for all of our non-SDK call sites — no allocation on retry.
- * - **Stream/Blob/FormData body**: materialize once to an ArrayBuffer so
- *   subsequent attempts read the same bytes. Defensive path; currently
- *   unused by our call sites but keeps the invariant airtight.
+ * `Request` inputs clone per attempt; primitive bodies (string /
+ * ArrayBuffer / TypedArray / none) pass through — the hot path for all
+ * non-SDK call sites. Streams / Blobs / FormData are drained once to an
+ * ArrayBuffer so subsequent attempts see the same bytes.
  */
 async function buildAttemptFactory(
   input: Request | string | URL,
   init: RequestInit | undefined
 ): Promise<AttemptInputFactory> {
   if (input instanceof Request) {
-    // Cast mirrors the cacheResponse pattern: Bun's `Request` adds
-    // toJSON/count/getAll that the DOM lib's Request type doesn't carry
-    // through `.clone()`, but at runtime the clone is a fully-usable Request.
+    // Cast: Bun's `Request` has extras (toJSON/count/getAll) that `.clone()`
+    // drops from the DOM type — runtime shape is unaffected.
     return () => ({ input: input.clone() as unknown as Request, init });
   }
 
@@ -519,11 +432,6 @@ async function buildAttemptFactory(
     return () => ({ input, init });
   }
 
-  // Stream / Blob / FormData / URLSearchParams — drain once to an ArrayBuffer
-  // so every retry attempt can reuse the same bytes. `new Response(body)`
-  // accepts every valid BodyInit and normalizes to an ArrayBuffer. The cast
-  // is needed because `BodyInit` isn't globally available without the DOM
-  // lib, but at runtime any valid `RequestInit.body` is a valid `BodyInit`.
   const snapshot = await new Response(
     body as ConstructorParameters<typeof Response>[0]
   ).arrayBuffer();
@@ -779,25 +687,14 @@ export function resetAuthenticatedFetch(): void {
   cachedFetch = null;
 }
 
-/**
- * Resolve the effective per-request timeout for a URL.
- *
- * Exported for tests and for introspection. The 30 s default is returned
- * unless the URL matches an {@link ENDPOINT_TIMEOUT_OVERRIDES} pattern.
- */
-export function getRequestTimeoutMs(fullUrl: string): number {
+/** @internal Test-only — see {@link ENDPOINT_TIMEOUT_OVERRIDES}. */
+export function __resolveRequestTimeoutMsForTests(fullUrl: string): number {
   return resolveTimeoutMs(fullUrl);
 }
 
 /**
- * Test-only helper: temporarily prepend a timeout override and return a
- * disposer that restores the original list.
- *
- * Lets tests exercise the real timeout → `TimeoutError` path without
- * having to wait 30 s for the default timeout to fire. Prepended (not
- * appended) so the injected pattern always wins over existing entries.
- *
- * @internal
+ * @internal Test-only — temporarily prepend a timeout override. The returned
+ * disposer restores the original list.
  */
 export function __injectTimeoutOverrideForTests(
   override: TimeoutOverride

--- a/src/lib/sentry-client.ts
+++ b/src/lib/sentry-client.ts
@@ -406,10 +406,14 @@ type AttemptInputFactory = () => {
  * attempt 1; without this cloning every retry after a timeout / 5xx /
  * 401-refresh would throw `TypeError: Request body already used` (CLI-1D6).
  *
- * `Request` inputs clone per attempt; primitive bodies (string /
- * ArrayBuffer / TypedArray / none) pass through — the hot path for all
- * non-SDK call sites. Streams / Blobs / FormData are drained once to an
- * ArrayBuffer so subsequent attempts see the same bytes.
+ * `Request` inputs clone per attempt. Bodies that `fetch` re-reads on
+ * each call (string / ArrayBuffer / TypedArray / Blob / FormData /
+ * URLSearchParams / none) pass through unchanged — this is the hot path
+ * for every non-SDK call site, and importantly preserves the auto-
+ * negotiated `Content-Type: multipart/form-data; boundary=...` header
+ * that `fetch` derives from `FormData` bodies (sourcemap chunk upload).
+ * A bare `ReadableStream` is the only single-use body shape, so it's
+ * drained once to an `ArrayBuffer`.
  */
 async function buildAttemptFactory(
   input: Request | string | URL,
@@ -422,20 +426,12 @@ async function buildAttemptFactory(
   }
 
   const body = init?.body;
-  if (
-    body === undefined ||
-    body === null ||
-    typeof body === "string" ||
-    body instanceof ArrayBuffer ||
-    ArrayBuffer.isView(body)
-  ) {
-    return () => ({ input, init });
+  if (body instanceof ReadableStream) {
+    const snapshot = await new Response(body).arrayBuffer();
+    return () => ({ input, init: { ...init, body: snapshot } });
   }
 
-  const snapshot = await new Response(
-    body as ConstructorParameters<typeof Response>[0]
-  ).arrayBuffer();
-  return () => ({ input, init: { ...init, body: snapshot } });
+  return () => ({ input, init });
 }
 
 /**

--- a/test/lib/sentry-client.test.ts
+++ b/test/lib/sentry-client.test.ts
@@ -161,6 +161,61 @@ describe("fetchWithRetry / buildAttemptFactory", () => {
     expect(callCount).toBe(2);
     expect(seen).toEqual(["streamed-body", "streamed-body"]);
   });
+
+  test("retries a FormData body without losing the multipart boundary", async () => {
+    // Regression for a Cursor Bugbot finding: materializing FormData to
+    // an ArrayBuffer drops the auto-negotiated
+    // `Content-Type: multipart/form-data; boundary=...` header that
+    // `fetch` derives from the FormData body. Sourcemap chunk upload
+    // (src/lib/api/sourcemaps.ts) sends FormData through this path;
+    // without correct handling even the first upload attempt fails.
+    let callCount = 0;
+    const contentTypes: (string | null)[] = [];
+    const bodies: string[] = [];
+
+    globalThis.fetch = mockFetch(async (input, init) => {
+      callCount += 1;
+      const req = new Request(input as string, init);
+      contentTypes.push(req.headers.get("content-type"));
+      bodies.push(await req.text());
+      if (callCount === 1) {
+        return new Response("retry me", { status: 503 });
+      }
+      return new Response("", { status: 200 });
+    });
+
+    const form = new FormData();
+    form.append(
+      "file",
+      new Blob([new Uint8Array([1, 2, 3, 4])], {
+        type: "application/octet-stream",
+      }),
+      "chunk.bin"
+    );
+
+    const authFetch = getAuthenticatedFetch();
+    const res = await authFetch("https://us.sentry.io/api/0/chunks/", {
+      method: "POST",
+      body: form,
+    });
+
+    expect(res.status).toBe(200);
+    expect(callCount).toBe(2);
+    // Both attempts must carry a well-formed multipart Content-Type.
+    // Bun picks a fresh boundary per serialization, so the two
+    // headers differ — the invariant is that each attempt's
+    // header+body is internally consistent, and that
+    // Content-Type is never lost to a raw `application/octet-stream`
+    // or missing header (the pre-fix failure mode).
+    for (const ct of contentTypes) {
+      expect(ct).toMatch(/^multipart\/form-data; boundary=.+/u);
+    }
+    // And both attempts carried the same FormData contents.
+    for (const body of bodies) {
+      expect(body).toContain('name="file"');
+      expect(body).toContain("chunk.bin");
+    }
+  });
 });
 
 describe("fetchWithTimeout internal timeout classification", () => {

--- a/test/lib/sentry-client.test.ts
+++ b/test/lib/sentry-client.test.ts
@@ -1,17 +1,6 @@
 /**
- * Sentry Client Tests (CLI-1D6 regression coverage)
- *
- * Covers the retry-safety + timeout-classification invariants:
- *
- * 1. Body-reuse: POST retries re-send the request body (previously threw
- *    `TypeError: Request body already used` on every retry).
- * 2. Internal timeout: our per-request AbortController firing produces a
- *    `TimeoutError` with a clear message, not an opaque "Network error".
- * 3. User aborts: external abort signals propagate unchanged.
- * 4. Per-endpoint timeout override: `/autofix/` (and any future entries)
- *    get the configured longer budget; default paths keep the 30 s ceiling.
- * 5. Retry-after-5xx reuses the body.
- * 6. 401 refresh still marks the retry and succeeds.
+ * Tests for the authenticated fetch retry + timeout behavior — CLI-1D6
+ * regression coverage.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -19,7 +8,7 @@ import { setAuthToken } from "../../src/lib/db/auth.js";
 import { TimeoutError } from "../../src/lib/errors.js";
 import {
   __injectTimeoutOverrideForTests,
-  getRequestTimeoutMs,
+  __resolveRequestTimeoutMsForTests,
   getSdkConfig,
   resetAuthenticatedFetch,
 } from "../../src/lib/sentry-client.js";
@@ -32,8 +21,7 @@ const REGION_URL = "https://us.sentry.io";
 
 beforeEach(async () => {
   originalFetch = globalThis.fetch;
-  // Store a non-expiring token so refreshToken() is a no-op and won't hit
-  // the network during tests (see db/auth.ts: expiresAt === null → no refresh).
+  // Non-expiring token — refreshToken() becomes a no-op.
   await setAuthToken("test-token");
   resetAuthenticatedFetch();
 });
@@ -43,14 +31,9 @@ afterEach(() => {
   resetAuthenticatedFetch();
 });
 
-/** Build the authenticated fetch by way of the public SDK config API. */
 function getAuthenticatedFetch(): typeof fetch {
   return getSdkConfig(REGION_URL).fetch as typeof fetch;
 }
-
-// ============================================================================
-// 1. Body-reuse regression (CLI-1D6 root cause)
-// ============================================================================
 
 describe("fetchWithRetry / buildAttemptFactory", () => {
   test("retries a POST with a string body without re-consuming the body", async () => {
@@ -59,8 +42,6 @@ describe("fetchWithRetry / buildAttemptFactory", () => {
 
     globalThis.fetch = mockFetch(async (_input, init) => {
       callCount += 1;
-      // Read the body bytes on every attempt — the whole point of the fix
-      // is that each retry sees a fresh, readable body.
       const body = init?.body;
       if (typeof body === "string") {
         seen.push(body);
@@ -69,7 +50,6 @@ describe("fetchWithRetry / buildAttemptFactory", () => {
       } else {
         seen.push("<empty>");
       }
-      // First attempt fails with retryable 503, second succeeds.
       if (callCount === 1) {
         return new Response("busy", { status: 503 });
       }
@@ -88,7 +68,6 @@ describe("fetchWithRetry / buildAttemptFactory", () => {
 
     expect(res.status).toBe(200);
     expect(callCount).toBe(2);
-    // Every attempt saw the full body bytes — no "already used" errors.
     expect(seen).toEqual([
       JSON.stringify({ slug: "acme" }),
       JSON.stringify({ slug: "acme" }),
@@ -96,9 +75,8 @@ describe("fetchWithRetry / buildAttemptFactory", () => {
   });
 
   test("retries a POST built from a Request object without consuming its body", async () => {
-    // The SDK path: @sentry/api constructs a Request and hands it to our
-    // authenticatedFetch as the sole argument. Previously the second
-    // attempt would call fetch(sameRequest) with a consumed body stream.
+    // SDK path: @sentry/api hands us a Request as the sole argument.
+    // Pre-fix: attempt 2 saw a consumed body stream.
     let callCount = 0;
     const seen: string[] = [];
 
@@ -137,9 +115,8 @@ describe("fetchWithRetry / buildAttemptFactory", () => {
   });
 
   test("retries with a ReadableStream body by materializing once", async () => {
-    // Defensive coverage for the "stream / Blob / FormData" branch of
-    // buildAttemptFactory: streams are consumed on first read, so without
-    // up-front materialization the second attempt would see undefined.
+    // Streams are consumed on first read; without up-front materialization
+    // attempt 2 would see an undefined body.
     let callCount = 0;
     const seen: string[] = [];
 
@@ -172,12 +149,11 @@ describe("fetchWithRetry / buildAttemptFactory", () => {
     });
 
     const authFetch = getAuthenticatedFetch();
+    // Node's fetch requires duplex: "half" for streamed bodies; Bun accepts
+    // it as a no-op.
     const res = await authFetch("https://us.sentry.io/api/0/streamed/", {
       method: "POST",
       body: stream,
-      // `fetch` requires duplex: "half" for streamed bodies on Node; Bun
-      // accepts it as a no-op, so set it unconditionally to keep both
-      // runtimes happy.
       duplex: "half",
     } as RequestInit & { duplex?: string });
 
@@ -187,26 +163,18 @@ describe("fetchWithRetry / buildAttemptFactory", () => {
   });
 });
 
-// ============================================================================
-// 2. Internal timeout classification
-// ============================================================================
-
 describe("fetchWithTimeout internal timeout classification", () => {
   test("surfaces TimeoutError on the last attempt when our own timeout fires", async () => {
-    // Inject a tiny timeout for a test-only path so we don't wait 30 s.
-    // Matches /___timeout-test___/; the restore() cleans up in finally.
+    // Inject a tiny timeout so we don't wait 30 s for the default to fire.
     const restore = __injectTimeoutOverrideForTests({
       pattern: /\/___timeout-test___\//,
       timeoutMs: 50,
-      reason: "unit-test: force quick timeout",
     });
 
     try {
       let calls = 0;
       globalThis.fetch = mockFetch(async (_input, init) => {
         calls += 1;
-        // Hang until the caller aborts. We return a promise that only
-        // rejects when the signal fires.
         return await new Promise<Response>((_resolve, reject) => {
           const signal = init?.signal;
           if (!signal) {
@@ -237,17 +205,13 @@ describe("fetchWithTimeout internal timeout classification", () => {
       expect((thrown as TimeoutError).message).toContain(
         "Request timed out after"
       );
-      // All 3 attempts should have fired (MAX_RETRIES = 2 → attempts 0,1,2).
+      // MAX_RETRIES = 2 → attempts 0, 1, 2.
       expect(calls).toBe(3);
     } finally {
       restore();
     }
   });
 });
-
-// ============================================================================
-// 3. User abort passthrough
-// ============================================================================
 
 describe("user abort passthrough", () => {
   test("external AbortSignal.abort() propagates the original AbortError", async () => {
@@ -273,7 +237,6 @@ describe("user abort passthrough", () => {
     const promise = authFetch("https://us.sentry.io/api/0/organizations/", {
       signal: controller.signal,
     });
-    // Schedule the abort after the fetch is in flight.
     setTimeout(() => controller.abort(), 10);
 
     let thrown: unknown;
@@ -284,34 +247,27 @@ describe("user abort passthrough", () => {
     }
 
     expect(fetchCalled).toBe(true);
-    // The user abort produces a plain AbortError — NOT a TimeoutError and
-    // NOT an ApiError. The central error handler in app.ts relies on the
-    // original DOMException surviving.
+    // User aborts must propagate unchanged — neither a TimeoutError nor an
+    // ApiError wrapper. The central error handler in app.ts depends on it.
     expect(thrown).toBeInstanceOf(DOMException);
     expect((thrown as DOMException).name).toBe("AbortError");
   });
 });
 
-// ============================================================================
-// 4. Per-endpoint timeout override
-// ============================================================================
-
-describe("getRequestTimeoutMs", () => {
+describe("resolveTimeoutMs", () => {
   test("returns 120 000 ms for Seer /autofix/ POST paths", () => {
     expect(
-      getRequestTimeoutMs(
+      __resolveRequestTimeoutMsForTests(
         "https://us.sentry.io/api/0/organizations/acme/issues/1/autofix/"
       )
     ).toBe(120_000);
-    // Trailing query params shouldn't break matching.
     expect(
-      getRequestTimeoutMs(
+      __resolveRequestTimeoutMsForTests(
         "https://us.sentry.io/api/0/organizations/acme/issues/1/autofix/?run_id=42"
       )
     ).toBe(120_000);
-    // Without trailing slash.
     expect(
-      getRequestTimeoutMs(
+      __resolveRequestTimeoutMsForTests(
         "https://us.sentry.io/api/0/organizations/acme/issues/1/autofix"
       )
     ).toBe(120_000);
@@ -319,89 +275,20 @@ describe("getRequestTimeoutMs", () => {
 
   test("returns the 30 000 ms default for non-overridden paths", () => {
     expect(
-      getRequestTimeoutMs("https://us.sentry.io/api/0/organizations/")
+      __resolveRequestTimeoutMsForTests(
+        "https://us.sentry.io/api/0/organizations/"
+      )
     ).toBe(30_000);
     expect(
-      getRequestTimeoutMs("https://us.sentry.io/api/0/issues/1/events/")
+      __resolveRequestTimeoutMsForTests(
+        "https://us.sentry.io/api/0/issues/1/events/"
+      )
     ).toBe(30_000);
-    // Paths that only contain "autofix" as a substring of another segment
-    // should NOT inherit the override.
+    // Substring-only matches must not inherit the override.
     expect(
-      getRequestTimeoutMs("https://us.sentry.io/api/0/autofixation-report/")
+      __resolveRequestTimeoutMsForTests(
+        "https://us.sentry.io/api/0/autofixation-report/"
+      )
     ).toBe(30_000);
-  });
-
-  test("survives unparseable URLs by matching the raw string", () => {
-    // Not a real URL, but defensive: a caller that somehow bypasses the
-    // usual URL construction shouldn't crash the timeout lookup.
-    expect(getRequestTimeoutMs("///bad:/autofix/")).toBe(120_000);
-  });
-});
-
-// ============================================================================
-// 5. Retry marker on 401 refresh
-// ============================================================================
-
-describe("401 refresh path", () => {
-  test("marks the retried request with x-sentry-cli-retry and reuses the body", async () => {
-    let callCount = 0;
-    const retryMarkers: (string | null)[] = [];
-    const bodies: string[] = [];
-
-    globalThis.fetch = mockFetch(async (input, init) => {
-      callCount += 1;
-      retryMarkers.push(
-        init?.headers
-          ? new Headers(init.headers).get("x-sentry-cli-retry")
-          : null
-      );
-      if (input instanceof Request) {
-        bodies.push(await input.clone().text());
-      } else if (typeof init?.body === "string") {
-        bodies.push(init.body);
-      } else {
-        bodies.push("<none>");
-      }
-
-      if (callCount === 1) {
-        return new Response(JSON.stringify({ detail: "auth" }), {
-          status: 401,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-      return new Response(JSON.stringify({ ok: true }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-    });
-
-    // Seed a token with a refresh_token + short expiry so handleUnauthorized
-    // triggers performTokenRefresh. Refresh itself would hit the network,
-    // so we intercept it by observing that the retry marker gets set
-    // *regardless* of refresh success — failure just returns the 401.
-    // Here we verify the simpler invariant: the body is present on the
-    // retry attempt if one occurs, which is covered by token-refresh path.
-    //
-    // Since token refresh in this test would need to hit the OAuth server,
-    // we instead assert the non-refresh branch: no refresh_token → 401
-    // propagates as 200 from the second attempt isn't reached. So this
-    // test doubles as a guard that a 401 without a refresh-token terminates
-    // without mangling the body.
-    const authFetch = getAuthenticatedFetch();
-    const res = await authFetch("https://us.sentry.io/api/0/organizations/", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ hello: "world" }),
-    });
-
-    // Without a refresh_token, refresh fails and the 401 is returned to
-    // the caller (single attempt; no retry). If this ever changes to
-    // exercise the refresh loop, the body check below still holds.
-    expect(res.status).toBe(401);
-    expect(callCount).toBe(1);
-    // The single attempt saw the full request body.
-    expect(bodies).toEqual([JSON.stringify({ hello: "world" })]);
-    // No retry marker on the first attempt.
-    expect(retryMarkers[0]).toBeNull();
   });
 });

--- a/test/lib/sentry-client.test.ts
+++ b/test/lib/sentry-client.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Sentry Client Tests (CLI-1D6 regression coverage)
+ *
+ * Covers the retry-safety + timeout-classification invariants:
+ *
+ * 1. Body-reuse: POST retries re-send the request body (previously threw
+ *    `TypeError: Request body already used` on every retry).
+ * 2. Internal timeout: our per-request AbortController firing produces a
+ *    `TimeoutError` with a clear message, not an opaque "Network error".
+ * 3. User aborts: external abort signals propagate unchanged.
+ * 4. Per-endpoint timeout override: `/autofix/` (and any future entries)
+ *    get the configured longer budget; default paths keep the 30 s ceiling.
+ * 5. Retry-after-5xx reuses the body.
+ * 6. 401 refresh still marks the retry and succeeds.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { setAuthToken } from "../../src/lib/db/auth.js";
+import { TimeoutError } from "../../src/lib/errors.js";
+import {
+  __injectTimeoutOverrideForTests,
+  getRequestTimeoutMs,
+  getSdkConfig,
+  resetAuthenticatedFetch,
+} from "../../src/lib/sentry-client.js";
+import { mockFetch, useTestConfigDir } from "../helpers.js";
+
+useTestConfigDir("sentry-client-");
+
+let originalFetch: typeof globalThis.fetch;
+const REGION_URL = "https://us.sentry.io";
+
+beforeEach(async () => {
+  originalFetch = globalThis.fetch;
+  // Store a non-expiring token so refreshToken() is a no-op and won't hit
+  // the network during tests (see db/auth.ts: expiresAt === null → no refresh).
+  await setAuthToken("test-token");
+  resetAuthenticatedFetch();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  resetAuthenticatedFetch();
+});
+
+/** Build the authenticated fetch by way of the public SDK config API. */
+function getAuthenticatedFetch(): typeof fetch {
+  return getSdkConfig(REGION_URL).fetch as typeof fetch;
+}
+
+// ============================================================================
+// 1. Body-reuse regression (CLI-1D6 root cause)
+// ============================================================================
+
+describe("fetchWithRetry / buildAttemptFactory", () => {
+  test("retries a POST with a string body without re-consuming the body", async () => {
+    const seen: string[] = [];
+    let callCount = 0;
+
+    globalThis.fetch = mockFetch(async (_input, init) => {
+      callCount += 1;
+      // Read the body bytes on every attempt — the whole point of the fix
+      // is that each retry sees a fresh, readable body.
+      const body = init?.body;
+      if (typeof body === "string") {
+        seen.push(body);
+      } else if (body) {
+        seen.push(await new Response(body as BodyInit).text());
+      } else {
+        seen.push("<empty>");
+      }
+      // First attempt fails with retryable 503, second succeeds.
+      if (callCount === 1) {
+        return new Response("busy", { status: 503 });
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const authFetch = getAuthenticatedFetch();
+    const res = await authFetch("https://us.sentry.io/api/0/organizations/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ slug: "acme" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(callCount).toBe(2);
+    // Every attempt saw the full body bytes — no "already used" errors.
+    expect(seen).toEqual([
+      JSON.stringify({ slug: "acme" }),
+      JSON.stringify({ slug: "acme" }),
+    ]);
+  });
+
+  test("retries a POST built from a Request object without consuming its body", async () => {
+    // The SDK path: @sentry/api constructs a Request and hands it to our
+    // authenticatedFetch as the sole argument. Previously the second
+    // attempt would call fetch(sameRequest) with a consumed body stream.
+    let callCount = 0;
+    const seen: string[] = [];
+
+    globalThis.fetch = mockFetch(async (input) => {
+      callCount += 1;
+      if (input instanceof Request) {
+        seen.push(await input.clone().text());
+      } else {
+        seen.push("<non-request>");
+      }
+      if (callCount === 1) {
+        return new Response("gateway", { status: 502 });
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const payload = JSON.stringify({ stopping_point: "root_cause" });
+    const request = new Request(
+      "https://us.sentry.io/api/0/organizations/acme/issues/1/autofix/",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: payload,
+      }
+    );
+
+    const authFetch = getAuthenticatedFetch();
+    const res = await authFetch(request);
+
+    expect(res.status).toBe(200);
+    expect(callCount).toBe(2);
+    expect(seen).toEqual([payload, payload]);
+  });
+
+  test("retries with a ReadableStream body by materializing once", async () => {
+    // Defensive coverage for the "stream / Blob / FormData" branch of
+    // buildAttemptFactory: streams are consumed on first read, so without
+    // up-front materialization the second attempt would see undefined.
+    let callCount = 0;
+    const seen: string[] = [];
+
+    globalThis.fetch = mockFetch(async (_input, init) => {
+      callCount += 1;
+      const body = init?.body;
+      if (body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
+        seen.push(new TextDecoder().decode(body as ArrayBuffer));
+      } else if (typeof body === "string") {
+        seen.push(body);
+      } else if (body) {
+        seen.push(await new Response(body as BodyInit).text());
+      } else {
+        seen.push("<empty>");
+      }
+      if (callCount === 1) {
+        return new Response("", { status: 500 });
+      }
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("streamed-body"));
+        controller.close();
+      },
+    });
+
+    const authFetch = getAuthenticatedFetch();
+    const res = await authFetch("https://us.sentry.io/api/0/streamed/", {
+      method: "POST",
+      body: stream,
+      // `fetch` requires duplex: "half" for streamed bodies on Node; Bun
+      // accepts it as a no-op, so set it unconditionally to keep both
+      // runtimes happy.
+      duplex: "half",
+    } as RequestInit & { duplex?: string });
+
+    expect(res.status).toBe(200);
+    expect(callCount).toBe(2);
+    expect(seen).toEqual(["streamed-body", "streamed-body"]);
+  });
+});
+
+// ============================================================================
+// 2. Internal timeout classification
+// ============================================================================
+
+describe("fetchWithTimeout internal timeout classification", () => {
+  test("surfaces TimeoutError on the last attempt when our own timeout fires", async () => {
+    // Inject a tiny timeout for a test-only path so we don't wait 30 s.
+    // Matches /___timeout-test___/; the restore() cleans up in finally.
+    const restore = __injectTimeoutOverrideForTests({
+      pattern: /\/___timeout-test___\//,
+      timeoutMs: 50,
+      reason: "unit-test: force quick timeout",
+    });
+
+    try {
+      let calls = 0;
+      globalThis.fetch = mockFetch(async (_input, init) => {
+        calls += 1;
+        // Hang until the caller aborts. We return a promise that only
+        // rejects when the signal fires.
+        return await new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (!signal) {
+            reject(new Error("no signal provided — test bug"));
+            return;
+          }
+          if (signal.aborted) {
+            reject(new DOMException("aborted", "AbortError"));
+            return;
+          }
+          signal.addEventListener(
+            "abort",
+            () => reject(new DOMException("aborted", "AbortError")),
+            { once: true }
+          );
+        });
+      });
+
+      const authFetch = getAuthenticatedFetch();
+      let thrown: unknown;
+      try {
+        await authFetch("https://us.sentry.io/___timeout-test___/");
+      } catch (err) {
+        thrown = err;
+      }
+
+      expect(thrown).toBeInstanceOf(TimeoutError);
+      expect((thrown as TimeoutError).message).toContain(
+        "Request timed out after"
+      );
+      // All 3 attempts should have fired (MAX_RETRIES = 2 → attempts 0,1,2).
+      expect(calls).toBe(3);
+    } finally {
+      restore();
+    }
+  });
+});
+
+// ============================================================================
+// 3. User abort passthrough
+// ============================================================================
+
+describe("user abort passthrough", () => {
+  test("external AbortSignal.abort() propagates the original AbortError", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = mockFetch(async (_input, init) => {
+      fetchCalled = true;
+      return await new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (signal?.aborted) {
+          reject(new DOMException("aborted", "AbortError"));
+          return;
+        }
+        signal?.addEventListener(
+          "abort",
+          () => reject(new DOMException("aborted", "AbortError")),
+          { once: true }
+        );
+      });
+    });
+
+    const controller = new AbortController();
+    const authFetch = getAuthenticatedFetch();
+    const promise = authFetch("https://us.sentry.io/api/0/organizations/", {
+      signal: controller.signal,
+    });
+    // Schedule the abort after the fetch is in flight.
+    setTimeout(() => controller.abort(), 10);
+
+    let thrown: unknown;
+    try {
+      await promise;
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(fetchCalled).toBe(true);
+    // The user abort produces a plain AbortError — NOT a TimeoutError and
+    // NOT an ApiError. The central error handler in app.ts relies on the
+    // original DOMException surviving.
+    expect(thrown).toBeInstanceOf(DOMException);
+    expect((thrown as DOMException).name).toBe("AbortError");
+  });
+});
+
+// ============================================================================
+// 4. Per-endpoint timeout override
+// ============================================================================
+
+describe("getRequestTimeoutMs", () => {
+  test("returns 120 000 ms for Seer /autofix/ POST paths", () => {
+    expect(
+      getRequestTimeoutMs(
+        "https://us.sentry.io/api/0/organizations/acme/issues/1/autofix/"
+      )
+    ).toBe(120_000);
+    // Trailing query params shouldn't break matching.
+    expect(
+      getRequestTimeoutMs(
+        "https://us.sentry.io/api/0/organizations/acme/issues/1/autofix/?run_id=42"
+      )
+    ).toBe(120_000);
+    // Without trailing slash.
+    expect(
+      getRequestTimeoutMs(
+        "https://us.sentry.io/api/0/organizations/acme/issues/1/autofix"
+      )
+    ).toBe(120_000);
+  });
+
+  test("returns the 30 000 ms default for non-overridden paths", () => {
+    expect(
+      getRequestTimeoutMs("https://us.sentry.io/api/0/organizations/")
+    ).toBe(30_000);
+    expect(
+      getRequestTimeoutMs("https://us.sentry.io/api/0/issues/1/events/")
+    ).toBe(30_000);
+    // Paths that only contain "autofix" as a substring of another segment
+    // should NOT inherit the override.
+    expect(
+      getRequestTimeoutMs("https://us.sentry.io/api/0/autofixation-report/")
+    ).toBe(30_000);
+  });
+
+  test("survives unparseable URLs by matching the raw string", () => {
+    // Not a real URL, but defensive: a caller that somehow bypasses the
+    // usual URL construction shouldn't crash the timeout lookup.
+    expect(getRequestTimeoutMs("///bad:/autofix/")).toBe(120_000);
+  });
+});
+
+// ============================================================================
+// 5. Retry marker on 401 refresh
+// ============================================================================
+
+describe("401 refresh path", () => {
+  test("marks the retried request with x-sentry-cli-retry and reuses the body", async () => {
+    let callCount = 0;
+    const retryMarkers: (string | null)[] = [];
+    const bodies: string[] = [];
+
+    globalThis.fetch = mockFetch(async (input, init) => {
+      callCount += 1;
+      retryMarkers.push(
+        init?.headers
+          ? new Headers(init.headers).get("x-sentry-cli-retry")
+          : null
+      );
+      if (input instanceof Request) {
+        bodies.push(await input.clone().text());
+      } else if (typeof init?.body === "string") {
+        bodies.push(init.body);
+      } else {
+        bodies.push("<none>");
+      }
+
+      if (callCount === 1) {
+        return new Response(JSON.stringify({ detail: "auth" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    // Seed a token with a refresh_token + short expiry so handleUnauthorized
+    // triggers performTokenRefresh. Refresh itself would hit the network,
+    // so we intercept it by observing that the retry marker gets set
+    // *regardless* of refresh success — failure just returns the 401.
+    // Here we verify the simpler invariant: the body is present on the
+    // retry attempt if one occurs, which is covered by token-refresh path.
+    //
+    // Since token refresh in this test would need to hit the OAuth server,
+    // we instead assert the non-refresh branch: no refresh_token → 401
+    // propagates as 200 from the second attempt isn't reached. So this
+    // test doubles as a guard that a 401 without a refresh-token terminates
+    // without mangling the body.
+    const authFetch = getAuthenticatedFetch();
+    const res = await authFetch("https://us.sentry.io/api/0/organizations/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ hello: "world" }),
+    });
+
+    // Without a refresh_token, refresh fails and the 401 is returned to
+    // the caller (single attempt; no retry). If this ever changes to
+    // exercise the refresh loop, the body check below still holds.
+    expect(res.status).toBe(401);
+    expect(callCount).toBe(1);
+    // The single attempt saw the full request body.
+    expect(bodies).toEqual([JSON.stringify({ hello: "world" })]);
+    // No retry marker on the first attempt.
+    expect(retryMarkers[0]).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes CLI-1D6. The authenticated fetch retry loop reused the same `(input, init)` pair across attempts; any `Request` with a body (SDK path) or a `ReadableStream` `init.body` had its body consumed on attempt 1, so every retry after a timeout/5xx/401-refresh failed with `TypeError: Request body already used`. That bubbled up as the misleading `ApiError: Unable to reach Sentry API. Cause: Request body already used` — seen in the wild on a `POST /autofix/` that timed out at 30s and couldn't retry.

## Changes

All in `src/lib/sentry-client.ts`:

1. **Body re-use fix** — `buildAttemptFactory` yields a fresh `(input, init)` per attempt:
   - `Request` input → `request.clone()` per attempt (teed body stream).
   - `ReadableStream` body → materialized once to an `ArrayBuffer` (single-use shape).
   - Everything else (string / `ArrayBuffer` / `TypedArray` / `Blob` / `FormData` / `URLSearchParams` / none) passes through unchanged. `fetch` re-serializes these on every call, and re-serialization is **required** for `FormData` so the auto-negotiated `Content-Type: multipart/form-data; boundary=...` header is regenerated (used by sourcemap chunk upload).

2. **Internal-timeout classification** — Our per-request `setTimeout`-triggered abort now tags the caught error with a `Symbol` marker plus `timeoutMs`. `handleFetchError` surfaces a `TimeoutError` with `"Request timed out after Ns."` + actionable hint on the last attempt instead of the opaque "Network error" wrapper. User aborts (external signal) still propagate the original `AbortError` unchanged.

3. **Per-endpoint timeout allowlist** — `ENDPOINT_TIMEOUT_OVERRIDES` table. Seer `/autofix/` POSTs trigger server-side root-cause analysis that can take ~2 minutes; they now get 120s. Default stays 30s. Adding new slow endpoints is a one-line change.

No caller changes needed — `TimeoutError` and `ApiError` both extend `CliError`, so the central error handler and existing `instanceof ApiError` branches in `explain.ts` / `plan.ts` keep working.

## User-facing effect

Before: `sentry issue explain <issue>` against a Seer-slow backend produced `ApiError: Unable to reach Sentry API. Cause: Request body already used` after ~33s (30s timeout + 3s retry backoff that always failed).

After: the request either succeeds thanks to the 120s budget, or produces a clean `TimeoutError: Request timed out after 120s.` with a link to https://status.sentry.io.

## Tests

New `test/lib/sentry-client.test.ts` — first test coverage this file has had. 8 tests:

- Retry-after-5xx reuses a string body.
- Retry-after-5xx reuses a `Request` body (SDK path, was CLI-1D6 root cause).
- Retry-after-5xx reuses a `ReadableStream` body via one-time materialization.
- Retry-after-5xx preserves the multipart `Content-Type` on a `FormData` body (regression from Cursor Bugbot finding on 78dea18).
- Internal timeout surfaces as `TimeoutError` after exhausting retries (uses `__injectTimeoutOverrideForTests` so the test doesn't wait 30s).
- External abort still propagates the original `AbortError` unchanged.
- `resolveTimeoutMs` returns 120_000 for `/autofix/` paths (with/without trailing slash, with query params).
- `resolveTimeoutMs` returns 30_000 for non-overridden paths, including substring false-positives like `/autofixation-report/`.

## Verification

- `bunx tsc --noEmit` — clean
- `bun run lint` — clean (one pre-existing warning in `markdown.ts`, unrelated)
- `bun test test/lib/sentry-client.test.ts` — 8/8 pass
- `bun test test/lib/api/ test/commands/issue/` — broader suite green

## Notes

- AGENTS.md churn from this branch is deliberately excluded — it belongs to separate lore-commits.
- The hot path (string body via `apiRequestToRegion` / `rawApiRequest`) is allocation-free on retry — no regressions for the typical call.
- Cursor Bugbot caught a real regression on the first iteration: materializing `FormData` stripped the multipart boundary. Fixed in f659777 by narrowing the materialization branch to just `ReadableStream`.