### PR TITLE
fix(api): guard against excessively long query strings in issue list (CLI-FA)

### DIFF
--- a/src/lib/api/issues.ts
+++ b/src/lib/api/issues.ts
@@ -28,6 +28,17 @@ import {
 const TRAILING_SLASH_RE = /\/$/;
 
 /**
+ * Maximum length for the search query parameter (before URL encoding).
+ *
+ * Most HTTP servers/load balancers limit total URL length to ~8KB.
+ * With URL encoding overhead (~3x for non-ASCII) and other query params
+ * (project, cursor, sort, collapse, statsPeriod), 4KB for the query
+ * value alone is a safe threshold. Exceeding this causes the Sentry API
+ * to return 400 Bad Request with no actionable detail.
+ */
+const MAX_QUERY_LENGTH = 4096;
+
+/**
  * Sort options for issue listing, derived from the @sentry/api SDK types.
  * Uses the SDK type directly for compile-time safety against parameter drift.
  */
@@ -137,6 +148,22 @@ export async function listIssuesPaginated(
     projectFilter = `project:${projectSlug}`;
   }
   const fullQuery = [projectFilter, options.query].filter(Boolean).join(" ");
+
+  // Guard against excessively long query strings that would cause the API
+  // server to reject the request with 400 Bad Request. Most HTTP servers
+  // limit URL length to ~8KB; with URL encoding overhead, a 4KB query
+  // value is a safe threshold. This provides a clearer error message than
+  // the API's generic "400 Bad Request" response.
+  if (fullQuery.length > MAX_QUERY_LENGTH) {
+    throw new ValidationError(
+      `Query is too long (${fullQuery.length} characters, max ${MAX_QUERY_LENGTH}).\n` +
+        "  Try narrowing your search:\n" +
+        "  • Use fewer OR terms\n" +
+        "  • Filter by time range with --period 14d\n" +
+        "  • Use project-level filters instead of listing individual IDs",
+      "query"
+    );
+  }
 
   const config = await getOrgSdkConfig(orgSlug);
 

--- a/test/lib/api/issues.test.ts
+++ b/test/lib/api/issues.test.ts
@@ -7,6 +7,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
+  listIssuesPaginated,
   mergeIssues,
   parseResolveSpec,
   RESOLVE_COMMIT_EXPLICIT_PREFIX,
@@ -291,6 +292,51 @@ describe("mergeIssues: cross-origin legacy cache", () => {
 
     for (const id of ["100", "200", "300"]) {
       expect(await getCachedResponse("GET", legacyUrl(id), {})).toBeUndefined();
+    }
+  });
+});
+
+describe("listIssuesPaginated: query length guard", () => {
+  useTestConfigDir("issues-query-len-");
+
+  beforeEach(async () => {
+    await setAuthToken("test-token", 3600, "test-refresh");
+  });
+
+  test("rejects excessively long query strings with ValidationError", async () => {
+    // Generate a query longer than 4096 characters
+    const longQuery = "id:" + Array.from({ length: 500 }, (_, i) => `PROJ-${i}`).join(" OR id:");
+
+    await expect(
+      listIssuesPaginated("test-org", "test-project", { query: longQuery })
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  test("rejects long query with helpful message", async () => {
+    const longQuery = "x".repeat(5000);
+
+    try {
+      await listIssuesPaginated("test-org", "test-project", { query: longQuery });
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError);
+      expect((error as ValidationError).message).toContain("Query is too long");
+      expect((error as ValidationError).message).toContain("max 4096");
+    }
+  });
+
+  test("accepts queries within the length limit", async () => {
+    const shortQuery = "is:unresolved level:error";
+
+    // This will fail at the API level (no mock), but it should NOT
+    // throw ValidationError — it should get past the length check
+    try {
+      await listIssuesPaginated("test-org", "test-project", {
+        query: shortQuery,
+      });
+    } catch (error) {
+      // Expected: API error (no mock fetch), but NOT a ValidationError
+      expect(error).not.toBeInstanceOf(ValidationError);
     }
   });
 });

--- a/test/lib/api/issues.test.ts
+++ b/test/lib/api/issues.test.ts
@@ -305,7 +305,9 @@ describe("listIssuesPaginated: query length guard", () => {
 
   test("rejects excessively long query strings with ValidationError", async () => {
     // Generate a query longer than 4096 characters
-    const longQuery = "id:" + Array.from({ length: 500 }, (_, i) => `PROJ-${i}`).join(" OR id:");
+    const longQuery =
+      "id:" +
+      Array.from({ length: 500 }, (_, i) => `PROJ-${i}`).join(" OR id:");
 
     await expect(
       listIssuesPaginated("test-org", "test-project", { query: longQuery })
@@ -316,7 +318,9 @@ describe("listIssuesPaginated: query length guard", () => {
     const longQuery = "x".repeat(5000);
 
     try {
-      await listIssuesPaginated("test-org", "test-project", { query: longQuery });
+      await listIssuesPaginated("test-org", "test-project", {
+        query: longQuery,
+      });
       expect.unreachable("should have thrown");
     } catch (error) {
       expect(error).toBeInstanceOf(ValidationError);


### PR DESCRIPTION
## Summary
- Adds a 4KB query length guard in `listIssuesPaginated` that throws a helpful `ValidationError` before the request is sent
- Prevents the cryptic "400 Bad Request" error that 95 users (1589 events) hit when passing complex queries with many OR terms
- The error message suggests narrowing the search, reducing OR terms, or using `--period` to limit the time range

## Changes
- **`src/lib/api/issues.ts`**: Add `MAX_QUERY_LENGTH` constant (4096) and pre-flight check in `listIssuesPaginated`
- **`test/lib/api/issues.test.ts`**: Add tests for the query length guard (too long → ValidationError, within limit → passes through)

## Why 4KB?
Most HTTP servers/load balancers limit total URL length to ~8KB. With URL encoding overhead (~3x for non-ASCII/special chars) and other query params (project, cursor, sort, collapse, statsPeriod), 4KB for the query value alone is a safe threshold.

Fixes https://sentry.sentry.io/issues/7341195391/
