### PR TITLE
fix(search-query): make normalizeQuery quote-aware to prevent corrupting quoted values

### DIFF
--- a/src/lib/search-query.ts
+++ b/src/lib/search-query.ts
@@ -511,27 +511,82 @@ const BALANCED_BRACKET_RE = /\[[^\]]*\]/g;
 const TRAILING_LIST_COMMA_RE = /,\s*\]$/;
 
 /**
+ * Pattern that splits a query into alternating unquoted / quoted segments.
+ *
+ * Matches double-quoted strings (including escaped quotes inside them).
+ * Between matches is unquoted text that can be safely normalized.
+ */
+const QUOTED_SEGMENT_RE = /"(?:[^"\\]|\\.)*"/g;
+
+/**
  * Normalize a search query by applying a pipeline of text repairs.
  *
  * Runs on every query BEFORE PEG parsing. Each pass is a small, focused
  * transform that fixes a common agent/user mistake. The pipeline is ordered
  * from most common to least common pattern.
  *
+ * Quoted regions (`"..."`) are preserved verbatim — only unquoted text is
+ * normalized. This prevents `message:"error [500,] found"` from being
+ * corrupted.
+ *
  * Returns the original query unchanged if no repairs were applicable.
  */
 function normalizeQuery(query: string): string {
-  let q = query;
+  return transformUnquoted(query, (segment) => {
+    let q = segment;
 
-  // 1. Fix mismatched closing delimiters: `[a,b,)` → `[a,b]`
-  //    The `)` is a common typo/autocomplete artifact.
-  q = fixMismatchedBrackets(q);
+    // 1. Fix mismatched closing delimiters: `[a,b,)` → `[a,b]`
+    //    The `)` is a common typo/autocomplete artifact.
+    q = fixMismatchedBrackets(q);
 
-  // 2. Strip trailing commas in in-list: `[a,b,]` → `[a,b]`
-  q = stripTrailingListCommas(q);
+    // 2. Strip trailing commas in in-list: `[a,b,]` → `[a,b]`
+    q = stripTrailingListCommas(q);
 
-  // Future passes can be added here (e.g., quote balancing, date normalization)
+    // Future passes can be added here (e.g., date normalization)
 
-  return q;
+    return q;
+  });
+}
+
+/**
+ * Apply a transform function only to the unquoted segments of a query.
+ *
+ * Splits the query at double-quoted boundaries, applies `fn` to each
+ * unquoted segment, and re-assembles with the quoted segments untouched.
+ */
+function transformUnquoted(
+  query: string,
+  fn: (unquoted: string) => string
+): string {
+  // Fast path: no quotes → transform the whole string
+  if (!query.includes('"')) {
+    return fn(query);
+  }
+
+  const parts: string[] = [];
+  let lastIndex = 0;
+
+  // Reset the regex state for each call (global regex)
+  QUOTED_SEGMENT_RE.lastIndex = 0;
+  let match = QUOTED_SEGMENT_RE.exec(query);
+
+  while (match !== null) {
+    // Unquoted segment before this quoted match
+    if (match.index > lastIndex) {
+      parts.push(fn(query.slice(lastIndex, match.index)));
+    }
+    // Quoted segment — preserved as-is
+    parts.push(match[0]);
+    lastIndex = match.index + match[0].length;
+    match = QUOTED_SEGMENT_RE.exec(query);
+  }
+
+  // Trailing unquoted segment after last quote
+  if (lastIndex < query.length) {
+    parts.push(fn(query.slice(lastIndex)));
+  }
+
+  return parts.join("");
 }
 
 /**
@@ -573,4 +628,5 @@ export const __testing = {
   serializeNode,
   serializeNodes,
   normalizeQuery,
+  transformUnquoted,
 };

--- a/test/lib/search-query.test.ts
+++ b/test/lib/search-query.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, test } from "bun:test";
 import { ValidationError } from "../../src/lib/errors.js";
 import { __testing, sanitizeQuery } from "../../src/lib/search-query.js";
 
-const { normalizeQuery } = __testing;
+const { normalizeQuery, transformUnquoted } = __testing;
 
 // ---------------------------------------------------------------------------
 // Passthrough (no operators)
@@ -390,6 +390,66 @@ describe("normalizeQuery: pre-parse text normalization", () => {
       // Two filters — each should be repaired independently
       expect(normalizeQuery("a:[1,) b:[2,)")).toBe("a:[1] b:[2]");
     });
+  });
+
+  describe("quote awareness", () => {
+    test("does not modify bracket content inside double quotes", () => {
+      expect(normalizeQuery('message:"error [500,] found"')).toBe(
+        'message:"error [500,] found"'
+      );
+    });
+
+    test("does not modify mismatched brackets inside quotes", () => {
+      expect(normalizeQuery('message:"codes [401,403,)"')).toBe(
+        'message:"codes [401,403,)"'
+      );
+    });
+
+    test("repairs unquoted filter but preserves quoted content", () => {
+      expect(
+        normalizeQuery('level:[error,warning,) message:"[trailing,]"')
+      ).toBe('level:[error,warning] message:"[trailing,]"');
+    });
+
+    test("handles multiple quoted regions", () => {
+      expect(normalizeQuery('a:"[1,]" level:[x,) b:"[2,]"')).toBe(
+        'a:"[1,]" level:[x] b:"[2,]"'
+      );
+    });
+
+    test("handles escaped quotes inside quoted strings", () => {
+      // The input has backslash-escaped quotes inside the quoted value:
+      // message:"say \"hello [500,]\"" level:[a,]
+      const input = 'message:"say \\"hello [500,]\\"" level:[a,]';
+      const expected = 'message:"say \\"hello [500,]\\"" level:[a]';
+      expect(normalizeQuery(input)).toBe(expected);
+    });
+  });
+});
+
+describe("transformUnquoted", () => {
+  const upper = (s: string) => s.toUpperCase();
+
+  test("transforms entire string when no quotes present", () => {
+    expect(transformUnquoted("hello world", upper)).toBe("HELLO WORLD");
+  });
+
+  test("preserves quoted segments", () => {
+    expect(transformUnquoted('hello "world" foo', upper)).toBe(
+      'HELLO "world" FOO'
+    );
+  });
+
+  test("handles string that is entirely quoted", () => {
+    expect(transformUnquoted('"hello world"', upper)).toBe('"hello world"');
+  });
+
+  test("handles adjacent quoted segments", () => {
+    expect(transformUnquoted('"a""b"', upper)).toBe('"a""b"');
+  });
+
+  test("handles empty string", () => {
+    expect(transformUnquoted("", upper)).toBe("");
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes a bug from PR #880 where `normalizeQuery` could corrupt quoted string content. Since the normalization pipeline runs on **every** query (not just PEG failures), bracket repairs like `[500,]` → `[500]` would also fire inside quoted values like `message:"error [500,] found"`.

## Fix
Introduces `transformUnquoted()` — splits the query at double-quoted boundaries (respecting escaped quotes `\"`) and only applies normalization passes to unquoted segments. Quoted regions are preserved verbatim.

## Changes
- **`src/lib/search-query.ts`**: Add `QUOTED_SEGMENT_RE`, `transformUnquoted()`, wrap `normalizeQuery` pipeline inside `transformUnquoted`
- **`test/lib/search-query.test.ts`**: 10 new tests covering quote preservation, mixed quoted/unquoted repairs, escaped quotes, and `transformUnquoted` unit tests

## Examples
| Input | Before this fix | After this fix |
|---|---|---|
| `message:"error [500,] found"` | `message:"error [500] found"` (corrupted) | `message:"error [500,] found"` (preserved) |
| `level:[error,) message:"[trailing,]"` | both brackets fixed | only `level` fixed, quote preserved |

Addresses https://github.com/getsentry/cli/pull/880#discussion_r3158653763
