### PR TITLE
feat(explore): auto-paginate queryEvents to support --limit > 100

### DIFF
--- a/plugins/sentry-cli/skills/sentry-cli/references/explore.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/explore.md
@@ -20,7 +20,7 @@ Query aggregate event data (Explore)
 - `-d, --dataset <value> - Dataset to query (errors, spans, metrics, logs) - (default: "errors")`
 - `-q, --query <value> - Search query (Sentry search syntax)`
 - `-s, --sort <value> - Sort field (prefix with - for desc, e.g., "-count()")`
-- `-n, --limit <value> - Number of rows (1-100) - (default: "25")`
+- `-n, --limit <value> - Number of rows (1-1000) - (default: "25")`
 - `-t, --period <value> - Time range: "7d", "2026-03-01..2026-04-01", ">=2026-03-01" - (default: "24h")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`

--- a/src/commands/explore.ts
+++ b/src/commands/explore.ts
@@ -7,7 +7,7 @@
  */
 
 import type { SentryContext } from "../context.js";
-import { API_MAX_PER_PAGE, queryEvents } from "../lib/api-client.js";
+import { queryEvents } from "../lib/api-client.js";
 import {
   buildProjectQuery,
   parseOrgProjectArg,
@@ -28,6 +28,7 @@ import {
   appendQueryHint,
   appendSortHint,
   buildListCommand,
+  LIST_MAX_LIMIT,
   PERIOD_ALIASES,
   paginationHint,
 } from "../lib/list-command.js";
@@ -155,12 +156,11 @@ function parseDataset(value: string): string {
 }
 
 /**
- * Parse --limit flag. Capped at `API_MAX_PER_PAGE` (100) since the Events
- * API silently caps `per_page` server-side and `queryEvents` does not yet
- * auto-paginate. Tracked for follow-up in #861.
+ * Parse --limit flag. Capped at {@link LIST_MAX_LIMIT} (1000).
+ * `queryEvents` auto-paginates when the limit exceeds the API's per-page cap.
  */
 function parseLimit(value: string): number {
-  return validateLimit(value, 1, API_MAX_PER_PAGE);
+  return validateLimit(value, 1, LIST_MAX_LIMIT);
 }
 
 // ---------------------------------------------------------------------------
@@ -461,7 +461,7 @@ export const exploreCommand = buildListCommand("explore", {
       limit: {
         kind: "parsed",
         parse: parseLimit,
-        brief: `Number of rows (1-${API_MAX_PER_PAGE})`,
+        brief: `Number of rows (1-${LIST_MAX_LIMIT})`,
         default: "25",
       },
       period: {

--- a/src/lib/api/discover.ts
+++ b/src/lib/api/discover.ts
@@ -10,7 +10,9 @@ import type { EventsTableResponse } from "../../types/dashboard.js";
 import { EventsTableResponseSchema } from "../../types/dashboard.js";
 import { resolveOrgRegion } from "../region.js";
 import {
+  API_MAX_PER_PAGE,
   apiRequestToRegion,
+  MAX_PAGINATION_PAGES,
   type PaginatedResponse,
   parseLinkHeader,
 } from "./infrastructure.js";
@@ -41,22 +43,23 @@ export type ExploreQueryOptions = {
 };
 
 /**
- * Query the Explore/Events endpoint for aggregate or tabular event data.
+ * Fetch a single page of events from the Explore/Events endpoint.
  *
- * Calls `GET /organizations/{org}/events/` with the specified fields, dataset,
- * query, sort, and time range. Supports all standard Sentry Explore fields
- * including aggregates like `count()`, `count_unique(user)`, `p50(transaction.duration)`.
+ * Internal helper used by {@link queryEvents} for both single-page and
+ * multi-page (auto-paginating) fetches.
  *
+ * @param regionUrl - Resolved region base URL
  * @param orgSlug - Organization slug
  * @param options - Query options
+ * @param perPage - Number of rows to request per page
  * @returns Paginated response with tabular data and field metadata
  */
-export async function queryEvents(
+async function fetchEventsPage(
+  regionUrl: string,
   orgSlug: string,
-  options: ExploreQueryOptions
+  options: ExploreQueryOptions,
+  perPage: number
 ): Promise<PaginatedResponse<EventsTableResponse>> {
-  const regionUrl = await resolveOrgRegion(orgSlug);
-
   const { data, headers } = await apiRequestToRegion<EventsTableResponse>(
     regionUrl,
     `/organizations/${orgSlug}/events/`,
@@ -66,7 +69,7 @@ export async function queryEvents(
         field: options.fields,
         query: options.query || undefined,
         sort: options.sort || undefined,
-        per_page: options.limit ?? 25,
+        per_page: perPage,
         statsPeriod:
           options.start || options.end
             ? undefined
@@ -81,4 +84,74 @@ export async function queryEvents(
 
   const { nextCursor } = parseLinkHeader(headers.get("link") ?? null);
   return { data, nextCursor };
+}
+
+/**
+ * Query the Explore/Events endpoint for aggregate or tabular event data.
+ *
+ * Calls `GET /organizations/{org}/events/` with the specified fields, dataset,
+ * query, sort, and time range. Supports all standard Sentry Explore fields
+ * including aggregates like `count()`, `count_unique(user)`, `p50(transaction.duration)`.
+ *
+ * When `limit` exceeds {@link API_MAX_PER_PAGE}, transparently fetches multiple
+ * pages using cursor-based pagination (bounded by {@link MAX_PAGINATION_PAGES}).
+ * Meta is taken from the first page — it is identical across pages.
+ *
+ * @param orgSlug - Organization slug
+ * @param options - Query options
+ * @returns Paginated response with tabular data and field metadata
+ */
+export async function queryEvents(
+  orgSlug: string,
+  options: ExploreQueryOptions
+): Promise<PaginatedResponse<EventsTableResponse>> {
+  const regionUrl = await resolveOrgRegion(orgSlug);
+  const limit = options.limit ?? 25;
+  const perPage = Math.min(limit, API_MAX_PER_PAGE);
+
+  // Fast path: single-page fetch when limit fits in one API page
+  if (limit <= API_MAX_PER_PAGE) {
+    return fetchEventsPage(regionUrl, orgSlug, options, perPage);
+  }
+
+  // Multi-page: accumulate rows across pages up to the requested limit
+  const allRows: Record<string, unknown>[] = [];
+  let meta: EventsTableResponse["meta"] | undefined;
+  let cursor: string | undefined = options.cursor;
+
+  for (let page = 0; page < MAX_PAGINATION_PAGES; page += 1) {
+    const result = await fetchEventsPage(
+      regionUrl,
+      orgSlug,
+      { ...options, cursor },
+      perPage
+    );
+
+    if (page === 0) {
+      meta = result.data.meta;
+    }
+
+    allRows.push(...result.data.data);
+
+    // Stop when we've reached the requested limit or there are no more pages
+    if (allRows.length >= limit || !result.nextCursor) {
+      // Overshot — trim and drop nextCursor (cursor would skip items)
+      if (allRows.length > limit) {
+        return {
+          data: { data: allRows.slice(0, limit), meta },
+        };
+      }
+      return {
+        data: { data: allRows, meta },
+        nextCursor: result.nextCursor,
+      };
+    }
+
+    cursor = result.nextCursor;
+  }
+
+  // Safety limit reached — return what we have, no nextCursor
+  return {
+    data: { data: allRows.slice(0, limit), meta },
+  };
 }

--- a/test/lib/api/discover.test.ts
+++ b/test/lib/api/discover.test.ts
@@ -219,4 +219,153 @@ describe("queryEvents", () => {
 
     expect(result.nextCursor).toBeUndefined();
   });
+
+  // ---------------------------------------------------------------------------
+  // Auto-pagination tests (limit > API_MAX_PER_PAGE)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Helper to mock sequential fetch responses for multi-page tests.
+   * Each call to fetch returns the next response in the queue.
+   */
+  function mockSequential(
+    responses: Array<{ body: unknown; headers?: Record<string, string> }>
+  ): { getCapturedUrls: () => string[] } {
+    const capturedUrls: string[] = [];
+    let callIndex = 0;
+
+    globalThis.fetch = mockFetch(async (input, init) => {
+      const req = new Request(input!, init);
+      capturedUrls.push(req.url);
+
+      const resp = responses[callIndex]!;
+      callIndex += 1;
+
+      return new Response(JSON.stringify(resp.body), {
+        status: 200,
+        headers: { "Content-Type": "application/json", ...resp.headers },
+      });
+    });
+
+    return { getCapturedUrls: () => capturedUrls };
+  }
+
+  /** Generate N rows of fake event data */
+  function makeRows(n: number): Record<string, unknown>[] {
+    return Array.from({ length: n }, (_, i) => ({
+      title: `Error ${i}`,
+      "count()": 100 - i,
+    }));
+  }
+
+  const PAGE_META = {
+    fields: { title: "string", "count()": "integer" },
+    units: {},
+  };
+
+  test("auto-paginates when limit exceeds API_MAX_PER_PAGE", async () => {
+    const { getCapturedUrls } = mockSequential([
+      {
+        body: { data: makeRows(100), meta: PAGE_META },
+        headers: {
+          Link: `<https://us.sentry.io/api/0/next/>; rel="next"; results="true"; cursor="0:100:0"`,
+        },
+      },
+      {
+        body: { data: makeRows(50), meta: PAGE_META },
+        headers: {
+          Link: `<https://us.sentry.io/api/0/next/>; rel="next"; results="false"; cursor=""`,
+        },
+      },
+    ]);
+
+    const result = await queryEvents("my-org", {
+      fields: ["title", "count()"],
+      limit: 150,
+    });
+
+    expect(result.data.data).toHaveLength(150);
+    expect(result.data.meta?.fields).toEqual(PAGE_META.fields);
+    expect(result.nextCursor).toBeUndefined();
+    expect(getCapturedUrls()).toHaveLength(2);
+  });
+
+  test("trims results and drops nextCursor when overshoot", async () => {
+    mockSequential([
+      {
+        body: { data: makeRows(100), meta: PAGE_META },
+        headers: {
+          Link: `<https://us.sentry.io/api/0/next/>; rel="next"; results="true"; cursor="0:100:0"`,
+        },
+      },
+      {
+        body: { data: makeRows(100), meta: PAGE_META },
+        headers: {
+          Link: `<https://us.sentry.io/api/0/next/>; rel="next"; results="true"; cursor="0:200:0"`,
+        },
+      },
+    ]);
+
+    const result = await queryEvents("my-org", {
+      fields: ["title", "count()"],
+      limit: 120,
+    });
+
+    expect(result.data.data).toHaveLength(120);
+    expect(result.nextCursor).toBeUndefined();
+  });
+
+  test("single-page fast path when limit <= API_MAX_PER_PAGE", async () => {
+    const { getCapturedUrls } = mockSequential([
+      {
+        body: { data: makeRows(50), meta: PAGE_META },
+        headers: {
+          Link: `<https://us.sentry.io/api/0/next/>; rel="next"; results="false"; cursor=""`,
+        },
+      },
+    ]);
+
+    const result = await queryEvents("my-org", {
+      fields: ["title"],
+      limit: 50,
+    });
+
+    expect(result.data.data).toHaveLength(50);
+    expect(getCapturedUrls()).toHaveLength(1);
+    expect(getCapturedUrls()[0]).toContain("per_page=50");
+  });
+
+  test("preserves meta from first page across multi-page fetch", async () => {
+    const firstPageMeta = {
+      fields: { title: "string", "count()": "integer" },
+      units: { "count()": null },
+    };
+    const secondPageMeta = {
+      fields: { title: "string", "count()": "integer" },
+      units: { "count()": null },
+    };
+
+    mockSequential([
+      {
+        body: { data: makeRows(100), meta: firstPageMeta },
+        headers: {
+          Link: `<https://us.sentry.io/api/0/next/>; rel="next"; results="true"; cursor="0:100:0"`,
+        },
+      },
+      {
+        body: { data: makeRows(50), meta: secondPageMeta },
+        headers: {
+          Link: `<https://us.sentry.io/api/0/next/>; rel="next"; results="false"; cursor=""`,
+        },
+      },
+    ]);
+
+    const result = await queryEvents("my-org", {
+      fields: ["title", "count()"],
+      limit: 150,
+    });
+
+    // Meta should come from the first page
+    expect(result.data.meta).toEqual(firstPageMeta);
+  });
 });

--- a/test/lib/db/auth.test.ts
+++ b/test/lib/db/auth.test.ts
@@ -447,7 +447,9 @@ describe("hasStoredAuthCredentials memoization", () => {
     // Write directly to DB without going through setAuthToken
     // (simulates a code path the cache doesn't know about).
     const db = getDatabase();
-    db.query("INSERT OR REPLACE INTO auth (id, token) VALUES (1, 'sneaky')").run();
+    db.query(
+      "INSERT OR REPLACE INTO auth (id, token) VALUES (1, 'sneaky')"
+    ).run();
 
     // Cache still returns stale false
     expect(hasStoredAuthCredentials()).toBe(false);


### PR DESCRIPTION
## Summary
- Auto-paginate `queryEvents` when `--limit` exceeds `API_MAX_PER_PAGE` (100), matching the `listIssuesAllPages` pattern
- Raise explore `--limit` cap from 100 to `LIST_MAX_LIMIT` (1000)
- Extract `fetchEventsPage` internal helper for single-page API calls
- Trim-and-drop-cursor on overshoot to avoid skip issues

## Test Plan
- Added 4 new tests for multi-page pagination in `test/lib/api/discover.test.ts`
- All existing explore + discover tests pass (39 tests across 2 files)

Closes #861