### PR TITLE
fix(init): add force-exit safety net for Bun fresh+readline hang

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -270,8 +270,7 @@ export const initCommand = buildCommand<
     }
 
     // 6. Run the wizard. It owns the temporary `/dev/tty` forwarding used
-    //    for `curl | bash` flows and tears it down on every exit path, so
-    //    init can return naturally once its own refs are released.
+    //    for `curl | bash` flows and tears it down on every exit path.
     await runWizard({
       directory: targetDir,
       yes: flags.yes,
@@ -281,5 +280,41 @@ export const initCommand = buildCommand<
       org: explicitOrg,
       project: explicitProject,
     });
+
+    // 7. Force-exit safety net for a Bun libuv refcount bug.
+    //
+    // On Bun 1.3.11, combining our fresh `/dev/tty` ReadStream (needed for
+    // the `curl | bash` TTY-delivery workaround in stdin-reopen.ts) with
+    // clack's internal `readline.createInterface(process.stdin)` leaks a
+    // libuv handle that NO userland cleanup releases:
+    // `process.stdin.{pause,destroy,close}`, `rl.close()`,
+    // `removeAllListeners`, and every combination of the above all leave
+    // the event loop ref'd. `process.stdin.unref` is `undefined` on Bun.
+    // The wizard prints "Sentry SDK installed successfully!" and the
+    // process then hangs until the user presses a key (which wakes libuv).
+    //
+    // PRs #802, #824, #825, and #831 each fixed a legit contributing cause
+    // (ReadStream ref, `using` teardown, MastraClient sockets, stream
+    // flowing state) and should all stay — but none address the underlying
+    // Bun refcount bug because that's not a userland issue. PR #782's
+    // original `process.exit(0)` workaround was removed on the assumption
+    // that natural drain would work after the other fixes; it doesn't.
+    //
+    // Safety net: schedule a force-exit with `.unref()` so the timer
+    // itself doesn't hold the loop. If the loop drains naturally (future
+    // Bun versions, non-TTY flows, `--yes` with no prompts), the timer
+    // never fires and the process exits normally. If the Bun bug bites,
+    // the timer fires after a 100ms grace period — imperceptible to
+    // the user and enough for Sentry telemetry + stdio flushes to
+    // complete first.
+    //
+    // Skipped under `bun test` (which sets `NODE_ENV=test`) because the
+    // test runner calls `initCommand.func` directly; an unref'd timer
+    // would still fire and terminate the runner mid-suite.
+    if (process.env.NODE_ENV !== "test") {
+      setTimeout(() => {
+        process.exit(process.exitCode ?? 0);
+      }, 100).unref();
+    }
   },
 });


### PR DESCRIPTION
## Summary

After "Sentry SDK installed successfully!", `sentry init` still hangs until a keypress despite #802/#824/#825/#831. Root cause is a Bun 1.3.11 libuv refcount bug that userland cannot fix.

Restores PR #782's `process.exit` workaround, but properly wrapped in `setTimeout(..., 100).unref()` so it's transparent in the happy path and terminal only when the Bun bug bites.

## Root cause (verified)

Opening our fresh `/dev/tty` ReadStream (the `curl | bash` TTY-delivery workaround in `stdin-reopen.ts`) combined with clack's internal `readline.createInterface(process.stdin)` leaks a libuv handle that NO userland cleanup releases. Verified by systematic matrix test against real `/dev/tty` under a pty:

| Scenario                              | Result    |
|---------------------------------------|-----------|
| `fresh` alone                         | FAST ✓    |
| `readline.createInterface` alone      | FAST ✓    |
| `readline` + our pause/resume patch   | FAST ✓    |
| `fresh + readline`                    | HANG 7s   |
| `fresh + readline + fresh.destroy()`  | HANG 7s   |
| `fresh + readline + rl.close()`       | HANG 7s   |
| `fresh + readline + process.stdin.destroy()` | HANG 7s |
| `fresh + readline + removeAllListeners` | HANG 7s |
| `fresh + readline + setTimeout(exit, 100).unref()` | FAST (via forced exit) |

`process.stdin.unref()` is `undefined` on Bun 1.3.11, so Node's canonical "let the process exit" escape hatch isn't available.

## Why PRs #802/#824/#825/#831 didn't fix it

Each peeled off a **legitimate contributing cause** — all should stay:

- #802: `/dev/tty` ReadStream being ref'd (explicit `fresh.destroy()`)
- #824: hardened teardown via `using`/`Symbol.dispose` + termios restore
- #825: MastraClient keep-alive sockets (AbortController)
- #831: `process.stdin` flowing state (restored `pause()` call)

But the libuv refcount bug is a Bun-internal issue, not a stream-state or socket issue. No amount of userland cleanup fixes it.

## Fix

Restore a force-exit safety net in `src/commands/init.ts`, wrapped in `setTimeout(..., 100).unref()`:

```ts
if (process.env.NODE_ENV !== "test") {
  setTimeout(() => {
    process.exit(process.exitCode ?? 0);
  }, 100).unref();
}
```

Properties:
- **Transparent in the happy path** — when the loop drains naturally (future Bun versions that fix the refcount bug, non-TTY flows, `--yes` with no prompts), the `.unref()` timer doesn't hold the loop. Process exits before the timer fires.
- **Terminal when needed** — when the Bun bug bites, the timer fires after a 100ms grace period. Imperceptible to the user.
- **100ms grace period** — enough for Sentry telemetry flush and stdio buffer flush to complete first. Matches best practices for terminal commands.

## Test gate

`NODE_ENV !== "test"` guard: `bun test` sets `NODE_ENV=test` automatically. Without this guard, each call to `initCommand.func` in tests would schedule an unref'd 100ms timer; accumulated timers fire across test files and terminate the test runner mid-suite. The guard avoids this while leaving the safety net active in all real-world invocations (including `bun run dev`, compiled binary, npm bundle).

## Test plan

- [x] `bun test test/commands/init.test.ts test/lib/init/` — 193 pass
- [x] `bun test --timeout 15000 test/lib test/commands test/types` — 5777 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (only pre-existing markdown.ts warning)
- [x] Manual repro: the production scenario (real `/dev/tty` under a pty) hangs for 7s without this fix, exits in 286ms with it.
- [ ] User validation via `curl -fsSL https://cli.sentry.dev/install | SENTRY_INIT=1 bash` after merge.

## Follow-ups

- Exploration task: find an alternative to the fresh `/dev/tty` ReadStream approach for the `curl | bash` TTY-delivery workaround (the original bug #767 was fixing). If we can make that work without a second ReadStream on stdin, the Bun refcount bug is sidestepped entirely and the safety net becomes redundant.
- File a Bun upstream issue with the systematic matrix repro.

## Risk

Low. Single-file change. `.unref()` ensures the timer is transparent in healthy flows. Guarded against test-runner interference. All prior fixes remain in place because each addresses a legit cause.