### PR TITLE
fix(init): restore /dev/tty workaround on macOS only

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -279,5 +279,30 @@ export const initCommand = buildCommand<
       org: explicitOrg,
       project: explicitProject,
     });
+
+    // 7. macOS-only force-exit safety net.
+    //
+    // On Darwin, `runWizard` installs the `/dev/tty` forwarding workaround
+    // from stdin-reopen.ts to get keystrokes through to clack. That
+    // workaround opens a second `tty.ReadStream` which leaks a libuv
+    // handle on Bun 1.3.11 — no userland cleanup releases it (upstream
+    // oven-sh/bun#29126). After the wizard returns the event loop stays
+    // ref'd and the process hangs until the user presses a key.
+    //
+    // The .unref() timer doesn't hold the loop itself, so it's a no-op in
+    // the happy path (Linux: no workaround installed, loop drains
+    // naturally; `--yes` on Darwin: no prompts, no keystroke issue, may
+    // still drain naturally). On the Darwin hang path, it force-exits
+    // after a 100ms grace window — imperceptible to the user and enough
+    // for Sentry telemetry + stdio flushes to complete first.
+    //
+    // Skipped under `bun test` (which sets NODE_ENV=test automatically)
+    // because the test runner calls `initCommand.func` directly; an
+    // unref'd timer would still fire and terminate the runner mid-suite.
+    if (process.platform === "darwin" && process.env.NODE_ENV !== "test") {
+      setTimeout(() => {
+        process.exit(process.exitCode ?? 0);
+      }, 100).unref();
+    }
   },
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -270,39 +270,49 @@ export const initCommand = buildCommand<
     }
 
     // 6. Run the wizard.
-    await runWizard({
-      directory: targetDir,
-      yes: flags.yes,
-      dryRun: flags["dry-run"],
-      features: featuresList,
-      team: flags.team,
-      org: explicitOrg,
-      project: explicitProject,
-    });
-
-    // 7. macOS-only force-exit safety net.
     //
-    // On Darwin, `runWizard` installs the `/dev/tty` forwarding workaround
-    // from stdin-reopen.ts to get keystrokes through to clack. That
-    // workaround opens a second `tty.ReadStream` which leaks a libuv
-    // handle on Bun 1.3.11 — no userland cleanup releases it (upstream
-    // oven-sh/bun#29126). After the wizard returns the event loop stays
-    // ref'd and the process hangs until the user presses a key.
-    //
-    // The .unref() timer doesn't hold the loop itself, so it's a no-op in
-    // the happy path (Linux: no workaround installed, loop drains
-    // naturally; `--yes` on Darwin: no prompts, no keystroke issue, may
-    // still drain naturally). On the Darwin hang path, it force-exits
-    // after a 100ms grace window — imperceptible to the user and enough
-    // for Sentry telemetry + stdio flushes to complete first.
-    //
-    // Skipped under `bun test` (which sets NODE_ENV=test automatically)
-    // because the test runner calls `initCommand.func` directly; an
-    // unref'd timer would still fire and terminate the runner mid-suite.
-    if (process.platform === "darwin" && process.env.NODE_ENV !== "test") {
-      setTimeout(() => {
-        process.exit(process.exitCode ?? 0);
-      }, 100).unref();
+    // Wrapped in try/finally so the macOS force-exit safety net (step 7)
+    // is scheduled on every exit path: success, WizardError, user cancel,
+    // and any other thrown error. Without finally, a thrown WizardError
+    // would skip the timer and the process would hang on the error
+    // display — exactly what Cursor Bugbot flagged on an earlier revision.
+    try {
+      await runWizard({
+        directory: targetDir,
+        yes: flags.yes,
+        dryRun: flags["dry-run"],
+        features: featuresList,
+        team: flags.team,
+        org: explicitOrg,
+        project: explicitProject,
+      });
+    } finally {
+      // 7. macOS-only force-exit safety net.
+      //
+      // On Darwin, `runWizard` installs the `/dev/tty` forwarding
+      // workaround from stdin-reopen.ts to get keystrokes through to
+      // clack. That workaround opens a second `tty.ReadStream` which
+      // leaks a libuv handle on Bun 1.3.11 — no userland cleanup
+      // releases it (upstream oven-sh/bun#29126). After `runWizard`
+      // returns (or throws), the event loop stays ref'd and the process
+      // hangs until the user presses a key.
+      //
+      // The .unref() timer doesn't hold the loop itself, so it's a no-op
+      // in the happy path (Linux: no workaround installed, loop drains
+      // naturally; `--yes` on Darwin: no prompts, no keystroke issue,
+      // may still drain naturally). On the Darwin hang path, it
+      // force-exits after a 100ms grace window — imperceptible to the
+      // user and enough for Sentry telemetry + stdio flushes to
+      // complete first.
+      //
+      // Skipped under `bun test` (which sets NODE_ENV=test automatically)
+      // because the test runner calls `initCommand.func` directly; an
+      // unref'd timer would still fire and terminate the runner mid-suite.
+      if (process.platform === "darwin" && process.env.NODE_ENV !== "test") {
+        setTimeout(() => {
+          process.exit(process.exitCode ?? 0);
+        }, 100).unref();
+      }
     }
   },
 });

--- a/src/lib/init/stdin-reopen.ts
+++ b/src/lib/init/stdin-reopen.ts
@@ -1,0 +1,331 @@
+/**
+ * Workaround for a Bun single-file-binary issue where TTY fds inherited via
+ * shell redirection (e.g. `curl | bash` → `exec "$sentry_bin" init </dev/tty`
+ * in install.sh) report as TTYs and accept `setRawMode(true)` but never
+ * deliver keypress events. A freshly-opened `/dev/tty` fd from inside the
+ * process works correctly — so we open one and forward its data events onto
+ * the existing `process.stdin` object that clack has already captured via
+ * `import { stdin } from "node:process"`.
+ *
+ * We patch `process.stdin` in place rather than replacing it because
+ * `Object.defineProperty(process, "stdin", ...)` does not propagate to the
+ * `node:process` ESM binding (clack's `stdin` import is a snapshot of the
+ * original object). But the original `process.stdin` object IS the same
+ * reference clack holds, so patching listeners + setRawMode on it reaches
+ * clack transparently.
+ *
+ * Platform scope: **macOS only (Bun 1.3.11).** PRs #824/#831/#833/#835
+ * tracked this down: the original keystroke-delivery bug is FIXED on Linux
+ * (verified via PTY harness mimicking install.sh's `exec bin </dev/tty`
+ * flow), so `wizard-runner.ts` only installs this workaround when
+ * `process.platform === "darwin"`. It comes with a side cost — opening a
+ * second `tty.ReadStream` leaks a libuv handle that keeps the event loop
+ * alive after the wizard completes (upstream oven-sh/bun#29126), so the
+ * `initCommand.func` caller pairs this install with a
+ * `setTimeout(process.exit, 100).unref()` safety net to force-exit on
+ * macOS once the wizard returns.
+ */
+
+import { openSync } from "node:fs";
+import { isatty, ReadStream } from "node:tty";
+
+/**
+ * Mutable subset of `process.stdin` that the TTY-forwarding workaround
+ * temporarily patches while the init wizard is running.
+ */
+type StdinHandle = {
+  setRawMode: (mode: boolean) => NodeJS.ReadStream;
+  pause: () => NodeJS.ReadStream;
+  resume: () => NodeJS.ReadStream;
+  _read: (size: number) => void;
+};
+
+/**
+ * State captured when the init wizard installs fresh `/dev/tty` forwarding.
+ * Stored so teardown can release the temporary TTY handle and restore
+ * `process.stdin` to its original behavior.
+ */
+type InstalledState = {
+  fresh: ReadStream;
+  dataListener: (chunk: Buffer) => void;
+  original: {
+    setRawMode: StdinHandle["setRawMode"];
+    pause: StdinHandle["pause"];
+    resume: StdinHandle["resume"];
+    read: StdinHandle["_read"];
+  };
+  /**
+   * Value of `process.stdin.isTTY` before we touched it. Teardown restores
+   * exactly this value rather than hardcoding `undefined`, so a concurrent
+   * writer (e.g. another library that also backfills isTTY) doesn't get
+   * silently stomped on.
+   */
+  previousIsTty: boolean | undefined;
+  /** True when we wrote to `process.stdin.isTTY` at install time. */
+  backfilledIsTty: boolean;
+};
+
+let installedState: InstalledState | null = null;
+
+/**
+ * Factory that returns a `/dev/tty` file descriptor. Overridable for tests
+ * so we can exercise the install→teardown state transitions without depending
+ * on the host's actual TTY.
+ */
+export type OpenTtyFactory = () => number;
+
+/**
+ * Predicate that reports whether fd 0 is a TTY. Overridable for tests
+ * because `isatty(0)` reads real kernel state we can't mock easily — and
+ * `bun test` runs with piped stdin where the predicate is always false.
+ */
+export type IsTtyPredicate = () => boolean;
+
+/** Bundle of host primitives that tests can override. */
+export type TtyDeps = {
+  openTty?: OpenTtyFactory;
+  isTty?: IsTtyPredicate;
+};
+
+const defaultOpenTty: OpenTtyFactory = () => openSync("/dev/tty", "r");
+const defaultIsTty: IsTtyPredicate = () => isatty(0);
+
+/**
+ * Disposable returned by {@link forwardFreshTtyToStdin}. Calling
+ * `[Symbol.dispose]()` — or equivalently letting a `using` declaration go
+ * out of scope — releases the temporary TTY handle and restores
+ * `process.stdin`. Always returned (never null) so callers don't need to
+ * null-check inside `using` blocks.
+ */
+export type TtyForwardingHandle = Disposable;
+
+/** Shared no-op disposable for the secondary-caller / already-installed case. */
+const NOOP_HANDLE: TtyForwardingHandle = {
+  [Symbol.dispose]: (): void => {
+    // intentionally empty — primary caller owns teardown
+  },
+};
+
+/**
+ * Build a handle that routes disposal through
+ * {@link closeFreshTtyForwarding}. Using the module-level function (rather
+ * than a captured reference) preserves test observability — tests can spy
+ * on `closeFreshTtyForwarding` and see it fire even on branches that didn't
+ * install forwarding, matching the semantics of the pre-`using`
+ * try/finally pattern. The underlying function is a no-op when
+ * `installedState` is null, so extra calls are safe.
+ */
+function makeHandle(): TtyForwardingHandle {
+  return {
+    [Symbol.dispose]: (): void => {
+      closeFreshTtyForwarding();
+    },
+  };
+}
+
+/**
+ * Open a fresh `/dev/tty` fd and wire it up to feed `process.stdin`'s event
+ * listeners.
+ *
+ * Always returns a {@link TtyForwardingHandle} (a `Disposable`) so callers
+ * can use `using tty = forwardFreshTtyToStdin()` to guarantee teardown on
+ * every exit path without null-checking. When no TTY is available or
+ * `/dev/tty` can't be opened the disposable is a no-op by virtue of
+ * `closeFreshTtyForwarding` short-circuiting on un-installed state — the
+ * wizard still runs; non-interactive (`--yes`, piped stdin) flows stay as-is.
+ *
+ * Idempotent: repeated calls after the first successful install return a
+ * pure no-op `Disposable` (the first caller owns teardown). Secondary
+ * callers don't duplicate the data listener (which would cause clack to
+ * receive each keystroke twice) or leak additional `/dev/tty` fds.
+ *
+ * @param deps - Optional dependency injection for tests. `openTty` overrides
+ *   the `/dev/tty` factory; `isTty` overrides the `isatty(0)` predicate.
+ *   Production callers pass no args — the defaults do the right thing.
+ */
+export function forwardFreshTtyToStdin(
+  deps: TtyDeps = {}
+): TtyForwardingHandle {
+  const { openTty = defaultOpenTty, isTty = defaultIsTty } = deps;
+
+  if (installedState) {
+    // Another caller already installed forwarding and owns teardown. Hand
+    // back a pure no-op so disposing the secondary handle does NOT call
+    // `closeFreshTtyForwarding` — which would tear down the primary's
+    // install before the primary's disposable fires.
+    return NOOP_HANDLE;
+  }
+  if (!isTty()) {
+    return makeHandle();
+  }
+
+  let fd: number;
+  try {
+    fd = openTty();
+  } catch {
+    return makeHandle();
+  }
+
+  const fresh = new ReadStream(fd);
+  const stdinHandle = process.stdin as unknown as StdinHandle;
+  const original = {
+    setRawMode: stdinHandle.setRawMode,
+    pause: stdinHandle.pause,
+    resume: stdinHandle.resume,
+    read: stdinHandle._read,
+  };
+
+  // Capture the current `isTTY` value before touching it so teardown can
+  // restore it verbatim. Bun's compiled binary can leave
+  // `process.stdin.isTTY === undefined` on inherited-via-redirect fds even
+  // when `isatty(0)` is true. Clack gates its internal `setRawMode(true)`
+  // call on `input.isTTY`, so without this backfill the patched setRawMode
+  // below is never invoked and the fresh fd stays in canonical mode
+  // (line-buffered, no keypresses).
+  //
+  // Use `Object.defineProperty` rather than plain assignment because on
+  // some Node/Bun runtimes `process.stdin.isTTY` is defined as a
+  // non-writable property (notably when stdin is not a TTY) — bare
+  // `stdin.isTTY = …` throws a TypeError in strict mode in that case.
+  const previousIsTty = process.stdin.isTTY;
+  let backfilledIsTty = false;
+  if (process.stdin.isTTY === undefined) {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+    backfilledIsTty = true;
+  }
+
+  // Forward keystrokes from the working fd onto process.stdin so any
+  // listeners clack attaches (readline's 'data', emitKeypressEvents'
+  // 'keypress') fire as expected.
+  const dataListener = (chunk: Buffer): void => {
+    process.stdin.emit("data", chunk);
+  };
+  fresh.on("data", dataListener);
+
+  // A ReadStream without an `error` listener crashes the process when it
+  // emits (e.g. terminal disconnected, SSH dropped). The wizard can't
+  // recover from a dead TTY, so silently drop — the next operation that
+  // actually needs input will fail with a more meaningful error. The
+  // listener stays attached across teardown intentionally: Bun can
+  // asynchronously emit `'error'` (EBADF) after `destroy()` closes the
+  // underlying fd, and an unhandled error on the stream crashes the
+  // process. Keeping the listener attached absorbs any late emission.
+  fresh.on("error", (): void => {
+    // intentionally empty
+  });
+
+  // setRawMode issues a TCSETS ioctl on the underlying TTY device. The device
+  // is shared between the broken fd 0 and the fresh fd, but the broken fd's
+  // ioctl path may be the root cause — so route raw-mode toggles through the
+  // fresh fd, which we know works.
+  stdinHandle.setRawMode = (mode: boolean): NodeJS.ReadStream => {
+    fresh.setRawMode(mode);
+    return process.stdin;
+  };
+
+  // Prevent the stream machinery from touching the broken fd. Clack closes
+  // each prompt with `input.unpipe()` and opens the next one by attaching
+  // new listeners — that triggers Readable's `pause()`/`resume()` hooks,
+  // which on Bun call kqueue against fd 0 and fail with EINVAL on the
+  // second transition. We deliver bytes via `emit('data', …)` from the
+  // fresh fd, so the fd-level flow machinery is dead weight here.
+  const noop = (): NodeJS.ReadStream => process.stdin;
+  stdinHandle.pause = noop;
+  stdinHandle.resume = noop;
+  stdinHandle._read = (_size: number): void => {
+    // intentionally empty — see comment above
+  };
+
+  // Put the fresh stream into flowing mode so the OS delivers bytes to it and
+  // our 'data' handler fires.
+  fresh.resume();
+
+  installedState = {
+    fresh,
+    dataListener,
+    original,
+    previousIsTty,
+    backfilledIsTty,
+  };
+
+  return makeHandle();
+}
+
+/**
+ * Tear down the fresh `/dev/tty` forwarding installed by
+ * {@link forwardFreshTtyToStdin}.
+ *
+ * Must be safe on every wizard exit path, including when forwarding was never
+ * installed. Destroying the temporary `ReadStream` releases the TTY handle so
+ * the process can exit naturally once the wizard is done.
+ *
+ * Callers who opt into the {@link TtyForwardingHandle} `Disposable` API (via
+ * `using tty = forwardFreshTtyToStdin()`) get this teardown for free — this
+ * function exists for the imperative API and for explicit cleanup in tests.
+ */
+export function closeFreshTtyForwarding(): void {
+  if (!installedState) {
+    return;
+  }
+
+  const { fresh, dataListener, original, previousIsTty, backfilledIsTty } =
+    installedState;
+  installedState = null;
+
+  fresh.off("data", dataListener);
+
+  // Restore termios before destroying the fresh stream. If the wizard threw
+  // mid-prompt (between clack's `setRawMode(true)` and its matching
+  // `setRawMode(false)`), the TTY is still in raw mode — leaving it there
+  // produces a shell with no echo after a crash. Best-effort: the fresh fd
+  // may already be destroyed from a prior error, so swallow any throw.
+  try {
+    fresh.setRawMode(false);
+  } catch {
+    // intentionally empty — stream already torn down
+  }
+
+  // Pause before destroy so no queued read callback tries to deliver bytes
+  // after the stream has been torn down. The error listener installed at
+  // setup time stays attached across destroy — see the comment at the
+  // install site for why.
+  fresh.pause();
+  fresh.destroy();
+
+  const stdinHandle = process.stdin as unknown as StdinHandle;
+  stdinHandle.setRawMode = original.setRawMode;
+  stdinHandle.pause = original.pause;
+  stdinHandle.resume = original.resume;
+  stdinHandle._read = original.read;
+
+  // Release the libuv handle on fd 0. Clack's prompt lifecycle relies on
+  // `rl.close() → rl.pause() → this.input.pause()` to pause stdin, but we
+  // replaced `process.stdin.pause` with a no-op at install time (needed to
+  // dodge Bun's fd-0 EINVAL on pause/resume transitions — see the comment
+  // at the install site). So by the time we get here, stdin is still in
+  // flowing/ref'd mode from `readline.createInterface()`'s internal
+  // `input.resume()` — which keeps the libuv event loop alive indefinitely
+  // after the wizard returns, manifesting as a post-wizard hang until the
+  // user presses a key. Now that the original `.pause()` is restored,
+  // invoke it directly so stock Node/Bun cleanup can finish. Idempotent:
+  // safe when stdin was already paused.
+  try {
+    original.pause.call(process.stdin);
+  } catch {
+    // Defensive: swallow errors from runtimes that throw if stdin is
+    // already destroyed. This is end-of-lifecycle cleanup; nothing
+    // downstream needs stdin.
+  }
+
+  if (backfilledIsTty) {
+    Object.defineProperty(process.stdin, "isTTY", {
+      value: previousIsTty,
+      writable: true,
+      configurable: true,
+    });
+  }
+}

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -38,6 +38,7 @@ import { checkGitStatus } from "./git.js";
 import { handleInteractive } from "./interactive.js";
 import { resolveInitContext } from "./preflight.js";
 import { createWizardSpinner } from "./spinner.js";
+import { forwardFreshTtyToStdin } from "./stdin-reopen.js";
 import { describeTool, executeTool } from "./tools/registry.js";
 import type {
   ResolvedInitContext,
@@ -360,6 +361,29 @@ async function preamble(
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: sequential wizard orchestration with error handling branches
 export async function runWizard(initialOptions: WizardOptions): Promise<void> {
+  // macOS-only: Bun's compiled binaries on Darwin don't deliver keystrokes
+  // through TTY fds inherited via shell redirection (`curl | bash` →
+  // `exec sentry init </dev/tty` in install.sh), so clack prompts hang
+  // forever at the first question. The workaround in stdin-reopen.ts opens
+  // a fresh `/dev/tty` and forwards its data events onto process.stdin.
+  //
+  // The bug is fixed on Linux (verified via PTY harness in PR #835) — we
+  // skip the workaround there because it has a side cost: a libuv handle
+  // leak that requires `initCommand.func`'s `setTimeout().unref()` safety
+  // net to force-exit cleanly. Keep the install narrow.
+  //
+  // The `using` declaration guarantees teardown on every exit path via the
+  // Disposable returned by forwardFreshTtyToStdin(). On non-Darwin, the
+  // disposable is a no-op (install short-circuits on platform check).
+  using _tty =
+    process.platform === "darwin"
+      ? forwardFreshTtyToStdin()
+      : {
+          [Symbol.dispose]: (): void => {
+            // intentionally empty — workaround not installed on this platform
+          },
+        };
+
   const { directory, yes, dryRun, features } = initialOptions;
 
   if (!(await preamble(directory, yes, dryRun))) {

--- a/test/lib/init/stdin-reopen.test.ts
+++ b/test/lib/init/stdin-reopen.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Tests for the `/dev/tty` forwarding install→teardown lifecycle.
+ *
+ * The production code opens a real `/dev/tty` fd via `openSync` and checks
+ * `isatty(0)` for the environment gate. To exercise the state transitions
+ * deterministically we pass `TtyDeps` that:
+ *
+ *   - override `isTty` to return `true` (bun test runs with piped stdin, so
+ *     the default predicate short-circuits the install path),
+ *   - override `openTty` to return a `/dev/ptmx` fd — a pseudo-TTY master
+ *     that `new ReadStream(fd)` accepts, with no keyboard side effects.
+ *
+ * `/dev/ptmx` is Linux-specific. Tests skip gracefully on platforms where it
+ * isn't available.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, openSync } from "node:fs";
+import {
+  closeFreshTtyForwarding,
+  forwardFreshTtyToStdin,
+} from "../../../src/lib/init/stdin-reopen.js";
+
+const HAS_PTMX = existsSync("/dev/ptmx");
+
+/**
+ * Open a fresh `/dev/ptmx` fd for use as a pseudo-TTY fixture. The returned
+ * fd is owned by the `ReadStream` that the test attaches it to —
+ * `fresh.destroy()` inside teardown closes it. No explicit close needed
+ * from the test body.
+ */
+function makePtmxFd(): { fd: number } {
+  const fd = openSync("/dev/ptmx", "r+");
+  return { fd };
+}
+
+/**
+ * Assign `process.stdin.isTTY` via `Object.defineProperty` so the test
+ * works regardless of whether the runtime defined `isTTY` as writable or
+ * readonly. On CI (Node/Bun with piped stdin), `isTTY` is a non-writable
+ * property and bare assignment throws `TypeError: Attempted to assign to
+ * readonly property`. `defineProperty` overrides the descriptor in-place.
+ */
+function setIsTTY(value: boolean | undefined): void {
+  Object.defineProperty(process.stdin, "isTTY", {
+    value,
+    writable: true,
+    configurable: true,
+  });
+}
+
+/**
+ * `bun test` runs with piped stdin, so `process.stdin.setRawMode` is
+ * typically `undefined` (the method only exists on real TTY streams).
+ * The production code captures these methods at install time via
+ * `stdinHandle.setRawMode` etc., so we stub them on `process.stdin` before
+ * each test and restore after. This matches what the real Bun binary would
+ * provide when stdin is actually a TTY.
+ */
+type StdinStubState = {
+  restore: () => void;
+};
+
+function stubStdinTtyMethods(): StdinStubState {
+  const stdin = process.stdin as unknown as Record<string, unknown>;
+  const keys = ["setRawMode", "pause", "resume", "_read"] as const;
+  const originals: Record<string, unknown> = {};
+  const hadKey: Record<string, boolean> = {};
+  for (const key of keys) {
+    hadKey[key] = key in stdin;
+    originals[key] = stdin[key];
+  }
+  // Install test stubs. Each stub returns process.stdin so chainable-style
+  // callers (clack's setRawMode, etc.) behave sensibly.
+  stdin.setRawMode = (_mode: boolean) => process.stdin;
+  stdin.pause = () => process.stdin;
+  stdin.resume = () => process.stdin;
+  stdin._read = (_size: number) => {
+    // intentionally empty — test stub
+  };
+
+  return {
+    restore: () => {
+      for (const key of keys) {
+        if (hadKey[key]) {
+          stdin[key] = originals[key];
+        } else {
+          delete stdin[key];
+        }
+      }
+    },
+  };
+}
+
+let stdinStub: StdinStubState | undefined;
+
+beforeEach(() => {
+  stdinStub = stubStdinTtyMethods();
+});
+
+afterEach(() => {
+  // Defense-in-depth: if a test installs forwarding and throws before
+  // tearing down, reset the module state before the next test runs.
+  closeFreshTtyForwarding();
+  stdinStub?.restore();
+  stdinStub = undefined;
+});
+
+describe("closeFreshTtyForwarding (null-state paths)", () => {
+  test("is a no-op when forwarding was never installed", () => {
+    expect(() => closeFreshTtyForwarding()).not.toThrow();
+  });
+
+  test("is idempotent across repeated calls", () => {
+    expect(() => {
+      closeFreshTtyForwarding();
+      closeFreshTtyForwarding();
+      closeFreshTtyForwarding();
+    }).not.toThrow();
+  });
+});
+
+describe("forwardFreshTtyToStdin no-install paths", () => {
+  test("does not patch stdin methods when isTty predicate is false", () => {
+    const originalSetRawMode = process.stdin.setRawMode;
+    const handle = forwardFreshTtyToStdin({ isTty: () => false });
+    // Handle is a Disposable but install was skipped — stdin untouched.
+    expect(handle).toBeDefined();
+    expect(process.stdin.setRawMode).toBe(originalSetRawMode);
+    // Disposing the no-install handle is a safe no-op.
+    expect(() => handle[Symbol.dispose]()).not.toThrow();
+    expect(process.stdin.setRawMode).toBe(originalSetRawMode);
+  });
+
+  test("does not patch stdin methods when the openTty factory throws", () => {
+    const originalSetRawMode = process.stdin.setRawMode;
+    const openTty = mock(() => {
+      throw new Error("fake /dev/tty unavailable");
+    });
+    const handle = forwardFreshTtyToStdin({ isTty: () => true, openTty });
+    expect(handle).toBeDefined();
+    expect(openTty).toHaveBeenCalledTimes(1);
+    expect(process.stdin.setRawMode).toBe(originalSetRawMode);
+  });
+});
+
+describe("forwardFreshTtyToStdin → closeFreshTtyForwarding round trip", () => {
+  if (!HAS_PTMX) {
+    test("skipped: /dev/ptmx unavailable on this platform", () => {
+      expect(HAS_PTMX).toBe(false);
+    });
+    return;
+  }
+
+  test("install captures and teardown restores stdin methods", () => {
+    const { fd } = makePtmxFd();
+    const openTty = mock(() => fd);
+
+    const originalSetRawMode = process.stdin.setRawMode;
+    const originalPause = process.stdin.pause;
+    const originalResume = process.stdin.resume;
+
+    const handle = forwardFreshTtyToStdin({ isTty: () => true, openTty });
+    expect(handle).toBeDefined();
+    expect(openTty).toHaveBeenCalledTimes(1);
+
+    // After install, process.stdin methods are patched — they no longer
+    // match the pre-install references.
+    expect(process.stdin.setRawMode).not.toBe(originalSetRawMode);
+    expect(process.stdin.pause).not.toBe(originalPause);
+    expect(process.stdin.resume).not.toBe(originalResume);
+
+    closeFreshTtyForwarding();
+
+    // After teardown the originals are restored by reference equality.
+    expect(process.stdin.setRawMode).toBe(originalSetRawMode);
+    expect(process.stdin.pause).toBe(originalPause);
+    expect(process.stdin.resume).toBe(originalResume);
+  });
+
+  test("isTTY restored to its pre-install value (backfill branch)", () => {
+    const { fd } = makePtmxFd();
+    const stdin = process.stdin as { isTTY?: boolean };
+    const previousIsTty = stdin.isTTY;
+
+    // Force the backfill branch by clearing isTTY up-front.
+    setIsTTY(undefined);
+
+    try {
+      const handle = forwardFreshTtyToStdin({
+        isTty: () => true,
+        openTty: () => fd,
+      });
+      expect(handle).toBeDefined();
+      // Install backfilled isTTY to true.
+      expect(stdin.isTTY).toBe(true);
+
+      closeFreshTtyForwarding();
+      // Teardown restored to the pre-install value (undefined).
+      expect(stdin.isTTY).toBeUndefined();
+    } finally {
+      setIsTTY(previousIsTty);
+    }
+  });
+
+  test("isTTY untouched when already set (no-backfill branch)", () => {
+    const { fd } = makePtmxFd();
+    const stdin = process.stdin as { isTTY?: boolean };
+    const previousIsTty = stdin.isTTY;
+    setIsTTY(true);
+
+    try {
+      const handle = forwardFreshTtyToStdin({
+        isTty: () => true,
+        openTty: () => fd,
+      });
+      expect(handle).toBeDefined();
+      expect(stdin.isTTY).toBe(true);
+
+      closeFreshTtyForwarding();
+      // backfilledIsTty was false, so teardown must not touch isTTY.
+      expect(stdin.isTTY).toBe(true);
+    } finally {
+      setIsTTY(previousIsTty);
+    }
+  });
+
+  test("re-install after teardown succeeds with fresh state", () => {
+    const first = makePtmxFd();
+    const second = makePtmxFd();
+
+    const h1 = forwardFreshTtyToStdin({
+      isTty: () => true,
+      openTty: () => first.fd,
+    });
+    expect(h1).toBeDefined();
+    closeFreshTtyForwarding();
+
+    // Second install observes the newly-restored original methods as its
+    // capture target, so the cycle completes cleanly.
+    const h2 = forwardFreshTtyToStdin({
+      isTty: () => true,
+      openTty: () => second.fd,
+    });
+    expect(h2).toBeDefined();
+    closeFreshTtyForwarding();
+  });
+
+  test("secondary forward call returns a no-op disposable", () => {
+    const { fd } = makePtmxFd();
+    const stdin = process.stdin as { isTTY?: boolean };
+    const previousIsTty = stdin.isTTY;
+
+    try {
+      const h1 = forwardFreshTtyToStdin({
+        isTty: () => true,
+        openTty: () => fd,
+      });
+      expect(h1).toBeDefined();
+
+      // Second call — already installed. Factory NOT called again.
+      const secondaryFactory = mock(() => {
+        throw new Error("should not be invoked");
+      });
+      const h2 = forwardFreshTtyToStdin({
+        isTty: () => true,
+        openTty: secondaryFactory,
+      });
+      expect(h2).toBeDefined();
+      expect(secondaryFactory).not.toHaveBeenCalled();
+
+      // Disposing the secondary handle must NOT tear down the primary's
+      // state. stdin methods stay patched until the PRIMARY disposable fires.
+      const patchedSetRawMode = process.stdin.setRawMode;
+      h2[Symbol.dispose]();
+      expect(process.stdin.setRawMode).toBe(patchedSetRawMode);
+
+      // Primary disposal now actually tears down.
+      h1[Symbol.dispose]();
+    } finally {
+      setIsTTY(previousIsTty);
+    }
+  });
+
+  test("teardown tolerates double-close of the same install", () => {
+    const { fd } = makePtmxFd();
+
+    const handle = forwardFreshTtyToStdin({
+      isTty: () => true,
+      openTty: () => fd,
+    });
+    expect(handle).toBeDefined();
+
+    // First close tears down; second must be a no-op guarded by the
+    // installedState === null check at the top of closeFreshTtyForwarding.
+    closeFreshTtyForwarding();
+    expect(() => closeFreshTtyForwarding()).not.toThrow();
+  });
+
+  test("teardown tolerates raw mode being set before close", () => {
+    const { fd } = makePtmxFd();
+
+    const handle = forwardFreshTtyToStdin({
+      isTty: () => true,
+      openTty: () => fd,
+    });
+    expect(handle).toBeDefined();
+
+    // Simulate clack calling setRawMode(true) mid-prompt, then the
+    // wizard throwing before clack's matching setRawMode(false) fires.
+    // The patched setRawMode routes to fresh.setRawMode on the real
+    // ptmx fd — exercising the ioctl path.
+    process.stdin.setRawMode(true);
+
+    // Teardown should call fresh.setRawMode(false) before destroy.
+    // We can't observe the call directly without a deeper seam, but we
+    // verify teardown completes without throwing even after raw mode
+    // was set (covers the termios-restore try/catch).
+    expect(() => closeFreshTtyForwarding()).not.toThrow();
+  });
+
+  test("teardown invokes restored pause to release stdin handle", () => {
+    // Regression for CLI-1DD: post-wizard `sentry init` hang. Our no-op
+    // pause patch (installed to dodge Bun's fd-0 EINVAL) silently
+    // swallowed clack's `rl.close() → input.pause()` call, leaving stdin
+    // ref'd. Teardown must invoke the restored original so the libuv
+    // event loop can drain.
+    const { fd } = makePtmxFd();
+
+    // Replace the beforeEach stub with a counting spy BEFORE install so
+    // the install captures it as `original.pause`.
+    let pauseCalls = 0;
+    const pauseSpy = (): NodeJS.ReadStream => {
+      pauseCalls += 1;
+      return process.stdin;
+    };
+    (process.stdin as unknown as { pause: () => NodeJS.ReadStream }).pause =
+      pauseSpy;
+
+    const handle = forwardFreshTtyToStdin({
+      isTty: () => true,
+      openTty: () => fd,
+    });
+    expect(handle).toBeDefined();
+
+    // During install, process.stdin.pause is the patched no-op — clack's
+    // internal `rl.close() → input.pause()` would hit the no-op and the
+    // spy would never fire. Simulate that:
+    expect(process.stdin.pause).not.toBe(pauseSpy);
+    process.stdin.pause();
+    expect(pauseCalls).toBe(0);
+
+    closeFreshTtyForwarding();
+
+    // After teardown: pause is restored to our spy AND teardown invoked
+    // it exactly once to release the libuv handle.
+    expect(process.stdin.pause).toBe(pauseSpy);
+    expect(pauseCalls).toBe(1);
+  });
+
+  test("stdin is not flowing after teardown (releases event loop)", () => {
+    // Integration regression for CLI-1DD. Observes the actual stream
+    // state transition that blocks the event loop. Without the fix,
+    // `readableFlowing` stays `true` post-teardown and the process hangs
+    // until a keypress.
+    const { fd } = makePtmxFd();
+
+    // Route install's `original.pause` capture at the real
+    // `Readable.prototype.pause`, not the beforeEach no-op stub — so
+    // that invoking it actually transitions `readableFlowing: true → false`.
+    // Same for `.resume()`: used below to simulate clack's implicit flow.
+    const { Readable } = require("node:stream") as typeof import("node:stream");
+    const stdinMut = process.stdin as unknown as {
+      pause: () => NodeJS.ReadStream;
+      resume: () => NodeJS.ReadStream;
+    };
+    stdinMut.pause = Readable.prototype.pause as () => NodeJS.ReadStream;
+    stdinMut.resume = Readable.prototype.resume as () => NodeJS.ReadStream;
+
+    // Put stdin into flowing mode. This is effectively what clack does
+    // indirectly via `readline.createInterface()` → `input.resume()`.
+    process.stdin.resume();
+
+    try {
+      expect(
+        (process.stdin as { readableFlowing?: boolean | null }).readableFlowing
+      ).toBe(true);
+
+      const handle = forwardFreshTtyToStdin({
+        isTty: () => true,
+        openTty: () => fd,
+      });
+      expect(handle).toBeDefined();
+
+      closeFreshTtyForwarding();
+
+      // `readableFlowing` values: null (initial), true (flowing), false
+      // (paused). After teardown we must be NOT true — otherwise the
+      // libuv event loop stays alive.
+      expect(
+        (process.stdin as { readableFlowing?: boolean | null }).readableFlowing
+      ).not.toBe(true);
+    } finally {
+      // Defensive: ensure we don't leak a flowing-mode stdin into the
+      // next test even if an expectation above threw.
+      Readable.prototype.pause.call(process.stdin);
+    }
+  });
+});
+
+describe("using-declaration semantics", () => {
+  if (!HAS_PTMX) {
+    test("skipped: /dev/ptmx unavailable on this platform", () => {
+      expect(HAS_PTMX).toBe(false);
+    });
+    return;
+  }
+
+  test("`using` scope releases forwarding when the block exits", () => {
+    const { fd } = makePtmxFd();
+    const originalSetRawMode = process.stdin.setRawMode;
+
+    {
+      using tty = forwardFreshTtyToStdin({
+        isTty: () => true,
+        openTty: () => fd,
+      });
+      expect(tty).toBeDefined();
+      // Inside the block, setRawMode is patched.
+      expect(process.stdin.setRawMode).not.toBe(originalSetRawMode);
+    }
+    // Block exited → disposable fired → originals restored.
+    expect(process.stdin.setRawMode).toBe(originalSetRawMode);
+  });
+
+  test("`using` teardown fires even when the block throws", () => {
+    const { fd } = makePtmxFd();
+    const originalSetRawMode = process.stdin.setRawMode;
+
+    const run = (): void => {
+      using tty = forwardFreshTtyToStdin({
+        isTty: () => true,
+        openTty: () => fd,
+      });
+      expect(tty).toBeDefined();
+      throw new Error("boom");
+    };
+    expect(run).toThrow("boom");
+    // Throw unwound the `using` scope → disposable fired.
+    expect(process.stdin.setRawMode).toBe(originalSetRawMode);
+  });
+});


### PR DESCRIPTION
## Summary

PR #835 deleted `forwardFreshTtyToStdin` on the theory that Bun 1.3.11 fixes the inherited-TTY keystroke-delivery bug that the workaround was written for. That's true on **Linux** (verified via PTY harness). It's **NOT** true on **macOS**: `curl -fsSL https://cli.sentry.dev/install | SENTRY_INIT=1 bash` hangs at the first clack prompt — user can't type.

Restore the workaround, gated on `process.platform === "darwin"`.

## User-reported reproduction

```
curl -fsSL https://cli.sentry.dev/install | SENTRY_INIT=1 bash -s -- --version nightly
```

After install, wizard shows:

```
sentry init

EXPERIMENTAL: This feature is experimental and may modify your code. Continue?
● Yes / ○ No
```

Keystrokes (Y/N/Enter) don't reach clack. Prompt hangs indefinitely. Exactly what `forwardFreshTtyToStdin` was fixing originally.

## Fix

### `src/lib/init/wizard-runner.ts`
Gate the `using _tty = forwardFreshTtyToStdin()` install on `process.platform === "darwin"`:

```ts
using _tty =
  process.platform === "darwin"
    ? forwardFreshTtyToStdin()
    : { [Symbol.dispose]: (): void => { /* no-op on non-Darwin */ } };
```

- **Linux / WSL / Windows**: no workaround installed, loop drains naturally. Keeps the performance/simplicity win from #835.
- **macOS**: workaround installs, keystrokes deliver — original bug fixed again.

### `src/commands/init.ts`
Restore the `setTimeout(process.exit, 100).unref()` safety net from #833, also gated to darwin:

```ts
if (process.platform === "darwin" && process.env.NODE_ENV !== "test") {
  setTimeout(() => {
    process.exit(process.exitCode ?? 0);
  }, 100).unref();
}
```

The safety net is needed on macOS because the workaround opens a second `tty.ReadStream` which leaks a libuv handle (upstream [oven-sh/bun#29126](https://github.com/oven-sh/bun/issues/29126)). On Linux that leak doesn't occur (no workaround installed). The `NODE_ENV=test` gate ensures `bun test` doesn't accumulate unref'd timers mid-suite.

### Restored (unchanged from pre-#835 state)
- `src/lib/init/stdin-reopen.ts` (320 lines) — includes all hardening from #824 (`using`/Symbol.dispose, termios restore), #831 (`original.pause.call` in teardown), and #833-era CI fixes (`Object.defineProperty` for `isTTY`).
- `test/lib/init/stdin-reopen.test.ts` (452 lines) — 15 tests covering install/teardown lifecycle via `/dev/ptmx` fixture.

## Test plan

- [x] `bun test test/lib/init/ test/commands/init.test.ts` — 193 pass
- [x] `bun test --timeout 15000 test/lib test/commands test/types` — 5777 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (only pre-existing markdown.ts warning)
- [ ] **Required**: Manual verification on macOS via nightly: `curl -fsSL https://cli.sentry.dev/install | SENTRY_VERSION=nightly SENTRY_INIT=1 bash`. Expect: first clack prompt accepts keystrokes, wizard completes, shell returns promptly after "Setup complete".
- [ ] Also verify on Linux (Ubuntu glibc + Alpine musl) and WSL that the workaround is NOT installed and exit is still clean.

## Risk

Low. Platform-gated to darwin, so any bugs in the workaround only affect macOS users. Non-Darwin path unchanged from #835 (proven clean on Linux). If macOS has further issues, the revert is a single commit away.

## Follow-ups

- File an upstream Bun bug specifically about the macOS compiled-binary keystroke-delivery issue (distinct from oven-sh/bun#29126 which is about `process.stdin`'s readable-listener polling). A minimal repro running the stock `readline` module on a redirected `/dev/tty` fd should be straightforward.
- Revisit when Bun 1.3.12+ is available — if the macOS bug is fixed upstream, we can delete the workaround for good.