### PR TITLE
fix: use human-readable byte sizes in upgrade verbose output

### DIFF
--- a/src/commands/cli/upgrade.ts
+++ b/src/commands/cli/upgrade.ts
@@ -32,6 +32,7 @@ import {
 import { getVersionCheckInfo } from "../../lib/db/version-check.js";
 import { UpgradeError } from "../../lib/errors.js";
 import { formatUpgradeResult } from "../../lib/formatters/human.js";
+import { formatCompactWithUnit } from "../../lib/formatters/numbers.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import { logger } from "../../lib/logger.js";
 import { withProgress } from "../../lib/polling.js";
@@ -541,8 +542,9 @@ async function executeStandardUpgrade(opts: {
   );
 
   if (downloadResult?.patchBytes) {
-    const kb = (downloadResult.patchBytes / 1024).toFixed(1);
-    log.info(`Applied delta patch (${kb} KB downloaded)`);
+    log.info(
+      `Applied delta patch (${formatCompactWithUnit(downloadResult.patchBytes, "byte")} downloaded)`
+    );
   }
 
   // Run setup on the new binary to update completions, agent skills,
@@ -611,8 +613,9 @@ async function migrateToStandaloneForNightly(
   );
 
   if (downloadResult?.patchBytes) {
-    const kb = (downloadResult.patchBytes / 1024).toFixed(1);
-    log.info(`Applied delta patch (${kb} KB downloaded)`);
+    log.info(
+      `Applied delta patch (${formatCompactWithUnit(downloadResult.patchBytes, "byte")} downloaded)`
+    );
   }
 
   if (!downloadResult) {

--- a/src/commands/cli/upgrade.ts
+++ b/src/commands/cli/upgrade.ts
@@ -32,7 +32,7 @@ import {
 import { getVersionCheckInfo } from "../../lib/db/version-check.js";
 import { UpgradeError } from "../../lib/errors.js";
 import { formatUpgradeResult } from "../../lib/formatters/human.js";
-import { formatCompactWithUnit } from "../../lib/formatters/numbers.js";
+import { formatBytes } from "../../lib/formatters/numbers.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import { logger } from "../../lib/logger.js";
 import { withProgress } from "../../lib/polling.js";
@@ -543,7 +543,7 @@ async function executeStandardUpgrade(opts: {
 
   if (downloadResult?.patchBytes) {
     log.info(
-      `Applied delta patch (${formatCompactWithUnit(downloadResult.patchBytes, "byte")} downloaded)`
+      `Applied delta patch (${formatBytes(downloadResult.patchBytes)} downloaded)`
     );
   }
 
@@ -614,7 +614,7 @@ async function migrateToStandaloneForNightly(
 
   if (downloadResult?.patchBytes) {
     log.info(
-      `Applied delta patch (${formatCompactWithUnit(downloadResult.patchBytes, "byte")} downloaded)`
+      `Applied delta patch (${formatBytes(downloadResult.patchBytes)} downloaded)`
     );
   }
 

--- a/src/lib/delta-upgrade.ts
+++ b/src/lib/delta-upgrade.ts
@@ -30,6 +30,7 @@ import {
 } from "./binary.js";
 import { applyPatch } from "./bspatch.js";
 import { CLI_VERSION } from "./constants.js";
+import { formatCompactWithUnit } from "./formatters/numbers.js";
 import {
   downloadLayerBlob,
   fetchManifest,
@@ -1017,7 +1018,7 @@ async function resolveAndApplyDelta(
   if (cached) {
     Sentry.getActiveSpan()?.setAttribute("delta.source", "cache");
     log.debug(
-      `Using cached patches: ${cached.patches.length} patch(es), ${cached.totalSize} bytes total`
+      `Using cached patches: ${cached.patches.length} patch(es), ${formatCompactWithUnit(cached.totalSize, "byte")} total`
     );
     return await applyChainAndReturn(cached, oldBinaryPath, destPath);
   }
@@ -1034,7 +1035,7 @@ async function resolveAndApplyDelta(
   const chain = await resolveFromNetwork();
   if (chain) {
     log.debug(
-      `Resolved ${channel} chain: ${chain.patches.length} patch(es), ${chain.totalSize} bytes total`
+      `Resolved ${channel} chain: ${chain.patches.length} patch(es), ${formatCompactWithUnit(chain.totalSize, "byte")} total`
     );
   }
   if (!chain) {

--- a/src/lib/delta-upgrade.ts
+++ b/src/lib/delta-upgrade.ts
@@ -30,7 +30,7 @@ import {
 } from "./binary.js";
 import { applyPatch } from "./bspatch.js";
 import { CLI_VERSION } from "./constants.js";
-import { formatCompactWithUnit } from "./formatters/numbers.js";
+import { formatBytes } from "./formatters/numbers.js";
 import {
   downloadLayerBlob,
   fetchManifest,
@@ -1018,7 +1018,7 @@ async function resolveAndApplyDelta(
   if (cached) {
     Sentry.getActiveSpan()?.setAttribute("delta.source", "cache");
     log.debug(
-      `Using cached patches: ${cached.patches.length} patch(es), ${formatCompactWithUnit(cached.totalSize, "byte")} total`
+      `Using cached patches: ${cached.patches.length} patch(es), ${formatBytes(cached.totalSize)} total`
     );
     return await applyChainAndReturn(cached, oldBinaryPath, destPath);
   }
@@ -1035,7 +1035,7 @@ async function resolveAndApplyDelta(
   const chain = await resolveFromNetwork();
   if (chain) {
     log.debug(
-      `Resolved ${channel} chain: ${chain.patches.length} patch(es), ${formatCompactWithUnit(chain.totalSize, "byte")} total`
+      `Resolved ${channel} chain: ${chain.patches.length} patch(es), ${formatBytes(chain.totalSize)} total`
     );
   }
   if (!chain) {

--- a/src/lib/formatters/numbers.ts
+++ b/src/lib/formatters/numbers.ts
@@ -100,6 +100,33 @@ export function formatCompactWithUnit(
 }
 
 /**
+ * Format a byte count as a human-readable string with binary units.
+ *
+ * Uses 1024-based conversion with one fractional digit. Values below 1 KB
+ * are shown as whole bytes. Unlike {@link formatCompactWithUnit} with
+ * `"byte"`, this avoids the "BB" collision where `Intl.NumberFormat`
+ * compact notation uses "B" for billions and `appendUnitSuffix` adds
+ * another "B" for bytes.
+ *
+ * @example formatBytes(512)         // "512 B"
+ * @example formatBytes(3435689)     // "3.3 MB"
+ * @example formatBytes(106989888)   // "102.0 MB"
+ * @example formatBytes(1073741824)  // "1.0 GB"
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+/**
  * Format a percentage value with one decimal place, or "—" when absent.
  *
  * @example fmtPct(42.3) // "42.3%"

--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -29,7 +29,7 @@ import { getInstallInfo, setInstallInfo } from "./db/install-info.js";
 import type { ReleaseChannel } from "./db/release-channel.js";
 import { attemptDeltaUpgrade, type DeltaResult } from "./delta-upgrade.js";
 import { AbortError, UpgradeError } from "./errors.js";
-import { formatCompactWithUnit } from "./formatters/numbers.js";
+import { formatBytes } from "./formatters/numbers.js";
 import {
   downloadNightlyBlob,
   fetchManifest,
@@ -805,9 +805,7 @@ export async function downloadBinaryToTemp(
     // exponential backoff so a transient filesystem-visibility race
     // self-heals without asking the user to rerun.
     const verifiedSize = await waitForBinaryVisible(tempPath);
-    log.debug(
-      `Binary verified (${formatCompactWithUnit(verifiedSize, "byte")})`
-    );
+    log.debug(`Binary verified (${formatBytes(verifiedSize)})`);
 
     // Clear consumed patch cache — patches for the old version are useless
     // after the binary has been updated (whether via delta or full download).

--- a/src/lib/upgrade.ts
+++ b/src/lib/upgrade.ts
@@ -29,6 +29,7 @@ import { getInstallInfo, setInstallInfo } from "./db/install-info.js";
 import type { ReleaseChannel } from "./db/release-channel.js";
 import { attemptDeltaUpgrade, type DeltaResult } from "./delta-upgrade.js";
 import { AbortError, UpgradeError } from "./errors.js";
+import { formatCompactWithUnit } from "./formatters/numbers.js";
 import {
   downloadNightlyBlob,
   fetchManifest,
@@ -804,7 +805,9 @@ export async function downloadBinaryToTemp(
     // exponential backoff so a transient filesystem-visibility race
     // self-heals without asking the user to rerun.
     const verifiedSize = await waitForBinaryVisible(tempPath);
-    log.debug(`Downloaded binary verified (${verifiedSize} bytes)`);
+    log.debug(
+      `Binary verified (${formatCompactWithUnit(verifiedSize, "byte")})`
+    );
 
     // Clear consumed patch cache — patches for the old version are useless
     // after the binary has been updated (whether via delta or full download).


### PR DESCRIPTION
## Summary

- Replace raw byte counts (e.g. `3435689 bytes`) with formatted values (e.g. `3.4MB`) using existing `formatCompactWithUnit` utility
- Change "Downloaded binary verified" to "Binary verified" since the message applies to both delta-patched and downloaded binaries
- Replace manual KB formatting with `formatCompactWithUnit` for consistency

### Before
```
⚙ Resolved nightly chain: 3 patch(es), 3435689 bytes total
⚙ Downloaded binary verified (106989888 bytes)
ℹ Applied delta patch (3355.2 KB downloaded)
```

### After
```
⚙ Resolved nightly chain: 3 patch(es), 3.4MB total
⚙ Binary verified (107MB)
ℹ Applied delta patch (3.4MB downloaded)
```