### PR TITLE
fix(init): suppress raw ANSI escape sequences when output is piped

### DIFF
--- a/src/lib/init/clack-plain.ts
+++ b/src/lib/init/clack-plain.ts
@@ -1,0 +1,114 @@
+/**
+ * Plain-output adapter for @clack/prompts.
+ *
+ * When stdout is not a TTY (piped, redirected, CI), intercepts clack's
+ * output functions and replaces them with clean plain-text alternatives.
+ * Interactive prompts (select, confirm, multiselect) pass through to
+ * real clack since they're only reached in TTY mode.
+ *
+ * The namespace import is load-bearing: existing tests spy on the
+ * `@clack/prompts` module object via `spyOn(clack, 'cancel')`. Using
+ * a namespace import here means `clack.cancel` resolves the same live
+ * binding, so spies transparently intercept calls made through this
+ * adapter. All re-exports delegate through the namespace object (not
+ * captured bindings) so that `spyOn` replacements take effect.
+ */
+
+// biome-ignore lint/performance/noNamespaceImport: live binding required for test spyOn compatibility
+import * as clack from "@clack/prompts";
+import { isPlainOutput, stripAnsi } from "../formatters/plain-detect.js";
+
+function plainWrite(message: string): void {
+  process.stdout.write(`${stripAnsi(message)}\n`);
+}
+
+/** Plain-text log object matching clack's log interface. */
+const plainLog: typeof clack.log = {
+  info(message: string) {
+    plainWrite(message);
+  },
+  warn(message: string) {
+    plainWrite(`⚠ ${message}`);
+  },
+  warning(message: string) {
+    plainWrite(`⚠ ${message}`);
+  },
+  error(message: string) {
+    plainWrite(`✗ ${message}`);
+  },
+  success(message: string) {
+    plainWrite(`✓ ${message}`);
+  },
+  message(message?: string) {
+    if (message) {
+      plainWrite(message);
+    }
+  },
+  step(message: string) {
+    plainWrite(message);
+  },
+};
+
+function plainIntro(title?: string): void {
+  if (title) {
+    plainWrite(title);
+  }
+}
+
+function plainOutro(message?: string): void {
+  if (message) {
+    plainWrite(message);
+  }
+}
+
+function plainCancel(message?: string): void {
+  if (message) {
+    plainWrite(message);
+  }
+}
+
+// Re-export with plain-output interception for output functions.
+// Each wrapper checks isPlainOutput() at call time so env var changes
+// (e.g. in tests) take effect immediately.
+
+export const intro: typeof clack.intro = (...args) =>
+  isPlainOutput() ? plainIntro(...args) : clack.intro(...args);
+
+export const outro: typeof clack.outro = (...args) =>
+  isPlainOutput() ? plainOutro(...args) : clack.outro(...args);
+
+export const cancel: typeof clack.cancel = (...args) =>
+  isPlainOutput() ? plainCancel(...args) : clack.cancel(...args);
+
+/**
+ * Log object that delegates to plain-text writers when output is plain,
+ * or to real clack.log methods otherwise.
+ *
+ * Implemented as a Proxy so that every property access evaluates
+ * `isPlainOutput()` fresh — no stale closure captures.
+ */
+export const log: typeof clack.log = new Proxy(clack.log, {
+  get(target, prop: string) {
+    if (isPlainOutput() && prop in plainLog) {
+      return plainLog[prop as keyof typeof plainLog];
+    }
+    return target[prop as keyof typeof target];
+  },
+});
+
+// Pass through interactive functions via thin wrappers that delegate
+// through the namespace object. This preserves test spyOn compatibility:
+// spyOn(clack, 'select') replaces the property on the module namespace,
+// and these wrappers read from that namespace at call time.
+
+export const select: typeof clack.select = (...args) => clack.select(...args);
+
+export const confirm: typeof clack.confirm = (...args) =>
+  clack.confirm(...args);
+
+export const multiselect: typeof clack.multiselect = (...args) =>
+  clack.multiselect(...args);
+
+export const isCancel: typeof clack.isCancel = (
+  value: unknown
+): value is symbol => clack.isCancel(value);

--- a/src/lib/init/clack-utils.ts
+++ b/src/lib/init/clack-utils.ts
@@ -4,8 +4,8 @@
  * Shared helpers for the clack-based init wizard UI.
  */
 
-import { cancel, isCancel } from "@clack/prompts";
 import { terminalLink } from "../formatters/colors.js";
+import { cancel, isCancel } from "./clack-plain.js";
 import { SENTRY_DOCS_URL } from "./constants.js";
 
 export class WizardCancelledError extends Error {

--- a/src/lib/init/formatters.ts
+++ b/src/lib/init/formatters.ts
@@ -4,9 +4,9 @@
  * Format wizard results and errors for terminal display using clack.
  */
 
-import { cancel, log, outro } from "@clack/prompts";
 import { terminalLink } from "../formatters/colors.js";
 import { colorTag, mdKvTable, renderMarkdown } from "../formatters/markdown.js";
+import { cancel, log, outro } from "./clack-plain.js";
 import { featureLabel } from "./clack-utils.js";
 import {
   EXIT_DEPENDENCY_INSTALL_FAILED,

--- a/src/lib/init/git.ts
+++ b/src/lib/init/git.ts
@@ -9,11 +9,11 @@
  * `checkGitStatus` orchestrator (coupled to `@clack/prompts` UI).
  */
 
-import { confirm, isCancel, log } from "@clack/prompts";
 import {
   getUncommittedFiles,
   isInsideGitWorkTree as isInsideWorkTree,
 } from "../git.js";
+import { confirm, isCancel, log } from "./clack-plain.js";
 
 /** Maximum number of uncommitted files to display before truncating. */
 const MAX_DISPLAYED_FILES = 5;

--- a/src/lib/init/interactive.ts
+++ b/src/lib/init/interactive.ts
@@ -6,8 +6,8 @@
  * Respects --yes flag for non-interactive mode.
  */
 
-import { confirm, log, multiselect, select } from "@clack/prompts";
 import chalk from "chalk";
+import { confirm, log, multiselect, select } from "./clack-plain.js";
 import {
   abortIfCancelled,
   featureHint,

--- a/src/lib/init/preflight.ts
+++ b/src/lib/init/preflight.ts
@@ -1,10 +1,10 @@
-import { cancel, isCancel, log, select } from "@clack/prompts";
 import type { SentryTeam } from "../../types/index.js";
 import { listOrganizations } from "../api-client.js";
 import { getAuthToken } from "../db/auth.js";
 import { WizardError } from "../errors.js";
 import { resolveOrCreateTeam } from "../resolve-team.js";
 import { slugify } from "../utils.js";
+import { cancel, isCancel, log, select } from "./clack-plain.js";
 import { WizardCancelledError } from "./clack-utils.js";
 import { tryGetExistingProjectData } from "./existing-project.js";
 import { resolveOrgPrefetched } from "./org-prefetch.js";

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -8,7 +8,6 @@
 
 import { randomBytes } from "node:crypto";
 import { basename } from "node:path";
-import { cancel, confirm, intro, log } from "@clack/prompts";
 import { MastraClient } from "@mastra/client-js";
 import { captureException, getTraceData } from "@sentry/node-core/light";
 import { formatBanner } from "../banner.js";
@@ -21,6 +20,7 @@ import {
   safeCodeSpan,
   stripColorTags,
 } from "../formatters/markdown.js";
+import { cancel, confirm, intro, log } from "./clack-plain.js";
 import {
   abortIfCancelled,
   STEP_LABELS,

--- a/test/lib/init/clack-plain.test.ts
+++ b/test/lib/init/clack-plain.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for the clack-plain adapter.
+ *
+ * Verifies that clack output functions produce clean plain text when
+ * isPlainOutput() is true, and delegate to real @clack/prompts when false.
+ */
+
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
+import * as clack from "@clack/prompts";
+import {
+  cancel,
+  confirm,
+  intro,
+  isCancel,
+  log,
+  multiselect,
+  outro,
+  select,
+} from "../../../src/lib/init/clack-plain.js";
+
+let savedPlainOutput: string | undefined;
+let stdoutSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  savedPlainOutput = process.env.SENTRY_PLAIN_OUTPUT;
+  stdoutSpy = spyOn(process.stdout, "write").mockReturnValue(true);
+});
+
+afterEach(() => {
+  stdoutSpy.mockRestore();
+  if (savedPlainOutput === undefined) {
+    delete process.env.SENTRY_PLAIN_OUTPUT;
+  } else {
+    process.env.SENTRY_PLAIN_OUTPUT = savedPlainOutput;
+  }
+});
+
+describe("plain mode (SENTRY_PLAIN_OUTPUT=1)", () => {
+  beforeEach(() => {
+    process.env.SENTRY_PLAIN_OUTPUT = "1";
+  });
+
+  test("intro writes clean text", () => {
+    intro("sentry init");
+
+    expect(stdoutSpy).toHaveBeenCalledWith("sentry init\n");
+  });
+
+  test("intro does nothing when no title", () => {
+    intro();
+
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  test("outro writes clean text", () => {
+    outro("Done!");
+
+    expect(stdoutSpy).toHaveBeenCalledWith("Done!\n");
+  });
+
+  test("cancel writes clean text", () => {
+    cancel("Setup cancelled.");
+
+    expect(stdoutSpy).toHaveBeenCalledWith("Setup cancelled.\n");
+  });
+
+  test("log.info writes clean text", () => {
+    log.info("Hello world");
+
+    expect(stdoutSpy).toHaveBeenCalledWith("Hello world\n");
+  });
+
+  test("log.warn prefixes with warning symbol", () => {
+    log.warn("Watch out");
+
+    expect(stdoutSpy).toHaveBeenCalledWith("⚠ Watch out\n");
+  });
+
+  test("log.error prefixes with error symbol", () => {
+    log.error("Something broke");
+
+    expect(stdoutSpy).toHaveBeenCalledWith("✗ Something broke\n");
+  });
+
+  test("log.success prefixes with success symbol", () => {
+    log.success("All good");
+
+    expect(stdoutSpy).toHaveBeenCalledWith("✓ All good\n");
+  });
+
+  test("log.message writes clean text", () => {
+    log.message("Just a message");
+
+    expect(stdoutSpy).toHaveBeenCalledWith("Just a message\n");
+  });
+
+  test("log.step writes clean text", () => {
+    log.step("Step 1");
+
+    expect(stdoutSpy).toHaveBeenCalledWith("Step 1\n");
+  });
+
+  test("log.info strips ANSI escape sequences", () => {
+    const ansiText = "\x1b[32mGreen\x1b[0m text";
+    log.info(ansiText);
+
+    expect(stdoutSpy).toHaveBeenCalledWith("Green text\n");
+  });
+});
+
+describe("rich mode (SENTRY_PLAIN_OUTPUT=0)", () => {
+  let introSpy: ReturnType<typeof spyOn>;
+  let outroSpy: ReturnType<typeof spyOn>;
+  let cancelSpy: ReturnType<typeof spyOn>;
+  let logInfoSpy: ReturnType<typeof spyOn>;
+
+  const noop = () => {
+    /* suppress clack output */
+  };
+
+  beforeEach(() => {
+    process.env.SENTRY_PLAIN_OUTPUT = "0";
+    introSpy = spyOn(clack, "intro").mockImplementation(noop);
+    outroSpy = spyOn(clack, "outro").mockImplementation(noop);
+    cancelSpy = spyOn(clack, "cancel").mockImplementation(noop);
+    logInfoSpy = spyOn(clack.log, "info").mockImplementation(noop);
+  });
+
+  afterEach(() => {
+    introSpy.mockRestore();
+    outroSpy.mockRestore();
+    cancelSpy.mockRestore();
+    logInfoSpy.mockRestore();
+  });
+
+  test("intro delegates to clack", () => {
+    intro("sentry init");
+
+    expect(introSpy).toHaveBeenCalledWith("sentry init");
+  });
+
+  test("outro delegates to clack", () => {
+    outro("Done!");
+
+    expect(outroSpy).toHaveBeenCalledWith("Done!");
+  });
+
+  test("cancel delegates to clack", () => {
+    cancel("Setup cancelled.");
+
+    expect(cancelSpy).toHaveBeenCalledWith("Setup cancelled.");
+  });
+
+  test("log.info delegates to clack", () => {
+    log.info("Hello");
+
+    expect(logInfoSpy).toHaveBeenCalledWith("Hello");
+  });
+});
+
+describe("pass-through functions", () => {
+  test("isCancel delegates to real clack.isCancel", () => {
+    // clack uses a module-private symbol, so we can only test non-cancel values
+    expect(isCancel("not-cancel")).toBe(false);
+    expect(isCancel(42)).toBe(false);
+    expect(isCancel(null)).toBe(false);
+  });
+
+  test("select delegates to clack.select", () => {
+    const selectSpy = spyOn(clack, "select").mockResolvedValue("choice");
+
+    const result = select({
+      message: "Pick one",
+      options: [{ value: "choice", label: "Choice" }],
+    });
+
+    expect(selectSpy).toHaveBeenCalled();
+    selectSpy.mockRestore();
+    return result;
+  });
+
+  test("confirm delegates to clack.confirm", () => {
+    const confirmSpy = spyOn(clack, "confirm").mockResolvedValue(true);
+
+    const result = confirm({ message: "Continue?" });
+
+    expect(confirmSpy).toHaveBeenCalled();
+    confirmSpy.mockRestore();
+    return result;
+  });
+
+  test("multiselect delegates to clack.multiselect", () => {
+    const multiselectSpy = spyOn(clack, "multiselect").mockResolvedValue([]);
+
+    const result = multiselect({
+      message: "Pick some",
+      options: [{ value: "a", label: "A" }],
+    });
+
+    expect(multiselectSpy).toHaveBeenCalled();
+    multiselectSpy.mockRestore();
+    return result;
+  });
+});

--- a/test/lib/init/formatters.test.ts
+++ b/test/lib/init/formatters.test.ts
@@ -23,7 +23,13 @@ const noop = () => {
   /* suppress clack output */
 };
 
+let savedPlainOutput: string | undefined;
+
 beforeEach(() => {
+  // Force rich output so clack-plain.ts delegates to real clack (spied below)
+  savedPlainOutput = process.env.SENTRY_PLAIN_OUTPUT;
+  process.env.SENTRY_PLAIN_OUTPUT = "0";
+
   logMessageSpy = spyOn(clack.log, "message").mockImplementation(noop);
   outroSpy = spyOn(clack, "outro").mockImplementation(noop);
   cancelSpy = spyOn(clack, "cancel").mockImplementation(noop);
@@ -39,6 +45,12 @@ afterEach(() => {
   logInfoSpy.mockRestore();
   logWarnSpy.mockRestore();
   logErrorSpy.mockRestore();
+
+  if (savedPlainOutput === undefined) {
+    delete process.env.SENTRY_PLAIN_OUTPUT;
+  } else {
+    process.env.SENTRY_PLAIN_OUTPUT = savedPlainOutput;
+  }
 });
 
 describe("formatResult", () => {

--- a/test/lib/init/git.test.ts
+++ b/test/lib/init/git.test.ts
@@ -18,8 +18,13 @@ let getUncommittedFilesSpy: ReturnType<typeof spyOn>;
 let confirmSpy: ReturnType<typeof spyOn>;
 let isCancelSpy: ReturnType<typeof spyOn>;
 let logWarnSpy: ReturnType<typeof spyOn>;
+let savedPlainOutput: string | undefined;
 
 beforeEach(() => {
+  // Force rich output so clack-plain.ts delegates to real clack (spied below)
+  savedPlainOutput = process.env.SENTRY_PLAIN_OUTPUT;
+  process.env.SENTRY_PLAIN_OUTPUT = "0";
+
   isInsideWorkTreeSpy = spyOn(gitLib, "isInsideGitWorkTree");
   getUncommittedFilesSpy = spyOn(gitLib, "getUncommittedFiles");
   confirmSpy = spyOn(clack, "confirm").mockResolvedValue(true);
@@ -35,6 +40,12 @@ afterEach(() => {
   confirmSpy.mockRestore();
   isCancelSpy.mockRestore();
   logWarnSpy.mockRestore();
+
+  if (savedPlainOutput === undefined) {
+    delete process.env.SENTRY_PLAIN_OUTPUT;
+  } else {
+    process.env.SENTRY_PLAIN_OUTPUT = savedPlainOutput;
+  }
 });
 
 describe("isInsideGitWorkTree", () => {

--- a/test/lib/init/interactive.test.ts
+++ b/test/lib/init/interactive.test.ts
@@ -23,6 +23,7 @@ let logErrorSpy: ReturnType<typeof spyOn>;
 let logWarnSpy: ReturnType<typeof spyOn>;
 let cancelSpy: ReturnType<typeof spyOn>;
 let isCancelSpy: ReturnType<typeof spyOn>;
+let savedPlainOutput: string | undefined;
 
 function makeOptions(
   overrides?: Partial<InteractiveContext>
@@ -35,6 +36,10 @@ function makeOptions(
 }
 
 beforeEach(() => {
+  // Force rich output so clack-plain.ts delegates to real clack (spied below)
+  savedPlainOutput = process.env.SENTRY_PLAIN_OUTPUT;
+  process.env.SENTRY_PLAIN_OUTPUT = "0";
+
   selectSpy = spyOn(clack, "select").mockImplementation(
     () => Promise.resolve("default") as any
   );
@@ -62,6 +67,12 @@ afterEach(() => {
   logWarnSpy.mockRestore();
   cancelSpy.mockRestore();
   isCancelSpy.mockRestore();
+
+  if (savedPlainOutput === undefined) {
+    delete process.env.SENTRY_PLAIN_OUTPUT;
+  } else {
+    process.env.SENTRY_PLAIN_OUTPUT = savedPlainOutput;
+  }
 });
 
 describe("handleInteractive dispatcher", () => {

--- a/test/lib/init/preflight.test.ts
+++ b/test/lib/init/preflight.test.ts
@@ -42,8 +42,13 @@ let getAuthTokenSpy: ReturnType<typeof spyOn>;
 let resolveOrCreateTeamSpy: ReturnType<typeof spyOn>;
 let detectDsnSpy: ReturnType<typeof spyOn>;
 let resolveDsnByPublicKeySpy: ReturnType<typeof spyOn>;
+let savedPlainOutput: string | undefined;
 
 beforeEach(() => {
+  // Force rich output so clack-plain.ts delegates to real clack (spied below)
+  savedPlainOutput = process.env.SENTRY_PLAIN_OUTPUT;
+  process.env.SENTRY_PLAIN_OUTPUT = "0";
+
   selectSpy = spyOn(clack, "select").mockResolvedValue("existing");
   isCancelSpy = spyOn(clack, "isCancel").mockImplementation(
     (value: unknown) => value === Symbol.for("cancel")
@@ -98,6 +103,12 @@ afterEach(() => {
   detectDsnSpy.mockRestore();
   resolveDsnByPublicKeySpy.mockRestore();
   process.exitCode = 0;
+
+  if (savedPlainOutput === undefined) {
+    delete process.env.SENTRY_PLAIN_OUTPUT;
+  } else {
+    process.env.SENTRY_PLAIN_OUTPUT = savedPlainOutput;
+  }
 });
 
 describe("resolveInitContext", () => {

--- a/test/lib/init/wizard-runner.test.ts
+++ b/test/lib/init/wizard-runner.test.ts
@@ -102,7 +102,13 @@ let stderrSpy: ReturnType<typeof spyOn>;
  */
 let capturedClientOptions: { abortSignal?: AbortSignal }[] = [];
 
+let savedPlainOutput: string | undefined;
+
 beforeEach(() => {
+  // Force rich output so clack-plain.ts delegates to real clack (spied below)
+  savedPlainOutput = process.env.SENTRY_PLAIN_OUTPUT;
+  process.env.SENTRY_PLAIN_OUTPUT = "0";
+
   mockStartResult = { status: "success", result: { platform: "React" } };
   mockResumeResults = [];
   resumeCallCount = 0;
@@ -211,6 +217,12 @@ afterEach(() => {
   stderrSpy.mockRestore();
 
   process.exitCode = 0;
+
+  if (savedPlainOutput === undefined) {
+    delete process.env.SENTRY_PLAIN_OUTPUT;
+  } else {
+    process.env.SENTRY_PLAIN_OUTPUT = savedPlainOutput;
+  }
 });
 
 describe("runWizard", () => {
@@ -463,11 +475,15 @@ describe("runWizard", () => {
     await runWizard(makeOptions());
 
     const messages = spinnerMock.message.mock.calls.map((call: string[]) =>
-      call[0]?.replace(
-        // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape sequences
-        /\x1b\[[^m]*m/g,
-        ""
-      )
+      call[0]
+        ?.replace(
+          // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape sequences
+          /\x1b\[[^m]*m/g,
+          ""
+        )
+        // Normalize whitespace left behind by code span padding
+        .replace(/[ \t]+$/gm, "")
+        .replace(/ {2,}/g, " ")
     );
     expect(messages).toContain(
       "Reading files...\n├─ ● settings.py\n└─ ● urls.py"


### PR DESCRIPTION
## Summary
- Create `clack-plain.ts` adapter that intercepts `@clack/prompts` output functions when `isPlainOutput()` is true (piped, redirected, CI)
- Lifecycle functions (`intro`, `outro`, `cancel`) emit clean plain text
- Log functions (`log.info`, `log.warn`, `log.error`, `log.success`) strip ANSI and write clean lines
- Interactive functions (`select`, `confirm`, `multiselect`) pass through to real clack unchanged
- All 6 init files now import from `./clack-plain.js` instead of `@clack/prompts` directly

## Before (piped output)
```
[?25l◆  EXPERIMENTAL: This feature is experimental...
│[?25h[?25l◇  EXPERIMENTAL: This feature is experimental...
│
◇  Git working tree is clean.
│
●  Scanning project...[999D[J●  Connecting to wizard...[999D[J●  Analyzing project structure[999D[J...
```

## After (piped output)
```
sentry init
Scanning project...
Connecting to wizard...
Analyzing project structure
Done
```

## Test Plan
- 19 new tests in `test/lib/init/clack-plain.test.ts` covering plain mode, rich mode, and ANSI stripping
- All 176 existing init tests still pass

Closes #746