### PR TITLE
build(deps): bump Bun from 1.3.11 to 1.3.13

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -203,7 +203,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -271,7 +271,7 @@
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
-    "bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -680,8 +680,6 @@
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
 
     "@peggyjs/from-mem/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "bun-types/@types/node": ["@types/node@20.19.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g=="],
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "dist/index.d.cts"
   ],
   "license": "FSL-1.1-Apache-2.0",
-  "packageManager": "bun@1.3.11",
+  "packageManager": "bun@1.3.13",
   "patchedDependencies": {
     "@stricli/core@1.2.5": "patches/@stricli%2Fcore@1.2.5.patch",
     "@sentry/node-core@10.50.0": "patches/@sentry%2Fnode-core@10.50.0.patch",

--- a/script/build.ts
+++ b/script/build.ts
@@ -326,11 +326,12 @@ async function compileTarget(target: BuildTarget): Promise<boolean> {
       // identifier renaming collision bug (oven-sh/bun#14585).
       minify: { whitespace: true, syntax: true, identifiers: false },
       // NOTE: `bytecode: true` would move JS parse cost from startup to
-      // build time, but as of Bun 1.3.11 it crashes our ESM bundle at
-      // runtime with "Expected CommonJS module to have a function wrapper"
-      // before any of our code runs. Likely related to oven-sh/bun#21097 /
-      // #23490. Revisit once Bun's bytecode path stabilizes for our two-
-      // step esbuild-then-compile pipeline.
+      // build time, but as of Bun 1.3.13 it still crashes our ESM bundle
+      // at runtime with "Expected CommonJS module to have a function
+      // wrapper" before any of our code runs (esbuild emits ESM at line
+      // 126; the bytecode loader mis-caches it as CJS). Tracks
+      // oven-sh/bun#21097 / #23490. Retested on Bun 1.3.13; still broken.
+      // Revisit once Bun's bytecode path supports ESM under compile.
     });
 
     if (!result.success) {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -105,7 +105,7 @@ export function getCliEnvironment(version: string = CLI_VERSION): string {
  * Generate the User-Agent string for API requests.
  * Format: sentry-cli/<version> (<os>-<arch>) <runtime>/<version>
  *
- * @example "sentry-cli/0.5.0 (linux-x64) bun/1.3.3"
+ * @example "sentry-cli/0.5.0 (linux-x64) bun/1.3.13"
  * @example "sentry-cli/0.5.0 (darwin-arm64) node/22.12.0"
  */
 export function getUserAgent(): string {

--- a/test/lib/bench/helpers.test.ts
+++ b/test/lib/bench/helpers.test.ts
@@ -133,7 +133,7 @@ describe("compareReports", () => {
   const baseline: BenchReport = {
     version: 1,
     generatedAt: "2026-01-01T00:00:00.000Z",
-    runtime: { bun: "1.3.11", platform: "linux", arch: "x64", cpus: 8 },
+    runtime: { bun: "1.3.13", platform: "linux", arch: "x64", cpus: 8 },
     entries: [
       {
         fixture: "synthetic/small",


### PR DESCRIPTION
## Summary

Bump Bun 1.3.11 → 1.3.13 (skip 1.3.12, cumulative) and re-test the long-disabled \`bytecode: true\` compile flag.

### Runtime wins from 1.3.13 (no code changes required)
- **5.5× faster gzip** (zlib-ng) — benefits chunk-upload in \`src/lib/api/sourcemaps.ts\`
- **Source maps 8× less memory**, ~1.8 MB smaller compiled binaries (maps are embedded)
- **Cgroup-aware \`availableParallelism()\`** on Linux — benefits \`src/lib/scan/\` workers under Docker/K8s limits
- **Faster \`Bun.stripANSI\` / \`Bun.stringWidth\`** (SIMD) — used in markdown/table rendering
- **Runtime 5% less memory** (mimalloc v3)
- Fixes: \`process.env\` empty under \`chmod 111\` CWDs; \`statx\` EPERM under seccomp; ARM64 \`fs.promises\` hang on Apple Silicon; Linux ELF \`.bun\` section for zero-I/O standalone startup

### Bytecode retry — still broken

Retested \`bytecode: true\` in \`script/build.ts\`. On Bun 1.3.13 it still crashes with:

\`\`\`
TypeError: Expected CommonJS module to have a function wrapper
\`\`\`

…before any of our code runs. Our esbuild step emits ESM (\`format: \"esm\"\` at \`script/build.ts:126\`), and the bytecode loader mis-caches it as CJS — exactly oven-sh/bun#21097 / #23490, which 1.3.13 did not address. Flag stays off; comment updated to record the retest.

### Workarounds left untouched (confirmed still needed)
- \`src/lib/init/stdin-reopen.ts\` (POSIX TTY forwarding) — no 1.3.13 fix
- \`src/lib/bspatch.ts\` copy-then-mmap — kernel-level (AMFI / ETXTBSY)
- \`spawnWithRetry\` EBUSY on Windows — Defender/SmartScreen race, not Bun
- Identifier-minify disabled (bun#14585) — no fix shipped
- \`autoloadDotenv/Bunfig: false\` — intentional hardening
- \`util.getSystemErrorMap\` existence check in telemetry
- CI \`bun install\` ENOTEMPTY retry on Windows

## Changes

| File | Change |
|------|--------|
| \`package.json\` | \`packageManager: bun@1.3.11\` → \`1.3.13\` |
| \`bun.lock\` | \`@types/bun\` + \`bun-types\` 1.3.6 → 1.3.13 (had silently drifted from runtime; \`\"latest\"\` wasn't re-resolving on plain \`bun install\`) |
| \`script/build.ts\` | Updated bytecode NOTE comment with 1.3.13 retest result |
| \`src/lib/constants.ts\` | Cosmetic JSDoc \`@example\` bump |
| \`test/lib/bench/helpers.test.ts\` | Cosmetic fixture bump |

\`docs/bun.lock\` was a no-op after \`bun install\`.

## Verification (linux-x64)

- ✅ \`bun run typecheck\`
- ✅ \`bun run lint\` (1 pre-existing warning unrelated to this PR)
- ✅ \`bun run test:unit\` — 5777 pass / 0 fail
- ✅ \`bun run test:isolated\` — 138 pass / 0 fail
- ✅ \`bun run build\` produces working binary; smoke-tested \`--version\`, \`--help\`, \`init --help\`, \`org list --help\`
- Startup: 547.5 ± 23.9 ms vs 534.5 ± 11 ms baseline (within noise on this hardware)

Relying on CI matrix for macOS (Darwin-gated \`stdin-reopen.ts\`) and Windows (\`spawnWithRetry\` EBUSY path) coverage.

## Out of scope

- \`bun test --parallel / --isolate / --shard / --changed\` (new 1.3.13 flags) — separate eval
- Simplifying the \`Bun.write(path, Response)\` workaround in \`src/lib/upgrade.ts\` — oven-sh/bun#13237 not explicitly resolved in 1.3.13 changelog