### PR TITLE
fix(span-list): query all projects in trace mode for cross-project traces

### DIFF
--- a/src/commands/span/list.ts
+++ b/src/commands/span/list.ts
@@ -389,6 +389,7 @@ async function handleTraceMode(
         cursor,
         ...timeRangeToApiParams(timeRange),
         extraFields: extraApiFields,
+        allProjects: true,
       })
   );
 

--- a/src/lib/api/traces.ts
+++ b/src/lib/api/traces.ts
@@ -386,6 +386,8 @@ type ListSpansOptions = {
   start?: string;
   /** Absolute end datetime (ISO-8601). Mutually exclusive with statsPeriod. */
   end?: string;
+  /** When true, search across all projects (sends project=-1). Used for trace mode. */
+  allProjects?: boolean;
 };
 
 /**
@@ -403,7 +405,14 @@ export async function listSpans(
   options: ListSpansOptions = {}
 ): Promise<PaginatedResponse<SpanListItem[]>> {
   const isNumericProject = isAllDigits(projectSlug);
-  const projectFilter = isNumericProject ? "" : `project:${projectSlug}`;
+  let projectFilter: string;
+  if (options.allProjects) {
+    projectFilter = "";
+  } else if (isNumericProject) {
+    projectFilter = "";
+  } else {
+    projectFilter = `project:${projectSlug}`;
+  }
   const fullQuery = [projectFilter, options.query].filter(Boolean).join(" ");
 
   const fields = options.extraFields?.length
@@ -412,6 +421,13 @@ export async function listSpans(
 
   const regionUrl = await resolveOrgRegion(orgSlug);
 
+  let projectParam: string | undefined;
+  if (options.allProjects) {
+    projectParam = "-1";
+  } else if (isNumericProject) {
+    projectParam = projectSlug;
+  }
+
   const { data: response, headers } = await apiRequestToRegion<SpansResponse>(
     regionUrl,
     `/organizations/${orgSlug}/events/`,
@@ -419,7 +435,7 @@ export async function listSpans(
       params: {
         dataset: "spans",
         field: fields,
-        project: isNumericProject ? projectSlug : undefined,
+        project: projectParam,
         query: fullQuery || undefined,
         per_page: options.limit || 10,
         statsPeriod:

--- a/test/commands/span/list.test.ts
+++ b/test/commands/span/list.test.ts
@@ -411,6 +411,31 @@ describe("listCommand.func (trace mode)", () => {
       })
     );
   });
+
+  test("trace mode passes allProjects: true to listSpans", async () => {
+    listSpansSpy.mockResolvedValue({ data: [], nextCursor: undefined });
+
+    const { context } = createContext();
+
+    await func.call(
+      context,
+      {
+        limit: 25,
+        sort: "date",
+        period: parsePeriod("7d"),
+        fresh: false,
+      },
+      VALID_TRACE_ID
+    );
+
+    expect(listSpansSpy).toHaveBeenCalledWith(
+      "test-org",
+      "test-project",
+      expect.objectContaining({
+        allProjects: true,
+      })
+    );
+  });
 });
 
 // ============================================================================
@@ -668,6 +693,27 @@ describe("listCommand.func (project mode)", () => {
 
     const output = getStdout();
     expect(output).toContain("No spans matched the query.");
+  });
+
+  test("project mode does not pass allProjects to listSpans", async () => {
+    listSpansSpy.mockResolvedValue({ data: [], nextCursor: undefined });
+
+    const { context } = createContext();
+
+    await func.call(
+      context,
+      {
+        limit: 25,
+        sort: "date",
+        period: parsePeriod("7d"),
+        fresh: false,
+      },
+      "my-org/my-project"
+    );
+
+    const callArgs = listSpansSpy.mock.calls[0];
+    const options = callArgs[2];
+    expect(options.allProjects).toBeUndefined();
   });
 
   test("hint shows -c next with project target when more pages available", async () => {


### PR DESCRIPTION
## Summary
- Fix empty results when running `sentry span list <trace-id>` on traces spanning multiple projects
- Add `allProjects` option to `listSpans()` that sends `project=-1` to the API, querying across all projects
- Enable `allProjects: true` in trace mode — the `trace:{id}` query already scopes results to the correct trace
- Project mode (no trace ID) unchanged — continues to scope by project slug

## Root Cause
`listSpans()` always prepended `project:{slug}` to the query. For cross-project traces, the auto-detected project might not participate in the trace, causing the API to return zero spans.

## Test Plan
- 2 new tests verifying `allProjects: true` is passed in trace mode and NOT in project mode
- All 31 span list tests pass

Closes #735