### PR TITLE
fix(init): release stdin handle to unblock event loop on wizard exit

### DIFF
--- a/src/lib/init/stdin-reopen.ts
+++ b/src/lib/init/stdin-reopen.ts
@@ -291,6 +291,25 @@ export function closeFreshTtyForwarding(): void {
   stdinHandle.resume = original.resume;
   stdinHandle._read = original.read;
 
+  // Release the libuv handle on fd 0. Clack's prompt lifecycle relies on
+  // `rl.close() → rl.pause() → this.input.pause()` to pause stdin, but we
+  // replaced `process.stdin.pause` with a no-op at install time (needed to
+  // dodge Bun's fd-0 EINVAL on pause/resume transitions — see the comment
+  // at the install site). So by the time we get here, stdin is still in
+  // flowing/ref'd mode from `readline.createInterface()`'s internal
+  // `input.resume()` — which keeps the libuv event loop alive indefinitely
+  // after the wizard returns, manifesting as a post-wizard hang until the
+  // user presses a key. Now that the original `.pause()` is restored,
+  // invoke it directly so stock Node/Bun cleanup can finish. Idempotent:
+  // safe when stdin was already paused.
+  try {
+    original.pause.call(process.stdin);
+  } catch {
+    // Defensive: swallow errors from runtimes that throw if stdin is
+    // already destroyed. This is end-of-lifecycle cleanup; nothing
+    // downstream needs stdin.
+  }
+
   if (backfilledIsTty) {
     Object.defineProperty(process.stdin, "isTTY", {
       value: previousIsTty,

--- a/test/lib/init/stdin-reopen.test.ts
+++ b/test/lib/init/stdin-reopen.test.ts
@@ -318,6 +318,94 @@ describe("forwardFreshTtyToStdin → closeFreshTtyForwarding round trip", () => 
     // was set (covers the termios-restore try/catch).
     expect(() => closeFreshTtyForwarding()).not.toThrow();
   });
+
+  test("teardown invokes restored pause to release stdin handle", () => {
+    // Regression for CLI-1DD: post-wizard `sentry init` hang. Our no-op
+    // pause patch (installed to dodge Bun's fd-0 EINVAL) silently
+    // swallowed clack's `rl.close() → input.pause()` call, leaving stdin
+    // ref'd. Teardown must invoke the restored original so the libuv
+    // event loop can drain.
+    const { fd } = makePtmxFd();
+
+    // Replace the beforeEach stub with a counting spy BEFORE install so
+    // the install captures it as `original.pause`.
+    let pauseCalls = 0;
+    const pauseSpy = (): NodeJS.ReadStream => {
+      pauseCalls += 1;
+      return process.stdin;
+    };
+    (process.stdin as unknown as { pause: () => NodeJS.ReadStream }).pause =
+      pauseSpy;
+
+    const handle = forwardFreshTtyToStdin({
+      isTty: () => true,
+      openTty: () => fd,
+    });
+    expect(handle).toBeDefined();
+
+    // During install, process.stdin.pause is the patched no-op — clack's
+    // internal `rl.close() → input.pause()` would hit the no-op and the
+    // spy would never fire. Simulate that:
+    expect(process.stdin.pause).not.toBe(pauseSpy);
+    process.stdin.pause();
+    expect(pauseCalls).toBe(0);
+
+    closeFreshTtyForwarding();
+
+    // After teardown: pause is restored to our spy AND teardown invoked
+    // it exactly once to release the libuv handle.
+    expect(process.stdin.pause).toBe(pauseSpy);
+    expect(pauseCalls).toBe(1);
+  });
+
+  test("stdin is not flowing after teardown (releases event loop)", () => {
+    // Integration regression for CLI-1DD. Observes the actual stream
+    // state transition that blocks the event loop. Without the fix,
+    // `readableFlowing` stays `true` post-teardown and the process hangs
+    // until a keypress.
+    const { fd } = makePtmxFd();
+
+    // Route install's `original.pause` capture at the real
+    // `Readable.prototype.pause`, not the beforeEach no-op stub — so
+    // that invoking it actually transitions `readableFlowing: true → false`.
+    // Same for `.resume()`: used below to simulate clack's implicit flow.
+    const { Readable } = require("node:stream") as typeof import("node:stream");
+    const stdinMut = process.stdin as unknown as {
+      pause: () => NodeJS.ReadStream;
+      resume: () => NodeJS.ReadStream;
+    };
+    stdinMut.pause = Readable.prototype.pause as () => NodeJS.ReadStream;
+    stdinMut.resume = Readable.prototype.resume as () => NodeJS.ReadStream;
+
+    // Put stdin into flowing mode. This is effectively what clack does
+    // indirectly via `readline.createInterface()` → `input.resume()`.
+    process.stdin.resume();
+
+    try {
+      expect(
+        (process.stdin as { readableFlowing?: boolean | null }).readableFlowing
+      ).toBe(true);
+
+      const handle = forwardFreshTtyToStdin({
+        isTty: () => true,
+        openTty: () => fd,
+      });
+      expect(handle).toBeDefined();
+
+      closeFreshTtyForwarding();
+
+      // `readableFlowing` values: null (initial), true (flowing), false
+      // (paused). After teardown we must be NOT true — otherwise the
+      // libuv event loop stays alive.
+      expect(
+        (process.stdin as { readableFlowing?: boolean | null }).readableFlowing
+      ).not.toBe(true);
+    } finally {
+      // Defensive: ensure we don't leak a flowing-mode stdin into the
+      // next test even if an expectation above threw.
+      Readable.prototype.pause.call(process.stdin);
+    }
+  });
 });
 
 describe("using-declaration semantics", () => {


### PR DESCRIPTION
## Summary

At the end of a `sentry init` flow, the process hangs until the user presses a key. Follow-up to #802, #824, #825 — addresses the third and final contributor to the post-wizard hang.

## Root cause

Our no-op patch of `process.stdin.pause` silently swallowed clack's `rl.close() → input.pause()` call. Stdin stayed in flowing/ref'd mode from `readline.createInterface()`'s internal `input.resume()`, keeping the libuv event loop alive until any keypress delivered a `data` event.

### Why the patch was needed

`stdin-reopen.ts` replaces `process.stdin.pause`/`resume` with no-ops at install time to dodge Bun's fd-0 `EINVAL` on pause/resume transitions (see the comment at the install site). That fix is correct and must stay.

### Why the bug was invisible

`rl.close()` is the only place clack ever pauses stdin — it relies entirely on Node's standard readline cleanup discipline. Our no-op patch swallowed every call without any visible error, so there was no log line, no warning, no failed assertion.

### Why PRs #802/#824/#825 didn't catch it

- #802 fixed the `/dev/tty` ReadStream contribution (explicit `.destroy()`).
- #824 adopted `using`/`Symbol.dispose` for guaranteed teardown + termios restore.
- #825 aborted the MastraClient signal to release keep-alive sockets.

Post-teardown state after all three fixes:
- `/dev/tty` ReadStream: destroyed ✓
- MastraClient AbortController: aborted ✓
- **`process.stdin`: still ref'd and flowing ✗** ← the remaining anchor

PR #782's original `process.exit(0)` workaround masked this by killing the process unconditionally. Each subsequent PR peeled off one contributor; stdin was the last one standing.

## Fix

One call to the just-restored `original.pause` at the end of `closeFreshTtyForwarding()`:

```ts
// Release the libuv handle on fd 0. Clack's prompt lifecycle relies on
// `rl.close() → rl.pause() → this.input.pause()` to pause stdin, but we
// replaced `process.stdin.pause` with a no-op at install time... Now that
// the original `.pause()` is restored, invoke it directly so stock
// Node/Bun cleanup can finish. Idempotent: safe when stdin was already
// paused.
try {
  original.pause.call(process.stdin);
} catch {
  // Defensive: swallow errors from runtimes that throw if stdin is
  // already destroyed.
}
```

Rationale for `.pause()` over alternatives:
- Exactly what Node's `rl.close()` would have called — matches clack's implicit contract.
- Idempotent on already-paused streams.
- Doesn't destroy the stream (unlike `.destroy()`); any future code that wanted to read stdin (none does in `init`; it's a terminal command) could still resume.

## Regression tests

Two new tests in `test/lib/init/stdin-reopen.test.ts`:

### Unit: teardown invokes restored pause exactly once

Replaces the beforeEach stub with a counting spy BEFORE install (so install captures the spy as `original.pause`). Verifies:
- During install, `process.stdin.pause` is the patched no-op (not the spy).
- Calls made mid-wizard hit the no-op (spy count stays 0).
- After teardown, `process.stdin.pause` is restored to the spy AND the spy was invoked exactly once.

### Integration: stdin is not flowing after teardown

Puts `process.stdin` into flowing mode via real `Readable.prototype.resume` (simulating what clack does via `readline.createInterface`). Runs install + teardown. Asserts `process.stdin.readableFlowing !== true` after disposal — without the fix, this assertion would fail because the no-op pause never actually pauses.

## Test plan

- [x] `bun test test/lib/init/stdin-reopen.test.ts` — 15 pass (13 existing + 2 new)
- [x] `bun test test/lib/init/ test/commands/init.test.ts` — 193 pass
- [x] `bun test --timeout 15000 test/lib test/commands test/types` — 5777 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (only pre-existing markdown.ts warning)
- [ ] Manual: `curl -fsSL https://cli.sentry.dev/install | SENTRY_INIT=1 bash` — shell prompt should return immediately after "Setup complete" without a keypress.

## Risk

Very low. Single call to a restored function (known state) guarded by try/catch. No API changes, no new dependencies, no test fixture churn. Two new tests exercise the exact regression.

## Out of scope

- Revisiting whether the no-op `pause`/`resume` patch is still necessary with current Bun (Bun's fd-0 EINVAL may be fixed — worth investigating later as a simplification, but not as part of this hot-fix).
- E2E spawn test asserting process-exits-without-keypress (requires pty fixture infrastructure we don't currently have).