### PR TITLE
fix(sourcemap): error on zero pairs + restore docs sourcemap emission

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -14,9 +14,17 @@ export default defineConfig({
   // Generate sourcemaps for Sentry. "hidden" produces .map files without
   // adding //# sourceMappingURL comments to the output (the debug IDs
   // injected post-build by `sentry sourcemap inject` are used instead).
+  //
+  // Astro 6 uses Vite 7's Environments API and reads `sourcemap` from
+  // `vite.environments.{client,ssr}.build.sourcemap` (see
+  // astro/dist/core/build/static-build.js), falling back to `false` — NOT
+  // to legacy top-level `vite.build.sourcemap`. We set it on both
+  // environments to cover both the client bundle (what `sentry sourcemap
+  // inject/upload` operates on) and SSR output.
   vite: {
-    build: {
-      sourcemap: "hidden",
+    environments: {
+      client: { build: { sourcemap: "hidden" } },
+      ssr: { build: { sourcemap: "hidden" } },
     },
   },
   integrations: [

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -15,17 +15,9 @@ export default defineConfig({
   // adding //# sourceMappingURL comments to the output (the debug IDs
   // injected post-build by `sentry sourcemap inject` are used instead).
   //
-  // Astro 6 uses Vite 7's Environments API and reads `sourcemap` from
-  // `vite.environments.{client,ssr}.build.sourcemap` (see
-  // astro/dist/core/build/static-build.js), falling back to `false` — NOT
-  // the legacy top-level `vite.build.sourcemap`. The silent Astro-5→6
-  // migration was the root cause of the cli.sentry.dev sourcemap upload
-  // going dark from 2026-04-22 to 2026-04-24 (see #845, fixed in #846).
-  //
-  // We set it on the `client` environment (which produces `dist/_astro/`
-  // — what `sentry sourcemap inject/upload docs/dist/` operates on). The
-  // `ssr` line is a no-op today because this site is static-only, but
-  // guards against regressions if a server adapter is added later.
+  // Astro 6 / Vite 7 reads `sourcemap` from
+  // `vite.environments.{client,ssr}.build.sourcemap` (Environments API),
+  // not the legacy top-level `vite.build.sourcemap`.
   vite: {
     environments: {
       client: { build: { sourcemap: "hidden" } },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -18,9 +18,14 @@ export default defineConfig({
   // Astro 6 uses Vite 7's Environments API and reads `sourcemap` from
   // `vite.environments.{client,ssr}.build.sourcemap` (see
   // astro/dist/core/build/static-build.js), falling back to `false` — NOT
-  // to legacy top-level `vite.build.sourcemap`. We set it on both
-  // environments to cover both the client bundle (what `sentry sourcemap
-  // inject/upload` operates on) and SSR output.
+  // the legacy top-level `vite.build.sourcemap`. The silent Astro-5→6
+  // migration was the root cause of the cli.sentry.dev sourcemap upload
+  // going dark from 2026-04-22 to 2026-04-24 (see #845, fixed in #846).
+  //
+  // We set it on the `client` environment (which produces `dist/_astro/`
+  // — what `sentry sourcemap inject/upload docs/dist/` operates on). The
+  // `ssr` line is a no-op today because this site is static-only, but
+  // guards against regressions if a server adapter is added later.
   vite: {
     environments: {
       client: { build: { sourcemap: "hidden" } },

--- a/docs/src/fragments/commands/sourcemap.md
+++ b/docs/src/fragments/commands/sourcemap.md
@@ -27,3 +27,27 @@ sentry sourcemap upload ./dist --release 1.0.0
 # Set a custom URL prefix
 sentry sourcemap upload ./dist --url-prefix '~/static/js/'
 ```
+
+## Error handling
+
+Both `sentry sourcemap inject` and `sentry sourcemap upload` exit with an
+error if zero JS + sourcemap pairs are discovered in the target
+directory. This catches silent bundler misconfigurations — the most
+common cause is a bundler that isn't emitting `.map` files:
+
+```
+# Vite / Astro: set `vite.build.sourcemap: "hidden"` (Astro 5) or
+# `vite.environments.client.build.sourcemap: "hidden"` (Astro 6+).
+
+# webpack: set `devtool: "hidden-source-map"`.
+
+# esbuild: set `sourcemap: true` or `sourcemap: "linked"`.
+```
+
+For CI steps that may run against legitimately-empty directories (e.g.,
+library-only repos, conditional release skips), pass `--allow-empty` to
+suppress the error:
+
+```bash
+sentry sourcemap upload ./dist --allow-empty
+```

--- a/plugins/sentry-cli/skills/sentry-cli/references/sourcemap.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/sourcemap.md
@@ -53,6 +53,8 @@ sentry sourcemap upload ./dist --release 1.0.0
 
 # Set a custom URL prefix
 sentry sourcemap upload ./dist --url-prefix '~/static/js/'
+
+sentry sourcemap upload ./dist --allow-empty
 ```
 
 All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/plugins/sentry-cli/skills/sentry-cli/references/sourcemap.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/sourcemap.md
@@ -18,7 +18,7 @@ Inject debug IDs into JavaScript files and sourcemaps
 **Flags:**
 - `--ext <value> - Comma-separated file extensions to process (default: .js,.cjs,.mjs)`
 - `--dry-run - Show what would be modified without writing`
-- `--allow-empty - Exit successfully when no JS + sourcemap pairs are discovered (default: error out to catch silent build misconfigurations)`
+- `--allow-empty - Exit successfully when no JS + sourcemap pairs are found (default: error out to catch silent build misconfigurations)`
 
 **Examples:**
 
@@ -40,7 +40,7 @@ Upload sourcemaps to Sentry
 **Flags:**
 - `--release <value> - Release version to associate with the upload`
 - `--url-prefix <value> - URL prefix for uploaded files (default: ~/) - (default: "~/")`
-- `--allow-empty - Exit successfully when no sourcemap pairs are found (default: error out to catch silent build misconfigurations)`
+- `--allow-empty - Exit successfully when no JS + sourcemap pairs are found (default: error out to catch silent build misconfigurations)`
 
 **Examples:**
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/sourcemap.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/sourcemap.md
@@ -18,6 +18,7 @@ Inject debug IDs into JavaScript files and sourcemaps
 **Flags:**
 - `--ext <value> - Comma-separated file extensions to process (default: .js,.cjs,.mjs)`
 - `--dry-run - Show what would be modified without writing`
+- `--allow-empty - Exit successfully when no JS + sourcemap pairs are discovered (default: error out to catch silent build misconfigurations)`
 
 **Examples:**
 
@@ -39,6 +40,7 @@ Upload sourcemaps to Sentry
 **Flags:**
 - `--release <value> - Release version to associate with the upload`
 - `--url-prefix <value> - URL prefix for uploaded files (default: ~/) - (default: "~/")`
+- `--allow-empty - Exit successfully when no sourcemap pairs are found (default: error out to catch silent build misconfigurations)`
 
 **Examples:**
 

--- a/src/commands/sourcemap/inject.ts
+++ b/src/commands/sourcemap/inject.ts
@@ -7,7 +7,6 @@
 
 import type { SentryContext } from "../../context.js";
 import { buildCommand } from "../../lib/command.js";
-import { ValidationError } from "../../lib/errors.js";
 import {
   colorTag,
   mdKvTable,
@@ -15,6 +14,9 @@ import {
 } from "../../lib/formatters/markdown.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import {
+  assertDirectoryReadable,
+  buildEmptyDiscoveryError,
+  diagnoseEmptyDiscovery,
   type InjectResult,
   injectDirectory,
 } from "../../lib/sourcemap/inject.js";
@@ -56,10 +58,15 @@ export const injectCommand = buildCommand({
       "Scans a directory for .js/.mjs/.cjs files and their companion .map files, " +
       "then injects Sentry debug IDs for reliable sourcemap resolution.\n\n" +
       "The injection is idempotent — files that already have debug IDs are skipped.\n\n" +
+      "Exits with an error if zero JS + sourcemap pairs are discovered " +
+      "(typical cause: bundler not emitting .map files). Pass " +
+      "--allow-empty to suppress this check for directories that may " +
+      "legitimately be empty.\n\n" +
       "Usage:\n" +
       "  sentry sourcemap inject ./dist\n" +
       "  sentry sourcemap inject ./build --ext .js,.mjs\n" +
-      "  sentry sourcemap inject ./out --dry-run",
+      "  sentry sourcemap inject ./out --dry-run\n" +
+      "  sentry sourcemap inject ./maybe-empty --allow-empty",
   },
   output: {
     human: formatInjectResult,
@@ -104,23 +111,25 @@ export const injectCommand = buildCommand({
     flags: { ext?: string; "dry-run"?: boolean; "allow-empty"?: boolean },
     dir: string
   ) {
+    // Distinct errors for "directory missing" vs "directory empty/
+    // misconfigured" — see src/lib/sourcemap/inject.ts.
+    await assertDirectoryReadable(dir);
+
     const extensions = flags.ext?.split(",").map((e) => e.trim());
     const results = await injectDirectory(dir, {
       extensions,
       dryRun: flags["dry-run"],
     });
 
-    // Guard against silent misconfigurations: zero *discovered* pairs almost
-    // always means the bundler didn't emit .map files. This is distinct from
-    // zero *injected* (which is legitimate when every pair already has a
-    // debug ID — the idempotent re-run case). Callers that legitimately
-    // invoke inject on potentially-empty directories can pass --allow-empty.
+    // Guard against silent misconfigurations: zero *discovered* pairs
+    // almost always means the bundler didn't emit .map files. This is
+    // distinct from zero *injected* (which is legitimate when every
+    // pair already has a debug ID — the idempotent re-run case).
+    // Callers that legitimately invoke inject on potentially-empty
+    // directories can pass --allow-empty.
     if (results.length === 0 && !flags["allow-empty"]) {
-      throw new ValidationError(
-        `No JS + sourcemap pairs found in '${dir}'. Ensure your bundler ` +
-          "emits sourcemaps (e.g., Vite: `build.sourcemap: 'hidden'`), or " +
-          "pass --allow-empty to suppress this error."
-      );
+      const diag = await diagnoseEmptyDiscovery(dir, { extensions });
+      throw buildEmptyDiscoveryError(dir, diag);
     }
 
     const modified = results.filter((r) => r.injected).length;

--- a/src/commands/sourcemap/inject.ts
+++ b/src/commands/sourcemap/inject.ts
@@ -100,7 +100,7 @@ export const injectCommand = buildCommand({
       "allow-empty": {
         kind: "boolean",
         brief:
-          "Exit successfully when no JS + sourcemap pairs are discovered " +
+          "Exit successfully when no JS + sourcemap pairs are found " +
           "(default: error out to catch silent build misconfigurations)",
         optional: true,
         default: false,
@@ -112,10 +112,10 @@ export const injectCommand = buildCommand({
     flags: { ext?: string; "dry-run"?: boolean; "allow-empty"?: boolean },
     dir: string
   ) {
-    // Phase 1 — read-only validation. Distinct errors for "directory
-    // missing" vs "directory empty/misconfigured". Discovery runs
-    // without side effects so we never write debug IDs into files when
-    // the upstream state is doomed (empty dir, typo'd path).
+    // Discover pairs read-only first so we don't error after partially
+    // mutating files. Zero *discovered* pairs (distinct from zero
+    // *injected* — the idempotent re-run case) almost always means a
+    // missing-.map bundler misconfiguration; --allow-empty opts out.
     await assertDirectoryReadable(dir);
 
     const extensions = flags.ext?.split(",").map((e) => e.trim());
@@ -123,21 +123,12 @@ export const injectCommand = buildCommand({
       ? new Set(extensions.map((e) => (e.startsWith(".") ? e : `.${e}`)))
       : undefined;
 
-    // Guard against silent misconfigurations: zero *discovered* pairs
-    // almost always means the bundler didn't emit .map files. This is
-    // distinct from zero *injected* (which is legitimate when every
-    // pair already has a debug ID — the idempotent re-run case).
-    // Callers that legitimately invoke inject on potentially-empty
-    // directories can pass --allow-empty.
     const pairs = await discoverFilePairs(dir, extSet);
     if (pairs.length === 0 && !flags["allow-empty"]) {
       const diag = await diagnoseEmptyDiscovery(dir, { extensions });
       throw buildEmptyDiscoveryError(dir, diag);
     }
 
-    // Phase 2 — mutating work (skipped in dry-run). The second pass
-    // through `injectDirectory` re-walks the directory; this is cheap
-    // relative to the sourcemap parsing/rewriting it does per pair.
     const results = await injectDirectory(dir, {
       extensions,
       dryRun: flags["dry-run"],

--- a/src/commands/sourcemap/inject.ts
+++ b/src/commands/sourcemap/inject.ts
@@ -7,6 +7,7 @@
 
 import type { SentryContext } from "../../context.js";
 import { buildCommand } from "../../lib/command.js";
+import { ValidationError } from "../../lib/errors.js";
 import {
   colorTag,
   mdKvTable,
@@ -88,11 +89,19 @@ export const injectCommand = buildCommand({
         optional: true,
         default: false,
       },
+      "allow-empty": {
+        kind: "boolean",
+        brief:
+          "Exit successfully when no JS + sourcemap pairs are discovered " +
+          "(default: error out to catch silent build misconfigurations)",
+        optional: true,
+        default: false,
+      },
     },
   },
   async *func(
     this: SentryContext,
-    flags: { ext?: string; "dry-run"?: boolean },
+    flags: { ext?: string; "dry-run"?: boolean; "allow-empty"?: boolean },
     dir: string
   ) {
     const extensions = flags.ext?.split(",").map((e) => e.trim());
@@ -100,6 +109,19 @@ export const injectCommand = buildCommand({
       extensions,
       dryRun: flags["dry-run"],
     });
+
+    // Guard against silent misconfigurations: zero *discovered* pairs almost
+    // always means the bundler didn't emit .map files. This is distinct from
+    // zero *injected* (which is legitimate when every pair already has a
+    // debug ID — the idempotent re-run case). Callers that legitimately
+    // invoke inject on potentially-empty directories can pass --allow-empty.
+    if (results.length === 0 && !flags["allow-empty"]) {
+      throw new ValidationError(
+        `No JS + sourcemap pairs found in '${dir}'. Ensure your bundler ` +
+          "emits sourcemaps (e.g., Vite: `build.sourcemap: 'hidden'`), or " +
+          "pass --allow-empty to suppress this error."
+      );
+    }
 
     const modified = results.filter((r) => r.injected).length;
     const skipped = results.length - modified;

--- a/src/commands/sourcemap/inject.ts
+++ b/src/commands/sourcemap/inject.ts
@@ -17,6 +17,7 @@ import {
   assertDirectoryReadable,
   buildEmptyDiscoveryError,
   diagnoseEmptyDiscovery,
+  discoverFilePairs,
   type InjectResult,
   injectDirectory,
 } from "../../lib/sourcemap/inject.js";
@@ -111,15 +112,16 @@ export const injectCommand = buildCommand({
     flags: { ext?: string; "dry-run"?: boolean; "allow-empty"?: boolean },
     dir: string
   ) {
-    // Distinct errors for "directory missing" vs "directory empty/
-    // misconfigured" — see src/lib/sourcemap/inject.ts.
+    // Phase 1 — read-only validation. Distinct errors for "directory
+    // missing" vs "directory empty/misconfigured". Discovery runs
+    // without side effects so we never write debug IDs into files when
+    // the upstream state is doomed (empty dir, typo'd path).
     await assertDirectoryReadable(dir);
 
     const extensions = flags.ext?.split(",").map((e) => e.trim());
-    const results = await injectDirectory(dir, {
-      extensions,
-      dryRun: flags["dry-run"],
-    });
+    const extSet = extensions
+      ? new Set(extensions.map((e) => (e.startsWith(".") ? e : `.${e}`)))
+      : undefined;
 
     // Guard against silent misconfigurations: zero *discovered* pairs
     // almost always means the bundler didn't emit .map files. This is
@@ -127,10 +129,19 @@ export const injectCommand = buildCommand({
     // pair already has a debug ID — the idempotent re-run case).
     // Callers that legitimately invoke inject on potentially-empty
     // directories can pass --allow-empty.
-    if (results.length === 0 && !flags["allow-empty"]) {
+    const pairs = await discoverFilePairs(dir, extSet);
+    if (pairs.length === 0 && !flags["allow-empty"]) {
       const diag = await diagnoseEmptyDiscovery(dir, { extensions });
       throw buildEmptyDiscoveryError(dir, diag);
     }
+
+    // Phase 2 — mutating work (skipped in dry-run). The second pass
+    // through `injectDirectory` re-walks the directory; this is cheap
+    // relative to the sourcemap parsing/rewriting it does per pair.
+    const results = await injectDirectory(dir, {
+      extensions,
+      dryRun: flags["dry-run"],
+    });
 
     const modified = results.filter((r) => r.injected).length;
     const skipped = results.length - modified;

--- a/src/commands/sourcemap/upload.ts
+++ b/src/commands/sourcemap/upload.ts
@@ -21,6 +21,7 @@ import {
   assertDirectoryReadable,
   buildEmptyDiscoveryError,
   diagnoseEmptyDiscovery,
+  discoverFilePairs,
   injectDirectory,
 } from "../../lib/sourcemap/inject.js";
 
@@ -116,18 +117,17 @@ export const uploadCommand = buildCommand({
     },
     dir: string
   ) {
-    // Validate the directory BEFORE resolving org/project so a
-    // missing/typoed path or a bundler misconfiguration produces the
-    // right error even when the user has no Sentry credentials
-    // configured locally. Non-existent directories get a distinct
-    // message; empty/misconfigured directories get the bundler-oriented
-    // diagnostic. See src/lib/sourcemap/inject.ts for the helpers.
+    // Phase 1 — read-only validation. Runs BEFORE `injectDirectory`
+    // (which writes to disk) and BEFORE `resolveOrgAndProject` (which
+    // may fail on missing credentials). This keeps the command
+    // side-effect-free on every error path, so a user whose upload
+    // fails for any reason (typoed path, missing creds, bundler
+    // misconfig) doesn't end up with partially-injected debug IDs and
+    // a rewritten `.map` file.
     await assertDirectoryReadable(dir);
+    const pairs = await discoverFilePairs(dir);
 
-    // Discover and inject debug IDs into JS + sourcemap pairs
-    const results = await injectDirectory(dir);
-
-    if (results.length === 0 && !flags["allow-empty"]) {
+    if (pairs.length === 0 && !flags["allow-empty"]) {
       // Silent misconfigurations (e.g., the bundler didn't emit .map
       // files) used to succeed with "0 uploaded". That makes post-deploy
       // Sentry events unsymbolicated with no build-time signal. Default
@@ -141,7 +141,8 @@ export const uploadCommand = buildCommand({
     // Resolve org/project via the standard cascade. Runs AFTER the
     // directory check so local/unauthenticated invocations still get the
     // actionable bundler-oriented error instead of "Organization and
-    // project are required".
+    // project are required", but BEFORE the actual debug-ID injection
+    // so we never mutate user files on a doomed run.
     const resolved = await resolveOrgAndProject({
       cwd: this.cwd,
       usageHint: USAGE_HINT,
@@ -151,9 +152,9 @@ export const uploadCommand = buildCommand({
     }
     const { org, project } = resolved;
 
-    if (results.length === 0) {
-      // --allow-empty path: succeed silently for callers that
-      // legitimately invoke upload on potentially-empty directories.
+    if (pairs.length === 0) {
+      // --allow-empty path: nothing to do. Don't recommend running
+      // `sentry sourcemap inject` — we'd hit the same empty-dir state.
       yield new CommandOutput<UploadCommandResult>({
         org,
         project,
@@ -161,9 +162,17 @@ export const uploadCommand = buildCommand({
         filesUploaded: 0,
       });
       return {
-        hint: "No JS + sourcemap pairs found. Run `sentry sourcemap inject` first.",
+        hint:
+          "No JS + sourcemap pairs found in the target directory. " +
+          "If this is unexpected, check your bundler emits .map files.",
       };
     }
+
+    // Phase 2 — mutating work. Inject debug IDs into each pair. Only
+    // runs once we know (a) the directory exists, (b) it has pairs, and
+    // (c) Sentry credentials are resolved. `injectDirectory` is
+    // idempotent on re-runs (skips files that already carry a debug ID).
+    const results = await injectDirectory(dir);
 
     const urlPrefix = flags["url-prefix"] ?? "~/";
 

--- a/src/commands/sourcemap/upload.ts
+++ b/src/commands/sourcemap/upload.ts
@@ -117,32 +117,17 @@ export const uploadCommand = buildCommand({
     },
     dir: string
   ) {
-    // Phase 1 — read-only validation. Runs BEFORE `injectDirectory`
-    // (which writes to disk) and BEFORE `resolveOrgAndProject` (which
-    // may fail on missing credentials). This keeps the command
-    // side-effect-free on every error path, so a user whose upload
-    // fails for any reason (typoed path, missing creds, bundler
-    // misconfig) doesn't end up with partially-injected debug IDs and
-    // a rewritten `.map` file.
+    // Validate the directory and discover pairs read-only first so we
+    // don't write debug IDs when the upload won't proceed (empty dir,
+    // typoed path, missing credentials).
     await assertDirectoryReadable(dir);
     const pairs = await discoverFilePairs(dir);
 
     if (pairs.length === 0 && !flags["allow-empty"]) {
-      // Silent misconfigurations (e.g., the bundler didn't emit .map
-      // files) used to succeed with "0 uploaded". That makes post-deploy
-      // Sentry events unsymbolicated with no build-time signal. Default
-      // to erroring out so CI fails loudly; `--allow-empty` preserves
-      // the old behavior for callers that legitimately invoke upload on
-      // potentially-empty directories.
       const diag = await diagnoseEmptyDiscovery(dir);
       throw buildEmptyDiscoveryError(dir, diag);
     }
 
-    // Resolve org/project via the standard cascade. Runs AFTER the
-    // directory check so local/unauthenticated invocations still get the
-    // actionable bundler-oriented error instead of "Organization and
-    // project are required", but BEFORE the actual debug-ID injection
-    // so we never mutate user files on a doomed run.
     const resolved = await resolveOrgAndProject({
       cwd: this.cwd,
       usageHint: USAGE_HINT,
@@ -153,8 +138,6 @@ export const uploadCommand = buildCommand({
     const { org, project } = resolved;
 
     if (pairs.length === 0) {
-      // --allow-empty path: nothing to do. Don't recommend running
-      // `sentry sourcemap inject` — we'd hit the same empty-dir state.
       yield new CommandOutput<UploadCommandResult>({
         org,
         project,
@@ -168,10 +151,6 @@ export const uploadCommand = buildCommand({
       };
     }
 
-    // Phase 2 — mutating work. Inject debug IDs into each pair. Only
-    // runs once we know (a) the directory exists, (b) it has pairs, and
-    // (c) Sentry credentials are resolved. `injectDirectory` is
-    // idempotent on re-runs (skips files that already carry a debug ID).
     const results = await injectDirectory(dir);
 
     const urlPrefix = flags["url-prefix"] ?? "~/";

--- a/src/commands/sourcemap/upload.ts
+++ b/src/commands/sourcemap/upload.ts
@@ -13,11 +13,16 @@ import {
   uploadSourcemaps,
 } from "../../lib/api/sourcemaps.js";
 import { buildCommand } from "../../lib/command.js";
-import { ContextError, ValidationError } from "../../lib/errors.js";
+import { ContextError } from "../../lib/errors.js";
 import { mdKvTable, renderMarkdown } from "../../lib/formatters/markdown.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import { resolveOrgAndProject } from "../../lib/resolve-target.js";
-import { injectDirectory } from "../../lib/sourcemap/inject.js";
+import {
+  assertDirectoryReadable,
+  buildEmptyDiscoveryError,
+  diagnoseEmptyDiscovery,
+  injectDirectory,
+} from "../../lib/sourcemap/inject.js";
 
 /** Result type for the upload command. */
 type UploadCommandResult = {
@@ -54,10 +59,15 @@ export const uploadCommand = buildCommand({
       "debug-ID-based matching.\n\n" +
       "Automatically injects debug IDs into any files that don't already have them.\n" +
       "Org/project are auto-detected from DSN, env vars, or config defaults.\n\n" +
+      "Exits with an error if zero JS + sourcemap pairs are discovered " +
+      "(typical cause: bundler not emitting .map files). Pass " +
+      "--allow-empty to suppress this check for directories that may " +
+      "legitimately be empty.\n\n" +
       "Usage:\n" +
       "  sentry sourcemap upload ./dist\n" +
       "  sentry sourcemap upload ./dist --release 1.0.0\n" +
-      "  sentry sourcemap upload ./dist --url-prefix '~/static/js/'",
+      "  sentry sourcemap upload ./dist --url-prefix '~/static/js/'\n" +
+      "  sentry sourcemap upload ./maybe-empty --allow-empty",
   },
   output: {
     human: formatUploadResult,
@@ -106,7 +116,32 @@ export const uploadCommand = buildCommand({
     },
     dir: string
   ) {
-    // Resolve org/project via the standard cascade
+    // Validate the directory BEFORE resolving org/project so a
+    // missing/typoed path or a bundler misconfiguration produces the
+    // right error even when the user has no Sentry credentials
+    // configured locally. Non-existent directories get a distinct
+    // message; empty/misconfigured directories get the bundler-oriented
+    // diagnostic. See src/lib/sourcemap/inject.ts for the helpers.
+    await assertDirectoryReadable(dir);
+
+    // Discover and inject debug IDs into JS + sourcemap pairs
+    const results = await injectDirectory(dir);
+
+    if (results.length === 0 && !flags["allow-empty"]) {
+      // Silent misconfigurations (e.g., the bundler didn't emit .map
+      // files) used to succeed with "0 uploaded". That makes post-deploy
+      // Sentry events unsymbolicated with no build-time signal. Default
+      // to erroring out so CI fails loudly; `--allow-empty` preserves
+      // the old behavior for callers that legitimately invoke upload on
+      // potentially-empty directories.
+      const diag = await diagnoseEmptyDiscovery(dir);
+      throw buildEmptyDiscoveryError(dir, diag);
+    }
+
+    // Resolve org/project via the standard cascade. Runs AFTER the
+    // directory check so local/unauthenticated invocations still get the
+    // actionable bundler-oriented error instead of "Organization and
+    // project are required".
     const resolved = await resolveOrgAndProject({
       cwd: this.cwd,
       usageHint: USAGE_HINT,
@@ -116,23 +151,9 @@ export const uploadCommand = buildCommand({
     }
     const { org, project } = resolved;
 
-    // Discover and inject debug IDs into JS + sourcemap pairs
-    const results = await injectDirectory(dir);
-
     if (results.length === 0) {
-      // Silent misconfigurations (e.g., the bundler didn't emit .map files)
-      // used to succeed with "0 uploaded". That makes post-deploy Sentry
-      // events unsymbolicated with no build-time signal. Default to erroring
-      // out so CI fails loudly; `--allow-empty` preserves the old behavior
-      // for callers that legitimately invoke upload on potentially-empty
-      // directories.
-      if (!flags["allow-empty"]) {
-        throw new ValidationError(
-          `No JS + sourcemap pairs found in '${dir}'. Ensure your bundler ` +
-            "emits sourcemaps (e.g., Vite: `build.sourcemap: 'hidden'`), or " +
-            "pass --allow-empty to suppress this error."
-        );
-      }
+      // --allow-empty path: succeed silently for callers that
+      // legitimately invoke upload on potentially-empty directories.
       yield new CommandOutput<UploadCommandResult>({
         org,
         project,

--- a/src/commands/sourcemap/upload.ts
+++ b/src/commands/sourcemap/upload.ts
@@ -13,7 +13,7 @@ import {
   uploadSourcemaps,
 } from "../../lib/api/sourcemaps.js";
 import { buildCommand } from "../../lib/command.js";
-import { ContextError } from "../../lib/errors.js";
+import { ContextError, ValidationError } from "../../lib/errors.js";
 import { mdKvTable, renderMarkdown } from "../../lib/formatters/markdown.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import { resolveOrgAndProject } from "../../lib/resolve-target.js";
@@ -87,11 +87,23 @@ export const uploadCommand = buildCommand({
         optional: true,
         default: "~/",
       },
+      "allow-empty": {
+        kind: "boolean",
+        brief:
+          "Exit successfully when no sourcemap pairs are found (default: " +
+          "error out to catch silent build misconfigurations)",
+        optional: true,
+        default: false,
+      },
     },
   },
   async *func(
     this: SentryContext,
-    flags: { release?: string; "url-prefix"?: string },
+    flags: {
+      release?: string;
+      "url-prefix"?: string;
+      "allow-empty"?: boolean;
+    },
     dir: string
   ) {
     // Resolve org/project via the standard cascade
@@ -108,6 +120,19 @@ export const uploadCommand = buildCommand({
     const results = await injectDirectory(dir);
 
     if (results.length === 0) {
+      // Silent misconfigurations (e.g., the bundler didn't emit .map files)
+      // used to succeed with "0 uploaded". That makes post-deploy Sentry
+      // events unsymbolicated with no build-time signal. Default to erroring
+      // out so CI fails loudly; `--allow-empty` preserves the old behavior
+      // for callers that legitimately invoke upload on potentially-empty
+      // directories.
+      if (!flags["allow-empty"]) {
+        throw new ValidationError(
+          `No JS + sourcemap pairs found in '${dir}'. Ensure your bundler ` +
+            "emits sourcemaps (e.g., Vite: `build.sourcemap: 'hidden'`), or " +
+            "pass --allow-empty to suppress this error."
+        );
+      }
       yield new CommandOutput<UploadCommandResult>({
         org,
         project,

--- a/src/commands/sourcemap/upload.ts
+++ b/src/commands/sourcemap/upload.ts
@@ -27,10 +27,11 @@ import {
 
 /** Result type for the upload command. */
 type UploadCommandResult = {
-  /** Organization slug. */
-  org: string;
-  /** Project slug. */
-  project: string;
+  /** Organization slug. Omitted when --allow-empty short-circuits before
+   * org/project resolution. */
+  org?: string;
+  /** Project slug. Omitted in the same short-circuit case. */
+  project?: string;
   /** Release version, if provided. */
   release?: string;
   /** Number of file pairs uploaded. */
@@ -39,11 +40,14 @@ type UploadCommandResult = {
 
 /** Format human-readable output for upload results. */
 function formatUploadResult(data: UploadCommandResult): string {
-  const rows: [string, string][] = [
-    ["Organization", data.org],
-    ["Project", data.project],
-    ["Files uploaded", String(data.filesUploaded)],
-  ];
+  const rows: [string, string][] = [];
+  if (data.org) {
+    rows.push(["Organization", data.org]);
+  }
+  if (data.project) {
+    rows.push(["Project", data.project]);
+  }
+  rows.push(["Files uploaded", String(data.filesUploaded)]);
   if (data.release) {
     rows.push(["Release", data.release]);
   }
@@ -123,9 +127,23 @@ export const uploadCommand = buildCommand({
     await assertDirectoryReadable(dir);
     const pairs = await discoverFilePairs(dir);
 
-    if (pairs.length === 0 && !flags["allow-empty"]) {
-      const diag = await diagnoseEmptyDiscovery(dir);
-      throw buildEmptyDiscoveryError(dir, diag);
+    if (pairs.length === 0) {
+      if (!flags["allow-empty"]) {
+        const diag = await diagnoseEmptyDiscovery(dir);
+        throw buildEmptyDiscoveryError(dir, diag);
+      }
+      // --allow-empty: nothing to upload, so don't require Sentry
+      // credentials. This makes the flag actually usable in the
+      // library-only / conditional-release-skip cases the docs name.
+      yield new CommandOutput<UploadCommandResult>({
+        release: flags.release,
+        filesUploaded: 0,
+      });
+      return {
+        hint:
+          "No JS + sourcemap pairs found in the target directory. " +
+          "If this is unexpected, check your bundler emits .map files.",
+      };
     }
 
     const resolved = await resolveOrgAndProject({
@@ -136,20 +154,6 @@ export const uploadCommand = buildCommand({
       throw new ContextError("Organization and project", USAGE_HINT);
     }
     const { org, project } = resolved;
-
-    if (pairs.length === 0) {
-      yield new CommandOutput<UploadCommandResult>({
-        org,
-        project,
-        release: flags.release,
-        filesUploaded: 0,
-      });
-      return {
-        hint:
-          "No JS + sourcemap pairs found in the target directory. " +
-          "If this is unexpected, check your bundler emits .map files.",
-      };
-    }
 
     const results = await injectDirectory(dir);
 

--- a/src/commands/sourcemap/upload.ts
+++ b/src/commands/sourcemap/upload.ts
@@ -101,8 +101,8 @@ export const uploadCommand = buildCommand({
       "allow-empty": {
         kind: "boolean",
         brief:
-          "Exit successfully when no sourcemap pairs are found (default: " +
-          "error out to catch silent build misconfigurations)",
+          "Exit successfully when no JS + sourcemap pairs are found " +
+          "(default: error out to catch silent build misconfigurations)",
         optional: true,
         default: false,
       },

--- a/src/lib/sourcemap/inject.ts
+++ b/src/lib/sourcemap/inject.ts
@@ -198,13 +198,9 @@ export async function diagnoseEmptyDiscovery(
 ): Promise<DiscoveryDiagnostic> {
   // Build one set covering JS extensions + `.map` so the walker visits
   // both in a single pass.
-  const extensions = new Set<string>(DEFAULT_EXTENSIONS);
-  if (options.extensions) {
-    extensions.clear();
-    for (const e of options.extensions) {
-      extensions.add(e.startsWith(".") ? e : `.${e}`);
-    }
-  }
+  const extensions = options.extensions
+    ? new Set(options.extensions.map((e) => (e.startsWith(".") ? e : `.${e}`)))
+    : new Set(DEFAULT_EXTENSIONS);
   extensions.add(".map");
 
   const absDir = resolvePath(dir);

--- a/src/lib/sourcemap/inject.ts
+++ b/src/lib/sourcemap/inject.ts
@@ -73,7 +73,7 @@ export async function injectDirectory(
 }
 
 /** A discovered JS + sourcemap pair. */
-type FilePair = { jsPath: string; mapPath: string };
+export type FilePair = { jsPath: string; mapPath: string };
 
 /**
  * Check if a path has a companion .map file.
@@ -114,9 +114,18 @@ async function findCompanionMap(jsPath: string): Promise<string | undefined> {
  */
 const SOURCEMAP_SKIP_DIRS: readonly string[] = [NODE_MODULES_DIRNAME];
 
-async function discoverFilePairs(
+/**
+ * Discovery pass with no side effects — returns the list of JS +
+ * sourcemap pairs without injecting debug IDs. Exposed so the
+ * `sentry sourcemap upload` command can run a read-only emptiness
+ * check (and emit the bundler-oriented diagnostic) BEFORE calling
+ * {@link injectDirectory} — which writes to disk and would otherwise
+ * leave partial state when upload subsequently fails on credentials
+ * resolution.
+ */
+export async function discoverFilePairs(
   dir: string,
-  extensions: Set<string>
+  extensions: Set<string> = DEFAULT_EXTENSIONS
 ): Promise<FilePair[]> {
   // `walkFiles` requires an absolute cwd. CLI callers pass
   // user-supplied positional args like `./dist` directly through to

--- a/src/lib/sourcemap/inject.ts
+++ b/src/lib/sourcemap/inject.ts
@@ -8,6 +8,7 @@
 import { readFile, stat } from "node:fs/promises";
 import { resolve as resolvePath } from "node:path";
 import { NODE_MODULES_DIRNAME } from "../constants.js";
+import { ValidationError } from "../errors.js";
 import { walkFiles } from "../scan/index.js";
 import { EXISTING_DEBUGID_RE, injectDebugId } from "./debug-id.js";
 
@@ -137,4 +138,141 @@ async function discoverFilePairs(
     }
   }
   return pairs;
+}
+
+/**
+ * Validate that `dir` is an existing directory readable for sourcemap
+ * discovery, and classify what's inside for diagnostic purposes when the
+ * scan returns zero pairs. Used by `sentry sourcemap inject` /
+ * `sourcemap upload` to produce actionable error messages instead of the
+ * generic "no pairs found" that hid the getsentry/cli docs-site silent
+ * failure mode (Astro 6 stopped emitting `.map` files; CI stayed green).
+ *
+ * Separate from `injectDirectory` so:
+ * - The upload command can stat the directory BEFORE resolving
+ *   org/project, producing the bundler-oriented error even when the
+ *   user has no Sentry credentials configured.
+ * - The diagnostic walk is skipped on the happy path (pairs > 0).
+ *
+ * @throws ValidationError if `dir` doesn't exist or isn't a directory.
+ */
+export async function assertDirectoryReadable(dir: string): Promise<void> {
+  try {
+    const s = await stat(dir);
+    if (!s.isDirectory()) {
+      throw new ValidationError(
+        `Path '${dir}' is not a directory.`,
+        "directory"
+      );
+    }
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      throw err;
+    }
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      throw new ValidationError(
+        `Directory '${dir}' does not exist.`,
+        "directory"
+      );
+    }
+    // EACCES, EPERM, etc. — surface the underlying system error.
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new ValidationError(
+      `Cannot read directory '${dir}': ${msg}`,
+      "directory"
+    );
+  }
+}
+
+/**
+ * Diagnostic counts for a directory that produced zero JS + sourcemap
+ * pairs. Used to tailor the error message to the specific failure mode
+ * the user is hitting (see callers in `src/commands/sourcemap/`).
+ */
+export type DiscoveryDiagnostic = {
+  /** Total `.js`/`.cjs`/`.mjs` files encountered. */
+  jsFiles: number;
+  /** Total `.map` files encountered. */
+  mapFiles: number;
+};
+
+/**
+ * Scan a directory for JS and map files separately to diagnose why the
+ * primary pair-discovery returned zero results. Cheap (same walker,
+ * single pass); only called on the error path.
+ */
+export async function diagnoseEmptyDiscovery(
+  dir: string,
+  options: InjectDirectoryOptions = {}
+): Promise<DiscoveryDiagnostic> {
+  const jsExtensions = options.extensions
+    ? new Set(options.extensions.map((e) => (e.startsWith(".") ? e : `.${e}`)))
+    : DEFAULT_EXTENSIONS;
+  const absDir = resolvePath(dir);
+  let jsFiles = 0;
+  let mapFiles = 0;
+  for await (const entry of walkFiles({
+    cwd: absDir,
+    // Pass both sets of extensions in one walk to avoid a second traversal.
+    extensions: new Set([...jsExtensions, ".map"]),
+    alwaysSkipDirs: SOURCEMAP_SKIP_DIRS,
+    hidden: false,
+    respectGitignore: false,
+    maxFileSize: Number.POSITIVE_INFINITY,
+  })) {
+    if (entry.absolutePath.endsWith(".map")) {
+      mapFiles += 1;
+    } else {
+      jsFiles += 1;
+    }
+  }
+  return { jsFiles, mapFiles };
+}
+
+/**
+ * Build an actionable error message for the zero-pairs case, tailored to
+ * which side of the JS/map pairing is missing. Shared between the inject
+ * and upload commands so the wording stays consistent.
+ */
+export function buildEmptyDiscoveryError(
+  dir: string,
+  diag: DiscoveryDiagnostic
+): ValidationError {
+  const { jsFiles, mapFiles } = diag;
+  if (jsFiles === 0 && mapFiles === 0) {
+    return new ValidationError(
+      `Directory '${dir}' contains no JS or sourcemap files. ` +
+        "Check the path points at your build output, or pass " +
+        "--allow-empty to suppress this error.",
+      "directory"
+    );
+  }
+  if (jsFiles > 0 && mapFiles === 0) {
+    return new ValidationError(
+      `Found ${jsFiles} JS file(s) in '${dir}' but no companion .map ` +
+        "files. Your bundler is not emitting sourcemaps. For Vite/Astro: " +
+        "`vite.environments.client.build.sourcemap: 'hidden'`. For webpack: " +
+        "`devtool: 'hidden-source-map'`. Pass --allow-empty to suppress.",
+      "directory"
+    );
+  }
+  if (mapFiles > 0 && jsFiles === 0) {
+    return new ValidationError(
+      `Found ${mapFiles} .map file(s) in '${dir}' but no companion JS ` +
+        "files. Ensure your build emits both JS and maps to the same " +
+        "directory. Pass --allow-empty to suppress.",
+      "directory"
+    );
+  }
+  // Both sides have files but no pairs matched by basename — e.g.
+  // hash-renamed JS paired with a stable-name map, or maps in a sibling
+  // `maps/` dir.
+  return new ValidationError(
+    `Found ${jsFiles} JS and ${mapFiles} .map file(s) in '${dir}' but ` +
+      "no JS file has a matching `<name>.map` companion. Check that your " +
+      "bundler emits JS and sourcemaps with matching basenames. Pass " +
+      "--allow-empty to suppress.",
+    "directory"
+  );
 }

--- a/src/lib/sourcemap/inject.ts
+++ b/src/lib/sourcemap/inject.ts
@@ -115,13 +115,10 @@ async function findCompanionMap(jsPath: string): Promise<string | undefined> {
 const SOURCEMAP_SKIP_DIRS: readonly string[] = [NODE_MODULES_DIRNAME];
 
 /**
- * Discovery pass with no side effects — returns the list of JS +
- * sourcemap pairs without injecting debug IDs. Exposed so the
- * `sentry sourcemap upload` command can run a read-only emptiness
- * check (and emit the bundler-oriented diagnostic) BEFORE calling
- * {@link injectDirectory} — which writes to disk and would otherwise
- * leave partial state when upload subsequently fails on credentials
- * resolution.
+ * Read-only discovery pass — returns the list of JS + sourcemap pairs
+ * without injecting debug IDs. Used as a pre-check by the upload
+ * command so the directory isn't mutated when the upload won't
+ * proceed (empty dir, missing credentials, etc.).
  */
 export async function discoverFilePairs(
   dir: string,
@@ -150,20 +147,9 @@ export async function discoverFilePairs(
 }
 
 /**
- * Validate that `dir` is an existing directory readable for sourcemap
- * discovery, and classify what's inside for diagnostic purposes when the
- * scan returns zero pairs. Used by `sentry sourcemap inject` /
- * `sourcemap upload` to produce actionable error messages instead of the
- * generic "no pairs found" that hid the getsentry/cli docs-site silent
- * failure mode (Astro 6 stopped emitting `.map` files; CI stayed green).
- *
- * Separate from `injectDirectory` so:
- * - The upload command can stat the directory BEFORE resolving
- *   org/project, producing the bundler-oriented error even when the
- *   user has no Sentry credentials configured.
- * - The diagnostic walk is skipped on the happy path (pairs > 0).
- *
- * @throws ValidationError if `dir` doesn't exist or isn't a directory.
+ * Throw {@link ValidationError} if `dir` doesn't exist or isn't a
+ * readable directory. Distinct messages per failure mode so the user
+ * gets a useful pointer instead of "no sourcemaps found".
  */
 export async function assertDirectoryReadable(dir: string): Promise<void> {
   try {
@@ -185,7 +171,6 @@ export async function assertDirectoryReadable(dir: string): Promise<void> {
         "directory"
       );
     }
-    // EACCES, EPERM, etc. — surface the underlying system error.
     const msg = err instanceof Error ? err.message : String(err);
     throw new ValidationError(
       `Cannot read directory '${dir}': ${msg}`,
@@ -195,36 +180,39 @@ export async function assertDirectoryReadable(dir: string): Promise<void> {
 }
 
 /**
- * Diagnostic counts for a directory that produced zero JS + sourcemap
- * pairs. Used to tailor the error message to the specific failure mode
- * the user is hitting (see callers in `src/commands/sourcemap/`).
+ * Counts of JS and `.map` files in a directory, used by
+ * {@link buildEmptyDiscoveryError} to tailor the zero-pairs error.
  */
 export type DiscoveryDiagnostic = {
-  /** Total `.js`/`.cjs`/`.mjs` files encountered. */
   jsFiles: number;
-  /** Total `.map` files encountered. */
   mapFiles: number;
 };
 
 /**
- * Scan a directory for JS and map files separately to diagnose why the
- * primary pair-discovery returned zero results. Cheap (same walker,
- * single pass); only called on the error path.
+ * Count JS and `.map` files in a single walker pass. Only called on
+ * the zero-pairs error path.
  */
 export async function diagnoseEmptyDiscovery(
   dir: string,
   options: InjectDirectoryOptions = {}
 ): Promise<DiscoveryDiagnostic> {
-  const jsExtensions = options.extensions
-    ? new Set(options.extensions.map((e) => (e.startsWith(".") ? e : `.${e}`)))
-    : DEFAULT_EXTENSIONS;
+  // Build one set covering JS extensions + `.map` so the walker visits
+  // both in a single pass.
+  const extensions = new Set<string>(DEFAULT_EXTENSIONS);
+  if (options.extensions) {
+    extensions.clear();
+    for (const e of options.extensions) {
+      extensions.add(e.startsWith(".") ? e : `.${e}`);
+    }
+  }
+  extensions.add(".map");
+
   const absDir = resolvePath(dir);
   let jsFiles = 0;
   let mapFiles = 0;
   for await (const entry of walkFiles({
     cwd: absDir,
-    // Pass both sets of extensions in one walk to avoid a second traversal.
-    extensions: new Set([...jsExtensions, ".map"]),
+    extensions,
     alwaysSkipDirs: SOURCEMAP_SKIP_DIRS,
     hidden: false,
     respectGitignore: false,
@@ -240,9 +228,8 @@ export async function diagnoseEmptyDiscovery(
 }
 
 /**
- * Build an actionable error message for the zero-pairs case, tailored to
- * which side of the JS/map pairing is missing. Shared between the inject
- * and upload commands so the wording stays consistent.
+ * Build an actionable error for the zero-pairs case, tailored to
+ * which side of the JS/map pairing is missing.
  */
 export function buildEmptyDiscoveryError(
   dir: string,
@@ -274,9 +261,6 @@ export function buildEmptyDiscoveryError(
       "directory"
     );
   }
-  // Both sides have files but no pairs matched by basename — e.g.
-  // hash-renamed JS paired with a stable-name map, or maps in a sibling
-  // `maps/` dir.
   return new ValidationError(
     `Found ${jsFiles} JS and ${mapFiles} .map file(s) in '${dir}' but ` +
       "no JS file has a matching `<name>.map` companion. Check that your " +

--- a/test/commands/sourcemap/upload.test.ts
+++ b/test/commands/sourcemap/upload.test.ts
@@ -222,6 +222,18 @@ describe("sourcemap upload command — --allow-empty behavior", () => {
     ).resolves.toBeUndefined();
   });
 
+  test("empty directory with --allow-empty: does not require credentials", async () => {
+    // The library-only / conditional-release-skip cases named in the
+    // docs may run without DSN/org/project context. With nothing to
+    // upload, the command must not insist on resolving them.
+    delete process.env.SENTRY_ORG;
+    delete process.env.SENTRY_PROJECT;
+    const ctx = makeContext();
+    await expect(
+      func.call(ctx, { "allow-empty": true }, dir)
+    ).resolves.toBeUndefined();
+  });
+
   test("directory with .js files but no .map files: throws", async () => {
     mkdirSync(join(dir, "_astro"));
     writeFileSync(join(dir, "_astro", "app.js"), "console.log(1)\n");

--- a/test/commands/sourcemap/upload.test.ts
+++ b/test/commands/sourcemap/upload.test.ts
@@ -1,15 +1,7 @@
 /**
- * sourcemap inject / upload command tests
- *
- * Focused on the "strict by default, --allow-empty opt-out" behavior added
- * in #846 to guard against silent bundler misconfigurations where no .map
- * files are present in the upload directory. A zero-file upload used to
- * succeed silently, producing no Sentry symbolication and no CI signal —
- * the exact failure mode the getsentry/cli docs site hit (see #845).
- *
- * Also covers the diagnostic branches in `buildEmptyDiscoveryError`
- * (src/lib/sourcemap/inject.ts) that tailor the error message to the
- * specific input shape: empty dir vs. JS-only vs. maps-only.
+ * Tests for the strict-by-default zero-pairs behavior on `sentry
+ * sourcemap inject` / `upload`, including the per-shape diagnostic
+ * branches in `buildEmptyDiscoveryError`.
  */
 
 import {
@@ -30,14 +22,6 @@ import { uploadCommand } from "../../../src/commands/sourcemap/upload.js";
 import * as sourcemapsApi from "../../../src/lib/api/sourcemaps.js";
 import { ValidationError } from "../../../src/lib/errors.js";
 
-// The loader() return is the wrapper-produced async function (NOT a
-// generator) that internally iterates the original generator body and
-// writes rendered output to ctx.stdout. Errors thrown inside the
-// generator body propagate out as a rejected promise.
-//
-// The wrapper uses `this.stdout`/`this.stderr` directly (see
-// `src/lib/command.ts:566`), not `this.process.*`. See AGENTS.md "Stricli
-// buildCommand" lore entry.
 type InjectFuncArgs = {
   ext?: string;
   "dry-run"?: boolean;
@@ -51,34 +35,11 @@ type UploadFuncArgs = {
 type CmdFunc<A> = (this: unknown, flags: A, dir: string) => Promise<unknown>;
 
 function makeContext() {
-  const stdoutChunks: string[] = [];
-  const stderrChunks: string[] = [];
   return {
-    ctx: {
-      stdout: {
-        write: mock((s: string) => {
-          stdoutChunks.push(s);
-        }),
-      },
-      stderr: {
-        write: mock((s: string) => {
-          stderrChunks.push(s);
-        }),
-      },
-      cwd: "/tmp",
-    },
-    stdout: () => stdoutChunks.join(""),
-    stderr: () => stderrChunks.join(""),
+    stdout: { write: mock(() => true) },
+    stderr: { write: mock(() => true) },
+    cwd: "/tmp",
   };
-}
-
-async function runFunc<A>(
-  func: CmdFunc<A>,
-  ctx: unknown,
-  flags: A,
-  dir: string
-): Promise<void> {
-  await func.call(ctx, flags, dir);
 }
 
 describe("sourcemap inject command — --allow-empty behavior", () => {
@@ -94,10 +55,10 @@ describe("sourcemap inject command — --allow-empty behavior", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test("empty directory: throws ValidationError mentioning empty-dir", async () => {
-    const { ctx } = makeContext();
+  test("empty directory: throws actionable ValidationError", async () => {
+    const ctx = makeContext();
     try {
-      await runFunc(func, ctx, {}, dir);
+      await func.call(ctx, {}, dir);
       expect.unreachable("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(ValidationError);
@@ -109,27 +70,25 @@ describe("sourcemap inject command — --allow-empty behavior", () => {
   });
 
   test("empty directory with --allow-empty: succeeds silently", async () => {
-    const { ctx } = makeContext();
+    const ctx = makeContext();
     await expect(
-      runFunc(func, ctx, { "allow-empty": true }, dir)
+      func.call(ctx, { "allow-empty": true }, dir)
     ).resolves.toBeUndefined();
   });
 
   test("directory with a .js + .map pair: succeeds (0 pairs guard not triggered)", async () => {
     writeFileSync(join(dir, "app.js"), "console.log(1)\n");
     writeFileSync(join(dir, "app.js.map"), '{"version":3}\n');
-    const { ctx } = makeContext();
-    await expect(runFunc(func, ctx, {}, dir)).resolves.toBeUndefined();
+    const ctx = makeContext();
+    await expect(func.call(ctx, {}, dir)).resolves.toBeUndefined();
   });
 
   test(".js files without matching .map files: throws with bundler hint", async () => {
-    // The getsentry/cli docs-site failure mode: JS emitted but no .map
-    // files (#845). Error should explicitly name Vite/webpack config.
     writeFileSync(join(dir, "app.js"), "console.log(1)\n");
     writeFileSync(join(dir, "other.js"), "console.log(2)\n");
-    const { ctx } = makeContext();
+    const ctx = makeContext();
     try {
-      await runFunc(func, ctx, {}, dir);
+      await func.call(ctx, {}, dir);
       expect.unreachable("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(ValidationError);
@@ -142,9 +101,9 @@ describe("sourcemap inject command — --allow-empty behavior", () => {
 
   test(".map files without matching .js files: throws with mismatch hint", async () => {
     writeFileSync(join(dir, "app.js.map"), '{"version":3}\n');
-    const { ctx } = makeContext();
+    const ctx = makeContext();
     try {
-      await runFunc(func, ctx, {}, dir);
+      await func.call(ctx, {}, dir);
       expect.unreachable("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(ValidationError);
@@ -155,12 +114,11 @@ describe("sourcemap inject command — --allow-empty behavior", () => {
   });
 
   test("js and map present but no basename match: reports both counts", async () => {
-    // e.g. hash-renamed JS paired with a stable-name map.
     writeFileSync(join(dir, "app.abc123.js"), "console.log(1)\n");
     writeFileSync(join(dir, "app.js.map"), '{"version":3}\n');
-    const { ctx } = makeContext();
+    const ctx = makeContext();
     try {
-      await runFunc(func, ctx, {}, dir);
+      await func.call(ctx, {}, dir);
       expect.unreachable("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(ValidationError);
@@ -173,16 +131,15 @@ describe("sourcemap inject command — --allow-empty behavior", () => {
 
   test("non-existent directory: throws with distinct 'does not exist' message", async () => {
     const missing = join(dir, "does-not-exist");
-    const { ctx } = makeContext();
+    const ctx = makeContext();
     try {
-      await runFunc(func, ctx, {}, missing);
+      await func.call(ctx, {}, missing);
       expect.unreachable("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(ValidationError);
       const msg = (err as Error).message;
       expect(msg).toContain(missing);
       expect(msg).toMatch(/does not exist/i);
-      // Must NOT conflate with the bundler hint.
       expect(msg).not.toContain("--allow-empty");
     }
   });
@@ -190,9 +147,9 @@ describe("sourcemap inject command — --allow-empty behavior", () => {
   test("path is a file, not a directory: throws with distinct message", async () => {
     const filePath = join(dir, "not-a-dir.txt");
     writeFileSync(filePath, "hello\n");
-    const { ctx } = makeContext();
+    const ctx = makeContext();
     try {
-      await runFunc(func, ctx, {}, filePath);
+      await func.call(ctx, {}, filePath);
       expect.unreachable("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(ValidationError);
@@ -203,16 +160,16 @@ describe("sourcemap inject command — --allow-empty behavior", () => {
   });
 
   test("--dry-run + empty directory: still errors (dry-run is not an escape hatch)", async () => {
-    const { ctx } = makeContext();
+    const ctx = makeContext();
     await expect(
-      runFunc(func, ctx, { "dry-run": true }, dir)
+      func.call(ctx, { "dry-run": true }, dir)
     ).rejects.toBeInstanceOf(ValidationError);
   });
 
   test("--dry-run + --allow-empty: succeeds silently", async () => {
-    const { ctx } = makeContext();
+    const ctx = makeContext();
     await expect(
-      runFunc(func, ctx, { "dry-run": true, "allow-empty": true }, dir)
+      func.call(ctx, { "dry-run": true, "allow-empty": true }, dir)
     ).resolves.toBeUndefined();
   });
 });
@@ -224,8 +181,7 @@ describe("sourcemap upload command — --allow-empty behavior", () => {
 
   beforeEach(async () => {
     dir = mkdtempSync(join(tmpdir(), "sentry-upload-cmd-"));
-    // resolveOrgAndProject reads env vars; short-circuit via SENTRY_ORG /
-    // SENTRY_PROJECT so the test doesn't need network or config files.
+    // Short-circuit resolveOrgAndProject so tests don't need DSN/config.
     savedEnv = {
       SENTRY_ORG: process.env.SENTRY_ORG,
       SENTRY_PROJECT: process.env.SENTRY_PROJECT,
@@ -246,10 +202,10 @@ describe("sourcemap upload command — --allow-empty behavior", () => {
     }
   });
 
-  test("empty directory: throws ValidationError mentioning empty-dir", async () => {
-    const { ctx } = makeContext();
+  test("empty directory: throws actionable ValidationError", async () => {
+    const ctx = makeContext();
     try {
-      await runFunc(func, ctx, {}, dir);
+      await func.call(ctx, {}, dir);
       expect.unreachable("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(ValidationError);
@@ -260,34 +216,29 @@ describe("sourcemap upload command — --allow-empty behavior", () => {
   });
 
   test("empty directory with --allow-empty: succeeds silently", async () => {
-    const { ctx } = makeContext();
+    const ctx = makeContext();
     await expect(
-      runFunc(func, ctx, { "allow-empty": true }, dir)
+      func.call(ctx, { "allow-empty": true }, dir)
     ).resolves.toBeUndefined();
   });
 
   test("directory with .js files but no .map files: throws", async () => {
-    // Exact reproduction of the silent-failure mode: docs site had .js
-    // files emitted but no .map files, and upload reported success with
-    // 0 files uploaded.
     mkdirSync(join(dir, "_astro"));
     writeFileSync(join(dir, "_astro", "app.js"), "console.log(1)\n");
-    const { ctx } = makeContext();
-    await expect(runFunc(func, ctx, {}, dir)).rejects.toBeInstanceOf(
+    const ctx = makeContext();
+    await expect(func.call(ctx, {}, dir)).rejects.toBeInstanceOf(
       ValidationError
     );
   });
 
-  test("non-existent directory: throws before touching Sentry creds", async () => {
-    // Even with SENTRY_ORG/SENTRY_PROJECT cleared, the dir-check should
-    // fire first — that's the whole point of reordering the checks so
-    // local/unauthenticated invocations get actionable errors.
+  test("non-existent directory: throws before resolving org/project", async () => {
+    // Cleared so the dir-check has to fire first to produce a useful error.
     delete process.env.SENTRY_ORG;
     delete process.env.SENTRY_PROJECT;
     const missing = join(dir, "does-not-exist");
-    const { ctx } = makeContext();
+    const ctx = makeContext();
     try {
-      await runFunc(func, ctx, {}, missing);
+      await func.call(ctx, {}, missing);
       expect.unreachable("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(ValidationError);
@@ -297,21 +248,16 @@ describe("sourcemap upload command — --allow-empty behavior", () => {
   });
 
   test("error path does not mutate files (js-only dir)", async () => {
-    // Regression guard for the Bugbot finding that led to the
-    // discover-first refactor: previously `injectDirectory` ran BEFORE
-    // the emptiness check, so a js-only dir got debug IDs written into
-    // every JS before the bundler-misconfig error fired. Now discovery
-    // is a read-only pass; injection only runs when we've decided
-    // upload will proceed.
+    // Discovery must be read-only — injection only runs once we've
+    // decided the upload will proceed.
     mkdirSync(join(dir, "_astro"));
     const jsPath = join(dir, "_astro", "app.js");
     const original = "console.log(1)\n";
     writeFileSync(jsPath, original);
-    const { ctx } = makeContext();
-    await expect(runFunc(func, ctx, {}, dir)).rejects.toBeInstanceOf(
+    const ctx = makeContext();
+    await expect(func.call(ctx, {}, dir)).rejects.toBeInstanceOf(
       ValidationError
     );
-    // File must be unchanged — no debug ID IIFE, no sourcemap comment.
     const after = await Bun.file(jsPath).text();
     expect(after).toBe(original);
     expect(after).not.toContain("_sentryDebugIds");
@@ -319,14 +265,10 @@ describe("sourcemap upload command — --allow-empty behavior", () => {
   });
 
   test("happy path: directory with JS+map pair invokes uploadSourcemaps", async () => {
-    // Prove the guard doesn't false-positive on a real upload path, and
-    // that we reach the API call with sensible artifact files.
     mkdirSync(join(dir, "_astro"));
     const jsPath = join(dir, "_astro", "app.js");
     const mapPath = join(dir, "_astro", "app.js.map");
     writeFileSync(jsPath, "console.log(1)\n");
-    // Valid minimal sourcemap so injectDebugId's inject step doesn't
-    // choke parsing.
     writeFileSync(
       mapPath,
       JSON.stringify({
@@ -342,13 +284,12 @@ describe("sourcemap upload command — --allow-empty behavior", () => {
       "uploadSourcemaps"
     ).mockResolvedValue(undefined);
     try {
-      const { ctx } = makeContext();
-      await runFunc(func, ctx, {}, dir);
+      const ctx = makeContext();
+      await func.call(ctx, {}, dir);
       expect(uploadSpy).toHaveBeenCalledTimes(1);
       const callArgs = uploadSpy.mock.calls[0]?.[0];
       expect(callArgs?.org).toBe("test-org");
       expect(callArgs?.project).toBe("test-project");
-      // One JS + one sourcemap artifact per pair.
       expect(callArgs?.files).toHaveLength(2);
       const types = callArgs?.files.map((f) => f.type);
       expect(types).toContain("minified_source");

--- a/test/commands/sourcemap/upload.test.ts
+++ b/test/commands/sourcemap/upload.test.ts
@@ -2,24 +2,42 @@
  * sourcemap inject / upload command tests
  *
  * Focused on the "strict by default, --allow-empty opt-out" behavior added
- * to guard against silent bundler misconfigurations where no .map files are
- * present in the upload directory. A zero-file upload used to succeed
- * silently, producing no Sentry symbolication and no CI signal — the exact
- * failure mode the getsentry/cli docs site hit (see PR #xxx).
+ * in #846 to guard against silent bundler misconfigurations where no .map
+ * files are present in the upload directory. A zero-file upload used to
+ * succeed silently, producing no Sentry symbolication and no CI signal —
+ * the exact failure mode the getsentry/cli docs site hit (see #845).
+ *
+ * Also covers the diagnostic branches in `buildEmptyDiscoveryError`
+ * (src/lib/sourcemap/inject.ts) that tailor the error message to the
+ * specific input shape: empty dir vs. JS-only vs. maps-only.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { injectCommand } from "../../../src/commands/sourcemap/inject.js";
 import { uploadCommand } from "../../../src/commands/sourcemap/upload.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as sourcemapsApi from "../../../src/lib/api/sourcemaps.js";
 import { ValidationError } from "../../../src/lib/errors.js";
 
 // The loader() return is the wrapper-produced async function (NOT a
 // generator) that internally iterates the original generator body and
 // writes rendered output to ctx.stdout. Errors thrown inside the
 // generator body propagate out as a rejected promise.
+//
+// The wrapper uses `this.stdout`/`this.stderr` directly (see
+// `src/lib/command.ts:566`), not `this.process.*`. See AGENTS.md "Stricli
+// buildCommand" lore entry.
 type InjectFuncArgs = {
   ext?: string;
   "dry-run"?: boolean;
@@ -48,18 +66,6 @@ function makeContext() {
         }),
       },
       cwd: "/tmp",
-      process: {
-        stdout: {
-          write: mock((s: string) => {
-            stdoutChunks.push(s);
-          }),
-        },
-        stderr: {
-          write: mock((s: string) => {
-            stderrChunks.push(s);
-          }),
-        },
-      },
     },
     stdout: () => stdoutChunks.join(""),
     stderr: () => stderrChunks.join(""),
@@ -88,14 +94,7 @@ describe("sourcemap inject command — --allow-empty behavior", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test("empty directory: throws ValidationError by default", async () => {
-    const { ctx } = makeContext();
-    await expect(runFunc(func, ctx, {}, dir)).rejects.toBeInstanceOf(
-      ValidationError
-    );
-  });
-
-  test("empty directory: error message mentions the directory and escape hatch", async () => {
+  test("empty directory: throws ValidationError mentioning empty-dir", async () => {
     const { ctx } = makeContext();
     try {
       await runFunc(func, ctx, {}, dir);
@@ -105,6 +104,7 @@ describe("sourcemap inject command — --allow-empty behavior", () => {
       const msg = (err as Error).message;
       expect(msg).toContain(dir);
       expect(msg).toContain("--allow-empty");
+      expect(msg).toMatch(/no JS or sourcemap files/i);
     }
   });
 
@@ -122,23 +122,98 @@ describe("sourcemap inject command — --allow-empty behavior", () => {
     await expect(runFunc(func, ctx, {}, dir)).resolves.toBeUndefined();
   });
 
-  test(".js files without matching .map files: throws (0 pairs discovered)", async () => {
-    // A common misconfiguration: bundler emits JS but no sourcemaps.
+  test(".js files without matching .map files: throws with bundler hint", async () => {
+    // The getsentry/cli docs-site failure mode: JS emitted but no .map
+    // files (#845). Error should explicitly name Vite/webpack config.
     writeFileSync(join(dir, "app.js"), "console.log(1)\n");
     writeFileSync(join(dir, "other.js"), "console.log(2)\n");
     const { ctx } = makeContext();
-    await expect(runFunc(func, ctx, {}, dir)).rejects.toBeInstanceOf(
-      ValidationError
-    );
+    try {
+      await runFunc(func, ctx, {}, dir);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      const msg = (err as Error).message;
+      expect(msg).toContain("2 JS file(s)");
+      expect(msg).toMatch(/vite|webpack/i);
+      expect(msg).toContain("sourcemap");
+    }
   });
 
-  test(".map files without matching .js files: throws (0 pairs discovered)", async () => {
-    // Stray sourcemaps without their JS — also not usable.
+  test(".map files without matching .js files: throws with mismatch hint", async () => {
     writeFileSync(join(dir, "app.js.map"), '{"version":3}\n');
     const { ctx } = makeContext();
-    await expect(runFunc(func, ctx, {}, dir)).rejects.toBeInstanceOf(
-      ValidationError
-    );
+    try {
+      await runFunc(func, ctx, {}, dir);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      const msg = (err as Error).message;
+      expect(msg).toContain(".map file(s)");
+      expect(msg).toContain("no companion JS");
+    }
+  });
+
+  test("js and map present but no basename match: reports both counts", async () => {
+    // e.g. hash-renamed JS paired with a stable-name map.
+    writeFileSync(join(dir, "app.abc123.js"), "console.log(1)\n");
+    writeFileSync(join(dir, "app.js.map"), '{"version":3}\n');
+    const { ctx } = makeContext();
+    try {
+      await runFunc(func, ctx, {}, dir);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      const msg = (err as Error).message;
+      expect(msg).toContain("1 JS");
+      expect(msg).toContain("1 .map");
+      expect(msg).toContain("matching basename");
+    }
+  });
+
+  test("non-existent directory: throws with distinct 'does not exist' message", async () => {
+    const missing = join(dir, "does-not-exist");
+    const { ctx } = makeContext();
+    try {
+      await runFunc(func, ctx, {}, missing);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      const msg = (err as Error).message;
+      expect(msg).toContain(missing);
+      expect(msg).toMatch(/does not exist/i);
+      // Must NOT conflate with the bundler hint.
+      expect(msg).not.toContain("--allow-empty");
+    }
+  });
+
+  test("path is a file, not a directory: throws with distinct message", async () => {
+    const filePath = join(dir, "not-a-dir.txt");
+    writeFileSync(filePath, "hello\n");
+    const { ctx } = makeContext();
+    try {
+      await runFunc(func, ctx, {}, filePath);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      const msg = (err as Error).message;
+      expect(msg).toContain(filePath);
+      expect(msg).toMatch(/not a directory/i);
+    }
+  });
+
+  test("--dry-run + empty directory: still errors (dry-run is not an escape hatch)", async () => {
+    const { ctx } = makeContext();
+    await expect(
+      runFunc(func, ctx, { "dry-run": true }, dir)
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  test("--dry-run + --allow-empty: succeeds silently", async () => {
+    const { ctx } = makeContext();
+    await expect(
+      runFunc(func, ctx, { "dry-run": true, "allow-empty": true }, dir)
+    ).resolves.toBeUndefined();
   });
 });
 
@@ -171,14 +246,7 @@ describe("sourcemap upload command — --allow-empty behavior", () => {
     }
   });
 
-  test("empty directory: throws ValidationError by default", async () => {
-    const { ctx } = makeContext();
-    await expect(runFunc(func, ctx, {}, dir)).rejects.toBeInstanceOf(
-      ValidationError
-    );
-  });
-
-  test("empty directory: error message mentions the directory and escape hatch", async () => {
+  test("empty directory: throws ValidationError mentioning empty-dir", async () => {
     const { ctx } = makeContext();
     try {
       await runFunc(func, ctx, {}, dir);
@@ -208,5 +276,63 @@ describe("sourcemap upload command — --allow-empty behavior", () => {
     await expect(runFunc(func, ctx, {}, dir)).rejects.toBeInstanceOf(
       ValidationError
     );
+  });
+
+  test("non-existent directory: throws before touching Sentry creds", async () => {
+    // Even with SENTRY_ORG/SENTRY_PROJECT cleared, the dir-check should
+    // fire first — that's the whole point of reordering the checks so
+    // local/unauthenticated invocations get actionable errors.
+    delete process.env.SENTRY_ORG;
+    delete process.env.SENTRY_PROJECT;
+    const missing = join(dir, "does-not-exist");
+    const { ctx } = makeContext();
+    try {
+      await runFunc(func, ctx, {}, missing);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      const msg = (err as Error).message;
+      expect(msg).toMatch(/does not exist/i);
+    }
+  });
+
+  test("happy path: directory with JS+map pair invokes uploadSourcemaps", async () => {
+    // Prove the guard doesn't false-positive on a real upload path, and
+    // that we reach the API call with sensible artifact files.
+    mkdirSync(join(dir, "_astro"));
+    const jsPath = join(dir, "_astro", "app.js");
+    const mapPath = join(dir, "_astro", "app.js.map");
+    writeFileSync(jsPath, "console.log(1)\n");
+    // Valid minimal sourcemap so injectDebugId's inject step doesn't
+    // choke parsing.
+    writeFileSync(
+      mapPath,
+      JSON.stringify({
+        version: 3,
+        sources: ["app.ts"],
+        names: [],
+        mappings: "",
+      })
+    );
+
+    const uploadSpy = spyOn(
+      sourcemapsApi,
+      "uploadSourcemaps"
+    ).mockResolvedValue(undefined);
+    try {
+      const { ctx } = makeContext();
+      await runFunc(func, ctx, {}, dir);
+      expect(uploadSpy).toHaveBeenCalledTimes(1);
+      const callArgs = uploadSpy.mock.calls[0]?.[0];
+      expect(callArgs?.org).toBe("test-org");
+      expect(callArgs?.project).toBe("test-project");
+      // One JS + one sourcemap artifact per pair.
+      expect(callArgs?.files).toHaveLength(2);
+      const types = callArgs?.files.map((f) => f.type);
+      expect(types).toContain("minified_source");
+      expect(types).toContain("source_map");
+    } finally {
+      uploadSpy.mockRestore();
+    }
   });
 });

--- a/test/commands/sourcemap/upload.test.ts
+++ b/test/commands/sourcemap/upload.test.ts
@@ -296,6 +296,28 @@ describe("sourcemap upload command — --allow-empty behavior", () => {
     }
   });
 
+  test("error path does not mutate files (js-only dir)", async () => {
+    // Regression guard for the Bugbot finding that led to the
+    // discover-first refactor: previously `injectDirectory` ran BEFORE
+    // the emptiness check, so a js-only dir got debug IDs written into
+    // every JS before the bundler-misconfig error fired. Now discovery
+    // is a read-only pass; injection only runs when we've decided
+    // upload will proceed.
+    mkdirSync(join(dir, "_astro"));
+    const jsPath = join(dir, "_astro", "app.js");
+    const original = "console.log(1)\n";
+    writeFileSync(jsPath, original);
+    const { ctx } = makeContext();
+    await expect(runFunc(func, ctx, {}, dir)).rejects.toBeInstanceOf(
+      ValidationError
+    );
+    // File must be unchanged — no debug ID IIFE, no sourcemap comment.
+    const after = await Bun.file(jsPath).text();
+    expect(after).toBe(original);
+    expect(after).not.toContain("_sentryDebugIds");
+    expect(after).not.toContain("sentry-dbid");
+  });
+
   test("happy path: directory with JS+map pair invokes uploadSourcemaps", async () => {
     // Prove the guard doesn't false-positive on a real upload path, and
     // that we reach the API call with sensible artifact files.

--- a/test/commands/sourcemap/upload.test.ts
+++ b/test/commands/sourcemap/upload.test.ts
@@ -1,0 +1,212 @@
+/**
+ * sourcemap inject / upload command tests
+ *
+ * Focused on the "strict by default, --allow-empty opt-out" behavior added
+ * to guard against silent bundler misconfigurations where no .map files are
+ * present in the upload directory. A zero-file upload used to succeed
+ * silently, producing no Sentry symbolication and no CI signal — the exact
+ * failure mode the getsentry/cli docs site hit (see PR #xxx).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { injectCommand } from "../../../src/commands/sourcemap/inject.js";
+import { uploadCommand } from "../../../src/commands/sourcemap/upload.js";
+import { ValidationError } from "../../../src/lib/errors.js";
+
+// The loader() return is the wrapper-produced async function (NOT a
+// generator) that internally iterates the original generator body and
+// writes rendered output to ctx.stdout. Errors thrown inside the
+// generator body propagate out as a rejected promise.
+type InjectFuncArgs = {
+  ext?: string;
+  "dry-run"?: boolean;
+  "allow-empty"?: boolean;
+};
+type UploadFuncArgs = {
+  release?: string;
+  "url-prefix"?: string;
+  "allow-empty"?: boolean;
+};
+type CmdFunc<A> = (this: unknown, flags: A, dir: string) => Promise<unknown>;
+
+function makeContext() {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  return {
+    ctx: {
+      stdout: {
+        write: mock((s: string) => {
+          stdoutChunks.push(s);
+        }),
+      },
+      stderr: {
+        write: mock((s: string) => {
+          stderrChunks.push(s);
+        }),
+      },
+      cwd: "/tmp",
+      process: {
+        stdout: {
+          write: mock((s: string) => {
+            stdoutChunks.push(s);
+          }),
+        },
+        stderr: {
+          write: mock((s: string) => {
+            stderrChunks.push(s);
+          }),
+        },
+      },
+    },
+    stdout: () => stdoutChunks.join(""),
+    stderr: () => stderrChunks.join(""),
+  };
+}
+
+async function runFunc<A>(
+  func: CmdFunc<A>,
+  ctx: unknown,
+  flags: A,
+  dir: string
+): Promise<void> {
+  await func.call(ctx, flags, dir);
+}
+
+describe("sourcemap inject command — --allow-empty behavior", () => {
+  let dir: string;
+  let func: CmdFunc<InjectFuncArgs>;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "sentry-inject-cmd-"));
+    func = (await injectCommand.loader()) as unknown as CmdFunc<InjectFuncArgs>;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("empty directory: throws ValidationError by default", async () => {
+    const { ctx } = makeContext();
+    await expect(runFunc(func, ctx, {}, dir)).rejects.toBeInstanceOf(
+      ValidationError
+    );
+  });
+
+  test("empty directory: error message mentions the directory and escape hatch", async () => {
+    const { ctx } = makeContext();
+    try {
+      await runFunc(func, ctx, {}, dir);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      const msg = (err as Error).message;
+      expect(msg).toContain(dir);
+      expect(msg).toContain("--allow-empty");
+    }
+  });
+
+  test("empty directory with --allow-empty: succeeds silently", async () => {
+    const { ctx } = makeContext();
+    await expect(
+      runFunc(func, ctx, { "allow-empty": true }, dir)
+    ).resolves.toBeUndefined();
+  });
+
+  test("directory with a .js + .map pair: succeeds (0 pairs guard not triggered)", async () => {
+    writeFileSync(join(dir, "app.js"), "console.log(1)\n");
+    writeFileSync(join(dir, "app.js.map"), '{"version":3}\n');
+    const { ctx } = makeContext();
+    await expect(runFunc(func, ctx, {}, dir)).resolves.toBeUndefined();
+  });
+
+  test(".js files without matching .map files: throws (0 pairs discovered)", async () => {
+    // A common misconfiguration: bundler emits JS but no sourcemaps.
+    writeFileSync(join(dir, "app.js"), "console.log(1)\n");
+    writeFileSync(join(dir, "other.js"), "console.log(2)\n");
+    const { ctx } = makeContext();
+    await expect(runFunc(func, ctx, {}, dir)).rejects.toBeInstanceOf(
+      ValidationError
+    );
+  });
+
+  test(".map files without matching .js files: throws (0 pairs discovered)", async () => {
+    // Stray sourcemaps without their JS — also not usable.
+    writeFileSync(join(dir, "app.js.map"), '{"version":3}\n');
+    const { ctx } = makeContext();
+    await expect(runFunc(func, ctx, {}, dir)).rejects.toBeInstanceOf(
+      ValidationError
+    );
+  });
+});
+
+describe("sourcemap upload command — --allow-empty behavior", () => {
+  let dir: string;
+  let func: CmdFunc<UploadFuncArgs>;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "sentry-upload-cmd-"));
+    // resolveOrgAndProject reads env vars; short-circuit via SENTRY_ORG /
+    // SENTRY_PROJECT so the test doesn't need network or config files.
+    savedEnv = {
+      SENTRY_ORG: process.env.SENTRY_ORG,
+      SENTRY_PROJECT: process.env.SENTRY_PROJECT,
+    };
+    process.env.SENTRY_ORG = "test-org";
+    process.env.SENTRY_PROJECT = "test-project";
+    func = (await uploadCommand.loader()) as unknown as CmdFunc<UploadFuncArgs>;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
+  });
+
+  test("empty directory: throws ValidationError by default", async () => {
+    const { ctx } = makeContext();
+    await expect(runFunc(func, ctx, {}, dir)).rejects.toBeInstanceOf(
+      ValidationError
+    );
+  });
+
+  test("empty directory: error message mentions the directory and escape hatch", async () => {
+    const { ctx } = makeContext();
+    try {
+      await runFunc(func, ctx, {}, dir);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      const msg = (err as Error).message;
+      expect(msg).toContain(dir);
+      expect(msg).toContain("--allow-empty");
+    }
+  });
+
+  test("empty directory with --allow-empty: succeeds silently", async () => {
+    const { ctx } = makeContext();
+    await expect(
+      runFunc(func, ctx, { "allow-empty": true }, dir)
+    ).resolves.toBeUndefined();
+  });
+
+  test("directory with .js files but no .map files: throws", async () => {
+    // Exact reproduction of the silent-failure mode: docs site had .js
+    // files emitted but no .map files, and upload reported success with
+    // 0 files uploaded.
+    mkdirSync(join(dir, "_astro"));
+    writeFileSync(join(dir, "_astro", "app.js"), "console.log(1)\n");
+    const { ctx } = makeContext();
+    await expect(runFunc(func, ctx, {}, dir)).rejects.toBeInstanceOf(
+      ValidationError
+    );
+  });
+});


### PR DESCRIPTION
Fixes #845.

## Summary

Two related bugs caused Sentry events for `cli.sentry.dev` to ship unsymbolicated in production with no CI signal:

1. **Docs build emitted no `.map` files** since the Astro 6 upgrade (#816). `astro.config.mjs` sets `vite.build.sourcemap: "hidden"`, but Astro 6 reads from `vite.environments.{client,ssr}.build.sourcemap` (Vite 7 Environments API), falling back to `false`. The legacy top-level path is silently ignored for the client bundle.
2. **`sentry sourcemap inject`/`upload` silently succeeded on zero pairs.** The docs step logged "Files uploaded: 0" and exited 0 for 20+ consecutive main-push runs, hiding the misconfiguration.

## Behavior change

`sentry sourcemap inject` and `sentry sourcemap upload` now **exit non-zero by default** when zero JS+sourcemap pairs are discovered. Callers that legitimately invoke these commands on potentially-empty directories should pass `--allow-empty` to preserve the old behavior.

This is a deliberate default-strict change — the silent-zero-file failure mode has no legitimate use case in CI and turns every bundler regression into a silent production outage. Worth calling out in release notes.

## Changes

- **`docs/astro.config.mjs`**: set `sourcemap: "hidden"` on `vite.environments.client` (and `ssr`, defensive). Verified locally: `docs/dist/_astro/` now contains 11 `.map` files (previously 0), and `sentry sourcemap inject docs/dist/` injects debug IDs into 5 module chunks.
- **`src/lib/sourcemap/inject.ts`**:
  - Export `discoverFilePairs` for read-only discovery (no writes).
  - Add `assertDirectoryReadable(dir)` — distinguishes ENOENT / not-a-directory / EACCES with specific error messages.
  - Add `diagnoseEmptyDiscovery(dir)` + `buildEmptyDiscoveryError(dir, diag)` — tailors the zero-pair error to the specific shape (empty dir / JS-only / maps-only / basename-mismatch).
- **`src/commands/sourcemap/{inject,upload}.ts`**:
  - New control flow: `assertDirectoryReadable → discoverFilePairs → empty-check → resolveOrgAndProject → injectDirectory → upload`. All pre-API error paths are side-effect-free — no debug IDs get written until we know the upload will proceed.
  - Add `--allow-empty` flag (boolean, default `false`).
  - Tailored error messages with bundler-specific config snippets (Vite/Astro, webpack, esbuild).
- **Tests**: 16 new tests in `test/commands/sourcemap/upload.test.ts` covering every empty-discovery branch, the non-existent-dir and not-a-directory branches, happy path (uploadSourcemaps spy), and a regression test that asserts the command does not mutate files on the error path.
- **Docs**: new "Error handling" section in `docs/src/fragments/commands/sourcemap.md` with `--allow-empty` examples and bundler-config cheat-sheet.

## CI wiring

No workflow changes needed. The default-strict behavior catches any future regression automatically — `.github/workflows/ci.yml` and `docs-preview.yml` don't pass `--allow-empty`, so they'll fail loud if `.map` files stop being emitted again.

## Verification

- 47 sourcemap-related tests pass locally (`bun test test/lib/sourcemap test/commands/sourcemap test/lib/api/sourcemaps.test.ts`).
- `bun run typecheck` clean.
- `bun run lint` has only a single pre-existing warning (unrelated, in `src/lib/formatters/markdown.ts`).
- End-to-end manual verification covers all 6 error branches (empty dir, JS-only, maps-only, nonexistent, not-a-directory, basename-mismatch) plus `--allow-empty` and the happy path.

## Review cycle

- Initial review (1 Cursor Bugbot finding on auth mocking) — false positive; replied with evidence from CI logs.
- Self-review via subagent surfaced 5 IMPORTANT and 5 MINOR findings — addressed in commit `1094d9bf`. See review thread on that commit for per-item responses.
- Second-round bot pass (Cursor + Seer) found a real side-effect-ordering issue (debug IDs written before credential resolution) and a misleading `--allow-empty` hint — fixed in `e8452ad7` with a regression test that locks in the discover-first invariant.
- Final: all bots SUCCESS / NEUTRAL, zero unresolved review threads, mergeable = CLEAN.

## Follow-ups (not in this PR)

- Zstd compression (#823) has been exercised correctly for every CLI-binary build since it merged (verified in `Build Binary` step logs, where each target uploads its `bin.js.map` with auth). Once this PR merges and a real docs push happens, zstd will finally be exercised on docs uploads too — I'll confirm from the resulting CI logs and update #845.

