### PR TITLE
fix(test): isolate repositories test to prevent response cache bleed

### DIFF
--- a/test/lib/api/repositories.test.ts
+++ b/test/lib/api/repositories.test.ts
@@ -9,10 +9,11 @@
 
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { listRepositoriesCached } from "../../../src/lib/api/repositories.js";
+import { setAuthToken } from "../../../src/lib/db/auth.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as repoCache from "../../../src/lib/db/repo-cache.js";
 import type { SentryRepository } from "../../../src/types/sentry.js";
-import { mockFetch } from "../../helpers.js";
+import { mockFetch, useTestConfigDir } from "../../helpers.js";
 
 function repoApiResponse(repos: { name: string }[]): Response {
   const body = repos.map((r) => ({
@@ -32,11 +33,13 @@ function repoApiResponse(repos: { name: string }[]): Response {
 }
 
 describe("listRepositoriesCached", () => {
+  useTestConfigDir("repo-cache-");
   let originalFetch: typeof globalThis.fetch;
   let getSpy: ReturnType<typeof spyOn>;
   let setSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
+    setAuthToken("test-token", 3600, "test-refresh");
     originalFetch = globalThis.fetch;
     getSpy = spyOn(repoCache, "getCachedRepos");
     setSpy = spyOn(repoCache, "setCachedRepos");


### PR DESCRIPTION
## Summary

Fix flaky `test/lib/api/repositories.test.ts` failure on main:

```
Expected: "owner/primary-succeeded"
Received: "owner/fresh"
```

## Root Cause

The test file was missing `useTestConfigDir()`, so all three tests shared the same config directory and disk-based HTTP response cache. Test 2's API response got cached to `~/.sentry/cache/responses/`, and test 3 was served that stale cached response instead of hitting its own fetch mock.

Every other API test file (`issues.test.ts`, `organizations.test.ts`, `releases.test.ts`) already uses `useTestConfigDir()` — this one was the outlier.

## Fix

- Add `useTestConfigDir("repo-cache-")` for per-test config directory isolation
- Add `setAuthToken()` in `beforeEach` to provide the auth token `authenticatedFetch` needs
