### PR TITLE
ci: shard Unit Tests 4-way to cut ~30s off the critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
       - run: bun run check:errors
 
   test-unit:
-    name: Unit Tests
+    name: Unit Tests (${{ matrix.shard }}/${{ strategy.job-total }})
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
@@ -198,6 +198,10 @@ jobs:
       actions: read
       pull-requests: write
       statuses: write
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
@@ -211,12 +215,15 @@ jobs:
       - name: Generate API Schema
         run: bun run generate:schema
       - name: Unit Tests
-        run: bun run test:unit
+        run: bun run test:unit -- --shard=${{ matrix.shard }}/${{ strategy.job-total }}
       - name: Coverage Report
         uses: getsentry/codecov-action@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: ./coverage/lcov.info
+          # Each shard uploads its own partial coverage report under a
+          # shard-scoped flag. Codecov merges them server-side.
+          flags: unit-shard-${{ matrix.shard }}
           informational-patch: ${{ github.event_name == 'push' }}
 
   build-binary:


### PR DESCRIPTION
## Summary

Bun 1.3.13's \`bun test --shard=M/N\` splits test files round-robin across CI runners. Adopting a 4-way shard on the \`test-unit\` job cuts ~30s off the CI critical path.

## Local benchmark

```
baseline (no shard):  54s
shard 1/4:            21.7s (slowest)
shard 2/4:            17.8s
shard 3/4:            19.3s
shard 4/4:            16.0s
```

## CI impact

The critical path is \`lint || test-unit → build-binary → test-e2e\`. From the last successful main run (24900297101):

| Job | Before | After (est.) |
|-----|-------:|-------------:|
| Unit Tests | 63s | ~31s (21.7s test + ~9s GHA setup) |
| **Total CI wall clock** | **5:05** | **~4:30** |

The real bottleneck is still \`test-e2e\` (166s), which can't shard because it spawns a single prebuilt binary. E2E sharding is a separate investigation.

## Implementation

A 4-way matrix on the existing \`test-unit\` job, each leg passing \`--shard\` through the unchanged \`test:unit\` npm script. Diff is **+9/−2** lines.

### Downstream wiring

Jobs that list \`test-unit\` in \`needs:\` (\`build-binary\`, \`build-npm\`) automatically wait for **all four matrix legs** to succeed — this is standard GHA behavior, no aggregator changes needed. The \`CI Status\` umbrella check already gates on \`build-binary\` / \`build-npm\` / \`test-e2e\` results, so it transitively reflects all shard outcomes.

### Coverage

Each shard uploads its own \`coverage/lcov.info\` to Codecov under a shard-scoped \`flags: unit-shard-\${matrix.shard}\` label. Codecov merges the partial reports server-side, so no local merge step is required (the \`script/merge-lcov.ts\` approach removed in #839 is not coming back).

### Cost

4× runner minutes on the test-unit job (~9s × 4 = 36s extra vs 63s before, partially offset by the 30s wall-clock savings). GitHub-hosted Linux runners are free for public repos, so this is only a carbon/load consideration. \`fail-fast: false\` keeps all shards reporting on failure so a single broken file doesn't mask issues elsewhere.

## Verification

- ✅ Each shard passes locally: 1179+1749+1662+1330 = **5920 tests across 4 shards** (matches baseline)
- ✅ \`bun run typecheck\`, \`bun run lint\`
- ✅ YAML structure follows the existing precedent for matrix jobs (\`Build Binary\`, \`Build npm Package\`, \`Analyze\`)

## What this does NOT change

- \`test:unit\` npm script behavior when run locally (\`bun run test:unit\` still runs all files in one process)
- \`test-e2e\` job — still 1 runner, no shard
- Branch protection / required checks — \`CI Status\` remains the umbrella check