### PR TITLE
feat: add `sentry explore` command for aggregate event queries

### DIFF
--- a/docs/src/content/docs/contributing.md
+++ b/docs/src/content/docs/contributing.md
@@ -65,6 +65,7 @@ cli/
 │   │   ├── trace/       # list, view, logs
 │   │   ├── trial/       # list, start
 │   │   ├── api.ts       # Make an authenticated API request
+│   │   ├── explore.ts   # Query aggregate event data (Explore)
 │   │   ├── help.ts      # Help command
 │   │   ├── init.ts      # Initialize Sentry in your project (experimental)
 │   │   └── schema.ts    # Browse the Sentry API schema

--- a/docs/src/fragments/commands/explore.md
+++ b/docs/src/fragments/commands/explore.md
@@ -30,29 +30,32 @@ sentry explore my-org/cli -F title -F "count()" \
   -q "error.type:TypeError" --period 1h
 ```
 
-### Transaction queries
+### Span queries (performance)
 
 ```bash
-# Transaction p50/p95 by endpoint
-sentry explore my-org/cli -F transaction \
-  -F "p50(transaction.duration)" -F "p95(transaction.duration)" \
-  --dataset transactions --period 1h
+# Span operation latency by route
+sentry explore my-org/cli -F span.op -F "p50(span.duration)" \
+  -F "p95(span.duration)" --dataset spans --period 1h
 
-# Slowest transactions
-sentry explore my-org/cli -F transaction -F "avg(transaction.duration)" \
-  --dataset transactions
-```
-
-### Span queries
-
-```bash
-# Span operations by count
-sentry explore my-org/cli -F span.op -F "count()" \
-  --dataset spans --period 1h
-
-# Sort by count (sort is supported on spans dataset)
+# Top spans by count
 sentry explore my-org/cli -F span.op -F "count()" \
   --dataset spans --sort "-count()"
+```
+
+### Metrics
+
+```bash
+# Custom metric aggregations
+sentry explore my-org/cli -F transaction -F "avg(measurements.fcp)" \
+  --dataset metrics --period 24h
+```
+
+### Logs
+
+```bash
+# Log severity counts in the last hour
+sentry explore my-org/cli -F severity -F "count()" \
+  --dataset logs --period 1h
 ```
 
 ### JSON output for scripting

--- a/docs/src/fragments/commands/explore.md
+++ b/docs/src/fragments/commands/explore.md
@@ -1,0 +1,76 @@
+
+
+## Examples
+
+### Top errors (default)
+
+```bash
+# Top errors in the last 24 hours, scoped to a project
+sentry explore my-org/cli
+
+# All projects in an org
+sentry explore my-org/
+
+# Bare project slug (searches across orgs)
+sentry explore cli
+
+# Auto-detect from DSN/config
+sentry explore
+```
+
+### Spike analysis
+
+```bash
+# Errors with user impact for a specific UTC window
+sentry explore my-org/cli -F title -F "count()" -F "count_unique(user)" \
+  --period "2024-01-15T00:00:00Z/2024-01-16T00:00:00Z"
+
+# Filter by specific error type (combines with auto-injected project filter)
+sentry explore my-org/cli -F title -F "count()" \
+  -q "error.type:TypeError" --period 1h
+```
+
+### Transaction queries
+
+```bash
+# Transaction p50/p95 by endpoint
+sentry explore my-org/cli -F transaction \
+  -F "p50(transaction.duration)" -F "p95(transaction.duration)" \
+  --dataset transactions --period 1h
+
+# Slowest transactions
+sentry explore my-org/cli -F transaction -F "avg(transaction.duration)" \
+  --dataset transactions
+```
+
+### Span queries
+
+```bash
+# Span operations by count
+sentry explore my-org/cli -F span.op -F "count()" \
+  --dataset spans --period 1h
+
+# Sort by count (sort is supported on spans dataset)
+sentry explore my-org/cli -F span.op -F "count()" \
+  --dataset spans --sort "-count()"
+```
+
+### JSON output for scripting
+
+```bash
+# Pipe to jq for filtering
+sentry explore my-org/cli -F title -F "count()" --json | jq '.data[:5]'
+
+# Get raw data for analysis
+sentry explore my-org/cli -F title -F "count()" -F "count_unique(user)" \
+  --json --limit 100
+```
+
+## Target Patterns
+
+| Target | Behavior |
+|--------|----------|
+| `<org>/<project>` | Auto-adds `project:<slug>` to query |
+| `<org>/` | All projects in org (no project filter) |
+| `<project>` | Searches for project across all accessible orgs |
+| (omitted) | Auto-detect from DSN/config |

--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -378,6 +378,14 @@ Work with Sentry teams
 
 → Full flags and examples: `references/team.md`
 
+### Explore
+
+Query aggregate event data (Explore)
+
+- `sentry explore <target>` — Query aggregate event data (Explore)
+
+→ Full flags and examples: `references/explore.md`
+
 ### Log
 
 View Sentry logs

--- a/plugins/sentry-cli/skills/sentry-cli/references/explore.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/explore.md
@@ -17,11 +17,11 @@ Query aggregate event data (Explore)
 
 **Flags:**
 - `-F, --field <value>... - API field or aggregate (repeatable). E.g., title, "count()", "p50(transaction.duration)"`
-- `-d, --dataset <value> - Dataset to query (errors, transactions, spans, discover) - (default: "errors")`
+- `-d, --dataset <value> - Dataset to query (errors, transactions, spans, metrics, discover) - (default: "errors")`
 - `-q, --query <value> - Search query (Sentry search syntax)`
 - `-s, --sort <value> - Sort field (prefix with - for desc, e.g., "-count()")`
 - `-n, --limit <value> - Number of rows (1-1000) - (default: "25")`
-- `-t, --period <value> - Time range: "7d", "2026-03-01..2026-04-01", ">=2026-03-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-03-01..2026-04-01", ">=2026-03-01" - (default: "24h")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/explore.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/explore.md
@@ -20,7 +20,7 @@ Query aggregate event data (Explore)
 - `-d, --dataset <value> - Dataset to query (errors, spans, metrics, logs) - (default: "errors")`
 - `-q, --query <value> - Search query (Sentry search syntax)`
 - `-s, --sort <value> - Sort field (prefix with - for desc, e.g., "-count()")`
-- `-n, --limit <value> - Number of rows (1-1000) - (default: "25")`
+- `-n, --limit <value> - Number of rows (1-100) - (default: "25")`
 - `-t, --period <value> - Time range: "7d", "2026-03-01..2026-04-01", ">=2026-03-01" - (default: "24h")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
@@ -48,22 +48,21 @@ sentry explore my-org/cli -F title -F "count()" -F "count_unique(user)" \
 sentry explore my-org/cli -F title -F "count()" \
   -q "error.type:TypeError" --period 1h
 
-# Transaction p50/p95 by endpoint
-sentry explore my-org/cli -F transaction \
-  -F "p50(transaction.duration)" -F "p95(transaction.duration)" \
-  --dataset transactions --period 1h
+# Span operation latency by route
+sentry explore my-org/cli -F span.op -F "p50(span.duration)" \
+  -F "p95(span.duration)" --dataset spans --period 1h
 
-# Slowest transactions
-sentry explore my-org/cli -F transaction -F "avg(transaction.duration)" \
-  --dataset transactions
-
-# Span operations by count
-sentry explore my-org/cli -F span.op -F "count()" \
-  --dataset spans --period 1h
-
-# Sort by count (sort is supported on spans dataset)
+# Top spans by count
 sentry explore my-org/cli -F span.op -F "count()" \
   --dataset spans --sort "-count()"
+
+# Custom metric aggregations
+sentry explore my-org/cli -F transaction -F "avg(measurements.fcp)" \
+  --dataset metrics --period 24h
+
+# Log severity counts in the last hour
+sentry explore my-org/cli -F severity -F "count()" \
+  --dataset logs --period 1h
 
 # Pipe to jq for filtering
 sentry explore my-org/cli -F title -F "count()" --json | jq '.data[:5]'

--- a/plugins/sentry-cli/skills/sentry-cli/references/explore.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/explore.md
@@ -17,7 +17,7 @@ Query aggregate event data (Explore)
 
 **Flags:**
 - `-F, --field <value>... - API field or aggregate (repeatable). E.g., title, "count()", "p50(transaction.duration)"`
-- `-d, --dataset <value> - Dataset to query (errors, transactions, spans, metrics, discover) - (default: "errors")`
+- `-d, --dataset <value> - Dataset to query (errors, spans, metrics, logs) - (default: "errors")`
 - `-q, --query <value> - Search query (Sentry search syntax)`
 - `-s, --sort <value> - Sort field (prefix with - for desc, e.g., "-count()")`
 - `-n, --limit <value> - Number of rows (1-1000) - (default: "25")`

--- a/plugins/sentry-cli/skills/sentry-cli/references/explore.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/explore.md
@@ -1,0 +1,76 @@
+---
+name: sentry-cli-explore
+version: 0.30.0-dev.0
+description: Query aggregate event data (Explore)
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Explore Commands
+
+Query aggregate event data (Explore)
+
+### `sentry explore <target>`
+
+Query aggregate event data (Explore)
+
+**Flags:**
+- `-F, --field <value>... - API field or aggregate (repeatable). E.g., title, "count()", "p50(transaction.duration)"`
+- `-d, --dataset <value> - Dataset to query (errors, transactions, spans, discover) - (default: "errors")`
+- `-q, --query <value> - Search query (Sentry search syntax)`
+- `-s, --sort <value> - Sort field (prefix with - for desc, e.g., "-count()")`
+- `-n, --limit <value> - Number of rows (1-1000) - (default: "25")`
+- `-t, --period <value> - Time range: "7d", "2026-03-01..2026-04-01", ">=2026-03-01" - (default: "7d")`
+- `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
+- `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
+
+**Examples:**
+
+```bash
+# Top errors in the last 24 hours, scoped to a project
+sentry explore my-org/cli
+
+# All projects in an org
+sentry explore my-org/
+
+# Bare project slug (searches across orgs)
+sentry explore cli
+
+# Auto-detect from DSN/config
+sentry explore
+
+# Errors with user impact for a specific UTC window
+sentry explore my-org/cli -F title -F "count()" -F "count_unique(user)" \
+  --period "2024-01-15T00:00:00Z/2024-01-16T00:00:00Z"
+
+# Filter by specific error type (combines with auto-injected project filter)
+sentry explore my-org/cli -F title -F "count()" \
+  -q "error.type:TypeError" --period 1h
+
+# Transaction p50/p95 by endpoint
+sentry explore my-org/cli -F transaction \
+  -F "p50(transaction.duration)" -F "p95(transaction.duration)" \
+  --dataset transactions --period 1h
+
+# Slowest transactions
+sentry explore my-org/cli -F transaction -F "avg(transaction.duration)" \
+  --dataset transactions
+
+# Span operations by count
+sentry explore my-org/cli -F span.op -F "count()" \
+  --dataset spans --period 1h
+
+# Sort by count (sort is supported on spans dataset)
+sentry explore my-org/cli -F span.op -F "count()" \
+  --dataset spans --sort "-count()"
+
+# Pipe to jq for filtering
+sentry explore my-org/cli -F title -F "count()" --json | jq '.data[:5]'
+
+# Get raw data for analysis
+sentry explore my-org/cli -F title -F "count()" -F "count_unique(user)" \
+  --json --limit 100
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import { dashboardRoute } from "./commands/dashboard/index.js";
 import { listCommand as dashboardListCommand } from "./commands/dashboard/list.js";
 import { eventRoute } from "./commands/event/index.js";
 import { listCommand as eventListCommand } from "./commands/event/list.js";
+import { exploreCommand } from "./commands/explore.js";
 import { helpCommand } from "./commands/help.js";
 import { initCommand } from "./commands/init.js";
 import { issueRoute } from "./commands/issue/index.js";
@@ -90,6 +91,7 @@ export const routes = buildRouteMap({
     issue: issueRoute,
     event: eventRoute,
     events: eventListCommand,
+    explore: exploreCommand,
     log: logRoute,
     sourcemap: sourcemapRoute,
     sourcemaps: sourcemapRoute,

--- a/src/commands/explore.ts
+++ b/src/commands/explore.ts
@@ -154,7 +154,6 @@ function parseDataset(value: string): string {
   return resolved;
 }
 
-/** Parse --limit flag with range validation */
 /**
  * Parse --limit flag. Capped at `API_MAX_PER_PAGE` (100) since the Events
  * API silently caps `per_page` server-side and `queryEvents` does not yet

--- a/src/commands/explore.ts
+++ b/src/commands/explore.ts
@@ -28,7 +28,6 @@ import { type Column, formatTable } from "../lib/formatters/table.js";
 import {
   buildListCommand,
   LIST_MAX_LIMIT,
-  LIST_PERIOD_FLAG,
   PERIOD_ALIASES,
   paginationHint,
 } from "../lib/list-command.js";
@@ -38,6 +37,8 @@ import { resolveOrg, resolveProjectBySlug } from "../lib/resolve-target.js";
 import { sanitizeQuery } from "../lib/search-query.js";
 import {
   appendPeriodHint,
+  PERIOD_BRIEF,
+  parsePeriod,
   serializeTimeRange,
   type TimeRange,
   timeRangeToApiParams,
@@ -69,11 +70,18 @@ const DATASET_ALIASES: Record<string, string> = {
   transaction: "transactions",
   spans: "spans",
   span: "spans",
+  metrics: "metricsEnhanced",
   discover: "discover",
 };
 
 /** Canonical dataset names for display */
-const VALID_DATASETS = ["errors", "transactions", "spans", "discover"];
+const VALID_DATASETS = [
+  "errors",
+  "transactions",
+  "spans",
+  "metrics",
+  "discover",
+];
 
 /** Sentry field types that should be right-aligned and formatted as numbers */
 const NUMERIC_FIELD_TYPES = new Set([
@@ -424,6 +432,7 @@ export const exploreCommand = buildListCommand("explore", {
       "  errors         Error events (default)\n" +
       "  transactions   Transaction events\n" +
       "  spans          Span data\n" +
+      "  metrics        Custom metrics (metricsEnhanced)\n" +
       "  discover       Legacy discover dataset\n\n" +
       "Targets:\n" +
       "  <org>/<project>  Filter by project (auto-adds project:<slug> to query)\n" +
@@ -488,7 +497,12 @@ export const exploreCommand = buildListCommand("explore", {
         brief: `Number of rows (1-${LIST_MAX_LIMIT})`,
         default: "25",
       },
-      period: LIST_PERIOD_FLAG,
+      period: {
+        kind: "parsed" as const,
+        parse: parsePeriod,
+        brief: PERIOD_BRIEF,
+        default: DEFAULT_PERIOD,
+      },
     },
     aliases: {
       ...PERIOD_ALIASES,

--- a/src/commands/explore.ts
+++ b/src/commands/explore.ts
@@ -62,26 +62,32 @@ const DEFAULT_PERIOD = "24h";
 /** Command key for pagination cursor storage */
 const PAGINATION_KEY = "explore";
 
-/** Valid dataset values and their API-level names */
+/**
+ * Dataset aliases: user-facing name → API-level dataset name.
+ *
+ * All entries are accepted as `--dataset` values. `VALID_DATASETS` controls
+ * which appear in `--help` and validation error messages.
+ */
 const DATASET_ALIASES: Record<string, string> = {
   errors: "errors",
   error: "errors",
-  transactions: "transactions",
-  transaction: "transactions",
   spans: "spans",
   span: "spans",
   metrics: "metricsEnhanced",
+  logs: "logs",
+  log: "logs",
+  // Deprecated but still functional — hidden from help
+  transactions: "transactions",
+  transaction: "transactions",
   discover: "discover",
 };
 
-/** Canonical dataset names for display */
-const VALID_DATASETS = [
-  "errors",
-  "transactions",
-  "spans",
-  "metrics",
-  "discover",
-];
+/**
+ * User-facing dataset names shown in `--help` and validation errors.
+ * Deprecated datasets (transactions, discover) are omitted from the display
+ * list but still work as `--dataset` values via `DATASET_ALIASES`.
+ */
+const VALID_DATASETS = ["errors", "spans", "metrics", "logs"];
 
 /**
  * Reverse map from API-level dataset name → canonical user-facing name.
@@ -440,11 +446,10 @@ export const exploreCommand = buildListCommand("explore", {
       "aggregates (count(), count_unique(user), p50(transaction.duration)),\n" +
       "and equations. Results are returned as a table.\n\n" +
       "Datasets:\n" +
-      "  errors         Error events (default)\n" +
-      "  transactions   Transaction events\n" +
-      "  spans          Span data\n" +
-      "  metrics        Custom metrics (metricsEnhanced)\n" +
-      "  discover       Legacy discover dataset\n\n" +
+      "  errors   Error events (default)\n" +
+      "  spans    Span data\n" +
+      "  metrics  Custom metrics\n" +
+      "  logs     Log entries\n\n" +
       "Targets:\n" +
       "  <org>/<project>  Filter by project (auto-adds project:<slug> to query)\n" +
       "  <org>/           All projects in org\n" +

--- a/src/commands/explore.ts
+++ b/src/commands/explore.ts
@@ -83,6 +83,14 @@ const VALID_DATASETS = [
   "discover",
 ];
 
+/**
+ * Reverse map from API-level dataset name → canonical user-facing name.
+ * Used by pagination hints so they emit `--dataset metrics` not `--dataset metricsEnhanced`.
+ */
+const API_TO_USER_DATASET: Record<string, string> = Object.fromEntries(
+  VALID_DATASETS.map((name) => [DATASET_ALIASES[name] ?? name, name])
+);
+
 /** Sentry field types that should be right-aligned and formatted as numbers */
 const NUMERIC_FIELD_TYPES = new Set([
   "integer",
@@ -254,7 +262,8 @@ function formatExploreHuman(data: ExploreData): string {
   const columns = buildColumns(fieldNames, data.meta?.fields, data.meta?.units);
 
   const scope = data.project ? `${data.org}/${data.project}` : data.org;
-  const header = `Querying ${data.dataset} in ${scope}:\n\n`;
+  const displayDataset = API_TO_USER_DATASET[data.dataset] ?? data.dataset;
+  const header = `Querying ${displayDataset} in ${scope}:\n\n`;
   return header + formatTable(data.data, columns);
 }
 
@@ -293,7 +302,9 @@ function appendFlagHints(
 ): string {
   const parts: string[] = [];
   if (flags.dataset !== DEFAULT_DATASET) {
-    parts.push(`--dataset ${flags.dataset}`);
+    // Emit user-facing name, not API-level name (e.g. "metrics" not "metricsEnhanced")
+    const displayDataset = API_TO_USER_DATASET[flags.dataset] ?? flags.dataset;
+    parts.push(`--dataset ${displayDataset}`);
   }
   if (flags.sort) {
     parts.push(`--sort ${flags.sort}`);

--- a/src/commands/explore.ts
+++ b/src/commands/explore.ts
@@ -344,11 +344,8 @@ function resolveSort(
   dataset: string,
   explicitSort?: string
 ): string | undefined {
-  const sort =
-    explicitSort ??
-    (findFirstAggregate(fieldList)
-      ? `-${findFirstAggregate(fieldList)}`
-      : undefined);
+  const firstAgg = findFirstAggregate(fieldList);
+  const sort = explicitSort ?? (firstAgg ? `-${firstAgg}` : undefined);
 
   if (dataset === "spans") {
     return sort;

--- a/src/commands/explore.ts
+++ b/src/commands/explore.ts
@@ -362,7 +362,7 @@ function resolveSort(
 /** Build the result hint string from pagination state and row count */
 function buildResultHint(rowCount: number, nav: string): string | undefined {
   if (rowCount === 0 && nav) {
-    return `No results on this page. ${nav}`;
+    return nav;
   }
   if (rowCount > 0) {
     const countText = `Showing ${rowCount} result${rowCount === 1 ? "" : "s"}.`;

--- a/src/commands/explore.ts
+++ b/src/commands/explore.ts
@@ -249,10 +249,16 @@ function jsonTransformExplore(data: ExploreData, fields?: string[]): unknown {
 // Pagination hints
 // ---------------------------------------------------------------------------
 
+/** Default limit value matching the flag default for hint comparison */
+const DEFAULT_LIMIT = 25;
+
 /** Append active non-default flags to a base command string */
 function appendFlagHints(
   base: string,
-  flags: Pick<ExploreFlags, "dataset" | "sort" | "query" | "period" | "field">
+  flags: Pick<
+    ExploreFlags,
+    "dataset" | "sort" | "query" | "period" | "field" | "limit"
+  >
 ): string {
   const parts: string[] = [];
   if (flags.dataset !== DEFAULT_DATASET) {
@@ -270,6 +276,9 @@ function appendFlagHints(
     for (const f of fieldList) {
       parts.push(`-F "${f}"`);
     }
+  }
+  if (flags.limit !== DEFAULT_LIMIT) {
+    parts.push(`--limit ${flags.limit}`);
   }
   appendPeriodHint(parts, flags.period, DEFAULT_PERIOD);
   return parts.length > 0 ? `${base} ${parts.join(" ")}` : base;

--- a/src/commands/explore.ts
+++ b/src/commands/explore.ts
@@ -21,11 +21,12 @@ import {
 } from "../lib/db/pagination.js";
 import { ContextError, ValidationError } from "../lib/errors.js";
 import { filterFields } from "../lib/formatters/json.js";
-import { escapeMarkdownCell } from "../lib/formatters/markdown.js";
-import { appendUnitSuffix, formatNumber } from "../lib/formatters/numbers.js";
+import { buildMetaColumns } from "../lib/formatters/meta-table.js";
 import { CommandOutput } from "../lib/formatters/output.js";
-import { type Column, formatTable } from "../lib/formatters/table.js";
+import { formatTable } from "../lib/formatters/table.js";
 import {
+  appendQueryHint,
+  appendSortHint,
   buildListCommand,
   LIST_MAX_LIMIT,
   PERIOD_ALIASES,
@@ -86,25 +87,18 @@ const DATASET_ALIASES: Record<string, string> = {
  * User-facing dataset names shown in `--help` and validation errors.
  * Deprecated datasets (transactions, discover) are omitted from the display
  * list but still work as `--dataset` values via `DATASET_ALIASES`.
+ *
+ * Set preserves insertion order for the join-based help/error rendering.
  */
-const VALID_DATASETS = ["errors", "spans", "metrics", "logs"];
+const VALID_DATASETS = new Set(["errors", "spans", "metrics", "logs"]);
 
 /**
  * Reverse map from API-level dataset name → canonical user-facing name.
  * Used by pagination hints so they emit `--dataset metrics` not `--dataset metricsEnhanced`.
  */
-const API_TO_USER_DATASET: Record<string, string> = Object.fromEntries(
-  VALID_DATASETS.map((name) => [DATASET_ALIASES[name] ?? name, name])
+const API_TO_USER_DATASET = new Map(
+  Array.from(VALID_DATASETS, (name) => [DATASET_ALIASES[name] ?? name, name])
 );
-
-/** Sentry field types that should be right-aligned and formatted as numbers */
-const NUMERIC_FIELD_TYPES = new Set([
-  "integer",
-  "number",
-  "duration",
-  "percentage",
-  "size",
-]);
 
 // ---------------------------------------------------------------------------
 // Types
@@ -154,7 +148,7 @@ function parseDataset(value: string): string {
   const resolved = DATASET_ALIASES[lower];
   if (!resolved) {
     throw new ValidationError(
-      `Invalid dataset "${value}". Must be one of: ${VALID_DATASETS.join(", ")}`,
+      `Invalid dataset "${value}". Must be one of: ${[...VALID_DATASETS].join(", ")}`,
       "dataset"
     );
   }
@@ -164,60 +158,6 @@ function parseDataset(value: string): string {
 /** Parse --limit flag with range validation */
 function parseLimit(value: string): number {
   return validateLimit(value, 1, LIST_MAX_LIMIT);
-}
-
-// ---------------------------------------------------------------------------
-// Formatting helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Format a cell value based on its type metadata.
- *
- * Uses type hints from the API response `meta.fields` to apply appropriate
- * formatting: numbers with grouping, durations with units, etc.
- */
-function formatCellValue(
-  value: unknown,
-  fieldType?: string,
-  unit?: string | null
-): string {
-  if (value === null || value === undefined) {
-    return "—";
-  }
-  if (typeof value === "number") {
-    if (fieldType === "duration" || fieldType === "size") {
-      return appendUnitSuffix(formatNumber(value), unit);
-    }
-    if (fieldType === "percentage") {
-      return `${formatNumber(value * 100)}%`;
-    }
-    return formatNumber(value);
-  }
-  return escapeMarkdownCell(String(value));
-}
-
-/**
- * Build dynamic table columns from the API response metadata.
- *
- * Each field in the response becomes a column. Numeric fields are right-aligned.
- */
-function buildColumns(
-  fieldNames: string[],
-  fieldTypes?: Record<string, string>,
-  fieldUnits?: Record<string, string | null>
-): Column<Record<string, unknown>>[] {
-  return fieldNames.map((name) => {
-    const fieldType = fieldTypes?.[name];
-    const unit = fieldUnits?.[name];
-    const isNumeric = fieldType ? NUMERIC_FIELD_TYPES.has(fieldType) : false;
-
-    return {
-      header: name.toUpperCase(),
-      value: (row) => formatCellValue(row[name], fieldType, unit),
-      align: isNumeric ? ("right" as const) : ("left" as const),
-      truncate: !isNumeric,
-    };
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -265,10 +205,14 @@ function formatExploreHuman(data: ExploreData): string {
   }
 
   const fieldNames = orderFieldNames(data.requestedFields, data);
-  const columns = buildColumns(fieldNames, data.meta?.fields, data.meta?.units);
+  const columns = buildMetaColumns(
+    fieldNames,
+    data.meta?.fields,
+    data.meta?.units
+  );
 
   const scope = data.project ? `${data.org}/${data.project}` : data.org;
-  const displayDataset = API_TO_USER_DATASET[data.dataset] ?? data.dataset;
+  const displayDataset = API_TO_USER_DATASET.get(data.dataset) ?? data.dataset;
   const header = `Querying ${displayDataset} in ${scope}:\n\n`;
   return header + formatTable(data.data, columns);
 }
@@ -309,15 +253,12 @@ function appendFlagHints(
   const parts: string[] = [];
   if (flags.dataset !== DEFAULT_DATASET) {
     // Emit user-facing name, not API-level name (e.g. "metrics" not "metricsEnhanced")
-    const displayDataset = API_TO_USER_DATASET[flags.dataset] ?? flags.dataset;
+    const displayDataset =
+      API_TO_USER_DATASET.get(flags.dataset) ?? flags.dataset;
     parts.push(`--dataset ${displayDataset}`);
   }
-  if (flags.sort) {
-    parts.push(`--sort ${flags.sort}`);
-  }
-  if (flags.query) {
-    parts.push(`-q "${flags.query}"`);
-  }
+  appendSortHint(parts, flags.sort);
+  appendQueryHint(parts, flags.query);
   // Include --field flags when non-default
   const fieldList = flags.field ?? [];
   const currentFieldStr = fieldList.join(",");
@@ -349,7 +290,7 @@ type ExploreTarget = {
 };
 
 /** Usage hint shown when target resolution fails */
-const USAGE_HINT = "sentry explore [<org>/[<project>]]";
+const USAGE_HINT = "sentry explore <target>";
 
 /**
  * Resolve the explore target to an org slug and optional project filter.
@@ -492,7 +433,7 @@ export const exploreCommand = buildListCommand("explore", {
       dataset: {
         kind: "parsed",
         parse: parseDataset,
-        brief: `Dataset to query (${VALID_DATASETS.join(", ")})`,
+        brief: `Dataset to query (${[...VALID_DATASETS].join(", ")})`,
         default: DEFAULT_DATASET,
       },
       query: {

--- a/src/commands/explore.ts
+++ b/src/commands/explore.ts
@@ -1,0 +1,579 @@
+/**
+ * sentry explore
+ *
+ * Query aggregate event data using the Sentry Explore/Events API.
+ * Supports arbitrary fields, aggregates, and datasets for spike analysis
+ * and ad-hoc event queries.
+ */
+
+import type { SentryContext } from "../context.js";
+import { queryEvents } from "../lib/api-client.js";
+import {
+  buildProjectQuery,
+  parseOrgProjectArg,
+  validateLimit,
+} from "../lib/arg-parsing.js";
+import {
+  advancePaginationState,
+  buildPaginationContextKey,
+  hasPreviousPage,
+  resolveCursor,
+} from "../lib/db/pagination.js";
+import { ContextError, ValidationError } from "../lib/errors.js";
+import { filterFields } from "../lib/formatters/json.js";
+import { escapeMarkdownCell } from "../lib/formatters/markdown.js";
+import { appendUnitSuffix, formatNumber } from "../lib/formatters/numbers.js";
+import { CommandOutput } from "../lib/formatters/output.js";
+import { type Column, formatTable } from "../lib/formatters/table.js";
+import {
+  buildListCommand,
+  LIST_MAX_LIMIT,
+  LIST_PERIOD_FLAG,
+  PERIOD_ALIASES,
+  paginationHint,
+} from "../lib/list-command.js";
+import { logger } from "../lib/logger.js";
+import { withProgress } from "../lib/polling.js";
+import { resolveOrg, resolveProjectBySlug } from "../lib/resolve-target.js";
+import { sanitizeQuery } from "../lib/search-query.js";
+import {
+  appendPeriodHint,
+  serializeTimeRange,
+  type TimeRange,
+  timeRangeToApiParams,
+} from "../lib/time-range.js";
+
+const log = logger.withTag("explore");
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Default fields when none specified — top errors view */
+const DEFAULT_FIELDS = ["title", "count()"];
+
+/** Default dataset */
+const DEFAULT_DATASET = "errors";
+
+/** Default time period */
+const DEFAULT_PERIOD = "24h";
+
+/** Command key for pagination cursor storage */
+const PAGINATION_KEY = "explore";
+
+/** Valid dataset values and their API-level names */
+const DATASET_ALIASES: Record<string, string> = {
+  errors: "errors",
+  error: "errors",
+  transactions: "transactions",
+  transaction: "transactions",
+  spans: "spans",
+  span: "spans",
+  discover: "discover",
+};
+
+/** Canonical dataset names for display */
+const VALID_DATASETS = ["errors", "transactions", "spans", "discover"];
+
+/** Sentry field types that should be right-aligned and formatted as numbers */
+const NUMERIC_FIELD_TYPES = new Set([
+  "integer",
+  "number",
+  "duration",
+  "percentage",
+  "size",
+]);
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ExploreFlags = {
+  readonly field: string[];
+  readonly dataset: string;
+  readonly query?: string;
+  readonly sort?: string;
+  readonly period: TimeRange;
+  readonly limit: number;
+  readonly cursor?: string;
+  readonly json: boolean;
+  readonly fresh: boolean;
+  readonly fields?: string[];
+};
+
+/** Data yielded by the explore command for both JSON and human output */
+type ExploreData = {
+  data: Record<string, unknown>[];
+  meta?: {
+    fields?: Record<string, string>;
+    units?: Record<string, string | null>;
+  };
+  hasMore: boolean;
+  hasPrev: boolean;
+  nextCursor?: string | null;
+  dataset: string;
+  org: string;
+  /** Project filter, when target was `org/project` */
+  project?: string;
+  /** The fields the user requested, in their original order — drives column order */
+  requestedFields: string[];
+};
+
+// ---------------------------------------------------------------------------
+// Flag parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse and validate dataset flag value.
+ * Accepts canonical names and common aliases.
+ */
+function parseDataset(value: string): string {
+  const lower = value.toLowerCase();
+  const resolved = DATASET_ALIASES[lower];
+  if (!resolved) {
+    throw new ValidationError(
+      `Invalid dataset "${value}". Must be one of: ${VALID_DATASETS.join(", ")}`,
+      "dataset"
+    );
+  }
+  return resolved;
+}
+
+/** Parse --limit flag with range validation */
+function parseLimit(value: string): number {
+  return validateLimit(value, 1, LIST_MAX_LIMIT);
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a cell value based on its type metadata.
+ *
+ * Uses type hints from the API response `meta.fields` to apply appropriate
+ * formatting: numbers with grouping, durations with units, etc.
+ */
+function formatCellValue(
+  value: unknown,
+  fieldType?: string,
+  unit?: string | null
+): string {
+  if (value === null || value === undefined) {
+    return "—";
+  }
+  if (typeof value === "number") {
+    if (fieldType === "duration" || fieldType === "size") {
+      return appendUnitSuffix(formatNumber(value), unit);
+    }
+    if (fieldType === "percentage") {
+      return `${formatNumber(value * 100)}%`;
+    }
+    return formatNumber(value);
+  }
+  return escapeMarkdownCell(String(value));
+}
+
+/**
+ * Build dynamic table columns from the API response metadata.
+ *
+ * Each field in the response becomes a column. Numeric fields are right-aligned.
+ */
+function buildColumns(
+  fieldNames: string[],
+  fieldTypes?: Record<string, string>,
+  fieldUnits?: Record<string, string | null>
+): Column<Record<string, unknown>>[] {
+  return fieldNames.map((name) => {
+    const fieldType = fieldTypes?.[name];
+    const unit = fieldUnits?.[name];
+    const isNumeric = fieldType ? NUMERIC_FIELD_TYPES.has(fieldType) : false;
+
+    return {
+      header: name.toUpperCase(),
+      value: (row) => formatCellValue(row[name], fieldType, unit),
+      align: isNumeric ? ("right" as const) : ("left" as const),
+      truncate: !isNumeric,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Output formatters
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine the column order for the table.
+ *
+ * Preserves the user's `--field` order, then appends any extra fields the
+ * API returned that weren't in the request (rare, but possible for derived
+ * fields like equations). Falls back to API response keys when no requested
+ * fields are available.
+ */
+function orderFieldNames(
+  requestedFields: string[],
+  data: ExploreData
+): string[] {
+  const apiFields = data.meta?.fields
+    ? Object.keys(data.meta.fields)
+    : Object.keys(data.data[0] ?? {});
+
+  if (requestedFields.length === 0) {
+    return apiFields;
+  }
+
+  const apiSet = new Set(apiFields);
+  const ordered = requestedFields.filter((f) => apiSet.has(f));
+  // Append any API-returned fields that weren't requested (preserves API order)
+  const requestedSet = new Set(ordered);
+  for (const f of apiFields) {
+    if (!requestedSet.has(f)) {
+      ordered.push(f);
+    }
+  }
+  return ordered;
+}
+
+/** Format explore results for human-readable terminal output */
+function formatExploreHuman(data: ExploreData): string {
+  if (data.data.length === 0) {
+    return data.hasMore
+      ? "No results on this page."
+      : "No results matched the query.";
+  }
+
+  const fieldNames = orderFieldNames(data.requestedFields, data);
+  const columns = buildColumns(fieldNames, data.meta?.fields, data.meta?.units);
+
+  const scope = data.project ? `${data.org}/${data.project}` : data.org;
+  const header = `Querying ${data.dataset} in ${scope}:\n\n`;
+  return header + formatTable(data.data, columns);
+}
+
+/** Transform explore results for JSON output */
+function jsonTransformExplore(data: ExploreData, fields?: string[]): unknown {
+  const items =
+    fields && fields.length > 0
+      ? data.data.map((row) => filterFields(row, fields))
+      : data.data;
+
+  const envelope: Record<string, unknown> = {
+    data: items,
+    meta: data.meta,
+    hasMore: data.hasMore,
+    hasPrev: data.hasPrev,
+    dataset: data.dataset,
+  };
+  if (
+    data.nextCursor !== null &&
+    data.nextCursor !== undefined &&
+    data.nextCursor !== ""
+  ) {
+    envelope.nextCursor = data.nextCursor;
+  }
+  return envelope;
+}
+
+// ---------------------------------------------------------------------------
+// Pagination hints
+// ---------------------------------------------------------------------------
+
+/** Append active non-default flags to a base command string */
+function appendFlagHints(
+  base: string,
+  flags: Pick<ExploreFlags, "dataset" | "sort" | "query" | "period" | "field">
+): string {
+  const parts: string[] = [];
+  if (flags.dataset !== DEFAULT_DATASET) {
+    parts.push(`--dataset ${flags.dataset}`);
+  }
+  if (flags.sort) {
+    parts.push(`--sort ${flags.sort}`);
+  }
+  if (flags.query) {
+    parts.push(`-q "${flags.query}"`);
+  }
+  // Include --field flags when non-default
+  const fieldList = flags.field ?? [];
+  const currentFieldStr = fieldList.join(",");
+  if (currentFieldStr !== DEFAULT_FIELDS.join(",") && fieldList.length > 0) {
+    for (const f of fieldList) {
+      parts.push(`-F "${f}"`);
+    }
+  }
+  appendPeriodHint(parts, flags.period, DEFAULT_PERIOD);
+  return parts.length > 0 ? `${base} ${parts.join(" ")}` : base;
+}
+
+/**
+ * Detect the first aggregate function in the field list.
+ * Aggregates contain parentheses, e.g., `count()`, `p50(transaction.duration)`.
+ */
+function findFirstAggregate(fieldList: string[]): string | undefined {
+  return fieldList.find((f) => f.includes("(") && f.includes(")"));
+}
+
+// ---------------------------------------------------------------------------
+// Org resolution helper — extracted from func() for complexity
+// ---------------------------------------------------------------------------
+
+/** Resolved explore target: org slug + optional project filter */
+type ExploreTarget = {
+  org: string;
+  project?: string;
+};
+
+/** Usage hint shown when target resolution fails */
+const USAGE_HINT = "sentry explore [<org>/[<project>]]";
+
+/**
+ * Resolve the explore target to an org slug and optional project filter.
+ *
+ * Semantics:
+ * - `<org>/<project>` → explicit org with project filter (adds `project:slug` to query)
+ * - `<org>/` → org-all mode (no project filter)
+ * - `<project>` (bare) → fuzzy-search across all orgs for the project
+ * - undefined → auto-detect from DSN/config
+ */
+async function resolveExploreTarget(
+  target: string | undefined,
+  cwd: string
+): Promise<ExploreTarget> {
+  const parsed = parseOrgProjectArg(target);
+
+  if (parsed.type === "explicit") {
+    return { org: parsed.org, project: parsed.project };
+  }
+  if (parsed.type === "org-all") {
+    return { org: parsed.org };
+  }
+  if (parsed.type === "project-search") {
+    // Bare slug — search across orgs to find the project
+    const found = await resolveProjectBySlug(
+      parsed.projectSlug,
+      USAGE_HINT,
+      `sentry explore <org>/${parsed.projectSlug}`,
+      parsed.originalSlug
+    );
+    return { org: found.org, project: found.project };
+  }
+
+  // auto-detect: resolve org only
+  const resolved = await resolveOrg({ cwd });
+  if (!resolved) {
+    throw new ContextError("Organization", USAGE_HINT, [
+      "SENTRY_ORG environment variable",
+      "sentry cli defaults",
+    ]);
+  }
+  return { org: resolved.org };
+}
+
+/**
+ * Determine the effective sort value, accounting for dataset restrictions.
+ * Sort is only supported on the `spans` dataset.
+ */
+function resolveSort(
+  fieldList: string[],
+  dataset: string,
+  explicitSort?: string
+): string | undefined {
+  const sort =
+    explicitSort ??
+    (findFirstAggregate(fieldList)
+      ? `-${findFirstAggregate(fieldList)}`
+      : undefined);
+
+  if (dataset === "spans") {
+    return sort;
+  }
+  // Warn only when user explicitly passed --sort on a non-spans dataset
+  if (sort && explicitSort) {
+    log.warn(
+      `--sort is only supported on the spans dataset. Ignoring sort for ${dataset}.`
+    );
+  }
+  return;
+}
+
+/** Build the result hint string from pagination state and row count */
+function buildResultHint(rowCount: number, nav: string): string | undefined {
+  if (rowCount === 0 && nav) {
+    return `No results on this page. ${nav}`;
+  }
+  if (rowCount > 0) {
+    const countText = `Showing ${rowCount} result${rowCount === 1 ? "" : "s"}.`;
+    return nav ? `${countText} ${nav}` : countText;
+  }
+  return;
+}
+
+// ---------------------------------------------------------------------------
+// Command definition
+// ---------------------------------------------------------------------------
+
+export const exploreCommand = buildListCommand("explore", {
+  docs: {
+    brief: "Query aggregate event data (Explore)",
+    fullDescription:
+      "Query the Sentry Explore API for aggregate event data.\n\n" +
+      "Supports arbitrary fields including columns (title, project),\n" +
+      "aggregates (count(), count_unique(user), p50(transaction.duration)),\n" +
+      "and equations. Results are returned as a table.\n\n" +
+      "Datasets:\n" +
+      "  errors         Error events (default)\n" +
+      "  transactions   Transaction events\n" +
+      "  spans          Span data\n" +
+      "  discover       Legacy discover dataset\n\n" +
+      "Targets:\n" +
+      "  <org>/<project>  Filter by project (auto-adds project:<slug> to query)\n" +
+      "  <org>/           All projects in org\n" +
+      "  <project>        Bare slug — searches across orgs\n" +
+      "  (omitted)        Auto-detect from DSN/config\n\n" +
+      "Examples:\n" +
+      '  sentry explore my-org/cli -F title -F "count()"\n' +
+      '  sentry explore my-org/ -F title -F "count()" -F "count_unique(user)" --period 1h\n' +
+      "  sentry explore my-org/cli -F transaction " +
+      '-F "p50(transaction.duration)" --dataset transactions\n' +
+      '  sentry explore -F span.op -F "count()" --dataset spans --period 1h\n' +
+      "  sentry explore --json",
+  },
+  output: {
+    human: formatExploreHuman,
+    jsonTransform: jsonTransformExplore,
+  },
+  parameters: {
+    positional: {
+      kind: "tuple" as const,
+      parameters: [
+        {
+          placeholder: "target",
+          brief:
+            "Target: <org>/<project>, <org>/, or <project>. Auto-detected if omitted.",
+          parse: String,
+          optional: true as const,
+        },
+      ],
+    },
+    flags: {
+      field: {
+        kind: "parsed",
+        parse: String,
+        brief:
+          'API field or aggregate (repeatable). E.g., title, "count()", "p50(transaction.duration)"',
+        variadic: true,
+        optional: true,
+      },
+      dataset: {
+        kind: "parsed",
+        parse: parseDataset,
+        brief: `Dataset to query (${VALID_DATASETS.join(", ")})`,
+        default: DEFAULT_DATASET,
+      },
+      query: {
+        kind: "parsed",
+        parse: sanitizeQuery,
+        brief: "Search query (Sentry search syntax)",
+        optional: true,
+      },
+      sort: {
+        kind: "parsed",
+        parse: String,
+        brief: 'Sort field (prefix with - for desc, e.g., "-count()")',
+        optional: true,
+      },
+      limit: {
+        kind: "parsed",
+        parse: parseLimit,
+        brief: `Number of rows (1-${LIST_MAX_LIMIT})`,
+        default: "25",
+      },
+      period: LIST_PERIOD_FLAG,
+    },
+    aliases: {
+      ...PERIOD_ALIASES,
+      F: "field",
+      d: "dataset",
+      q: "query",
+      s: "sort",
+      n: "limit",
+    },
+  },
+  async *func(this: SentryContext, flags: ExploreFlags, target?: string) {
+    const { cwd } = this;
+    const { org, project } = await resolveExploreTarget(target, cwd);
+
+    const fieldList =
+      flags.field && flags.field.length > 0 ? flags.field : DEFAULT_FIELDS;
+    const dataset = flags.dataset;
+    const timeRange = flags.period;
+    const effectiveSort = resolveSort(fieldList, dataset, flags.sort);
+
+    // When a project is in the target, prepend `project:<slug>` to the query
+    // so the API filters server-side. Mirrors `trace logs` / `log list` behavior.
+    const apiQuery = buildProjectQuery(flags.query, project);
+
+    // Pagination context includes project so different scopes don't share state
+    const contextKey = buildPaginationContextKey(
+      "explore",
+      project ? `${org}/${project}` : org,
+      {
+        dataset,
+        fields: fieldList.join(","),
+        q: flags.query,
+        sort: effectiveSort,
+        period: serializeTimeRange(timeRange),
+      }
+    );
+    const { cursor, direction } = resolveCursor(
+      flags.cursor,
+      PAGINATION_KEY,
+      contextKey
+    );
+
+    const { data: response, nextCursor } = await withProgress(
+      {
+        message: `Querying ${dataset} in ${project ? `${org}/${project}` : org}...`,
+        json: flags.json,
+      },
+      () =>
+        queryEvents(org, {
+          fields: fieldList,
+          dataset,
+          query: apiQuery,
+          sort: effectiveSort,
+          limit: flags.limit,
+          cursor,
+          ...timeRangeToApiParams(timeRange),
+        })
+    );
+
+    advancePaginationState(PAGINATION_KEY, contextKey, direction, nextCursor);
+    const hasPrev = hasPreviousPage(PAGINATION_KEY, contextKey);
+    const hasMore = !!nextCursor;
+
+    // Pagination hints preserve the original target shape (org/ vs org/project)
+    const baseTarget = project ? `${org}/${project}` : `${org}/`;
+    const nav = paginationHint({
+      hasPrev,
+      hasMore,
+      prevHint: appendFlagHints(`sentry explore ${baseTarget} -c prev`, flags),
+      nextHint: appendFlagHints(`sentry explore ${baseTarget} -c next`, flags),
+    });
+
+    const hint = buildResultHint(response.data.length, nav);
+
+    yield new CommandOutput({
+      data: response.data,
+      meta: response.meta,
+      hasMore,
+      hasPrev,
+      nextCursor,
+      dataset,
+      org,
+      project,
+      requestedFields: fieldList,
+    });
+    return { hint };
+  },
+});

--- a/src/commands/explore.ts
+++ b/src/commands/explore.ts
@@ -7,7 +7,7 @@
  */
 
 import type { SentryContext } from "../context.js";
-import { queryEvents } from "../lib/api-client.js";
+import { API_MAX_PER_PAGE, queryEvents } from "../lib/api-client.js";
 import {
   buildProjectQuery,
   parseOrgProjectArg,
@@ -28,7 +28,6 @@ import {
   appendQueryHint,
   appendSortHint,
   buildListCommand,
-  LIST_MAX_LIMIT,
   PERIOD_ALIASES,
   paginationHint,
 } from "../lib/list-command.js";
@@ -105,7 +104,7 @@ const API_TO_USER_DATASET = new Map(
 // ---------------------------------------------------------------------------
 
 type ExploreFlags = {
-  readonly field: string[];
+  readonly field?: string[];
   readonly dataset: string;
   readonly query?: string;
   readonly sort?: string;
@@ -156,8 +155,13 @@ function parseDataset(value: string): string {
 }
 
 /** Parse --limit flag with range validation */
+/**
+ * Parse --limit flag. Capped at `API_MAX_PER_PAGE` (100) since the Events
+ * API silently caps `per_page` server-side and `queryEvents` does not yet
+ * auto-paginate. Tracked for follow-up in #861.
+ */
 function parseLimit(value: string): number {
-  return validateLimit(value, 1, LIST_MAX_LIMIT);
+  return validateLimit(value, 1, API_MAX_PER_PAGE);
 }
 
 // ---------------------------------------------------------------------------
@@ -199,7 +203,8 @@ function orderFieldNames(
 /** Format explore results for human-readable terminal output */
 function formatExploreHuman(data: ExploreData): string {
   if (data.data.length === 0) {
-    return data.hasMore
+    // Empty page mid-pagination (more or prev pages exist) vs. truly no results.
+    return data.hasMore || data.hasPrev
       ? "No results on this page."
       : "No results matched the query.";
   }
@@ -396,8 +401,8 @@ export const exploreCommand = buildListCommand("explore", {
       "Examples:\n" +
       '  sentry explore my-org/cli -F title -F "count()"\n' +
       '  sentry explore my-org/ -F title -F "count()" -F "count_unique(user)" --period 1h\n' +
-      "  sentry explore my-org/cli -F transaction " +
-      '-F "p50(transaction.duration)" --dataset transactions\n' +
+      '  sentry explore my-org/cli -F span.op -F "p50(span.duration)" ' +
+      "--dataset spans\n" +
       '  sentry explore -F span.op -F "count()" --dataset spans --period 1h\n' +
       "  sentry explore --json",
   },
@@ -448,7 +453,7 @@ export const exploreCommand = buildListCommand("explore", {
       limit: {
         kind: "parsed",
         parse: parseLimit,
-        brief: `Number of rows (1-${LIST_MAX_LIMIT})`,
+        brief: `Number of rows (1-${API_MAX_PER_PAGE})`,
         default: "25",
       },
       period: {

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -27,6 +27,10 @@ export {
   updateDashboard,
 } from "./api/dashboards.js";
 export {
+  type ExploreQueryOptions,
+  queryEvents,
+} from "./api/discover.js";
+export {
   findEventAcrossOrgs,
   getEvent,
   getLatestEvent,

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -26,10 +26,7 @@ export {
   queryAllWidgets,
   updateDashboard,
 } from "./api/dashboards.js";
-export {
-  type ExploreQueryOptions,
-  queryEvents,
-} from "./api/discover.js";
+export { queryEvents } from "./api/discover.js";
 export {
   findEventAcrossOrgs,
   getEvent,

--- a/src/lib/api/discover.ts
+++ b/src/lib/api/discover.ts
@@ -1,0 +1,84 @@
+/**
+ * Sentry Explore/Discover API — aggregate event queries.
+ *
+ * Wraps `GET /organizations/{org}/events/` with user-specified fields, dataset,
+ * query, sort, and time range. This is the same endpoint used by the Sentry
+ * Explore UI for arbitrary event queries with aggregation support.
+ */
+
+import type { EventsTableResponse } from "../../types/dashboard.js";
+import { EventsTableResponseSchema } from "../../types/dashboard.js";
+import { resolveOrgRegion } from "../region.js";
+import {
+  apiRequestToRegion,
+  type PaginatedResponse,
+  parseLinkHeader,
+} from "./infrastructure.js";
+
+/** Options for querying the Explore/Events endpoint. */
+export type ExploreQueryOptions = {
+  /** Fields to request — columns, aggregates, or equations */
+  fields: string[];
+  /** Dataset to query: errors, transactions, spans, discover */
+  dataset?: string;
+  /** Sentry search query filter */
+  query?: string;
+  /**
+   * Sort field. Prefix with `-` for descending.
+   * Only supported on the `spans` dataset — other datasets reject it with 400.
+   */
+  sort?: string;
+  /** Maximum number of rows to return */
+  limit?: number;
+  /** Pagination cursor */
+  cursor?: string;
+  /** Relative time period (e.g., "24h", "7d"). Mutually exclusive with start/end. */
+  statsPeriod?: string;
+  /** Absolute start datetime (ISO-8601). Mutually exclusive with statsPeriod. */
+  start?: string;
+  /** Absolute end datetime (ISO-8601). Mutually exclusive with statsPeriod. */
+  end?: string;
+};
+
+/**
+ * Query the Explore/Events endpoint for aggregate or tabular event data.
+ *
+ * Calls `GET /organizations/{org}/events/` with the specified fields, dataset,
+ * query, sort, and time range. Supports all standard Sentry Explore fields
+ * including aggregates like `count()`, `count_unique(user)`, `p50(transaction.duration)`.
+ *
+ * @param orgSlug - Organization slug
+ * @param options - Query options
+ * @returns Paginated response with tabular data and field metadata
+ */
+export async function queryEvents(
+  orgSlug: string,
+  options: ExploreQueryOptions
+): Promise<PaginatedResponse<EventsTableResponse>> {
+  const regionUrl = await resolveOrgRegion(orgSlug);
+
+  const { data, headers } = await apiRequestToRegion<EventsTableResponse>(
+    regionUrl,
+    `/organizations/${orgSlug}/events/`,
+    {
+      params: {
+        dataset: options.dataset ?? "errors",
+        field: options.fields,
+        query: options.query || undefined,
+        sort: options.sort || undefined,
+        per_page: options.limit ?? 25,
+        statsPeriod:
+          options.start || options.end
+            ? undefined
+            : (options.statsPeriod ?? "24h"),
+        start: options.start,
+        end: options.end,
+        cursor: options.cursor,
+      },
+      schema: EventsTableResponseSchema,
+    }
+  );
+
+  const { nextCursor } = parseLinkHeader(headers.get("link") ?? null);
+  return { data, nextCursor };
+}

--- a/src/lib/formatters/meta-table.ts
+++ b/src/lib/formatters/meta-table.ts
@@ -1,0 +1,83 @@
+/**
+ * Generic table-rendering helpers driven by Sentry Events API
+ * `meta.fields` / `meta.units` metadata.
+ *
+ * Used by `sentry explore` (and any future command rendering dynamic
+ * Discover/Events results) to format cell values according to the
+ * field's declared type and unit, and to build right-aligned columns
+ * for numeric fields.
+ */
+
+import { escapeMarkdownCell } from "./markdown.js";
+import { appendUnitSuffix, formatNumber } from "./numbers.js";
+import type { Column } from "./table.js";
+
+/** Sentry field types that render as right-aligned numeric columns. */
+export const NUMERIC_FIELD_TYPES = new Set([
+  "integer",
+  "number",
+  "duration",
+  "percentage",
+  "size",
+]);
+
+/**
+ * Format a single cell value according to its `meta.fields` type.
+ *
+ * - `null` / `undefined` → `"—"`
+ * - `duration` / `size` → `formatNumber` + unit suffix (`"1,234ms"`, `"5MB"`)
+ * - `percentage` → multiplied by 100 and suffixed with `%`
+ * - other numbers → `formatNumber` (locale grouping, K/M/B above 1M)
+ * - non-numeric → `String(value)` with markdown-cell escaping
+ */
+export function formatCellValue(
+  value: unknown,
+  fieldType?: string,
+  unit?: string | null
+): string {
+  if (value === null || value === undefined) {
+    return "—";
+  }
+  if (typeof value === "number") {
+    if (fieldType === "duration" || fieldType === "size") {
+      return appendUnitSuffix(formatNumber(value), unit);
+    }
+    if (fieldType === "percentage") {
+      return `${formatNumber(value * 100)}%`;
+    }
+    return formatNumber(value);
+  }
+  return escapeMarkdownCell(String(value));
+}
+
+/**
+ * Build dynamic table columns from API response field metadata.
+ *
+ * Each field name becomes a column. Numeric fields (per
+ * {@link NUMERIC_FIELD_TYPES}) are right-aligned and not truncated.
+ *
+ * Cell values are extracted from `row[name]` and formatted via
+ * {@link formatCellValue}.
+ *
+ * @param fieldNames - Column order (typically the user's `--field` order)
+ * @param fieldTypes - Optional `meta.fields` map: field name → Sentry type
+ * @param fieldUnits - Optional `meta.units` map: field name → unit string
+ */
+export function buildMetaColumns(
+  fieldNames: string[],
+  fieldTypes?: Record<string, string>,
+  fieldUnits?: Record<string, string | null>
+): Column<Record<string, unknown>>[] {
+  return fieldNames.map((name) => {
+    const fieldType = fieldTypes?.[name];
+    const unit = fieldUnits?.[name];
+    const isNumeric = fieldType ? NUMERIC_FIELD_TYPES.has(fieldType) : false;
+
+    return {
+      header: name.toUpperCase(),
+      value: (row) => formatCellValue(row[name], fieldType, unit),
+      align: isNumeric ? ("right" as const) : ("left" as const),
+      truncate: !isNumeric,
+    };
+  });
+}

--- a/src/lib/list-command.ts
+++ b/src/lib/list-command.ts
@@ -264,6 +264,39 @@ export function paginationHint(opts: {
 }
 
 /**
+ * Append `-q "<query>"` to a hint-flag parts array when the user passed `--query`.
+ *
+ * Standard helper for pagination-hint builders that need to preserve the
+ * active search filter. Quotes are added unconditionally to handle queries
+ * containing spaces.
+ */
+export function appendQueryHint(
+  parts: string[],
+  query: string | undefined
+): void {
+  if (query) {
+    parts.push(`-q "${query}"`);
+  }
+}
+
+/**
+ * Append `--sort <value>` to a hint-flag parts array when the sort differs
+ * from the command's default.
+ *
+ * Stringly-typed to support both raw API sort strings (e.g. `"-count()"`)
+ * and command-specific enum values (e.g. `"date" | "duration"`).
+ */
+export function appendSortHint(
+  parts: string[],
+  sort: string | undefined,
+  defaultSort?: string
+): void {
+  if (sort && sort !== defaultSort) {
+    parts.push(`--sort ${sort}`);
+  }
+}
+
+/**
  * Build the `--limit` / `-n` flag for a list command.
  *
  * @param entityPlural - Plural entity name used in the brief (e.g. "teams")

--- a/src/lib/list-command.ts
+++ b/src/lib/list-command.ts
@@ -292,7 +292,7 @@ export function appendSortHint(
   defaultSort?: string
 ): void {
   if (sort && sort !== defaultSort) {
-    parts.push(`--sort ${sort}`);
+    parts.push(`--sort "${sort}"`);
   }
 }
 

--- a/test/commands/explore.test.ts
+++ b/test/commands/explore.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Tests for `sentry explore` command.
+ *
+ * Verifies target resolution (org, org/project, bare slug, auto-detect),
+ * API call parameters, output formatting, pagination, and dataset handling.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { exploreCommand } from "../../src/commands/explore.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as apiClient from "../../src/lib/api-client.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as paginationDb from "../../src/lib/db/pagination.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as resolveTarget from "../../src/lib/resolve-target.js";
+import { parsePeriod } from "../../src/lib/time-range.js";
+import { useTestConfigDir } from "../helpers.js";
+
+// Keep namespace references alive so biome doesn't strip the imports
+const _apiRef = apiClient;
+const _paginationRef = paginationDb;
+const _resolveRef = resolveTarget;
+
+useTestConfigDir("explore-test-");
+
+type ExploreFunc = (
+  this: unknown,
+  flags: Record<string, unknown>,
+  ...args: unknown[]
+) => Promise<void>;
+
+let func: ExploreFunc;
+
+function createContext() {
+  const stdoutChunks: string[] = [];
+  return {
+    context: {
+      stdout: {
+        write: mock((s: string) => {
+          stdoutChunks.push(s);
+        }),
+      },
+      stderr: {
+        write: mock((_s: string) => {
+          /* no-op */
+        }),
+      },
+      cwd: "/tmp/test-explore",
+    },
+    getStdout: () => stdoutChunks.join(""),
+  };
+}
+
+const MOCK_EVENTS_RESPONSE = {
+  data: [
+    { title: "TypeError: Cannot read property 'foo'", "count()": 1234 },
+    { title: "ReferenceError: bar is not defined", "count()": 567 },
+  ],
+  meta: {
+    fields: { title: "string", "count()": "integer" },
+    units: {},
+  },
+};
+
+let queryEventsSpy: ReturnType<typeof spyOn>;
+let resolveOrgSpy: ReturnType<typeof spyOn>;
+let resolveProjectBySlugSpy: ReturnType<typeof spyOn>;
+let resolveCursorSpy: ReturnType<typeof spyOn>;
+let advancePaginationStateSpy: ReturnType<typeof spyOn>;
+let hasPreviousPageSpy: ReturnType<typeof spyOn>;
+
+beforeEach(async () => {
+  func = (await exploreCommand.loader()) as unknown as ExploreFunc;
+
+  queryEventsSpy = spyOn(apiClient, "queryEvents");
+  queryEventsSpy.mockResolvedValue({
+    data: MOCK_EVENTS_RESPONSE,
+    nextCursor: undefined,
+  });
+
+  resolveOrgSpy = spyOn(resolveTarget, "resolveOrg");
+  resolveOrgSpy.mockResolvedValue({ org: "test-org" });
+
+  // Default: bare-slug lookups resolve to test-org/test-project
+  resolveProjectBySlugSpy = spyOn(resolveTarget, "resolveProjectBySlug");
+  resolveProjectBySlugSpy.mockResolvedValue({
+    org: "test-org",
+    project: "test-project",
+    projectData: {} as never,
+  });
+
+  resolveCursorSpy = spyOn(paginationDb, "resolveCursor").mockReturnValue({
+    cursor: undefined,
+    direction: "next" as const,
+  });
+  advancePaginationStateSpy = spyOn(
+    paginationDb,
+    "advancePaginationState"
+  ).mockReturnValue(undefined);
+  hasPreviousPageSpy = spyOn(paginationDb, "hasPreviousPage").mockReturnValue(
+    false
+  );
+});
+
+afterEach(() => {
+  queryEventsSpy.mockRestore();
+  resolveOrgSpy.mockRestore();
+  resolveProjectBySlugSpy.mockRestore();
+  resolveCursorSpy.mockRestore();
+  advancePaginationStateSpy.mockRestore();
+  hasPreviousPageSpy.mockRestore();
+});
+
+const DEFAULT_FLAGS = {
+  limit: 25,
+  dataset: "errors",
+  period: parsePeriod("24h"),
+  json: false,
+  fresh: false,
+};
+
+describe("sentry explore", () => {
+  describe("target resolution", () => {
+    test("`<org>/` uses org without project filter", async () => {
+      const { context } = createContext();
+
+      await func.call(context, DEFAULT_FLAGS, "my-org/");
+
+      // No resolveOrg call needed — org-all parses directly
+      expect(queryEventsSpy).toHaveBeenCalledWith(
+        "my-org",
+        expect.objectContaining({ query: undefined })
+      );
+    });
+
+    test("`<org>/<project>` adds project:<slug> to query automatically", async () => {
+      const { context } = createContext();
+
+      await func.call(context, DEFAULT_FLAGS, "my-org/cli");
+
+      expect(queryEventsSpy).toHaveBeenCalledWith(
+        "my-org",
+        expect.objectContaining({ query: "project:cli" })
+      );
+    });
+
+    test("`<org>/<project>` with --query merges project filter and user query", async () => {
+      const { context } = createContext();
+
+      await func.call(
+        context,
+        { ...DEFAULT_FLAGS, query: "level:error" },
+        "my-org/cli"
+      );
+
+      expect(queryEventsSpy).toHaveBeenCalledWith(
+        "my-org",
+        expect.objectContaining({ query: "project:cli level:error" })
+      );
+    });
+
+    test("bare slug resolves project across orgs and adds project filter", async () => {
+      const { context } = createContext();
+
+      await func.call(context, DEFAULT_FLAGS, "cli");
+
+      expect(resolveProjectBySlugSpy).toHaveBeenCalledWith(
+        "cli",
+        expect.any(String),
+        expect.any(String),
+        undefined
+      );
+      expect(queryEventsSpy).toHaveBeenCalledWith(
+        "test-org",
+        expect.objectContaining({ query: "project:test-project" })
+      );
+    });
+
+    test("auto-detects org when no target provided", async () => {
+      const { context } = createContext();
+
+      await func.call(context, DEFAULT_FLAGS);
+
+      expect(resolveOrgSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ cwd: "/tmp/test-explore" })
+      );
+      expect(queryEventsSpy).toHaveBeenCalledWith(
+        "test-org",
+        expect.objectContaining({ query: undefined })
+      );
+    });
+
+    test("throws ContextError when auto-detect fails", async () => {
+      resolveOrgSpy.mockResolvedValue(null);
+      const { context } = createContext();
+
+      await expect(func.call(context, DEFAULT_FLAGS)).rejects.toThrow(
+        "Organization"
+      );
+    });
+  });
+
+  describe("API call parameters", () => {
+    test("passes default fields and dataset when none specified", async () => {
+      const { context } = createContext();
+
+      await func.call(context, DEFAULT_FLAGS, "test-org/");
+
+      expect(queryEventsSpy).toHaveBeenCalledWith(
+        "test-org",
+        expect.objectContaining({
+          fields: ["title", "count()"],
+          dataset: "errors",
+        })
+      );
+    });
+
+    test("passes custom fields from --field flag", async () => {
+      const { context } = createContext();
+
+      await func.call(
+        context,
+        {
+          ...DEFAULT_FLAGS,
+          field: ["transaction", "p50(transaction.duration)"],
+        },
+        "test-org/"
+      );
+
+      expect(queryEventsSpy).toHaveBeenCalledWith(
+        "test-org",
+        expect.objectContaining({
+          fields: ["transaction", "p50(transaction.duration)"],
+        })
+      );
+    });
+
+    test("passes custom dataset", async () => {
+      const { context } = createContext();
+
+      await func.call(
+        context,
+        { ...DEFAULT_FLAGS, dataset: "transactions" },
+        "test-org/"
+      );
+
+      expect(queryEventsSpy).toHaveBeenCalledWith(
+        "test-org",
+        expect.objectContaining({ dataset: "transactions" })
+      );
+    });
+
+    test("passes user query unchanged when no project filter", async () => {
+      const { context } = createContext();
+
+      await func.call(
+        context,
+        { ...DEFAULT_FLAGS, query: "is:unresolved" },
+        "test-org/"
+      );
+
+      expect(queryEventsSpy).toHaveBeenCalledWith(
+        "test-org",
+        expect.objectContaining({ query: "is:unresolved" })
+      );
+    });
+
+    test("passes limit", async () => {
+      const { context } = createContext();
+
+      await func.call(context, { ...DEFAULT_FLAGS, limit: 100 }, "test-org/");
+
+      expect(queryEventsSpy).toHaveBeenCalledWith(
+        "test-org",
+        expect.objectContaining({ limit: 100 })
+      );
+    });
+  });
+
+  describe("sort handling", () => {
+    test("auto-sorts by first aggregate descending for non-spans", async () => {
+      const { context } = createContext();
+
+      await func.call(context, DEFAULT_FLAGS, "test-org/");
+
+      // Default fields are ["title", "count()"], so sort should be omitted
+      // for non-spans datasets (errors is the default)
+      expect(queryEventsSpy).toHaveBeenCalledWith(
+        "test-org",
+        expect.objectContaining({ sort: undefined })
+      );
+    });
+
+    test("applies explicit sort on spans dataset", async () => {
+      const { context } = createContext();
+
+      await func.call(
+        context,
+        { ...DEFAULT_FLAGS, dataset: "spans", sort: "-count()" },
+        "test-org/"
+      );
+
+      expect(queryEventsSpy).toHaveBeenCalledWith(
+        "test-org",
+        expect.objectContaining({ sort: "-count()", dataset: "spans" })
+      );
+    });
+
+    test("omits sort for non-spans dataset even when auto-detected", async () => {
+      const { context } = createContext();
+
+      await func.call(
+        context,
+        { ...DEFAULT_FLAGS, dataset: "errors" },
+        "test-org/"
+      );
+
+      expect(queryEventsSpy).toHaveBeenCalledWith(
+        "test-org",
+        expect.objectContaining({ sort: undefined })
+      );
+    });
+  });
+
+  describe("output", () => {
+    test("renders human-readable table with results", async () => {
+      const { context, getStdout } = createContext();
+
+      await func.call(context, DEFAULT_FLAGS, "test-org/");
+
+      const output = getStdout();
+      expect(output).toContain("errors");
+      expect(output).toContain("test-org");
+    });
+
+    test("includes project in human header when target is org/project", async () => {
+      const { context, getStdout } = createContext();
+
+      await func.call(context, DEFAULT_FLAGS, "my-org/cli");
+
+      expect(getStdout()).toContain("my-org/cli");
+    });
+
+    test("preserves user --field order in table columns", async () => {
+      // API returns fields in a different order than requested
+      queryEventsSpy.mockResolvedValue({
+        data: {
+          data: [{ title: "Error A", "count_unique(user)": 5, "count()": 100 }],
+          meta: {
+            // Note: API returns in alphabetical-ish order, NOT request order
+            fields: {
+              "count_unique(user)": "integer",
+              "count()": "integer",
+              title: "string",
+            },
+          },
+        },
+        nextCursor: undefined,
+      });
+      const { context, getStdout } = createContext();
+
+      await func.call(
+        context,
+        {
+          ...DEFAULT_FLAGS,
+          field: ["title", "count()", "count_unique(user)"],
+        },
+        "test-org/"
+      );
+
+      const output = getStdout();
+      const titleIdx = output.indexOf("TITLE");
+      const countIdx = output.indexOf("COUNT()");
+      const uniqueIdx = output.indexOf("COUNT_UNIQUE(USER)");
+
+      // All three columns must appear
+      expect(titleIdx).toBeGreaterThan(-1);
+      expect(countIdx).toBeGreaterThan(-1);
+      expect(uniqueIdx).toBeGreaterThan(-1);
+
+      // Order must match user input: TITLE < COUNT() < COUNT_UNIQUE(USER)
+      expect(titleIdx).toBeLessThan(countIdx);
+      expect(countIdx).toBeLessThan(uniqueIdx);
+    });
+
+    test("renders JSON output with envelope", async () => {
+      const { context, getStdout } = createContext();
+
+      await func.call(context, { ...DEFAULT_FLAGS, json: true }, "test-org/");
+
+      const parsed = JSON.parse(getStdout());
+      expect(parsed.data).toBeArray();
+      expect(parsed.dataset).toBe("errors");
+      expect(parsed.hasMore).toBe(false);
+      expect(parsed.hasPrev).toBe(false);
+      expect(parsed.meta).toBeDefined();
+    });
+
+    test("shows empty message when no results", async () => {
+      queryEventsSpy.mockResolvedValue({
+        data: { data: [], meta: { fields: {} } },
+        nextCursor: undefined,
+      });
+      const { context, getStdout } = createContext();
+
+      await func.call(context, DEFAULT_FLAGS, "test-org/");
+
+      expect(getStdout()).toContain("No results matched the query.");
+    });
+  });
+
+  describe("pagination", () => {
+    test("includes nextCursor in JSON when more results available", async () => {
+      queryEventsSpy.mockResolvedValue({
+        data: MOCK_EVENTS_RESPONSE,
+        nextCursor: "1735689600:0:1",
+      });
+      const { context, getStdout } = createContext();
+
+      await func.call(context, { ...DEFAULT_FLAGS, json: true }, "test-org/");
+
+      const parsed = JSON.parse(getStdout());
+      expect(parsed.hasMore).toBe(true);
+      expect(parsed.nextCursor).toBe("1735689600:0:1");
+    });
+
+    test("advances pagination state after query", async () => {
+      queryEventsSpy.mockResolvedValue({
+        data: MOCK_EVENTS_RESPONSE,
+        nextCursor: "cursor123",
+      });
+      const { context } = createContext();
+
+      await func.call(context, DEFAULT_FLAGS, "test-org/");
+
+      expect(advancePaginationStateSpy).toHaveBeenCalledWith(
+        "explore",
+        expect.any(String),
+        "next",
+        "cursor123"
+      );
+    });
+  });
+});

--- a/test/lib/api/discover.test.ts
+++ b/test/lib/api/discover.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for the discover/explore API helper.
+ *
+ * Verifies URL construction, query parameter encoding (especially repeated
+ * `field` params), schema validation, and pagination cursor extraction.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { queryEvents } from "../../../src/lib/api/discover.js";
+import { mockFetch, useTestConfigDir } from "../../helpers.js";
+
+describe("queryEvents", () => {
+  useTestConfigDir("discover-test-");
+
+  let originalFetch: typeof globalThis.fetch;
+  let capturedUrl = "";
+  let capturedMethod = "";
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    capturedUrl = "";
+    capturedMethod = "";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function mockOk(body: unknown, headers: Record<string, string> = {}) {
+    globalThis.fetch = mockFetch(async (input, init) => {
+      const req = new Request(input!, init);
+      capturedUrl = req.url;
+      capturedMethod = req.method;
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json", ...headers },
+      });
+    });
+  }
+
+  test("hits /organizations/{org}/events/ with GET", async () => {
+    mockOk({ data: [], meta: { fields: {} } });
+
+    await queryEvents("my-org", { fields: ["title", "count()"] });
+
+    expect(capturedMethod).toBe("GET");
+    expect(capturedUrl).toContain("/api/0/organizations/my-org/events/");
+  });
+
+  test("encodes fields as repeated query params (field=a&field=b)", async () => {
+    mockOk({ data: [], meta: { fields: {} } });
+
+    await queryEvents("my-org", {
+      fields: ["title", "count()", "count_unique(user)"],
+    });
+
+    // Each field appears as its own query param (not joined with comma).
+    // URLSearchParams encodes parens as %28/%29 — assert against decoded URL.
+    const decoded = decodeURIComponent(capturedUrl);
+    expect(decoded).toContain("field=title");
+    expect(decoded).toContain("field=count()");
+    expect(decoded).toContain("field=count_unique(user)");
+    // Verify we got 3 separate field= params, not 1 with commas
+    expect(capturedUrl.match(/field=/g)?.length).toBe(3);
+  });
+
+  test("defaults dataset to errors when not provided", async () => {
+    mockOk({ data: [], meta: { fields: {} } });
+
+    await queryEvents("my-org", { fields: ["title"] });
+
+    expect(capturedUrl).toContain("dataset=errors");
+  });
+
+  test("passes explicit dataset", async () => {
+    mockOk({ data: [], meta: { fields: {} } });
+
+    await queryEvents("my-org", {
+      fields: ["span.op"],
+      dataset: "spans",
+    });
+
+    expect(capturedUrl).toContain("dataset=spans");
+  });
+
+  test("omits empty query (does not send query=&)", async () => {
+    mockOk({ data: [], meta: { fields: {} } });
+
+    await queryEvents("my-org", { fields: ["title"], query: "" });
+
+    expect(capturedUrl).not.toContain("query=");
+  });
+
+  test("passes non-empty query", async () => {
+    mockOk({ data: [], meta: { fields: {} } });
+
+    await queryEvents("my-org", {
+      fields: ["title"],
+      query: "is:unresolved",
+    });
+
+    expect(capturedUrl).toContain(
+      `query=${encodeURIComponent("is:unresolved")}`
+    );
+  });
+
+  test("omits sort when not provided", async () => {
+    mockOk({ data: [], meta: { fields: {} } });
+
+    await queryEvents("my-org", { fields: ["title"] });
+
+    expect(capturedUrl).not.toContain("sort=");
+  });
+
+  test("passes sort when provided", async () => {
+    mockOk({ data: [], meta: { fields: {} } });
+
+    await queryEvents("my-org", {
+      fields: ["span.op"],
+      dataset: "spans",
+      sort: "-count()",
+    });
+
+    // URLSearchParams encodes ( and ) but leaves - and most chars alone
+    expect(decodeURIComponent(capturedUrl)).toContain("sort=-count()");
+  });
+
+  test("uses statsPeriod when no absolute range provided", async () => {
+    mockOk({ data: [], meta: { fields: {} } });
+
+    await queryEvents("my-org", {
+      fields: ["title"],
+      statsPeriod: "1h",
+    });
+
+    expect(capturedUrl).toContain("statsPeriod=1h");
+    expect(capturedUrl).not.toContain("start=");
+    expect(capturedUrl).not.toContain("end=");
+  });
+
+  test("uses absolute start/end and skips statsPeriod fallback", async () => {
+    mockOk({ data: [], meta: { fields: {} } });
+
+    await queryEvents("my-org", {
+      fields: ["title"],
+      start: "2024-01-15T00:00:00Z",
+      end: "2024-01-16T00:00:00Z",
+      // statsPeriod also passed but should be ignored
+      statsPeriod: "7d",
+    });
+
+    expect(capturedUrl).toContain(
+      `start=${encodeURIComponent("2024-01-15T00:00:00Z")}`
+    );
+    expect(capturedUrl).toContain(
+      `end=${encodeURIComponent("2024-01-16T00:00:00Z")}`
+    );
+    expect(capturedUrl).not.toContain("statsPeriod=");
+  });
+
+  test("passes per_page from limit", async () => {
+    mockOk({ data: [], meta: { fields: {} } });
+
+    await queryEvents("my-org", { fields: ["title"], limit: 50 });
+
+    expect(capturedUrl).toContain("per_page=50");
+  });
+
+  test("passes cursor when provided", async () => {
+    mockOk({ data: [], meta: { fields: {} } });
+
+    await queryEvents("my-org", {
+      fields: ["title"],
+      cursor: "0:50:0",
+    });
+
+    expect(capturedUrl).toContain(`cursor=${encodeURIComponent("0:50:0")}`);
+  });
+
+  test("returns parsed data and extracts nextCursor from Link header", async () => {
+    const cursor = "0:50:0";
+    mockOk(
+      {
+        data: [{ title: "Error A", "count()": 100 }],
+        meta: {
+          fields: { title: "string", "count()": "integer" },
+          units: {},
+        },
+      },
+      {
+        Link: `<https://us.sentry.io/api/0/next/>; rel="next"; results="true"; cursor="${cursor}"`,
+      }
+    );
+
+    const result = await queryEvents("my-org", {
+      fields: ["title", "count()"],
+    });
+
+    expect(result.data.data).toHaveLength(1);
+    expect(result.data.meta?.fields).toEqual({
+      title: "string",
+      "count()": "integer",
+    });
+    expect(result.nextCursor).toBe(cursor);
+  });
+
+  test("returns undefined nextCursor when results=false in Link header", async () => {
+    mockOk(
+      {
+        data: [],
+        meta: { fields: {} },
+      },
+      {
+        Link: `<https://us.sentry.io/api/0/next/>; rel="next"; results="false"; cursor=""`,
+      }
+    );
+
+    const result = await queryEvents("my-org", { fields: ["title"] });
+
+    expect(result.nextCursor).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Add a new top-level `sentry explore` command that wraps the Sentry Explore/Events API for aggregate queries — the missing capability for spike analysis from the CLI (#853).

## Usage

```bash
# Top errors in a project (last 24h)
sentry explore sentry/cli

# Custom fields and aggregates
sentry explore sentry/cli -F title -F "count()" -F "count_unique(user)" --period 1h

# Span performance — p50/p95 by route
sentry explore my-org/cli -F span.op -F "p50(span.duration)" -F "p95(span.duration)" \
  --dataset spans --sort "-count()"

# Custom metrics
sentry explore my-org/cli -F transaction -F "avg(measurements.fcp)" --dataset metrics

# Logs by severity
sentry explore my-org/cli -F severity -F "count()" --dataset logs --period 1h

# JSON for scripting
sentry explore my-org/cli -F title -F "count()" --json | jq '.data[:5]'
```

## Key design decisions

- **Top-level command** (`sentry explore`), not a subcommand — maps to Sentry's Explore UI, crosses dataset boundaries
- **`--field` / `-F` repeatable flag** for arbitrary fields and aggregates — each `-F` adds a column; column order in output preserves user input (the API returns `meta.fields` in non-deterministic order)
- **`--dataset`** — `errors` (default), `spans`, `metrics`, `logs`. Deprecated `transactions` and `discover` still work but are hidden from help
- **Target resolution**: `<org>/<project>` auto-injects `project:<slug>` into the query (via `buildProjectQuery`), `<org>/` queries all projects, bare `<slug>` fuzzy-searches across orgs
- **Sort only on `spans` dataset** — other datasets reject `sort` with 400; we silently omit it (matching `queryWidgetTable` behavior) and warn when the user explicitly passed `--sort`
- **Default: top errors** — `dataset=errors`, `field=[title, count()]`, last 24h — the most common spike-analysis starting point
- **`--limit` capped at 100** for now (Events API silently caps `per_page` server-side). Auto-pagination tracked in #861

## Shared helpers added

Driven by review feedback to avoid duplicating logic across commands:

- `src/lib/formatters/meta-table.ts` (NEW) — `buildMetaColumns()` + `formatCellValue()` + `NUMERIC_FIELD_TYPES` for rendering tables driven by Sentry Events API `meta.fields`/`meta.units`. Reusable for any future command rendering Discover/Explore results.
- `src/lib/list-command.ts` — `appendQueryHint()` and `appendSortHint()` helpers for consistent pagination-hint construction (sort values are quoted for shell safety).

## Files

| File | Description |
|------|-------------|
| `src/lib/api/discover.ts` | NEW — `queryEvents()` wraps `GET /organizations/{org}/events/` with `EventsTableResponseSchema` validation |
| `src/lib/api-client.ts` | Re-export `queryEvents` + `API_MAX_PER_PAGE` |
| `src/commands/explore.ts` | NEW — command definition, target resolution, dynamic formatting, pagination |
| `src/app.ts` | Register `explore` route |
| `src/lib/formatters/meta-table.ts` | NEW — extracted shared table-rendering helpers |
| `src/lib/list-command.ts` | Add `appendQueryHint` + `appendSortHint` |
| `test/commands/explore.test.ts` | 21 tests — target resolution, API params, sort, output, pagination, column order |
| `test/lib/api/discover.test.ts` | 14 tests — URL construction, repeated `field` params, schema validation, Link-header pagination |
| `docs/src/fragments/commands/explore.md` | Usage examples and target pattern docs |

## Follow-ups

- #860 — Generalize `resolveOrgProjectTarget` to support `org-all` (replaces local `resolveExploreTarget`)
- #861 — Auto-paginate `queryEvents` to support `--limit > 100`

Closes #853
