### PR TITLE
fix(telemetry): skip os.cpus() in NodeContext to prevent crash on restricted systems (CLI-1ED)

### DIFF
--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -368,7 +368,7 @@ const LIBRARY_EXCLUDED_INTEGRATIONS = new Set([
   "NodeFetch", // diagnostics_channel + trace headers
   "FunctionToString", // wraps Function.prototype.toString
   "ChildProcess", // monitors child processes
-  "NodeContext", // reads OS info
+  "Context", // reads OS info — name is "Context" in SDK, not "NodeContext"
   "NodeRuntimeMetrics", // runtime metrics timer would keep host event loop alive
 ]);
 

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -368,7 +368,6 @@ const LIBRARY_EXCLUDED_INTEGRATIONS = new Set([
   "NodeFetch", // diagnostics_channel + trace headers
   "FunctionToString", // wraps Function.prototype.toString
   "ChildProcess", // monitors child processes
-  "Context", // reads OS info — name is "Context" in SDK, not "NodeContext"
   "NodeRuntimeMetrics", // runtime metrics timer would keep host event loop alive
 ]);
 

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -346,6 +346,7 @@ export function recordApiErrorOnSpan(span: Span, error: ApiError): void {
  */
 const EXCLUDED_INTEGRATIONS = new Set([
   "Console", // Captures console output - too noisy for CLI
+  "Context", // Replaced below with cpu: false to avoid os.cpus() crash (CLI-1ED)
   "ContextLines", // Reads source files - we rely on uploaded sourcemaps instead
   "LocalVariables", // Captures local variables - adds significant overhead
   "Modules", // Lists all loaded modules - unnecessary for CLI telemetry
@@ -537,6 +538,14 @@ export function initSentry(
           !excluded.has(integration.name) &&
           (integration.name !== "NodeSystemError" || hasGetSystemErrorMap)
       );
+
+      // Re-add Context integration with cpu: false to avoid os.cpus() crash
+      // on systems where /proc/cpuinfo is not accessible (CLI-1ED).
+      if (!libraryMode) {
+        filtered.push(
+          Sentry.nodeContextIntegration({ device: { cpu: false } })
+        );
+      }
 
       // Collect runtime metrics (CPU, memory, event loop) for non-library mode.
       // Uses nodeRuntimeMetricsIntegration which degrades gracefully on Bun:


### PR DESCRIPTION
## Summary
- Fixes CLI crash caused by `os.cpus()` throwing on systems with restricted `/proc` access (Docker containers, some CI environments)
- The Sentry SDK's `Context` integration calls `os.cpus()` unconditionally for device context, which fails with `ENOENT` on some platforms
- Fix: exclude the default `Context` integration and re-add it with `device: { cpu: false }` to skip the problematic call while preserving OS, app, and culture context

## Changes
- **`src/lib/telemetry.ts`**: Add `"Context"` to `EXCLUDED_INTEGRATIONS`, re-add `nodeContextIntegration({ device: { cpu: false } })` in non-library mode

Fixes https://sentry.sentry.io/issues/7449019949/ (CLI-1ED, 6 users, 69 events)
