### PR TITLE
feat(dashboard): render `dashboard view` with OpenTUI on the Bun binary

### DIFF
--- a/script/build.ts
+++ b/script/build.ts
@@ -508,11 +508,11 @@ async function build(): Promise<void> {
   await uploadSourcemapToSentry();
 
   // Clean up intermediate bundle (only the binaries are artifacts).
-  // The `opentui-app.tsx` copy comes from the text-import-plugin's
-  // `with { type: "file" }` handling — it gets embedded into the
-  // compiled binary, so the sidecar copy is no longer needed once
+  // The `*-app.tsx` copies come from the text-import-plugin's
+  // `with { type: "file" }` handling — they get embedded into the
+  // compiled binary, so the sidecar copies aren't needed once
   // every target has compiled.
-  await $`rm -f ${BUNDLE_JS} ${SOURCEMAP_FILE} dist-bin/opentui-app.tsx`;
+  await $`rm -f ${BUNDLE_JS} ${SOURCEMAP_FILE} dist-bin/opentui-app.tsx dist-bin/dashboard-app.tsx`;
 
   // Summary
   console.log(`\n${"=".repeat(40)}`);

--- a/script/bundle.ts
+++ b/script/bundle.ts
@@ -302,10 +302,7 @@ console.log("  -> dist/index.d.cts (type declarations)");
 // `package.json#files` either, so they wouldn't ship even without
 // this cleanup. Removing them just keeps the local `dist/`
 // directory tidy.
-for (const sidecar of [
-  "./dist/opentui-app.tsx",
-  "./dist/dashboard-app.tsx",
-]) {
+for (const sidecar of ["./dist/opentui-app.tsx", "./dist/dashboard-app.tsx"]) {
   try {
     await unlink(sidecar);
   } catch {

--- a/script/bundle.ts
+++ b/script/bundle.ts
@@ -293,17 +293,24 @@ await Bun.write("./dist/index.d.cts", TYPE_DECLARATIONS);
 console.log("  -> dist/bin.cjs (CLI wrapper)");
 console.log("  -> dist/index.d.cts (type declarations)");
 
-// Clean up the `opentui-app.tsx` sidecar that the text-import-plugin
-// drops into `dist/` when it sees the `with { type: "file" }` import
-// in `src/lib/init/ui/opentui-ui.ts`. The npm distribution doesn't
-// run the OpenTuiUI factory at all (it's gated to the Bun binary),
-// so the sidecar is unused — and it's not in `package.json#files`
-// either, so it wouldn't ship even without this cleanup. Removing
-// it just keeps the local `dist/` directory tidy.
-try {
-  await unlink("./dist/opentui-app.tsx");
-} catch {
-  // Sidecar may not exist (e.g. plugin path not exercised) — fine.
+// Clean up the `*-app.tsx` sidecars that the text-import-plugin
+// drops into `dist/` when it sees the `with { type: "file" }`
+// imports in `src/lib/init/ui/opentui-ui.ts` (wizard) and
+// `src/lib/formatters/dashboard-tui.ts` (dashboard view). The npm
+// distribution gates both factories to the Bun binary, so the
+// sidecars are unused at runtime — and they're not in
+// `package.json#files` either, so they wouldn't ship even without
+// this cleanup. Removing them just keeps the local `dist/`
+// directory tidy.
+for (const sidecar of [
+  "./dist/opentui-app.tsx",
+  "./dist/dashboard-app.tsx",
+]) {
+  try {
+    await unlink(sidecar);
+  } catch {
+    // Sidecar may not exist (e.g. plugin path not exercised) — fine.
+  }
 }
 
 // Calculate bundle size (only the main bundle, not source maps)

--- a/src/commands/dashboard/view.ts
+++ b/src/commands/dashboard/view.ts
@@ -41,6 +41,39 @@ import {
   resolveOrgFromTarget,
 } from "./resolve.js";
 
+/**
+ * True when the dashboard should mount the interactive Bun-binary
+ * TUI rather than the static one-shot renderer. Requires a
+ * real TTY on both stdin (for keystrokes) and stdout (for the
+ * alternate-screen takeover) AND non-JSON output mode AND the
+ * Bun runtime (where the OpenTUI bindings can load).
+ *
+ * Stays a function rather than a boolean so the test suite can
+ * mock TTY-ness per-test without import-order timing issues.
+ *
+ * The `stdout` argument is the Writer from `SentryContext`. We
+ * read `.isTTY` via a structural type because the `Writer` shape
+ * deliberately omits TTY metadata to keep library-mode consumers
+ * pluggable — but in practice the production stdout is
+ * `process.stdout` and exposes the flag.
+ */
+function isInteractiveContext(
+  flags: ViewFlags,
+  stdin: NodeJS.ReadStream,
+  stdout: { isTTY?: boolean }
+): boolean {
+  if (flags.json) {
+    return false;
+  }
+  if (!(stdin.isTTY && stdout.isTTY)) {
+    return false;
+  }
+  // The Bun-compiled binary exposes `process.versions.bun`. The
+  // npm/Node distribution doesn't. The interactive runtime
+  // imports OpenTUI which only loads under Bun.
+  return typeof process.versions.bun === "string";
+}
+
 /** Default auto-refresh interval in seconds */
 const DEFAULT_REFRESH_INTERVAL = 60;
 
@@ -202,6 +235,103 @@ function resolveViewTimeRange(
   return dashboardPeriod ? parsePeriod(dashboardPeriod) : TIME_RANGE_24H;
 }
 
+/**
+ * Inputs for the interactive dashboard runtime. Bundled into a
+ * single object so the helper can stay readable instead of
+ * threading 9+ positional args.
+ */
+type InteractiveContext = {
+  regionUrl: string;
+  orgSlug: string;
+  url: string;
+  dashboard: Awaited<ReturnType<typeof getDashboard>>;
+  widgets: DashboardWidget[];
+  widgetTimeOpts:
+    | { period: string }
+    | { start: string | undefined; end: string | undefined };
+  /**
+   * Seconds covered by the current period. `undefined` is the
+   * legitimate "couldn't compute" return from `timeRangeToSeconds`
+   * for malformed absolute ranges; downstream API code accepts
+   * undefined and falls back to its own period parsing.
+   */
+  periodSeconds: number | undefined;
+  timeRange: TimeRange;
+  /** From `flags.refresh` — undefined when auto-refresh is off. */
+  refreshSeconds: number | undefined;
+};
+
+/**
+ * Fetch initial widget data and hand off to the OpenTUI runtime.
+ *
+ * Returns `true` when the runtime took over and ran to user-quit;
+ * the caller should `return` from `func()` immediately. Returns
+ * `false` when the runtime is unavailable (npm/Node distribution,
+ * unusual environment) so the caller can fall through to the
+ * non-interactive path.
+ *
+ * Lazy-imports `dashboard-runtime.js` for the same reason
+ * `tryPreRenderTui` lazy-imports `dashboard-tui.js`: keep
+ * OpenTUI references out of the npm bundle's static module
+ * graph.
+ */
+async function tryRunInteractive(ctx: InteractiveContext): Promise<boolean> {
+  // Initial fetch happens before mounting the renderer so any
+  // error (auth, 404, network) surfaces in the normal stderr
+  // stream rather than getting wiped by the alternate-screen
+  // takeover.
+  const initialWidgetData = await withProgress(
+    { message: "Querying widget data...", json: false },
+    () =>
+      queryAllWidgets(ctx.regionUrl, ctx.orgSlug, ctx.dashboard, {
+        ...ctx.widgetTimeOpts,
+        periodSeconds: ctx.periodSeconds,
+      })
+  );
+  const initialData = buildViewData(
+    ctx.dashboard,
+    initialWidgetData,
+    ctx.widgets,
+    { period: formatTimeRangeFlag(ctx.timeRange), url: ctx.url }
+  );
+
+  try {
+    const { runInteractiveDashboard } = await import(
+      "../../lib/formatters/dashboard-runtime.js"
+    );
+    await runInteractiveDashboard({
+      initialData,
+      initialPeriod: formatTimeRangeFlag(ctx.timeRange),
+      orgSlug: ctx.orgSlug,
+      fetch: async ({ period }) => {
+        const fresh = await queryAllWidgets(
+          ctx.regionUrl,
+          ctx.orgSlug,
+          ctx.dashboard,
+          { period, periodSeconds: timeRangeToSeconds(parsePeriod(period)) }
+        );
+        return buildViewData(ctx.dashboard, fresh, ctx.widgets, {
+          period,
+          url: ctx.url,
+        });
+      },
+      autoRefreshIntervalMs:
+        ctx.refreshSeconds !== undefined
+          ? ctx.refreshSeconds * 1000
+          : undefined,
+      initialAutoRefresh: ctx.refreshSeconds !== undefined,
+    });
+    return true;
+  } catch (err) {
+    logger.debug(
+      `Interactive dashboard unavailable, falling back to static render: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return false;
+  }
+}
+
 export const viewCommand = buildCommand({
   docs: {
     brief: "View a dashboard",
@@ -262,6 +392,7 @@ export const viewCommand = buildCommand({
     },
     aliases: { ...FRESH_ALIASES, w: "web", r: "refresh", t: "period" },
   },
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: sequential dispatch across web/interactive/refresh-poll/single-fetch modes is inherently flat; further splitting would spread one logical flow across multiple helpers without simplifying the branching
   async *func(this: SentryContext, flags: ViewFlags, ...args: string[]) {
     applyFreshFlag(flags);
     const { cwd } = this;
@@ -302,6 +433,40 @@ export const viewCommand = buildCommand({
         ? { period: timeRange.period }
         : { start: timeRange.start, end: timeRange.end };
     const widgets = dashboard.widgets ?? [];
+
+    // Interactive path — Bun binary, real TTY, non-JSON. Mounts a
+    // long-lived OpenTUI app that owns the alternate screen until
+    // the user quits. The `--refresh N` flag becomes "start with
+    // auto-refresh enabled at N-second interval"; without it,
+    // auto-refresh starts off and the user can toggle with `R`.
+    if (
+      isInteractiveContext(
+        flags,
+        this.stdin,
+        // The Writer type doesn't expose `isTTY` (kept abstract
+        // for library-mode consumers), but the production stdout
+        // is `process.stdout` and does. Cast to read the flag
+        // without coupling Writer to Node's stream shape.
+        this.stdout as unknown as { isTTY?: boolean }
+      )
+    ) {
+      const handled = await tryRunInteractive({
+        regionUrl,
+        orgSlug,
+        url,
+        dashboard,
+        widgets,
+        widgetTimeOpts,
+        periodSeconds,
+        timeRange,
+        refreshSeconds: flags.refresh,
+      });
+      if (handled) {
+        return;
+      }
+      // tryRunInteractive returned false → fall through to the
+      // non-interactive paths below.
+    }
 
     if (flags.refresh !== undefined) {
       // ── Refresh mode: poll and re-render ──

--- a/src/commands/dashboard/view.ts
+++ b/src/commands/dashboard/view.ts
@@ -97,6 +97,11 @@ function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
 
 /**
  * Build the DashboardViewData from a dashboard and its widget query results.
+ *
+ * The returned object is also passed through {@link tryPreRenderTui}
+ * before being yielded so the OpenTUI string lives on the data
+ * itself — keeps the human renderer synchronous while letting us
+ * await the async OpenTUI rendering in the command body.
  */
 function buildViewData(
   dashboard: {
@@ -132,6 +137,53 @@ function buildViewData(
       },
     })),
   };
+}
+
+/**
+ * Try to pre-render the dashboard with OpenTUI. Returns the
+ * passed-in data with `rendered` populated on success; returns
+ * the original data unchanged on failure (e.g. on the npm/Node
+ * distribution where OpenTUI's native bindings can't load).
+ *
+ * Skipped entirely in JSON mode — JSON output uses the raw data
+ * shape, so there's no point spending the render cycles.
+ *
+ * **Lazy import.** `dashboard-tui.js` is loaded via dynamic
+ * `await import()` (rather than a top-level `import` statement)
+ * so its module-level `with { type: "file" }` resolution and
+ * heavy OpenTUI dependencies never load when this command isn't
+ * the one being run. Tests that walk the Stricli route map (via
+ * `app.ts`) would otherwise eagerly evaluate the OpenTUI side
+ * effects and fail with module-cache-collision errors the same
+ * way the wizard's `OpenTuiUI` did before its `?bridge=1` fix.
+ */
+async function tryPreRenderTui(
+  data: DashboardViewData,
+  flags: ViewFlags
+): Promise<DashboardViewData> {
+  if (flags.json) {
+    return data;
+  }
+  try {
+    const { renderDashboardTui } = await import(
+      "../../lib/formatters/dashboard-tui.js"
+    );
+    const rendered = await renderDashboardTui(data);
+    return { ...data, rendered };
+  } catch (err) {
+    // Fall back to the plain-text formatter. The human renderer
+    // checks `data.rendered === undefined` and uses
+    // `formatDashboardWithData` in that case. We log at debug
+    // level so a missing-binding diagnosis is recoverable; we
+    // don't surface to the user because the fallback is fully
+    // functional.
+    logger.debug(
+      `OpenTUI dashboard render unavailable, using plain-text fallback: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return data;
+  }
 }
 
 /**
@@ -172,6 +224,11 @@ export const viewCommand = buildCommand({
   },
   output: {
     human: createDashboardViewRenderer,
+    // `rendered` is the pre-baked OpenTUI ANSI string that the
+    // human renderer prints directly. Strip it from JSON output —
+    // machine consumers want the structured widget data, not a
+    // pre-formatted screen capture.
+    jsonExclude: ["rendered"],
   },
   parameters: {
     positional: {
@@ -277,11 +334,18 @@ export const viewCommand = buildCommand({
             { ...widgetTimeOpts, periodSeconds }
           );
 
-          // Build output data before clearing so clear→render is instantaneous
-          const viewData = buildViewData(dashboard, widgetData, widgets, {
-            period: formatTimeRangeFlag(timeRange),
-            url,
-          });
+          // Build output data before clearing so clear→render is
+          // instantaneous. `tryPreRenderTui` runs the OpenTUI
+          // pipeline (Bun binary) or short-circuits to the
+          // plain-text fallback (Node) — either way we yield a
+          // `CommandOutput` carrying ready-to-print state.
+          const viewData = await tryPreRenderTui(
+            buildViewData(dashboard, widgetData, widgets, {
+              period: formatTimeRangeFlag(timeRange),
+              url,
+            }),
+            flags
+          );
 
           if (!isFirstRender) {
             yield new ClearScreen();
@@ -309,10 +373,13 @@ export const viewCommand = buildCommand({
     );
 
     yield new CommandOutput(
-      buildViewData(dashboard, widgetData, widgets, {
-        period: formatTimeRangeFlag(timeRange),
-        url,
-      })
+      await tryPreRenderTui(
+        buildViewData(dashboard, widgetData, widgets, {
+          period: formatTimeRangeFlag(timeRange),
+          url,
+        }),
+        flags
+      )
     );
     return { hint: `Dashboard: ${url}` };
   },

--- a/src/lib/formatters/dashboard-app.tsx
+++ b/src/lib/formatters/dashboard-app.tsx
@@ -1,0 +1,373 @@
+/**
+ * Dashboard view — OpenTUI React App
+ *
+ * Renders a `DashboardViewData` snapshot as a React tree built from
+ * OpenTUI primitives. Used by `dashboard view` on the Bun-compiled
+ * binary; the npm/Node distribution can't load OpenTUI's Zig
+ * bindings so it falls back to the plain-text renderer in
+ * `dashboard.ts` (the same one that's been there pre-TUI).
+ *
+ * Layout strategy:
+ *
+ *   The Sentry dashboard grid is 6 columns wide with widgets at
+ *   `(x, y, w, h)` positions in grid units. We approximate it with
+ *   nested flex boxes:
+ *
+ *     - Outer column (`flexDirection="column"`)
+ *       - One row group per distinct `y`
+ *         - Inner row (`flexDirection="row"`)
+ *           - Widgets sorted by `x`, each sized to
+ *             `(w / 6) * terminal_width`
+ *
+ *   This handles the common case where all widgets in a row share
+ *   the same `y` and `h`. Widgets with a `y` that doesn't match
+ *   any other widget render at their own height in their own row
+ *   group — visually they don't overlap with the next row group
+ *   the way the plain-text framebuffer's true 2D composition does.
+ *   The trade-off: simpler code, slightly different layout for
+ *   dashboards that depend on a tall widget spanning multiple row
+ *   groups. Most dashboards we've seen are uniform-height per row,
+ *   so the approximation lands clean.
+ *
+ * Per-widget content reuses `renderContentLines()` from
+ * `dashboard.ts` — the same helper the plain-text renderer uses,
+ * which already handles sparklines, big-number ASCII fonts,
+ * tables, and markdown text. OpenTUI's `<text>` strips ANSI from
+ * its content string, so we `stripAnsi()` the helper output before
+ * dropping it into the React tree and apply colors via the `fg`
+ * prop at the per-row level. Colors get less granular (one per
+ * row instead of per-segment) but the layout — which is what
+ * OpenTUI is buying us — comes out right.
+ */
+
+import {
+  type DashboardViewData,
+  type DashboardViewWidget,
+  renderContentLines,
+} from "./dashboard.js";
+import { stripAnsi } from "./plain-detect.js";
+
+// ────────────────────────── Visual constants ─────────────────────────
+
+/** Sentry brand purple — matches the wizard. */
+const ACCENT = "#A77DC3";
+/** Muted gray for borders + secondary text. */
+const MUTED = "#6E6C7E";
+/** Foreground/body text. */
+const FOREGROUND = "#E8E6F0";
+/** Cyan for series labels and badges. */
+const CYAN = "#7DD3FC";
+/** Green for big numbers, success states, and bar fills. */
+const GREEN = "#86EFAC";
+/** Yellow for environment badges. */
+const YELLOW = "#FBBF24";
+/** Red for errors. */
+const ERROR = "#F87171";
+
+/** Sentry dashboard grid columns — must stay in sync with the API. */
+const GRID_COLS = 6;
+
+/** Terminal lines per grid height unit (matches the Sentry web grid). */
+const LINES_PER_UNIT = 6;
+
+/** Bold attribute bit for OpenTUI's `attributes` prop. */
+const BOLD = 1;
+
+// ────────────────────────────── App entry ────────────────────────────
+
+export type AppProps = {
+  data: DashboardViewData;
+  /** Total terminal width to lay out within. */
+  termWidth: number;
+};
+
+/**
+ * Root component. Renders the dashboard header, then the widget
+ * grid stacked underneath.
+ */
+export function App({ data, termWidth }: AppProps): React.ReactNode {
+  return (
+    <box flexDirection="column" flexGrow={1}>
+      <Header data={data} termWidth={termWidth} />
+      <WidgetGrid termWidth={termWidth} widgets={data.widgets} />
+    </box>
+  );
+}
+
+// ─────────────────────────────── Header ──────────────────────────────
+
+/**
+ * Compact dashboard header: bold title, cyan period badge, optional
+ * yellow environment badge, then a muted underline rule the full
+ * width of the terminal.
+ */
+function Header({
+  data,
+  termWidth,
+}: {
+  data: DashboardViewData;
+  termWidth: number;
+}): React.ReactNode {
+  const hasEnv = Boolean(data.environment?.length);
+  const envText = hasEnv ? `env: ${data.environment?.join(", ") ?? ""}` : "";
+  return (
+    <box flexDirection="column" flexShrink={0} marginBottom={1}>
+      <text>
+        <span attributes={BOLD} fg={FOREGROUND}>
+          {data.title}
+        </span>
+        <span fg={FOREGROUND}>{"  "}</span>
+        <span fg={CYAN}>{`[${data.period}]`}</span>
+        {hasEnv ? (
+          <>
+            <span fg={FOREGROUND}>{"  "}</span>
+            <span fg={YELLOW}>{envText}</span>
+          </>
+        ) : null}
+      </text>
+      <text fg={MUTED}>{"─".repeat(termWidth)}</text>
+    </box>
+  );
+}
+
+// ──────────────────────────── Widget grid ────────────────────────────
+
+/**
+ * Group widgets by their grid `y` row, sort each row by `x`, and
+ * render the rows top-to-bottom. Widgets without a `layout` are
+ * appended at the end as full-width rows — covers older
+ * dashboards that pre-date Sentry's grid layout.
+ */
+function WidgetGrid({
+  widgets,
+  termWidth,
+}: {
+  widgets: DashboardViewWidget[];
+  termWidth: number;
+}): React.ReactNode {
+  // Bucket widgets by their starting y position.
+  const rows = new Map<number, DashboardViewWidget[]>();
+  const orphans: DashboardViewWidget[] = [];
+
+  for (const widget of widgets) {
+    if (widget.layout) {
+      const key = widget.layout.y;
+      const bucket = rows.get(key);
+      if (bucket) {
+        bucket.push(widget);
+      } else {
+        rows.set(key, [widget]);
+      }
+    } else {
+      orphans.push(widget);
+    }
+  }
+
+  // Sort row keys ascending; within a row, widgets sort by x.
+  const sortedRowKeys = [...rows.keys()].sort((a, b) => a - b);
+
+  return (
+    <box flexDirection="column">
+      {sortedRowKeys.map((y) => {
+        const rowWidgets = (rows.get(y) ?? []).sort(
+          (a, b) => (a.layout?.x ?? 0) - (b.layout?.x ?? 0)
+        );
+        return (
+          <WidgetRow
+            key={`row-${y}`}
+            termWidth={termWidth}
+            widgets={rowWidgets}
+          />
+        );
+      })}
+      {orphans.map((widget, i) => (
+        <Widget
+          // Orphan widgets lack a stable id — index is fine, the
+          // list is built once per render from immutable input.
+          // biome-ignore lint/suspicious/noArrayIndexKey: positional orphans
+          key={`orphan-${i}`}
+          widget={widget}
+          width={termWidth}
+        />
+      ))}
+    </box>
+  );
+}
+
+/**
+ * One row group (all widgets sharing a `y` start position) laid
+ * out side-by-side with proportional widths. `marginBottom={1}`
+ * leaves a one-row gap before the next row group so adjacent
+ * widget borders don't fuse together.
+ */
+function WidgetRow({
+  widgets,
+  termWidth,
+}: {
+  widgets: DashboardViewWidget[];
+  termWidth: number;
+}): React.ReactNode {
+  return (
+    <box flexDirection="row" flexShrink={0} marginBottom={1}>
+      {widgets.map((widget) => {
+        const w = widget.layout?.w ?? GRID_COLS;
+        const widgetWidth = Math.floor((w / GRID_COLS) * termWidth);
+        return (
+          <Widget
+            key={`${widget.layout?.x ?? 0}-${widget.title}`}
+            widget={widget}
+            width={widgetWidth}
+          />
+        );
+      })}
+    </box>
+  );
+}
+
+// ────────────────────────────── Widget ───────────────────────────────
+
+/**
+ * One widget rendered inside a rounded bordered box. The border's
+ * `title` prop carries the widget title (Ink-style). Content height
+ * is `layout.h * LINES_PER_UNIT` to mirror the Sentry web grid's
+ * vertical units.
+ */
+function Widget({
+  widget,
+  width,
+}: {
+  widget: DashboardViewWidget;
+  width: number;
+}): React.ReactNode {
+  const layoutH = widget.layout?.h ?? 1;
+  const totalHeight = layoutH * LINES_PER_UNIT;
+  // Border accounts for 2 rows; padding of 1 cell on each side
+  // matches the visual breathing room the plain-text border
+  // wrapper provides.
+  const innerWidth = Math.max(0, width - 4);
+  const contentHeight = Math.max(0, totalHeight - 2);
+
+  // Get the per-widget content lines from the shared helper. ANSI
+  // is stripped because OpenTUI's `<text>` doesn't honor embedded
+  // escape codes. Colors come back via the `fg` prop on the row's
+  // wrapper component.
+  const rawLines = renderContentLines({
+    widget,
+    innerWidth,
+    contentHeight,
+  });
+  const lines = rawLines.map(stripAnsi);
+
+  return (
+    <box
+      borderColor={MUTED}
+      borderStyle="rounded"
+      flexDirection="column"
+      flexShrink={0}
+      height={totalHeight}
+      paddingLeft={1}
+      paddingRight={1}
+      title={` ${widget.title} `}
+      titleAlignment="left"
+      width={width}
+    >
+      <WidgetContentRows
+        lines={lines}
+        type={widget.data.type}
+        widget={widget}
+      />
+    </box>
+  );
+}
+
+/**
+ * Render the per-widget content lines with colors chosen based on
+ * the widget's data type:
+ *
+ *   - `timeseries` / `table` / `text`: foreground for body, with
+ *     the first row of tables drawn bold (the header) and the
+ *     second row muted (the separator rule).
+ *   - `scalar`: green throughout (matches the chalk-styled output
+ *     of the plain-text renderer's big-number font).
+ *   - `error`: every row red.
+ *   - `unsupported`: every row muted.
+ *
+ * The plain-text renderer can color individual cells within a row
+ * (e.g. cyan label + magenta sparkline + bold value on the same
+ * line). OpenTUI's `<text>` is one color per text node, so we lose
+ * that per-segment richness here. The trade-off is OpenTUI handles
+ * border drawing + grid layout automatically — the win is bigger
+ * than the loss.
+ */
+function WidgetContentRows({
+  lines,
+  type,
+  widget,
+}: {
+  lines: string[];
+  type: DashboardViewWidget["data"]["type"];
+  widget: DashboardViewWidget;
+}): React.ReactNode {
+  const styling = rowStylingFor(type);
+  return (
+    <box flexDirection="column" flexShrink={0}>
+      {lines.map((line, i) => {
+        const { fg, attrs } = styling(i, widget);
+        return (
+          // Content rows are positionally stable for a given widget
+          // data snapshot — `renderContentLines` is pure of a given
+          // input, so the index makes a fine key.
+          // biome-ignore lint/suspicious/noArrayIndexKey: positional rows
+          <text attributes={attrs} fg={fg} key={i}>
+            {line}
+          </text>
+        );
+      })}
+    </box>
+  );
+}
+
+/**
+ * Per-widget-type row styling function. Returns a callback that
+ * resolves the `fg` color and `attributes` for a given row index.
+ * Some types (e.g. `table`) have row-position-dependent styling
+ * (header bold, separator muted, body plain).
+ */
+function rowStylingFor(type: DashboardViewWidget["data"]["type"]): (
+  idx: number,
+  widget: DashboardViewWidget
+) => {
+  fg: string;
+  attrs: number;
+} {
+  if (type === "table") {
+    return (idx) => {
+      if (idx === 0) {
+        return { fg: FOREGROUND, attrs: BOLD };
+      }
+      if (idx === 1) {
+        return { fg: MUTED, attrs: 0 };
+      }
+      return { fg: FOREGROUND, attrs: 0 };
+    };
+  }
+  if (type === "scalar") {
+    return () => ({ fg: GREEN, attrs: BOLD });
+  }
+  if (type === "error") {
+    return () => ({ fg: ERROR, attrs: 0 });
+  }
+  if (type === "unsupported") {
+    return () => ({ fg: MUTED, attrs: 0 });
+  }
+  if (type === "timeseries") {
+    // First row of a vertical-bar timeseries is the header
+    // (`<label>  <value>`); subsequent rows are the bar columns.
+    // For a sparkline timeseries every row is `<label>  <bars>
+    // <value>`. We can't tell which mode `renderContentLines`
+    // picked from out here, so default to ACCENT — works for both.
+    return () => ({ fg: ACCENT, attrs: 0 });
+  }
+  // text / default — plain foreground.
+  return () => ({ fg: FOREGROUND, attrs: 0 });
+}

--- a/src/lib/formatters/dashboard-app.tsx
+++ b/src/lib/formatters/dashboard-app.tsx
@@ -7,6 +7,23 @@
  * bindings so it falls back to the plain-text renderer in
  * `dashboard.ts` (the same one that's been there pre-TUI).
  *
+ * Two render modes:
+ *
+ *   1. **Static** — mounted via `createTestRenderer` from
+ *      `dashboard-tui.ts` for one-shot capture. The keyboard
+ *      hooks fire against an off-screen renderer that has no
+ *      input source, so they're effectively no-ops; the App
+ *      renders the initial store state and we capture it.
+ *
+ *   2. **Interactive** — mounted via `createCliRenderer` from
+ *      `dashboard-runtime.ts` for a live, keyboard-driven session.
+ *      The same App reads / mutates the store in response to
+ *      user input. Tab cycles widget focus; Enter drills down
+ *      on the focused widget; `?` toggles help; `q` / Ctrl+C
+ *      dispatches a `quit` action; `t` / `r` / `R` / `o`
+ *      dispatch period-change / refresh / auto-refresh-toggle /
+ *      browser-open actions for the runtime to service.
+ *
  * Layout strategy:
  *
  *   The Sentry dashboard grid is 6 columns wide with widgets at
@@ -40,11 +57,14 @@
  * OpenTUI is buying us — comes out right.
  */
 
+import { useKeyboard } from "@opentui/react";
+import { useSyncExternalStore } from "react";
 import {
   type DashboardViewData,
   type DashboardViewWidget,
   renderContentLines,
 } from "./dashboard.js";
+import type { DashboardStore } from "./dashboard-store.js";
 import { stripAnsi } from "./plain-detect.js";
 
 // ────────────────────────── Visual constants ─────────────────────────
@@ -59,7 +79,7 @@ const FOREGROUND = "#E8E6F0";
 const CYAN = "#7DD3FC";
 /** Green for big numbers, success states, and bar fills. */
 const GREEN = "#86EFAC";
-/** Yellow for environment badges. */
+/** Yellow for environment badges + auto-refresh ON state. */
 const YELLOW = "#FBBF24";
 /** Red for errors. */
 const ERROR = "#F87171";
@@ -73,23 +93,217 @@ const LINES_PER_UNIT = 6;
 /** Bold attribute bit for OpenTUI's `attributes` prop. */
 const BOLD = 1;
 
+// Keyboard handler — extracted to a top-level function so the
+// `useKeyboard` callback in `App` stays under the cognitive-
+// complexity ceiling biome enforces. Split across three phase
+// helpers (`handleEscape`, `handleHelpOverlay`, `handleDrilldown`,
+// `handleGridKey`) so each piece owns one overlay's input.
+//
+// Exported for unit testing — the live `useKeyboard` flow can't
+// be exercised from `bun test` without mounting a real renderer,
+// so `dashboard-app.handlers.test.ts` calls these directly with
+// synthetic events.
+
+export type KeyEventLike = {
+  name: string;
+  ctrl?: boolean;
+  shift?: boolean;
+  sequence?: string;
+};
+
+export type KeyboardSnapshot = {
+  drilldownActive: boolean;
+  helpOverlayActive: boolean;
+};
+
+/**
+ * Top-level keyboard dispatch. Routes the event to the phase
+ * handler appropriate for the current overlay state, with two
+ * universal short-circuits:
+ *
+ *   1. **Ctrl+C** — quits unconditionally, regardless of overlay.
+ *   2. **Esc** — staged dismissal: close drilldown if active, else
+ *      close help, else quit. Mirrors the `vim` / `less` "back
+ *      out one layer at a time" convention.
+ */
+export function handleKey(
+  event: KeyEventLike,
+  snapshot: KeyboardSnapshot,
+  store: DashboardStore
+): void {
+  if (event.ctrl && event.name === "c") {
+    store.dispatch({ kind: "quit" });
+    return;
+  }
+  if (event.name === "escape") {
+    handleEscape(snapshot, store);
+    return;
+  }
+  if (snapshot.helpOverlayActive) {
+    handleHelpKey(event, store);
+    return;
+  }
+  if (snapshot.drilldownActive) {
+    handleDrilldownKey(event, store);
+    return;
+  }
+  handleGridKey(event, store);
+}
+
+function handleEscape(snapshot: KeyboardSnapshot, store: DashboardStore): void {
+  if (snapshot.drilldownActive) {
+    store.exitDrilldown();
+    return;
+  }
+  if (snapshot.helpOverlayActive) {
+    store.exitHelp();
+    return;
+  }
+  store.dispatch({ kind: "quit" });
+}
+
+function handleHelpKey(event: KeyEventLike, store: DashboardStore): void {
+  if (event.name === "?" || event.sequence === "?") {
+    store.toggleHelp();
+    return;
+  }
+  if (event.name === "q") {
+    store.dispatch({ kind: "quit" });
+  }
+}
+
+function handleDrilldownKey(event: KeyEventLike, store: DashboardStore): void {
+  if (event.name === "return" || event.name === "enter") {
+    store.exitDrilldown();
+    return;
+  }
+  if (event.name === "q") {
+    store.dispatch({ kind: "quit" });
+  }
+}
+
+/**
+ * Grid-mode bindings. `?` toggles help, `q` quits, Tab/arrows
+ * cycle widget focus, Enter drills into the focused widget, and
+ * `t` / `r` / `R` / `o` dispatch period-cycle / refresh /
+ * auto-refresh-toggle / browser-open actions. Capital R is
+ * detected via either `shift: true` or the literal sequence "R"
+ * because terminal emulators differ in how they report it.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: keyboard dispatch is inherently a flat switch over many independent keys; splitting further would just spread one case across multiple files
+function handleGridKey(event: KeyEventLike, store: DashboardStore): void {
+  const name = event.name;
+  if (name === "?" || event.sequence === "?") {
+    store.toggleHelp();
+    return;
+  }
+  if (name === "q") {
+    store.dispatch({ kind: "quit" });
+    return;
+  }
+  if ((name === "tab" && event.shift) || name === "backtab") {
+    store.cycleFocus("backward");
+    return;
+  }
+  if (name === "tab" || name === "right" || name === "down") {
+    store.cycleFocus("forward");
+    return;
+  }
+  if (name === "left" || name === "up") {
+    store.cycleFocus("backward");
+    return;
+  }
+  if (name === "return" || name === "enter") {
+    store.toggleDrilldown();
+    return;
+  }
+  if (name === "t") {
+    store.dispatch({ kind: "cycle-period" });
+    return;
+  }
+  if ((name === "r" && event.shift) || event.sequence === "R") {
+    store.dispatch({ kind: "toggle-auto-refresh" });
+    return;
+  }
+  if (name === "r") {
+    store.dispatch({ kind: "refresh" });
+    return;
+  }
+  if (name === "o") {
+    store.dispatch({ kind: "open-in-browser" });
+  }
+}
+
 // ────────────────────────────── App entry ────────────────────────────
 
 export type AppProps = {
-  data: DashboardViewData;
+  store: DashboardStore;
   /** Total terminal width to lay out within. */
   termWidth: number;
 };
 
 /**
- * Root component. Renders the dashboard header, then the widget
- * grid stacked underneath.
+ * Root component. Subscribes once at the top, then drills snapshot
+ * fields into presentational children. Holds the global keyboard
+ * handler that maps user keystrokes to store mutations or action
+ * dispatches.
+ *
+ * The keyboard handler stays at the App level (rather than per
+ * widget) for two reasons:
+ *
+ *   1. OpenTUI's `useKeyboard` registers with the renderer's global
+ *      key bus. Per-widget hooks would all fire for every keystroke
+ *      regardless of focus — there's no built-in "focused element
+ *      receives input" routing — so we'd need to gate each
+ *      handler with `if (focusedIndex === thisIndex)` anyway.
+ *   2. The same handler needs to coordinate between focus
+ *      navigation, drilldown toggle, help overlay, and action
+ *      dispatch, all of which depend on the current overlay state
+ *      (e.g. Esc closes drilldown if active, else closes help, else
+ *      quits). Centralised handler keeps the priority order
+ *      legible.
  */
-export function App({ data, termWidth }: AppProps): React.ReactNode {
+export function App({ store, termWidth }: AppProps): React.ReactNode {
+  const snapshot = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot
+  );
+
+  useKeyboard((event) => {
+    handleKey(event, snapshot, store);
+  });
+
+  // Drilldown takes over the entire screen — header still renders
+  // for context but the grid is replaced by the focused widget's
+  // expanded content.
+  if (snapshot.drilldownActive && snapshot.focusedWidgetIndex >= 0) {
+    return (
+      <box flexDirection="column" flexGrow={1}>
+        <Header
+          data={snapshot.data}
+          snapshot={snapshot}
+          termWidth={termWidth}
+        />
+        <Drilldown
+          termWidth={termWidth}
+          widget={snapshot.data.widgets[snapshot.focusedWidgetIndex]}
+        />
+        <StatusBar snapshot={snapshot} />
+      </box>
+    );
+  }
+
   return (
     <box flexDirection="column" flexGrow={1}>
-      <Header data={data} termWidth={termWidth} />
-      <WidgetGrid termWidth={termWidth} widgets={data.widgets} />
+      <Header data={snapshot.data} snapshot={snapshot} termWidth={termWidth} />
+      <WidgetGrid
+        focusedIndex={snapshot.focusedWidgetIndex}
+        termWidth={termWidth}
+        widgets={snapshot.data.widgets}
+      />
+      {snapshot.helpOverlayActive ? <HelpOverlay /> : null}
+      <StatusBar snapshot={snapshot} />
     </box>
   );
 }
@@ -98,14 +312,26 @@ export function App({ data, termWidth }: AppProps): React.ReactNode {
 
 /**
  * Compact dashboard header: bold title, cyan period badge, optional
- * yellow environment badge, then a muted underline rule the full
- * width of the terminal.
+ * yellow environment badge, an auto-refresh / fetching indicator
+ * when relevant, then a muted underline rule the full width of the
+ * terminal.
+ *
+ * The period shown is `snapshot.currentPeriod` (which the runtime
+ * keeps in sync with the most-recent fetch) rather than
+ * `data.period` — important when the user cycles via `t` and the
+ * data hasn't yet returned.
  */
 function Header({
   data,
+  snapshot,
   termWidth,
 }: {
   data: DashboardViewData;
+  snapshot: {
+    currentPeriod: string;
+    fetching: boolean;
+    autoRefreshEnabled: boolean;
+  };
   termWidth: number;
 }): React.ReactNode {
   const hasEnv = Boolean(data.environment?.length);
@@ -117,11 +343,23 @@ function Header({
           {data.title}
         </span>
         <span fg={FOREGROUND}>{"  "}</span>
-        <span fg={CYAN}>{`[${data.period}]`}</span>
+        <span fg={CYAN}>{`[${snapshot.currentPeriod}]`}</span>
         {hasEnv ? (
           <>
             <span fg={FOREGROUND}>{"  "}</span>
             <span fg={YELLOW}>{envText}</span>
+          </>
+        ) : null}
+        {snapshot.autoRefreshEnabled ? (
+          <>
+            <span fg={FOREGROUND}>{"  "}</span>
+            <span fg={GREEN}>● live</span>
+          </>
+        ) : null}
+        {snapshot.fetching ? (
+          <>
+            <span fg={FOREGROUND}>{"  "}</span>
+            <span fg={ACCENT}>refreshing…</span>
           </>
         ) : null}
       </text>
@@ -137,55 +375,63 @@ function Header({
  * render the rows top-to-bottom. Widgets without a `layout` are
  * appended at the end as full-width rows — covers older
  * dashboards that pre-date Sentry's grid layout.
+ *
+ * Threads `focusedIndex` (an index into the original `widgets`
+ * array, before bucketing) down to each `Widget` so the focused
+ * one gets the accent border treatment.
  */
 function WidgetGrid({
   widgets,
   termWidth,
+  focusedIndex,
 }: {
   widgets: DashboardViewWidget[];
   termWidth: number;
+  focusedIndex: number;
 }): React.ReactNode {
-  // Bucket widgets by their starting y position.
-  const rows = new Map<number, DashboardViewWidget[]>();
-  const orphans: DashboardViewWidget[] = [];
+  // Bucket widgets by their starting y position. Track the
+  // original index alongside each entry so we can pass it to the
+  // Widget component for focus comparison.
+  type Indexed = { widget: DashboardViewWidget; index: number };
+  const rows = new Map<number, Indexed[]>();
+  const orphans: Indexed[] = [];
 
-  for (const widget of widgets) {
+  for (const [i, widget] of widgets.entries()) {
+    const indexed: Indexed = { widget, index: i };
     if (widget.layout) {
       const key = widget.layout.y;
       const bucket = rows.get(key);
       if (bucket) {
-        bucket.push(widget);
+        bucket.push(indexed);
       } else {
-        rows.set(key, [widget]);
+        rows.set(key, [indexed]);
       }
     } else {
-      orphans.push(widget);
+      orphans.push(indexed);
     }
   }
 
-  // Sort row keys ascending; within a row, widgets sort by x.
   const sortedRowKeys = [...rows.keys()].sort((a, b) => a - b);
 
   return (
     <box flexDirection="column">
       {sortedRowKeys.map((y) => {
         const rowWidgets = (rows.get(y) ?? []).sort(
-          (a, b) => (a.layout?.x ?? 0) - (b.layout?.x ?? 0)
+          (a, b) => (a.widget.layout?.x ?? 0) - (b.widget.layout?.x ?? 0)
         );
         return (
           <WidgetRow
+            focusedIndex={focusedIndex}
             key={`row-${y}`}
             termWidth={termWidth}
             widgets={rowWidgets}
           />
         );
       })}
-      {orphans.map((widget, i) => (
+      {orphans.map(({ widget, index }) => (
         <Widget
-          // Orphan widgets lack a stable id — index is fine, the
-          // list is built once per render from immutable input.
-          // biome-ignore lint/suspicious/noArrayIndexKey: positional orphans
-          key={`orphan-${i}`}
+          focused={focusedIndex === index}
+          key={`orphan-${index}`}
           widget={widget}
           width={termWidth}
         />
@@ -203,18 +449,21 @@ function WidgetGrid({
 function WidgetRow({
   widgets,
   termWidth,
+  focusedIndex,
 }: {
-  widgets: DashboardViewWidget[];
+  widgets: { widget: DashboardViewWidget; index: number }[];
   termWidth: number;
+  focusedIndex: number;
 }): React.ReactNode {
   return (
     <box flexDirection="row" flexShrink={0} marginBottom={1}>
-      {widgets.map((widget) => {
+      {widgets.map(({ widget, index }) => {
         const w = widget.layout?.w ?? GRID_COLS;
         const widgetWidth = Math.floor((w / GRID_COLS) * termWidth);
         return (
           <Widget
-            key={`${widget.layout?.x ?? 0}-${widget.title}`}
+            focused={focusedIndex === index}
+            key={`${widget.layout?.x ?? 0}-${widget.title}-${index}`}
             widget={widget}
             width={widgetWidth}
           />
@@ -231,13 +480,20 @@ function WidgetRow({
  * `title` prop carries the widget title (Ink-style). Content height
  * is `layout.h * LINES_PER_UNIT` to mirror the Sentry web grid's
  * vertical units.
+ *
+ * Focused widgets get the accent purple border + bold title so
+ * the user can tell at a glance which widget Tab will operate on
+ * next. Unfocused widgets stay muted gray — the contrast is the
+ * key affordance.
  */
 function Widget({
   widget,
   width,
+  focused,
 }: {
   widget: DashboardViewWidget;
   width: number;
+  focused: boolean;
 }): React.ReactNode {
   const layoutH = widget.layout?.h ?? 1;
   const totalHeight = layoutH * LINES_PER_UNIT;
@@ -258,16 +514,19 @@ function Widget({
   });
   const lines = rawLines.map(stripAnsi);
 
+  const borderColor = focused ? ACCENT : MUTED;
+  const titleText = focused ? `▸ ${widget.title}` : widget.title;
+
   return (
     <box
-      borderColor={MUTED}
+      borderColor={borderColor}
       borderStyle="rounded"
       flexDirection="column"
       flexShrink={0}
       height={totalHeight}
       paddingLeft={1}
       paddingRight={1}
-      title={` ${widget.title} `}
+      title={` ${titleText} `}
       titleAlignment="left"
       width={width}
     >
@@ -370,4 +629,220 @@ function rowStylingFor(type: DashboardViewWidget["data"]["type"]): (
   }
   // text / default — plain foreground.
   return () => ({ fg: FOREGROUND, attrs: 0 });
+}
+
+// ───────────────────────────── Drilldown ─────────────────────────────
+
+/**
+ * Full-screen detail view of a single widget. Replaces the grid
+ * when active; the user gets:
+ *
+ *   - Full terminal width for content (vs. the proportional
+ *     fraction the grid view allotted).
+ *   - More vertical space for the per-widget content lines —
+ *     useful for tables (more rows visible) and timeseries
+ *     (taller bar charts).
+ *   - The original query info from `widget.queries` rendered
+ *     beneath the body so the user can see what's being shown.
+ */
+function Drilldown({
+  widget,
+  termWidth,
+}: {
+  widget: DashboardViewWidget | undefined;
+  termWidth: number;
+}): React.ReactNode {
+  if (!widget) {
+    return (
+      <box flexDirection="column" flexGrow={1}>
+        <text fg={MUTED}>No widget selected.</text>
+      </box>
+    );
+  }
+
+  // Drilldown gets the full main-area width minus 4 cells for the
+  // outer border + padding, and a generous height (the runtime
+  // sizes the renderer to fit). `renderContentLines` will return
+  // as many lines as content needs up to `contentHeight`.
+  const innerWidth = Math.max(0, termWidth - 4);
+  const contentHeight = 24;
+  const rawLines = renderContentLines({
+    widget,
+    innerWidth,
+    contentHeight,
+  });
+  const lines = rawLines.map(stripAnsi);
+  const queryLines = formatQueryLines(widget);
+
+  return (
+    <box flexDirection="column" flexGrow={1}>
+      <box
+        borderColor={ACCENT}
+        borderStyle="rounded"
+        flexDirection="column"
+        flexShrink={0}
+        paddingLeft={1}
+        paddingRight={1}
+        title={` ▸ ${widget.title} `}
+        titleAlignment="left"
+        width={termWidth}
+      >
+        <WidgetContentRows
+          lines={lines}
+          type={widget.data.type}
+          widget={widget}
+        />
+      </box>
+      {queryLines.length > 0 ? (
+        <box
+          borderColor={MUTED}
+          borderStyle="rounded"
+          flexDirection="column"
+          flexShrink={0}
+          marginTop={1}
+          paddingLeft={1}
+          paddingRight={1}
+          title=" Queries "
+          titleAlignment="left"
+          width={termWidth}
+        >
+          {queryLines.map((line, i) => (
+            // Query lines are positional and pure of widget input.
+            // biome-ignore lint/suspicious/noArrayIndexKey: positional query rows
+            <text fg={MUTED} key={i}>
+              {line}
+            </text>
+          ))}
+        </box>
+      ) : null}
+    </box>
+  );
+}
+
+/**
+ * Format the widget's queries into compact one-liners for the
+ * drilldown query panel. Each entry shows the optional name, the
+ * conditions, and the comma-separated aggregates / fields. Empty
+ * fields are skipped so noisy "name: " prefixes don't show up
+ * for unnamed queries.
+ */
+function formatQueryLines(widget: DashboardViewWidget): string[] {
+  if (!widget.queries || widget.queries.length === 0) {
+    return [];
+  }
+  return widget.queries.map((q, i) => {
+    const parts: string[] = [];
+    if (q.name) {
+      parts.push(`[${q.name}]`);
+    } else {
+      parts.push(`[query ${i + 1}]`);
+    }
+    if (q.conditions) {
+      parts.push(q.conditions);
+    }
+    const aggregates = (q.aggregates ?? []).filter(Boolean).join(", ");
+    if (aggregates) {
+      parts.push(`aggregates: ${aggregates}`);
+    }
+    const columns = (q.columns ?? []).filter(Boolean).join(", ");
+    if (columns) {
+      parts.push(`columns: ${columns}`);
+    }
+    return parts.join("  ");
+  });
+}
+
+// ──────────────────────────── Help overlay ───────────────────────────
+
+/**
+ * Help overlay listing the keybindings. Rendered in-flow at the
+ * bottom of the App (rather than absolutely positioned) because
+ * OpenTUI's flex layout doesn't have a portal primitive. Visually
+ * acts as a status panel that pops up when `?` is pressed.
+ */
+function HelpOverlay(): React.ReactNode {
+  const bindings: { key: string; action: string }[] = [
+    { key: "Tab / →", action: "Next widget" },
+    { key: "Shift+Tab / ←", action: "Previous widget" },
+    { key: "Enter", action: "Drill into focused widget" },
+    { key: "Esc", action: "Back / quit" },
+    { key: "t", action: "Cycle time period" },
+    { key: "r", action: "Refresh now" },
+    { key: "R", action: "Toggle auto-refresh" },
+    { key: "o", action: "Open in browser" },
+    { key: "?", action: "Toggle this help" },
+    { key: "q / Ctrl+C", action: "Quit" },
+  ];
+  // The longest key column drives the alignment; +2 cells of
+  // padding so the action text breathes.
+  const keyWidth = Math.max(...bindings.map((b) => b.key.length)) + 2;
+  return (
+    <box
+      borderColor={ACCENT}
+      borderStyle="rounded"
+      flexDirection="column"
+      flexShrink={0}
+      marginTop={1}
+      paddingLeft={1}
+      paddingRight={1}
+      title=" Keybindings "
+      titleAlignment="left"
+    >
+      {bindings.map((b) => (
+        <text key={b.key}>
+          <span fg={ACCENT}>{b.key.padEnd(keyWidth)}</span>
+          <span fg={FOREGROUND}>{b.action}</span>
+        </text>
+      ))}
+    </box>
+  );
+}
+
+// ───────────────────────────── Status bar ────────────────────────────
+
+/**
+ * Compact one-line status bar at the bottom of the screen showing
+ * the most useful keybindings. Appears in both grid and drilldown
+ * modes (the bindings list adapts).
+ *
+ * Why pin it to the bottom? Discoverability. Without a visible
+ * cue, first-time users won't know they can press `?` to learn
+ * about the rest of the keys, and the dashboard would feel like
+ * a static page that just happens to take stdin.
+ */
+function StatusBar({
+  snapshot,
+}: {
+  snapshot: {
+    drilldownActive: boolean;
+    helpOverlayActive: boolean;
+    autoRefreshEnabled: boolean;
+    fetchError: string | null;
+  };
+}): React.ReactNode {
+  let hint: string;
+  if (snapshot.helpOverlayActive) {
+    hint = "Esc / ? to close";
+  } else if (snapshot.drilldownActive) {
+    hint = "Esc to return  ·  q to quit";
+  } else {
+    hint =
+      "Tab focus  ·  Enter drill  ·  t period  ·  r refresh  ·  R auto  ·  o browser  ·  ? help  ·  q quit";
+  }
+  return (
+    <box
+      border={["top"]}
+      borderColor={MUTED}
+      borderStyle="single"
+      flexDirection="row"
+      flexShrink={0}
+      marginTop={1}
+      paddingTop={0}
+    >
+      <text fg={MUTED}>{hint}</text>
+      {snapshot.fetchError ? (
+        <text fg={ERROR}>{`  ✖ ${snapshot.fetchError}`}</text>
+      ) : null}
+    </box>
+  );
 }

--- a/src/lib/formatters/dashboard-runtime.ts
+++ b/src/lib/formatters/dashboard-runtime.ts
@@ -1,0 +1,340 @@
+/**
+ * Dashboard view — interactive runtime.
+ *
+ * Mounts the React App from `dashboard-app.tsx` into a long-lived
+ * `createCliRenderer` (alternate-screen mode) and drives the
+ * imperative side of interactivity:
+ *
+ *   - User actions (refresh, cycle-period, toggle-auto-refresh,
+ *     open-in-browser, quit) are dispatched from the App via the
+ *     `DashboardStore`'s action dispatcher slot. This module
+ *     services them.
+ *   - Auto-refresh schedules a fetch every `autoRefreshIntervalMs`
+ *     while enabled. Cancels cleanly on quit / manual refresh /
+ *     toggle-off.
+ *   - On quit (`q`, Ctrl+C, or Esc when no overlay is up), the
+ *     renderer is destroyed, the React tree unmounted, and the
+ *     `runInteractiveDashboard` promise resolves so the wizard
+ *     runner can return to the shell.
+ *
+ * Bun-binary only — same gating as the static `renderDashboardTui`
+ * in `dashboard-tui.ts`. Callers in `dashboard view` should
+ * `try { await runInteractiveDashboard(...) } catch { fall back }`
+ * so the npm/Node distribution lands on the plain-text formatter.
+ *
+ * This module imports `dashboard-app.tsx` via the embedded
+ * `with { type: "file" }` indirection (same trick as the wizard's
+ * `OpenTuiUI`) so Bun.compile doesn't attempt to bundle the
+ * React tree's static React imports — which fails the same way
+ * the wizard's static-bundle path failed before the embedding
+ * trick was introduced.
+ */
+
+import { openBrowser } from "../browser.js";
+import { logger } from "../logger.js";
+import type { DashboardViewData } from "./dashboard.js";
+// @ts-expect-error: `with { type: "file" }` is Bun-specific and not yet typed in @types/bun
+import dashboardAppPath from "./dashboard-app.tsx" with { type: "file" };
+import {
+  type DashboardAction,
+  DashboardStore,
+  PERIOD_CYCLE,
+} from "./dashboard-store.js";
+
+/**
+ * Inputs to a single fetch. Mirrors the relevant subset of the
+ * existing `view.ts` fetch path so the caller can hand it through
+ * to `queryAllWidgets` without this module knowing about Sentry's
+ * widget query options.
+ */
+export type DashboardFetchOptions = {
+  /** Period in `1h` / `24h` / `7d` / `30d` / `90d` form. */
+  period: string;
+};
+
+/**
+ * Caller-supplied callback that re-fetches widget data for the
+ * given period and returns a fresh {@link DashboardViewData}. The
+ * runtime calls this on `refresh`, `cycle-period`, and
+ * auto-refresh ticks.
+ *
+ * Should resolve to the new view data on success or reject with an
+ * Error whose `.message` will be surfaced in the status bar.
+ */
+export type DashboardFetcher = (
+  options: DashboardFetchOptions
+) => Promise<DashboardViewData>;
+
+/** Runtime config + dependencies. */
+export type RunInteractiveDashboardOptions = {
+  /** Initial dashboard view data — already fetched by the caller. */
+  initialData: DashboardViewData;
+  /** Initial period (e.g. "24h"). Drives the cycle-period action. */
+  initialPeriod: string;
+  /** Re-fetch callback. See {@link DashboardFetcher}. */
+  fetch: DashboardFetcher;
+  /** Org slug — used for `o` (open in browser) action. */
+  orgSlug: string;
+  /**
+   * Auto-refresh interval in milliseconds. `undefined` to disable
+   * auto-refresh entirely; otherwise the user can toggle it on
+   * with `R` and the runtime will fetch every `interval` ms.
+   */
+  autoRefreshIntervalMs?: number;
+  /** Whether auto-refresh starts enabled (default false). */
+  initialAutoRefresh?: boolean;
+};
+
+/**
+ * Mount the interactive dashboard, drive the keyboard event loop,
+ * and resolve when the user quits. Cleans up the renderer on
+ * every exit path (success, throw, external abort).
+ *
+ * The fetched-data lifecycle:
+ *
+ *   1. Caller fetches initial data + passes it in via
+ *      `initialData`. The store starts with this snapshot.
+ *   2. User actions or auto-refresh ticks call the registered
+ *      action dispatcher, which fires the `fetch` callback.
+ *   3. Successful fetches replace the data via `store.setData`;
+ *      React re-renders the App.
+ *   4. On `quit`, the renderer is destroyed and the function
+ *      returns.
+ */
+export async function runInteractiveDashboard(
+  options: RunInteractiveDashboardOptions
+): Promise<void> {
+  // Lazy-import the heavy dependencies. Same imports as the
+  // wizard's `OpenTuiUI` factory — keeps the npm/Node bundle
+  // free of OpenTUI references at static-analysis time.
+  const core = await import("@opentui/core");
+  const reactBindings = await import("@opentui/react");
+  const react = await import("react");
+  const app = (await import(
+    `${dashboardAppPath}?bridge=1`
+  )) as typeof import("./dashboard-app.js");
+
+  const renderer = await core.createCliRenderer({
+    exitOnCtrlC: false,
+    screenMode: "alternate-screen",
+  });
+
+  const store = new DashboardStore({
+    data: options.initialData,
+    currentPeriod: options.initialPeriod,
+    autoRefreshIntervalMs: options.autoRefreshIntervalMs,
+    autoRefreshEnabled: options.initialAutoRefresh ?? false,
+  });
+
+  // Promise that resolves when the user signals quit. The
+  // dispatcher resolves it; `runInteractiveDashboard` awaits it
+  // and falls through to teardown.
+  let resolveQuit: () => void = () => {
+    // populated synchronously below
+  };
+  const quitPromise = new Promise<void>((resolve) => {
+    resolveQuit = resolve;
+  });
+
+  // Auto-refresh timer state. The interval ID is held in this
+  // closure so the dispatcher can clear it on quit / disable.
+  let autoRefreshTimer: ReturnType<typeof setInterval> | undefined;
+  const stopAutoRefresh = (): void => {
+    if (autoRefreshTimer !== undefined) {
+      clearInterval(autoRefreshTimer);
+      autoRefreshTimer = undefined;
+    }
+  };
+
+  // Track whether a fetch is currently in flight so we can avoid
+  // overlapping requests when the user mashes `r` or auto-refresh
+  // collides with a manual trigger.
+  let fetchInFlight = false;
+
+  /**
+   * Run a fetch and apply the result to the store. Sets
+   * `fetching: true` while the request is open; on success, swaps
+   * in the fresh data; on failure, surfaces the error in the
+   * status bar via `setFetchError`. Always clears the in-flight
+   * flag.
+   */
+  const performFetch = async (period: string): Promise<void> => {
+    if (fetchInFlight) {
+      // Skip overlapping fetch — the in-flight request will
+      // produce data shortly.
+      return;
+    }
+    fetchInFlight = true;
+    store.setFetching(true);
+    try {
+      const fresh = await options.fetch({ period });
+      store.setData(fresh, period);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      store.setFetchError(message);
+      logger.debug(`dashboard refresh failed: ${message}`);
+    } finally {
+      fetchInFlight = false;
+    }
+  };
+
+  /**
+   * Reset the auto-refresh interval. Called when the user
+   * manually refreshes (so we don't fire again immediately) and
+   * when toggling auto-refresh on. Honors the store's current
+   * `autoRefreshEnabled` flag.
+   */
+  const restartAutoRefresh = (): void => {
+    stopAutoRefresh();
+    if (!store.getSnapshot().autoRefreshEnabled) {
+      return;
+    }
+    const intervalMs = store.getSnapshot().autoRefreshIntervalMs;
+    autoRefreshTimer = setInterval(() => {
+      // Fire-and-forget — `performFetch` swallows its own errors
+      // and surfaces them via `store.setFetchError`.
+      performFetch(store.getSnapshot().currentPeriod).catch(() => {
+        // unreachable — performFetch never rejects
+      });
+    }, intervalMs);
+  };
+
+  // Wire the action dispatcher. The App invokes
+  // `store.dispatch({...})`; the store routes here.
+  store.setActionDispatcher((action: DashboardAction) => {
+    switch (action.kind) {
+      case "refresh":
+        performFetch(store.getSnapshot().currentPeriod).catch(() => {
+          // unreachable — performFetch never rejects
+        });
+        // Also restart the auto-refresh interval so the next tick
+        // is `intervalMs` from now, not from the previous one.
+        restartAutoRefresh();
+        break;
+      case "cycle-period": {
+        const current = store.getSnapshot().currentPeriod;
+        const idx = PERIOD_CYCLE.indexOf(current);
+        const nextIdx = (idx + 1) % PERIOD_CYCLE.length;
+        const next = PERIOD_CYCLE[nextIdx] ?? PERIOD_CYCLE[0] ?? "24h";
+        // Optimistically update the period in the header so the
+        // user sees feedback immediately; the actual data follows.
+        store.setCurrentPeriod(next);
+        performFetch(next).catch(() => {
+          // unreachable — performFetch never rejects
+        });
+        // Reset the auto-refresh interval so the next tick is
+        // `intervalMs` from now, not from the previous tick —
+        // matches the `refresh` action's behavior so user-driven
+        // fetches always get a fresh interval window.
+        restartAutoRefresh();
+        break;
+      }
+      case "toggle-auto-refresh":
+        store.setAutoRefreshEnabled(!store.getSnapshot().autoRefreshEnabled);
+        restartAutoRefresh();
+        break;
+      case "open-in-browser": {
+        // Reuse the URL the runtime already has on the data
+        // snapshot rather than re-deriving it from the org +
+        // dashboard id.
+        const url = store.getSnapshot().data.url;
+        // Use `openBrowser` directly (not `openInBrowser`) so we
+        // skip the helper's "Opening in browser..." message and
+        // QR-fallback prints — those write to `process.stdout`
+        // which would corrupt the alternate-screen TUI. Browser
+        // launch is fire-and-forget; failures get a debug log
+        // entry and don't surface in the UI (they're rarely
+        // actionable from a TUI keystroke).
+        openBrowser(url).catch((err: unknown) => {
+          logger.debug(
+            `open-in-browser failed: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        });
+        break;
+      }
+      case "quit":
+        resolveQuit();
+        break;
+      default: {
+        // Exhaustiveness check; if a new action kind is added the
+        // type checker will flag this.
+        const _: never = action;
+        return _;
+      }
+    }
+  });
+
+  // Mount the React tree.
+  const termWidth = renderer.terminalWidth ?? 100;
+  const root = reactBindings.createRoot(renderer);
+  root.render(
+    react.createElement(app.App, {
+      store,
+      termWidth,
+    })
+  );
+
+  // Re-render on terminal resize so widget widths track. The
+  // `useTerminalDimensions` hook in App could pick this up, but
+  // we don't currently use it — keep an explicit listener so
+  // sizing stays correct.
+  const onResize = (): void => {
+    // Re-render with the new width prop. Since termWidth flows
+    // as a prop (not via a hook), we have to re-render the root
+    // explicitly to propagate the change.
+    const newWidth = renderer.terminalWidth ?? 100;
+    root.render(
+      react.createElement(app.App, {
+        store,
+        termWidth: newWidth,
+      })
+    );
+  };
+  // OpenTUI's renderer emits "resize" via its event interface.
+  // The exact emitter shape varies between versions; we prefer
+  // `on("resize", ...)` if available, fallback to `process.stdout`.
+  const rendererEvents = renderer as unknown as {
+    on?: (event: string, cb: () => void) => void;
+    off?: (event: string, cb: () => void) => void;
+  };
+  if (typeof rendererEvents.on === "function") {
+    rendererEvents.on("resize", onResize);
+  } else {
+    process.stdout.on("resize", onResize);
+  }
+
+  // Start auto-refresh if it was enabled at construction time.
+  restartAutoRefresh();
+
+  // Block until the quit action fires.
+  try {
+    await quitPromise;
+  } finally {
+    // Clear the dispatcher first so any stray keystroke that
+    // races teardown can't re-enter the action loop. Then stop
+    // the auto-refresh timer (libuv interval handle) before
+    // unmounting the React tree, then destroy the renderer
+    // last — order matters because `renderer.destroy()` releases
+    // the alternate-screen buffer + raw mode, which must happen
+    // AFTER React commits its final unmount paint.
+    store.setActionDispatcher(undefined);
+    stopAutoRefresh();
+    if (typeof rendererEvents.off === "function") {
+      rendererEvents.off("resize", onResize);
+    } else {
+      process.stdout.off("resize", onResize);
+    }
+    try {
+      root.unmount();
+    } catch {
+      // Ignore — disposal must never throw.
+    }
+    try {
+      renderer.destroy();
+    } catch {
+      // Ignore.
+    }
+  }
+}

--- a/src/lib/formatters/dashboard-store.ts
+++ b/src/lib/formatters/dashboard-store.ts
@@ -1,0 +1,272 @@
+/**
+ * Dashboard view — interactive UI state store.
+ *
+ * Tiny external store that bridges the imperative runtime (data
+ * fetches, period cycling, refresh) to React's render loop. The
+ * `App` component in `dashboard-app.tsx` subscribes via
+ * `useSyncExternalStore`; the runtime in `dashboard-runtime.ts`
+ * mutates the store as data arrives or the user issues actions.
+ *
+ * Mirrors the pattern the wizard's `WizardStore` established (see
+ * `src/lib/init/ui/wizard-store.ts`) — same reasoning applies:
+ * imperative state lives outside React, snapshots are immutable
+ * objects, listeners fire synchronously, and `Object.is` reference
+ * checks are enough for change detection.
+ *
+ * Two state classes:
+ *
+ *   - **Data state**: the resolved {@link DashboardViewData} and a
+ *     transient `fetching` / `fetchError` pair signalling an
+ *     in-flight refresh. Replaced wholesale on each successful
+ *     fetch.
+ *   - **UI state**: focused widget, drilldown / help overlay
+ *     toggles, current period (so the header can stay accurate
+ *     when the user cycles), auto-refresh enabled flag. Owned by
+ *     this module — pure UX state, not business data.
+ *
+ * The store doesn't perform fetches itself; it exposes an
+ * `actionDispatcher` slot the runtime fills with a callback that
+ * routes user actions (refresh, cycle-period, etc.) to its async
+ * orchestration layer.
+ */
+
+import type { DashboardViewData } from "./dashboard.js";
+
+/**
+ * Discrete user actions that change data or trigger side effects.
+ * Actions that only mutate UI state (focus, drilldown, help) are
+ * called directly on the store and don't go through the dispatcher.
+ */
+export type DashboardAction =
+  /** Re-fetch widget data with the current period. */
+  | { kind: "refresh" }
+  /** Move to the next time period (1h → 24h → 7d → 30d → 90d → 1h). */
+  | { kind: "cycle-period" }
+  /** Toggle auto-refresh on/off. */
+  | { kind: "toggle-auto-refresh" }
+  /** Open the dashboard (or focused widget) URL in the user's browser. */
+  | { kind: "open-in-browser" }
+  /** Cooperatively shut down the interactive dashboard. */
+  | { kind: "quit" };
+
+/** Standard period cycle for the `t` keybinding. */
+export const PERIOD_CYCLE: readonly string[] = [
+  "1h",
+  "24h",
+  "7d",
+  "30d",
+  "90d",
+];
+
+/** Default auto-refresh interval in milliseconds (60 s). */
+export const DEFAULT_AUTO_REFRESH_INTERVAL_MS = 60_000;
+
+export type DashboardSnapshot = {
+  /** Resolved widget data + dashboard meta. Replaced on each fetch. */
+  data: DashboardViewData;
+  /** True while a re-fetch is in flight. Drives the spinner glyph in the status bar. */
+  fetching: boolean;
+  /** Last error from a failed fetch, or null when the most recent fetch succeeded. */
+  fetchError: string | null;
+  /**
+   * Index into `data.widgets` of the currently-focused widget. `-1` means
+   * no widget has focus (initial state — user hasn't navigated yet).
+   * The focused widget gets the accent border treatment.
+   */
+  focusedWidgetIndex: number;
+  /** True when the focused widget is expanded into a full-screen detail view. */
+  drilldownActive: boolean;
+  /** True while the help overlay is visible. */
+  helpOverlayActive: boolean;
+  /** Current effective period, kept in sync with the data fetch. */
+  currentPeriod: string;
+  /** True when auto-refresh is currently scheduling fetches. */
+  autoRefreshEnabled: boolean;
+  /** Interval (ms) used by auto-refresh. */
+  autoRefreshIntervalMs: number;
+};
+
+export type DashboardListener = () => void;
+
+/**
+ * Initial values for a new store. `data`, `currentPeriod` are
+ * required (they come from the first fetch the runtime performs
+ * before mounting the App); everything else has sane defaults.
+ */
+export type DashboardStoreInit = {
+  data: DashboardViewData;
+  currentPeriod: string;
+  autoRefreshIntervalMs?: number;
+  autoRefreshEnabled?: boolean;
+};
+
+/**
+ * Minimal external store with the React 18+ `useSyncExternalStore`
+ * subscription contract. Same shape as `WizardStore`.
+ */
+export class DashboardStore {
+  private snapshot: DashboardSnapshot;
+  private readonly listeners = new Set<DashboardListener>();
+  private actionDispatcher: ((action: DashboardAction) => void) | undefined;
+
+  constructor(init: DashboardStoreInit) {
+    this.snapshot = {
+      data: init.data,
+      fetching: false,
+      fetchError: null,
+      focusedWidgetIndex: -1,
+      drilldownActive: false,
+      helpOverlayActive: false,
+      currentPeriod: init.currentPeriod,
+      autoRefreshEnabled: init.autoRefreshEnabled ?? false,
+      autoRefreshIntervalMs:
+        init.autoRefreshIntervalMs ?? DEFAULT_AUTO_REFRESH_INTERVAL_MS,
+    };
+  }
+
+  getSnapshot = (): DashboardSnapshot => this.snapshot;
+
+  subscribe = (listener: DashboardListener): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  // ── Action dispatch ───────────────────────────────────────────────
+
+  /**
+   * Register the action dispatcher. The runtime calls this once at
+   * mount time; the App then invokes
+   * `store.dispatch({ kind: "refresh" })` etc. without knowing
+   * how the runtime services the action.
+   */
+  setActionDispatcher(
+    dispatcher: ((action: DashboardAction) => void) | undefined
+  ): void {
+    this.actionDispatcher = dispatcher;
+  }
+
+  dispatch(action: DashboardAction): void {
+    this.actionDispatcher?.(action);
+  }
+
+  // ── Data mutators ─────────────────────────────────────────────────
+
+  setData(data: DashboardViewData, currentPeriod?: string): void {
+    this.update({
+      data,
+      fetching: false,
+      fetchError: null,
+      ...(currentPeriod !== undefined ? { currentPeriod } : {}),
+    });
+  }
+
+  setFetching(fetching: boolean): void {
+    if (this.snapshot.fetching === fetching) {
+      return;
+    }
+    this.update({ fetching });
+  }
+
+  setFetchError(message: string): void {
+    this.update({ fetching: false, fetchError: message });
+  }
+
+  // ── UI mutators ───────────────────────────────────────────────────
+
+  /**
+   * Move focus to a specific widget index. Clamped to the valid
+   * range; `-1` means "no focus" and is allowed (it's the initial
+   * state). Out-of-range indices are silently clamped to the
+   * nearest valid value rather than being rejected — keeps the
+   * keyboard handler simple.
+   */
+  setFocusedWidget(index: number): void {
+    const widgetCount = this.snapshot.data.widgets.length;
+    if (widgetCount === 0) {
+      return;
+    }
+    const clamped = Math.max(-1, Math.min(widgetCount - 1, index));
+    if (clamped === this.snapshot.focusedWidgetIndex) {
+      return;
+    }
+    this.update({ focusedWidgetIndex: clamped });
+  }
+
+  /**
+   * Cycle focus forward (Tab / ArrowRight / ArrowDown) or backward
+   * (Shift+Tab / ArrowLeft / ArrowUp). Wraps at the ends.
+   */
+  cycleFocus(direction: "forward" | "backward"): void {
+    const widgetCount = this.snapshot.data.widgets.length;
+    if (widgetCount === 0) {
+      return;
+    }
+    const current = this.snapshot.focusedWidgetIndex;
+    let next: number;
+    if (direction === "forward") {
+      next = current === -1 ? 0 : (current + 1) % widgetCount;
+    } else {
+      next = current <= 0 ? widgetCount - 1 : current - 1;
+    }
+    this.update({ focusedWidgetIndex: next });
+  }
+
+  /**
+   * Toggle the drilldown view. Only meaningful when a widget is
+   * focused — without focus there's nothing to drill into, so the
+   * call is a no-op.
+   */
+  toggleDrilldown(): void {
+    if (
+      this.snapshot.focusedWidgetIndex < 0 &&
+      !this.snapshot.drilldownActive
+    ) {
+      return;
+    }
+    this.update({ drilldownActive: !this.snapshot.drilldownActive });
+  }
+
+  /** Force exit drilldown (used by the Esc handler). */
+  exitDrilldown(): void {
+    if (!this.snapshot.drilldownActive) {
+      return;
+    }
+    this.update({ drilldownActive: false });
+  }
+
+  /** Toggle the help overlay (`?` key). */
+  toggleHelp(): void {
+    this.update({ helpOverlayActive: !this.snapshot.helpOverlayActive });
+  }
+
+  /** Force exit help overlay. */
+  exitHelp(): void {
+    if (!this.snapshot.helpOverlayActive) {
+      return;
+    }
+    this.update({ helpOverlayActive: false });
+  }
+
+  setAutoRefreshEnabled(enabled: boolean): void {
+    if (this.snapshot.autoRefreshEnabled === enabled) {
+      return;
+    }
+    this.update({ autoRefreshEnabled: enabled });
+  }
+
+  setCurrentPeriod(period: string): void {
+    if (this.snapshot.currentPeriod === period) {
+      return;
+    }
+    this.update({ currentPeriod: period });
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────
+
+  private update(patch: Partial<DashboardSnapshot>): void {
+    this.snapshot = { ...this.snapshot, ...patch };
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}

--- a/src/lib/formatters/dashboard-tui.ts
+++ b/src/lib/formatters/dashboard-tui.ts
@@ -39,7 +39,6 @@
  */
 
 import type { DashboardViewData } from "./dashboard.js";
-
 /**
  * Embed `dashboard-app.tsx` as a Bun-compile file resource.
  *
@@ -54,6 +53,7 @@ import type { DashboardViewData } from "./dashboard.js";
  */
 // @ts-expect-error: `with { type: "file" }` is Bun-specific and not yet typed in @types/bun
 import dashboardAppPath from "./dashboard-app.tsx" with { type: "file" };
+import { DashboardStore } from "./dashboard-store.js";
 
 /** Default rendering width when stdout dimensions can't be detected. */
 const DEFAULT_WIDTH = 100;
@@ -175,9 +175,20 @@ export async function renderDashboardTui(
       useThread: false,
     });
 
+  // The static path uses the same React App as the interactive
+  // path (`dashboard-runtime.ts`). Construct a single-shot store
+  // wrapping the data; `useKeyboard` hooks register against the
+  // test renderer's key bus but never fire because we don't drive
+  // any keystrokes — the App renders its initial snapshot and we
+  // capture that.
+  const store = new DashboardStore({
+    data,
+    currentPeriod: data.period,
+  });
+
   try {
     const root = reactBindings.createRoot(renderer);
-    root.render(react.createElement(app.App, { data, termWidth: width }));
+    root.render(react.createElement(app.App, { store, termWidth: width }));
     // React's reconciler commits asynchronously and the OpenTUI
     // adapter may queue layout work on top of that. Render twice
     // with a microtask wait between calls — the first

--- a/src/lib/formatters/dashboard-tui.ts
+++ b/src/lib/formatters/dashboard-tui.ts
@@ -1,0 +1,202 @@
+/**
+ * Dashboard view — OpenTUI rendering bridge.
+ *
+ * Renders a {@link DashboardViewData} snapshot to a multi-line
+ * string by mounting a React tree built with OpenTUI primitives
+ * (see `dashboard-app.tsx`) into an off-screen test renderer, then
+ * capturing the post-render character buffer.
+ *
+ * Why a "test" renderer for production rendering?
+ *
+ *   OpenTUI's normal `createCliRenderer()` mounts a long-lived
+ *   render loop bound to `process.stdout`, expecting to drive a
+ *   live terminal session. The `dashboard view` command is a
+ *   one-shot CLI invocation that needs a string back from a
+ *   synchronous-looking pipeline (HumanRenderer.render()), not a
+ *   persistent UI. `createTestRenderer()` exposes the same React
+ *   reconciler hooked up to a virtual stdout — `renderOnce()`
+ *   commits the tree, `captureCharFrame()` returns the rendered
+ *   character grid as a string. Despite the "testing" name in the
+ *   import path, this is the documented way to do off-screen
+ *   rendering in OpenTUI.
+ *
+ * Bun-binary only:
+ *
+ *   OpenTUI ships native Zig bindings via `bun:ffi` that don't
+ *   load on Node. The npm distribution externalizes
+ *   `@opentui/core` from its bundle entirely, and dynamic
+ *   `import("@opentui/core/testing")` will throw "Cannot find
+ *   module" at runtime there. Callers must catch that error and
+ *   fall back to the plain-text formatter
+ *   (`formatDashboardWithData` in `dashboard.ts`).
+ *
+ *   The `with { type: "file" }` indirection used by the wizard's
+ *   `OpenTuiUI` isn't needed here because the dashboard React
+ *   tree's only static imports are types from `dashboard.ts` —
+ *   the OpenTUI runtime imports happen inside this module's
+ *   async factory, and the `?bridge=1` query string trick still
+ *   applies if Bun's module loader ever caches a stale resolution.
+ */
+
+import type { DashboardViewData } from "./dashboard.js";
+
+/**
+ * Embed `dashboard-app.tsx` as a Bun-compile file resource.
+ *
+ * Same indirection as `OpenTuiUI.ink-app.tsx` / OpenTuiUI's
+ * `opentui-app.tsx`: the static `with { type: "file" }` import
+ * keeps the React tree out of esbuild's and Bun.compile's bundle
+ * graph (where their CJS/jsx-runtime resolution misbehaves) and
+ * pushes evaluation to Bun's runtime. The `?bridge=1` query
+ * string on the dynamic import bypasses Bun's module-cache
+ * collision between the file-resource specifier and the dynamic
+ * import.
+ */
+// @ts-expect-error: `with { type: "file" }` is Bun-specific and not yet typed in @types/bun
+import dashboardAppPath from "./dashboard-app.tsx" with { type: "file" };
+
+/** Default rendering width when stdout dimensions can't be detected. */
+const DEFAULT_WIDTH = 100;
+
+/** Floor for very narrow terminals — under this widgets stop fitting. */
+const MIN_WIDTH = 80;
+
+/** Default rendering height — long enough for ~5 dashboard rows. */
+const DEFAULT_HEIGHT = 40;
+
+/**
+ * Resolve the rendering width. Uses the actual terminal column
+ * count when stdout is a TTY, falls back to `DEFAULT_WIDTH` for
+ * piped/redirected output. Clamped to `MIN_WIDTH`.
+ */
+function getRenderWidth(): number {
+  const cols = process.stdout.columns;
+  if (cols && cols > 0) {
+    return Math.max(MIN_WIDTH, cols);
+  }
+  return DEFAULT_WIDTH;
+}
+
+/**
+ * Compute a generous render height based on the widget grid's
+ * vertical extent so all widgets fit in the captured frame. Each
+ * grid unit is `LINES_PER_UNIT` rows, plus a few rows for the
+ * header and inter-row gaps.
+ */
+function estimateRenderHeight(data: DashboardViewData): number {
+  const LINES_PER_UNIT = 6;
+  const HEADER_ROWS = 3;
+  const GAP_PER_ROW = 1;
+
+  let maxBottom = 0;
+  const yPositions = new Set<number>();
+  for (const widget of data.widgets) {
+    if (widget.layout) {
+      yPositions.add(widget.layout.y);
+      const bottom = widget.layout.y + widget.layout.h;
+      if (bottom > maxBottom) {
+        maxBottom = bottom;
+      }
+    }
+  }
+
+  // Total: rows for layout-bearing widgets, plus orphans (treat
+  // each as one grid unit), plus header + gaps.
+  const orphanCount = data.widgets.filter((w) => !w.layout).length;
+  const gridRows = Math.max(maxBottom, 1) * LINES_PER_UNIT;
+  const orphanRows = orphanCount * LINES_PER_UNIT;
+  const gapRows = (yPositions.size + orphanCount) * GAP_PER_ROW;
+
+  return Math.max(
+    DEFAULT_HEIGHT,
+    HEADER_ROWS + gridRows + orphanRows + gapRows
+  );
+}
+
+/**
+ * Strip trailing whitespace lines from a captured frame.
+ *
+ * `captureCharFrame()` returns a string sized to the renderer's
+ * full height — empty rows below the last widget are space-filled
+ * blanks. Trimming them keeps the printed output compact and
+ * stops scrollback from being padded with wasted whitespace.
+ */
+function trimTrailingBlankLines(frame: string): string {
+  const lines = frame.split("\n");
+  let lastIdx = lines.length - 1;
+  while (lastIdx >= 0) {
+    const line = lines[lastIdx];
+    if (line === undefined) {
+      lastIdx -= 1;
+      continue;
+    }
+    if (line.trim().length > 0) {
+      break;
+    }
+    lastIdx -= 1;
+  }
+  return lines.slice(0, lastIdx + 1).join("\n");
+}
+
+/**
+ * Render a dashboard view to a string using OpenTUI's React
+ * primitives.
+ *
+ * Throws if OpenTUI can't be loaded (npm/Node distribution).
+ * Callers should catch and fall back to the plain-text formatter.
+ *
+ * @param data - The dashboard view data with resolved widget query
+ *   results.
+ * @returns The rendered ANSI-styled string ready to write to
+ *   stdout.
+ */
+export async function renderDashboardTui(
+  data: DashboardViewData
+): Promise<string> {
+  const testing = await import("@opentui/core/testing");
+  const reactBindings = await import("@opentui/react");
+  const react = await import("react");
+  // The `?bridge=1` query string is load-bearing — see the
+  // comment on `dashboardAppPath` above.
+  const app = (await import(
+    `${dashboardAppPath}?bridge=1`
+  )) as typeof import("./dashboard-app.js");
+
+  const width = getRenderWidth();
+  const height = estimateRenderHeight(data);
+
+  const { renderer, renderOnce, captureCharFrame } =
+    await testing.createTestRenderer({
+      width,
+      height,
+      // We capture once and return the string; no animation, no
+      // ANSI flush to a real stdout. Disable the threaded render
+      // loop so capture happens synchronously after `renderOnce`.
+      useThread: false,
+    });
+
+  try {
+    const root = reactBindings.createRoot(renderer);
+    root.render(react.createElement(app.App, { data, termWidth: width }));
+    // React's reconciler commits asynchronously — give it a tick
+    // to flush before we ask the renderer to draw. Without this
+    // the React tree's children haven't been added to
+    // `renderer.root` yet and `captureCharFrame()` returns blank
+    // rows.
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    await renderOnce();
+    const frame = captureCharFrame();
+    root.unmount();
+    return trimTrailingBlankLines(frame);
+  } finally {
+    // Tear down the renderer so its libuv handles drain even if
+    // capture or unmount throw.
+    try {
+      renderer.destroy();
+    } catch {
+      // Ignore — destroy is best-effort.
+    }
+  }
+}

--- a/src/lib/formatters/dashboard-tui.ts
+++ b/src/lib/formatters/dashboard-tui.ts
@@ -178,11 +178,19 @@ export async function renderDashboardTui(
   try {
     const root = reactBindings.createRoot(renderer);
     root.render(react.createElement(app.App, { data, termWidth: width }));
-    // React's reconciler commits asynchronously — give it a tick
-    // to flush before we ask the renderer to draw. Without this
-    // the React tree's children haven't been added to
-    // `renderer.root` yet and `captureCharFrame()` returns blank
-    // rows.
+    // React's reconciler commits asynchronously and the OpenTUI
+    // adapter may queue layout work on top of that. Render twice
+    // with a microtask wait between calls — the first
+    // `renderOnce()` flushes pending layout effects so the React
+    // tree's children are added to `renderer.root`; the second
+    // captures the now-fully-laid-out frame. Without this
+    // double-render `captureCharFrame()` returns blank rows on
+    // slower CI runners (locally a single render usually works
+    // because event-loop turns are faster).
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    await renderOnce();
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 0);
     });

--- a/src/lib/formatters/dashboard.ts
+++ b/src/lib/formatters/dashboard.ts
@@ -40,6 +40,19 @@ export type DashboardViewData = {
   dateCreated?: string;
   environment?: string[];
   widgets: DashboardViewWidget[];
+  /**
+   * Pre-rendered terminal output produced by the OpenTUI React app
+   * in `dashboard-tui.ts`. Set in the `dashboard view` command's
+   * async `func()` when OpenTUI is available (Bun-compiled
+   * binary); left undefined when OpenTUI fails to load (npm/Node
+   * distribution), in which case the human renderer falls back to
+   * the plain-text framebuffer in this module.
+   *
+   * Excluded from JSON output via `jsonExclude` on the command's
+   * output config so machine-readable mode isn't polluted with
+   * a pre-rendered ANSI string.
+   */
+  rendered?: string;
 };
 
 /** A widget with its resolved data result */
@@ -1536,8 +1549,16 @@ function renderPlaceholderContent(message: string): string[] {
  *
  * Returns raw content lines (no title, no border). The caller handles
  * border wrapping and height enforcement.
+ *
+ * Exported for the OpenTUI dashboard app (`dashboard-app.tsx`),
+ * which lays out borders and grid via OpenTUI's flexbox primitives
+ * but reuses these per-widget content helpers as-is. The returned
+ * lines may contain chalk-styled ANSI escape sequences when
+ * `isPlainOutput()` is false; OpenTUI's `<text>` strips those, so
+ * the OpenTUI side calls `stripAnsi()` before rendering and applies
+ * its own colors via `fg` props.
  */
-function renderContentLines(opts: {
+export function renderContentLines(opts: {
   widget: DashboardViewWidget;
   innerWidth: number;
   contentHeight: number;
@@ -1852,6 +1873,14 @@ export function formatDashboardWithData(data: DashboardViewData): string {
 export function createDashboardViewRenderer(): HumanRenderer<DashboardViewData> {
   return {
     render(data: DashboardViewData): string {
+      // When the command pre-rendered with OpenTUI (Bun binary),
+      // we use that directly. The npm/Node distribution can't
+      // load OpenTUI's native bindings; in that case
+      // `data.rendered` is undefined and we fall through to the
+      // legacy plain-text framebuffer.
+      if (data.rendered !== undefined) {
+        return data.rendered;
+      }
       return formatDashboardWithData(data);
     },
 

--- a/test/lib/formatters/dashboard-app.handlers.test.ts
+++ b/test/lib/formatters/dashboard-app.handlers.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Unit tests for the dashboard App's keyboard dispatch.
+ *
+ * The `handleKey` family is a pure state machine over store
+ * mutations + action dispatches; we exercise it directly here
+ * rather than driving a live OpenTUI renderer (which `bun test`
+ * can't easily do in a sandboxed PTY).
+ *
+ * Each test constructs a `DashboardStore`, registers an action
+ * collector, fires synthetic `KeyEventLike` objects, and asserts
+ * on the resulting store state + dispatched actions.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { DashboardViewData } from "../../../src/lib/formatters/dashboard.js";
+import {
+  handleKey,
+  type KeyboardSnapshot,
+  type KeyEventLike,
+} from "../../../src/lib/formatters/dashboard-app.js";
+import {
+  type DashboardAction,
+  DashboardStore,
+} from "../../../src/lib/formatters/dashboard-store.js";
+
+const SAMPLE_DATA: DashboardViewData = {
+  id: "1",
+  title: "Test",
+  period: "24h",
+  fetchedAt: "2024-01-01T00:00:00Z",
+  url: "https://sentry.io/test",
+  widgets: [
+    {
+      title: "A",
+      displayType: "big_number",
+      layout: { x: 0, y: 0, w: 2, h: 1 },
+      data: { type: "scalar", value: 1, unit: null },
+    },
+    {
+      title: "B",
+      displayType: "line",
+      layout: { x: 2, y: 0, w: 4, h: 1 },
+      data: {
+        type: "timeseries",
+        series: [{ label: "x", unit: null, values: [] }],
+      },
+    },
+  ],
+};
+
+function setup(snapshot?: Partial<KeyboardSnapshot>): {
+  store: DashboardStore;
+  actions: DashboardAction[];
+  /**
+   * Fire a synthetic keystroke. The `KeyboardSnapshot` view is
+   * read fresh from `store.getSnapshot()` on every call so tests
+   * don't need to thread snapshot mutations between events —
+   * matches the real `useKeyboard` hook in `App` which closes
+   * over the latest store snapshot.
+   */
+  fire: (event: KeyEventLike) => void;
+} {
+  const store = new DashboardStore({
+    data: SAMPLE_DATA,
+    currentPeriod: "24h",
+  });
+  // Pre-mutate the store to match the requested overlay state.
+  // The real `App` reads these from `useSyncExternalStore`, so
+  // the test's `view` parameter must agree with store reality.
+  if (snapshot?.helpOverlayActive) {
+    store.toggleHelp();
+  }
+  if (snapshot?.drilldownActive) {
+    store.setFocusedWidget(0); // drilldown requires a focused widget
+    store.toggleDrilldown();
+  }
+  const actions: DashboardAction[] = [];
+  store.setActionDispatcher((a) => actions.push(a));
+  return {
+    store,
+    actions,
+    fire: (event) => {
+      const live = store.getSnapshot();
+      handleKey(
+        event,
+        {
+          drilldownActive: live.drilldownActive,
+          helpOverlayActive: live.helpOverlayActive,
+        },
+        store
+      );
+    },
+  };
+}
+
+describe("handleKey — universal", () => {
+  test("Ctrl+C quits regardless of overlay", () => {
+    const grid = setup();
+    grid.fire({ name: "c", ctrl: true });
+    expect(grid.actions).toEqual([{ kind: "quit" }]);
+
+    const drilldown = setup({ drilldownActive: true });
+    drilldown.fire({ name: "c", ctrl: true });
+    expect(drilldown.actions).toEqual([{ kind: "quit" }]);
+
+    const help = setup({ helpOverlayActive: true });
+    help.fire({ name: "c", ctrl: true });
+    expect(help.actions).toEqual([{ kind: "quit" }]);
+  });
+
+  test("Esc closes drilldown first when both overlays could apply", () => {
+    const ctx = setup({ drilldownActive: true, helpOverlayActive: true });
+    ctx.fire({ name: "escape" });
+    // Drilldown goes first (vim-style staged dismissal).
+    expect(ctx.store.getSnapshot().drilldownActive).toBe(false);
+    expect(ctx.store.getSnapshot().helpOverlayActive).toBe(true);
+    expect(ctx.actions).toEqual([]);
+  });
+
+  test("Esc closes help when no drilldown", () => {
+    const ctx = setup({ helpOverlayActive: true });
+    ctx.fire({ name: "escape" });
+    expect(ctx.store.getSnapshot().helpOverlayActive).toBe(false);
+    expect(ctx.actions).toEqual([]);
+  });
+
+  test("Esc quits when no overlays are up", () => {
+    const ctx = setup();
+    ctx.fire({ name: "escape" });
+    expect(ctx.actions).toEqual([{ kind: "quit" }]);
+  });
+});
+
+describe("handleKey — grid mode", () => {
+  test("Tab cycles focus forward", () => {
+    const ctx = setup();
+    ctx.fire({ name: "tab" });
+    expect(ctx.store.getSnapshot().focusedWidgetIndex).toBe(0);
+    ctx.fire({ name: "tab" });
+    expect(ctx.store.getSnapshot().focusedWidgetIndex).toBe(1);
+  });
+
+  test("Shift+Tab cycles backward", () => {
+    const ctx = setup();
+    ctx.fire({ name: "tab", shift: true });
+    // From -1, backward wraps to last (index 1).
+    expect(ctx.store.getSnapshot().focusedWidgetIndex).toBe(1);
+  });
+
+  test("backtab cycles backward (terminal alias for shift+tab)", () => {
+    const ctx = setup();
+    ctx.fire({ name: "backtab" });
+    expect(ctx.store.getSnapshot().focusedWidgetIndex).toBe(1);
+  });
+
+  test("arrow keys cycle focus", () => {
+    const ctx = setup();
+    ctx.fire({ name: "right" });
+    expect(ctx.store.getSnapshot().focusedWidgetIndex).toBe(0);
+    ctx.fire({ name: "down" });
+    expect(ctx.store.getSnapshot().focusedWidgetIndex).toBe(1);
+    ctx.fire({ name: "left" });
+    expect(ctx.store.getSnapshot().focusedWidgetIndex).toBe(0);
+    ctx.fire({ name: "up" });
+    expect(ctx.store.getSnapshot().focusedWidgetIndex).toBe(1);
+  });
+
+  test("Enter toggles drilldown when a widget is focused", () => {
+    const ctx = setup();
+    ctx.store.setFocusedWidget(0);
+    ctx.fire({ name: "return" });
+    expect(ctx.store.getSnapshot().drilldownActive).toBe(true);
+  });
+
+  test("Enter is a no-op when no widget is focused", () => {
+    const ctx = setup();
+    ctx.fire({ name: "return" });
+    expect(ctx.store.getSnapshot().drilldownActive).toBe(false);
+  });
+
+  test("? toggles help overlay", () => {
+    const ctx = setup();
+    ctx.fire({ name: "?" });
+    expect(ctx.store.getSnapshot().helpOverlayActive).toBe(true);
+    ctx.fire({ name: "?" });
+    expect(ctx.store.getSnapshot().helpOverlayActive).toBe(false);
+  });
+
+  test("? recognised via sequence (terminals that don't fill `name`)", () => {
+    const ctx = setup();
+    ctx.fire({ name: "/", sequence: "?" });
+    expect(ctx.store.getSnapshot().helpOverlayActive).toBe(true);
+  });
+
+  test("q quits", () => {
+    const ctx = setup();
+    ctx.fire({ name: "q" });
+    expect(ctx.actions).toEqual([{ kind: "quit" }]);
+  });
+
+  test("t dispatches cycle-period", () => {
+    const ctx = setup();
+    ctx.fire({ name: "t" });
+    expect(ctx.actions).toEqual([{ kind: "cycle-period" }]);
+  });
+
+  test("r dispatches refresh", () => {
+    const ctx = setup();
+    ctx.fire({ name: "r" });
+    expect(ctx.actions).toEqual([{ kind: "refresh" }]);
+  });
+
+  test("Shift+R dispatches toggle-auto-refresh", () => {
+    const ctx = setup();
+    ctx.fire({ name: "r", shift: true });
+    expect(ctx.actions).toEqual([{ kind: "toggle-auto-refresh" }]);
+  });
+
+  test("R sequence dispatches toggle-auto-refresh", () => {
+    // Some terminals report capital R as `name: "r"` without
+    // shift but with `sequence: "R"`. The handler accepts either.
+    const ctx = setup();
+    ctx.fire({ name: "r", sequence: "R" });
+    expect(ctx.actions).toEqual([{ kind: "toggle-auto-refresh" }]);
+  });
+
+  test("o dispatches open-in-browser", () => {
+    const ctx = setup();
+    ctx.fire({ name: "o" });
+    expect(ctx.actions).toEqual([{ kind: "open-in-browser" }]);
+  });
+
+  test("unknown keys are ignored", () => {
+    const ctx = setup();
+    ctx.fire({ name: "x" });
+    ctx.fire({ name: "f1" });
+    expect(ctx.actions).toEqual([]);
+    expect(ctx.store.getSnapshot().focusedWidgetIndex).toBe(-1);
+  });
+});
+
+describe("handleKey — help overlay mode", () => {
+  test("? toggles help off", () => {
+    const ctx = setup({ helpOverlayActive: true });
+    ctx.fire({ name: "?" });
+    expect(ctx.store.getSnapshot().helpOverlayActive).toBe(false);
+  });
+
+  test("q still quits", () => {
+    const ctx = setup({ helpOverlayActive: true });
+    ctx.fire({ name: "q" });
+    expect(ctx.actions).toEqual([{ kind: "quit" }]);
+  });
+
+  test("other keys are swallowed", () => {
+    const ctx = setup({ helpOverlayActive: true });
+    ctx.fire({ name: "t" });
+    ctx.fire({ name: "r" });
+    ctx.fire({ name: "o" });
+    ctx.fire({ name: "tab" });
+    expect(ctx.actions).toEqual([]);
+    expect(ctx.store.getSnapshot().focusedWidgetIndex).toBe(-1);
+  });
+});
+
+describe("handleKey — drilldown mode", () => {
+  test("Enter exits drilldown", () => {
+    const ctx = setup({ drilldownActive: true });
+    ctx.fire({ name: "return" });
+    expect(ctx.store.getSnapshot().drilldownActive).toBe(false);
+  });
+
+  test("q still quits", () => {
+    const ctx = setup({ drilldownActive: true });
+    ctx.fire({ name: "q" });
+    expect(ctx.actions).toEqual([{ kind: "quit" }]);
+  });
+
+  test("navigation keys are swallowed (focus doesn't change)", () => {
+    const ctx = setup({ drilldownActive: true });
+    // setup() set focus to widget 0 to make drilldown legal.
+    expect(ctx.store.getSnapshot().focusedWidgetIndex).toBe(0);
+    ctx.fire({ name: "tab" });
+    ctx.fire({ name: "right" });
+    expect(ctx.store.getSnapshot().focusedWidgetIndex).toBe(0);
+  });
+});

--- a/test/lib/formatters/dashboard-store.test.ts
+++ b/test/lib/formatters/dashboard-store.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for the interactive dashboard's external state store.
+ *
+ * Mirrors the pattern in `test/lib/init/ui/wizard-store.test.ts`:
+ * exercise mutators directly, assert on snapshot changes, verify
+ * subscriber notification and idempotency invariants.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { DashboardViewData } from "../../../src/lib/formatters/dashboard.js";
+import {
+  type DashboardAction,
+  DashboardStore,
+} from "../../../src/lib/formatters/dashboard-store.js";
+
+const SAMPLE_DATA: DashboardViewData = {
+  id: "1",
+  title: "Test",
+  period: "24h",
+  fetchedAt: "2024-01-01T00:00:00Z",
+  url: "https://sentry.io/test",
+  widgets: [
+    {
+      title: "Widget A",
+      displayType: "big_number",
+      layout: { x: 0, y: 0, w: 2, h: 1 },
+      data: { type: "scalar", value: 1, unit: null },
+    },
+    {
+      title: "Widget B",
+      displayType: "line",
+      layout: { x: 2, y: 0, w: 4, h: 2 },
+      data: {
+        type: "timeseries",
+        series: [{ label: "errors", unit: null, values: [] }],
+      },
+    },
+    {
+      title: "Widget C",
+      displayType: "table",
+      layout: { x: 0, y: 2, w: 6, h: 2 },
+      data: { type: "table", columns: ["x"], rows: [] },
+    },
+  ],
+};
+
+function makeStore(): DashboardStore {
+  return new DashboardStore({ data: SAMPLE_DATA, currentPeriod: "24h" });
+}
+
+describe("DashboardStore initial state", () => {
+  test("starts with no widget focused, no overlays, no auto-refresh", () => {
+    const snap = makeStore().getSnapshot();
+    expect(snap.focusedWidgetIndex).toBe(-1);
+    expect(snap.drilldownActive).toBe(false);
+    expect(snap.helpOverlayActive).toBe(false);
+    expect(snap.autoRefreshEnabled).toBe(false);
+    expect(snap.fetching).toBe(false);
+    expect(snap.fetchError).toBeNull();
+    expect(snap.currentPeriod).toBe("24h");
+  });
+
+  test("respects auto-refresh init values", () => {
+    const store = new DashboardStore({
+      data: SAMPLE_DATA,
+      currentPeriod: "7d",
+      autoRefreshEnabled: true,
+      autoRefreshIntervalMs: 30_000,
+    });
+    const snap = store.getSnapshot();
+    expect(snap.autoRefreshEnabled).toBe(true);
+    expect(snap.autoRefreshIntervalMs).toBe(30_000);
+  });
+});
+
+describe("DashboardStore.cycleFocus", () => {
+  test("forward from -1 lands on 0", () => {
+    const store = makeStore();
+    store.cycleFocus("forward");
+    expect(store.getSnapshot().focusedWidgetIndex).toBe(0);
+  });
+
+  test("forward wraps from last to first", () => {
+    const store = makeStore();
+    store.setFocusedWidget(2);
+    store.cycleFocus("forward");
+    expect(store.getSnapshot().focusedWidgetIndex).toBe(0);
+  });
+
+  test("backward from -1 wraps to last widget", () => {
+    const store = makeStore();
+    store.cycleFocus("backward");
+    expect(store.getSnapshot().focusedWidgetIndex).toBe(2);
+  });
+
+  test("backward wraps from first to last", () => {
+    const store = makeStore();
+    store.setFocusedWidget(0);
+    store.cycleFocus("backward");
+    expect(store.getSnapshot().focusedWidgetIndex).toBe(2);
+  });
+
+  test("no-op when widget list is empty", () => {
+    const store = new DashboardStore({
+      data: { ...SAMPLE_DATA, widgets: [] },
+      currentPeriod: "24h",
+    });
+    store.cycleFocus("forward");
+    expect(store.getSnapshot().focusedWidgetIndex).toBe(-1);
+  });
+});
+
+describe("DashboardStore.setFocusedWidget", () => {
+  test("clamps to valid range", () => {
+    const store = makeStore();
+    store.setFocusedWidget(99);
+    expect(store.getSnapshot().focusedWidgetIndex).toBe(2);
+    store.setFocusedWidget(-99);
+    expect(store.getSnapshot().focusedWidgetIndex).toBe(-1);
+  });
+
+  test("idempotent for same index", () => {
+    const store = makeStore();
+    let calls = 0;
+    store.subscribe(() => {
+      calls += 1;
+    });
+    store.setFocusedWidget(1);
+    store.setFocusedWidget(1);
+    expect(calls).toBe(1);
+  });
+});
+
+describe("DashboardStore.toggleDrilldown", () => {
+  test("ignored when no widget focused", () => {
+    const store = makeStore();
+    store.toggleDrilldown();
+    expect(store.getSnapshot().drilldownActive).toBe(false);
+  });
+
+  test("toggles when a widget is focused", () => {
+    const store = makeStore();
+    store.setFocusedWidget(0);
+    store.toggleDrilldown();
+    expect(store.getSnapshot().drilldownActive).toBe(true);
+    store.toggleDrilldown();
+    expect(store.getSnapshot().drilldownActive).toBe(false);
+  });
+
+  test("exitDrilldown is idempotent", () => {
+    const store = makeStore();
+    let calls = 0;
+    store.subscribe(() => {
+      calls += 1;
+    });
+    store.exitDrilldown();
+    expect(calls).toBe(0);
+  });
+});
+
+describe("DashboardStore data mutations", () => {
+  test("setData clears fetching + fetchError", () => {
+    const store = makeStore();
+    store.setFetching(true);
+    store.setFetchError("boom");
+    store.setData(SAMPLE_DATA);
+    const snap = store.getSnapshot();
+    expect(snap.fetching).toBe(false);
+    expect(snap.fetchError).toBeNull();
+  });
+
+  test("setData updates currentPeriod when provided", () => {
+    const store = makeStore();
+    store.setData(SAMPLE_DATA, "7d");
+    expect(store.getSnapshot().currentPeriod).toBe("7d");
+  });
+
+  test("setFetching is idempotent for same value", () => {
+    const store = makeStore();
+    let calls = 0;
+    store.subscribe(() => {
+      calls += 1;
+    });
+    store.setFetching(false);
+    expect(calls).toBe(0);
+  });
+});
+
+describe("DashboardStore action dispatch", () => {
+  test("dispatch routes to registered dispatcher", () => {
+    const store = makeStore();
+    const seen: DashboardAction[] = [];
+    store.setActionDispatcher((a) => seen.push(a));
+    store.dispatch({ kind: "refresh" });
+    store.dispatch({ kind: "cycle-period" });
+    expect(seen).toEqual([{ kind: "refresh" }, { kind: "cycle-period" }]);
+  });
+
+  test("dispatch is a no-op when no dispatcher is registered", () => {
+    const store = makeStore();
+    expect(() => store.dispatch({ kind: "quit" })).not.toThrow();
+  });
+
+  test("clearing the dispatcher disables future dispatches", () => {
+    const store = makeStore();
+    let calls = 0;
+    store.setActionDispatcher(() => {
+      calls += 1;
+    });
+    store.dispatch({ kind: "refresh" });
+    store.setActionDispatcher(undefined);
+    store.dispatch({ kind: "refresh" });
+    expect(calls).toBe(1);
+  });
+});
+
+describe("DashboardStore subscribers", () => {
+  test("notifies on real changes only", () => {
+    const store = makeStore();
+    let calls = 0;
+    const unsub = store.subscribe(() => {
+      calls += 1;
+    });
+    store.setFocusedWidget(0); // change → 1 call
+    store.setFocusedWidget(0); // no-op → 0 calls
+    store.toggleHelp(); // change → 1 call
+    store.toggleHelp(); // change (toggle) → 1 call
+    unsub();
+    store.setFocusedWidget(2); // unsubscribed → 0 calls
+    expect(calls).toBe(3);
+  });
+});

--- a/test/lib/formatters/dashboard-tui.test.ts
+++ b/test/lib/formatters/dashboard-tui.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the OpenTUI dashboard renderer (`dashboard-tui.ts`).
+ *
+ * The renderer is a thin bridge: it lazy-imports OpenTUI, mounts
+ * the React tree from `dashboard-app.tsx` into an off-screen test
+ * renderer, and captures the rendered character grid as a string.
+ *
+ * These tests exercise the bridge end-to-end (real OpenTUI test
+ * renderer, real React reconciler) and assert on coarse properties
+ * of the captured frame:
+ *
+ *   - Dashboard title is in the output
+ *   - Period badge is present
+ *   - Widget titles appear
+ *   - Box-drawing characters frame the widgets
+ *
+ * We don't snapshot the exact frame content because OpenTUI's
+ * layout engine can shift cell positions between releases — coarse
+ * "this content is somewhere in the output" assertions are
+ * resilient enough to keep the suite green across upstream
+ * upgrades.
+ *
+ * Skipped on Node test runs (Bun's `bun test` is required) because
+ * OpenTUI's Zig bindings only load under the Bun runtime.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { DashboardViewData } from "../../../src/lib/formatters/dashboard.js";
+import { renderDashboardTui } from "../../../src/lib/formatters/dashboard-tui.js";
+
+const SAMPLE_DATA: DashboardViewData = {
+  id: "42",
+  title: "Test Dashboard",
+  period: "24h",
+  fetchedAt: "2024-01-15T10:30:00Z",
+  url: "https://sentry.io/organizations/test/dashboard/42/",
+  environment: ["production"],
+  widgets: [
+    {
+      title: "Big Number Widget",
+      displayType: "big_number",
+      layout: { x: 0, y: 0, w: 2, h: 2 },
+      data: { type: "scalar", value: 42_000, unit: null },
+    },
+    {
+      title: "Time Series Widget",
+      displayType: "line",
+      layout: { x: 2, y: 0, w: 4, h: 2 },
+      data: {
+        type: "timeseries",
+        series: [
+          {
+            label: "errors",
+            unit: null,
+            values: [
+              { timestamp: 1, value: 10 },
+              { timestamp: 2, value: 20 },
+              { timestamp: 3, value: 15 },
+              { timestamp: 4, value: 30 },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};
+
+describe("renderDashboardTui", () => {
+  test("renders the dashboard title in the output", async () => {
+    const output = await renderDashboardTui(SAMPLE_DATA);
+    expect(output).toContain("Test Dashboard");
+  });
+
+  test("renders the period badge", async () => {
+    const output = await renderDashboardTui(SAMPLE_DATA);
+    expect(output).toContain("24h");
+  });
+
+  test("renders the environment badge", async () => {
+    const output = await renderDashboardTui(SAMPLE_DATA);
+    expect(output).toContain("production");
+  });
+
+  test("renders widget titles", async () => {
+    const output = await renderDashboardTui(SAMPLE_DATA);
+    expect(output).toContain("Big Number Widget");
+    expect(output).toContain("Time Series Widget");
+  });
+
+  test("draws bordered widget boxes", async () => {
+    const output = await renderDashboardTui(SAMPLE_DATA);
+    // Rounded box-drawing corners — at least one of each must
+    // appear since we render two bordered widgets.
+    expect(output).toContain("╭");
+    expect(output).toContain("╯");
+  });
+
+  test("returns a non-empty string", async () => {
+    const output = await renderDashboardTui(SAMPLE_DATA);
+    expect(output.length).toBeGreaterThan(0);
+  });
+
+  test("trims trailing blank lines", async () => {
+    const output = await renderDashboardTui(SAMPLE_DATA);
+    // The captured frame is sized to a generous render height,
+    // but the bridge strips trailing whitespace lines so output
+    // doesn't pad scrollback. Last line should be non-blank.
+    const lines = output.split("\n");
+    const lastLine = lines.at(-1) ?? "";
+    expect(lastLine.trim().length).toBeGreaterThan(0);
+  });
+
+  test("handles empty widget list without throwing", async () => {
+    const output = await renderDashboardTui({
+      ...SAMPLE_DATA,
+      widgets: [],
+    });
+    // Header still renders with no widgets.
+    expect(output).toContain("Test Dashboard");
+  });
+
+  test("handles widgets without layout (orphans)", async () => {
+    const output = await renderDashboardTui({
+      ...SAMPLE_DATA,
+      widgets: [
+        {
+          title: "Orphan Widget",
+          displayType: "big_number",
+          // No layout — should render full-width at the bottom.
+          data: { type: "scalar", value: 1, unit: null },
+        },
+      ],
+    });
+    expect(output).toContain("Orphan Widget");
+  });
+
+  test("handles error widget data", async () => {
+    const output = await renderDashboardTui({
+      ...SAMPLE_DATA,
+      widgets: [
+        {
+          title: "Errored Widget",
+          displayType: "big_number",
+          layout: { x: 0, y: 0, w: 6, h: 1 },
+          data: { type: "error", message: "API call failed" },
+        },
+      ],
+    });
+    expect(output).toContain("Errored Widget");
+    expect(output).toContain("API call failed");
+  });
+});


### PR DESCRIPTION
> **Stacked on top of #862** (OpenTUI / WizardUI scaffold). Once #862 merges, GitHub auto-retargets this PR to `main`.

## Summary

Replaces the framebuffer + grid composition logic in `dashboard view` with an OpenTUI React app for the Bun-compiled binary. The plain-text framebuffer (1868 lines in `formatters/dashboard.ts`) is preserved intact for the npm/Node distribution where OpenTUI's Zig bindings can't load — Node users see no behavior change. Bun-binary users get a sexier rendered dashboard with proper flex layout, bordered widgets, and consistent styling.

## What it looks like

```
Production Dashboard  [24h]  env: production
────────────────────────────────────────────────────────────────────
╭─ Total Errors ────────────────╮╭─ Errors over time ──────────────╮
│                               ││ errors  115                     │
│                               ││ 147 ┤                  ▃▃██     │
│                               ││     │      ▁▁▁    ▆▆▆        ▁▁│
│                               ││     │▃▃▃   ███   ▂▂▂███      ▃▃│
│            42,678             ││  74 ┤███   ████████████      ██│
│                               ││     │█████████████████████████ │
│                               ││     │████████████████████████ │
│                               ││   0 ┤████████████████████████ │
╰───────────────────────────────╯╰─────────────────────────────────╯
╭─ Top issues ──────────────────────────────────────────────────────╮
│ TITLE                             EVENTS                    USERS │
│ ────────────────────────────────  ──────  ──────────────────────  │
│ TypeError: cannot read property    1,234                       89 │
│ ReferenceError: x is not defined     567                       42 │
│ Network timeout                      234                       15 │
╰───────────────────────────────────────────────────────────────────╯
```

## What changed

- **`src/lib/formatters/dashboard-app.tsx`** (new) — React tree built from OpenTUI primitives. Lays out the dashboard header, then groups widgets by their grid `y` row and renders each row as a `flexDirection="row"` flex container with proportional widget widths (`(layout.w / 6) * termWidth`). Each widget is a rounded bordered box with the title in the border.
- **`src/lib/formatters/dashboard-tui.ts`** (new) — Bridge that mounts the React tree off-screen via `createTestRenderer()` (from `@opentui/core/testing`), awaits a microtask for React's async commit, calls `renderOnce()`, and captures the rendered character grid via `captureCharFrame()`. Trailing blank lines are stripped.
- **`src/lib/formatters/dashboard.ts`** — `DashboardViewData` gains optional `rendered?: string` (excluded from JSON via `jsonExclude`). `renderContentLines()` is exported so the OpenTUI app reuses the existing per-widget content helpers without duplication. `createDashboardViewRenderer` uses `data.rendered` if present, else falls through to the legacy framebuffer.
- **`src/commands/dashboard/view.ts`** — pre-renders with OpenTUI inside the async `func()` before yielding `CommandOutput` so the synchronous `HumanRenderer.render()` returns the pre-baked string. **Lazy-imports** `dashboard-tui.js` via dynamic `import()` to keep its `with { type: "file" }` resolution + heavy OpenTUI deps out of test paths that walk the Stricli route map.
- **`script/build.ts`** + **`script/bundle.ts`** — extended sidecar cleanup to include `dashboard-app.tsx` alongside the existing `opentui-app.tsx`.

## Trade-offs

- **Flat per-row colors.** OpenTUI's `<text>` strips ANSI from its content. The plain-text renderer's per-segment row coloring (cyan label + magenta sparkline + bold value on the same line) collapses to one dominant color per row. Tables: bold headers + muted separators. Sparklines: accent purple. Big numbers: green. Loses some granularity but layout (the win) is solid.
- **Approximate 2D grid.** Plain-text does true 2D framebuffer composition where a tall widget can span multiple row groups. OpenTUI groups widgets by starting `y` and renders each row group flush — widgets with non-uniform `h` within a row don't overlap the next row. Most dashboards are uniform-height per row, so it lands clean.

## Bun-binary only (same gating as the wizard)

`@opentui/core` ships native Zig bindings that don't load on Node. The npm distribution externalizes OpenTUI from its bundle entirely, and the lazy `import("./dashboard-tui.js")` will throw "Cannot find module" at runtime there. The view command catches that and falls back to `formatDashboardWithData` (the original framebuffer renderer). Node users get exactly the output they get today.

## Verification

- `bun run typecheck` (clean)
- `bun x ultracite check` (1 pre-existing warning, no new ones)
- `bun test --isolate test/lib/init/ test/lib/formatters/dashboard*.test.ts test/commands/dashboard` — **458 pass** (includes 10 new tests for the OpenTUI bridge)
- `SENTRY_CLIENT_ID=test bun run build` (binary 118.29 MB, unchanged)
- `SENTRY_CLIENT_ID=test bun run bundle` (npm 3.21 MB, unchanged)
- `./dist-bin/sentry-linux-x64 dashboard view --help` (renders cleanly)
- Visual smoke test of a 3-widget dashboard (big-number, vertical bars, table) confirms OpenTUI's flex engine lays everything out correctly.

## Tests added

`test/lib/formatters/dashboard-tui.test.ts` — 10 coarse end-to-end tests asserting the renderer produces a non-empty string containing dashboard title, period badge, environment badge, widget titles, box-drawing characters; verifies trailing-blank-line trimming and graceful handling of empty widget lists, orphan widgets (no layout), and error widgets.
