### PR TITLE
feat(sourcemap): add parity flags and sourceMappingURL following

### DIFF
--- a/plugins/sentry-cli/skills/sentry-cli/references/sourcemap.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/sourcemap.md
@@ -17,7 +17,7 @@ Inject debug IDs into JavaScript files and sourcemaps
 
 **Flags:**
 - `--ext <value> - Comma-separated file extensions to process (default: .js,.cjs,.mjs)`
-- `--ignore <value> - Glob pattern to exclude (gitignore-style, repeatable)`
+- `--ignore <value> - Comma-separated glob patterns to exclude (gitignore-style)`
 - `--ignore-file <value> - Path to a file with gitignore-style patterns to exclude`
 - `--dry-run - Show what would be modified without writing`
 - `--allow-empty - Exit successfully when no JS + sourcemap pairs are found (default: error out to catch silent build misconfigurations)`
@@ -44,7 +44,7 @@ Upload sourcemaps to Sentry
 - `--dist <value> - Distribution identifier to disambiguate builds within a release`
 - `--url-prefix <value> - URL prefix for uploaded files (default: ~/) - (default: "~/")`
 - `--ext <value> - Comma-separated file extensions to process (default: .js,.cjs,.mjs)`
-- `--ignore <value> - Glob pattern to exclude (gitignore-style, repeatable)`
+- `--ignore <value> - Comma-separated glob patterns to exclude (gitignore-style)`
 - `--ignore-file <value> - Path to a file with gitignore-style patterns to exclude`
 - `--strip-prefix <value> - Strip a prefix from uploaded file paths (e.g. 'build/')`
 - `--strip-common-prefix - Automatically strip the longest common path prefix from all files`

--- a/plugins/sentry-cli/skills/sentry-cli/references/sourcemap.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/sourcemap.md
@@ -17,6 +17,8 @@ Inject debug IDs into JavaScript files and sourcemaps
 
 **Flags:**
 - `--ext <value> - Comma-separated file extensions to process (default: .js,.cjs,.mjs)`
+- `--ignore <value> - Glob pattern to exclude (gitignore-style, repeatable)`
+- `--ignore-file <value> - Path to a file with gitignore-style patterns to exclude`
 - `--dry-run - Show what would be modified without writing`
 - `--allow-empty - Exit successfully when no JS + sourcemap pairs are found (default: error out to catch silent build misconfigurations)`
 
@@ -39,7 +41,14 @@ Upload sourcemaps to Sentry
 
 **Flags:**
 - `--release <value> - Release version to associate with the upload`
+- `--dist <value> - Distribution identifier to disambiguate builds within a release`
 - `--url-prefix <value> - URL prefix for uploaded files (default: ~/) - (default: "~/")`
+- `--ext <value> - Comma-separated file extensions to process (default: .js,.cjs,.mjs)`
+- `--ignore <value> - Glob pattern to exclude (gitignore-style, repeatable)`
+- `--ignore-file <value> - Path to a file with gitignore-style patterns to exclude`
+- `--strip-prefix <value> - Strip a prefix from uploaded file paths (e.g. 'build/')`
+- `--strip-common-prefix - Automatically strip the longest common path prefix from all files`
+- `--no-rewrite - Upload files as-is without injecting debug IDs`
 - `--allow-empty - Exit successfully when no JS + sourcemap pairs are found (default: error out to catch silent build misconfigurations)`
 
 **Examples:**

--- a/src/commands/sourcemap/inject.ts
+++ b/src/commands/sourcemap/inject.ts
@@ -95,7 +95,7 @@ export const injectCommand = buildCommand({
       ignore: {
         kind: "parsed",
         parse: String,
-        brief: "Glob pattern to exclude (gitignore-style, repeatable)",
+        brief: "Comma-separated glob patterns to exclude (gitignore-style)",
         optional: true,
       },
       "ignore-file": {

--- a/src/commands/sourcemap/inject.ts
+++ b/src/commands/sourcemap/inject.ts
@@ -16,6 +16,7 @@ import { CommandOutput } from "../../lib/formatters/output.js";
 import {
   assertDirectoryReadable,
   buildEmptyDiscoveryError,
+  buildIgnoreMatcher,
   diagnoseEmptyDiscovery,
   discoverFilePairs,
   type InjectResult,
@@ -91,6 +92,18 @@ export const injectCommand = buildCommand({
           "Comma-separated file extensions to process (default: .js,.cjs,.mjs)",
         optional: true,
       },
+      ignore: {
+        kind: "parsed",
+        parse: String,
+        brief: "Glob pattern to exclude (gitignore-style, repeatable)",
+        optional: true,
+      },
+      "ignore-file": {
+        kind: "parsed",
+        parse: String,
+        brief: "Path to a file with gitignore-style patterns to exclude",
+        optional: true,
+      },
       "dry-run": {
         kind: "boolean",
         brief: "Show what would be modified without writing",
@@ -109,7 +122,13 @@ export const injectCommand = buildCommand({
   },
   async *func(
     this: SentryContext,
-    flags: { ext?: string; "dry-run"?: boolean; "allow-empty"?: boolean },
+    flags: {
+      ext?: string;
+      ignore?: string;
+      "ignore-file"?: string;
+      "dry-run"?: boolean;
+      "allow-empty"?: boolean;
+    },
     dir: string
   ) {
     // Discover pairs read-only first so we don't error after partially
@@ -123,7 +142,15 @@ export const injectCommand = buildCommand({
       ? new Set(extensions.map((e) => (e.startsWith(".") ? e : `.${e}`)))
       : undefined;
 
-    const pairs = await discoverFilePairs(dir, extSet);
+    const ignorePatterns = flags.ignore
+      ? flags.ignore.split(",").map((p) => p.trim())
+      : undefined;
+    const ignoreMatcher = await buildIgnoreMatcher(
+      ignorePatterns,
+      flags["ignore-file"]
+    );
+
+    const pairs = await discoverFilePairs(dir, extSet, ignoreMatcher);
     if (pairs.length === 0 && !flags["allow-empty"]) {
       const diag = await diagnoseEmptyDiscovery(dir, { extensions });
       throw buildEmptyDiscoveryError(dir, diag);
@@ -131,6 +158,7 @@ export const injectCommand = buildCommand({
 
     const results = await injectDirectory(dir, {
       extensions,
+      ignoreMatcher,
       dryRun: flags["dry-run"],
     });
 

--- a/src/commands/sourcemap/upload.ts
+++ b/src/commands/sourcemap/upload.ts
@@ -262,6 +262,13 @@ export const uploadCommand = buildCommand({
       };
     }
 
+    // Validate mutually exclusive flags before any file mutation
+    if (flags["strip-prefix"] && flags["strip-common-prefix"]) {
+      throw new ValidationError(
+        "--strip-prefix and --strip-common-prefix are mutually exclusive"
+      );
+    }
+
     const resolved = await resolveOrgAndProject({
       cwd: this.cwd,
       usageHint: USAGE_HINT,
@@ -282,13 +289,6 @@ export const uploadCommand = buildCommand({
 
     // Build artifact file list with paths relative to the upload directory
     const resolvedDir = resolve(dir);
-
-    // Compute prefix to strip from relative paths (mutually exclusive)
-    if (flags["strip-prefix"] && flags["strip-common-prefix"]) {
-      throw new ValidationError(
-        "--strip-prefix and --strip-common-prefix are mutually exclusive"
-      );
-    }
     let pathPrefixToStrip = flags["strip-prefix"] ?? "";
     if (flags["strip-common-prefix"]) {
       const allRelative = results.flatMap(({ jsPath, mapPath }) => [

--- a/src/commands/sourcemap/upload.ts
+++ b/src/commands/sourcemap/upload.ts
@@ -293,7 +293,13 @@ export const uploadCommand = buildCommand({
 
     // Build artifact file list with paths relative to the upload directory
     const resolvedDir = resolve(dir);
+    // Normalize --strip-prefix to end with "/" so it strips at directory
+    // boundaries. Without this, "build" would strip from "build/app.js"
+    // leaving "/app.js" instead of "app.js".
     let pathPrefixToStrip = flags["strip-prefix"] ?? "";
+    if (pathPrefixToStrip && !pathPrefixToStrip.endsWith("/")) {
+      pathPrefixToStrip = `${pathPrefixToStrip}/`;
+    }
     if (flags["strip-common-prefix"]) {
       const allRelative = results.flatMap(({ jsPath, mapPath }) => [
         relative(resolvedDir, jsPath).replaceAll("\\", "/"),

--- a/src/commands/sourcemap/upload.ts
+++ b/src/commands/sourcemap/upload.ts
@@ -6,7 +6,7 @@
  * env vars, config defaults) — no slash-separated arg parsing needed.
  */
 
-import { basename, relative, resolve } from "node:path";
+import { dirname, relative, resolve } from "node:path";
 import type { SentryContext } from "../../context.js";
 import {
   type ArtifactFile,
@@ -309,7 +309,13 @@ export const uploadCommand = buildCommand({
           mapRelative = stripPrefix(mapRelative, pathPrefixToStrip);
         }
 
-        const mapBasename = basename(mapPath);
+        // Sourcemap header is resolved relative to the JS file's URL.
+        // Use relative path from JS dir to map file so cross-directory
+        // maps (e.g. maps/bundle.js.map) link correctly.
+        const sourcemapRef = relative(dirname(jsPath), mapPath).replaceAll(
+          "\\",
+          "/"
+        );
         return [
           {
             path: jsPath,
@@ -318,7 +324,7 @@ export const uploadCommand = buildCommand({
             ...(debugId ? { debugId } : {}),
             type: "minified_source" as const,
             url: `${urlPrefix}${jsRelative}`,
-            sourcemapFilename: mapBasename,
+            sourcemapFilename: sourcemapRef,
           },
           {
             path: mapPath,

--- a/src/commands/sourcemap/upload.ts
+++ b/src/commands/sourcemap/upload.ts
@@ -69,9 +69,8 @@ const USAGE_HINT = "sentry sourcemap upload <directory>";
 /**
  * Compute the longest common directory prefix across a list of paths.
  *
- * Only strips at directory boundaries (slashes), so
- * `["a/b/c.js", "a/b/d.js"]` yields `"a/b/"` rather than `"a/b/"`.
- * Returns `""` when paths share no common directory prefix.
+ * Strips at directory boundaries only — `["a/bc.js", "a/bd.js"]`
+ * yields `"a/"` (not `"a/b"`). Returns `""` when no common dir prefix.
  */
 function computeCommonPrefix(paths: string[]): string {
   if (paths.length === 0) {

--- a/src/commands/sourcemap/upload.ts
+++ b/src/commands/sourcemap/upload.ts
@@ -13,13 +13,14 @@ import {
   uploadSourcemaps,
 } from "../../lib/api/sourcemaps.js";
 import { buildCommand } from "../../lib/command.js";
-import { ContextError } from "../../lib/errors.js";
+import { ContextError, ValidationError } from "../../lib/errors.js";
 import { mdKvTable, renderMarkdown } from "../../lib/formatters/markdown.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import { resolveOrgAndProject } from "../../lib/resolve-target.js";
 import {
   assertDirectoryReadable,
   buildEmptyDiscoveryError,
+  buildIgnoreMatcher,
   diagnoseEmptyDiscovery,
   discoverFilePairs,
   injectDirectory,
@@ -34,6 +35,8 @@ type UploadCommandResult = {
   project?: string;
   /** Release version, if provided. */
   release?: string;
+  /** Distribution identifier, if provided. */
+  dist?: string;
   /** Number of file pairs uploaded. */
   filesUploaded: number;
 };
@@ -51,10 +54,53 @@ function formatUploadResult(data: UploadCommandResult): string {
   if (data.release) {
     rows.push(["Release", data.release]);
   }
+  if (data.dist) {
+    rows.push(["Dist", data.dist]);
+  }
   return renderMarkdown(mdKvTable(rows));
 }
 
 const USAGE_HINT = "sentry sourcemap upload <directory>";
+
+/**
+ * Compute the longest common directory prefix across a list of paths.
+ *
+ * Only strips at directory boundaries (slashes), so
+ * `["a/b/c.js", "a/b/d.js"]` yields `"a/b/"` rather than `"a/b/"`.
+ * Returns `""` when paths share no common directory prefix.
+ */
+function computeCommonPrefix(paths: string[]): string {
+  if (paths.length === 0) {
+    return "";
+  }
+  const sorted = [...paths].sort();
+  const first = sorted[0];
+  const last = sorted.at(-1);
+  if (!(first && last)) {
+    return "";
+  }
+  let common = 0;
+  for (let i = 0; i < first.length && i < last.length; i += 1) {
+    if (first[i] !== last[i]) {
+      break;
+    }
+    if (first[i] === "/") {
+      common = i + 1;
+    }
+  }
+  return first.slice(0, common);
+}
+
+/**
+ * Strip a prefix from a file path. If the path doesn't start with
+ * the prefix, returns it unchanged.
+ */
+function stripPrefix(path: string, prefix: string): string {
+  if (prefix && path.startsWith(prefix)) {
+    return path.slice(prefix.length);
+  }
+  return path;
+}
 
 export const uploadCommand = buildCommand({
   docs: {
@@ -71,7 +117,10 @@ export const uploadCommand = buildCommand({
       "Usage:\n" +
       "  sentry sourcemap upload ./dist\n" +
       "  sentry sourcemap upload ./dist --release 1.0.0\n" +
+      "  sentry sourcemap upload ./dist --release 1.0.0 --dist 12345\n" +
       "  sentry sourcemap upload ./dist --url-prefix '~/static/js/'\n" +
+      "  sentry sourcemap upload ./dist --no-rewrite\n" +
+      "  sentry sourcemap upload ./dist --ext .js,.mjs\n" +
       "  sentry sourcemap upload ./maybe-empty --allow-empty",
   },
   output: {
@@ -95,12 +144,57 @@ export const uploadCommand = buildCommand({
         brief: "Release version to associate with the upload",
         optional: true,
       },
+      dist: {
+        kind: "parsed",
+        parse: String,
+        brief:
+          "Distribution identifier to disambiguate builds within a release",
+        optional: true,
+      },
       "url-prefix": {
         kind: "parsed",
         parse: String,
         brief: "URL prefix for uploaded files (default: ~/)",
         optional: true,
         default: "~/",
+      },
+      ext: {
+        kind: "parsed",
+        parse: String,
+        brief:
+          "Comma-separated file extensions to process (default: .js,.cjs,.mjs)",
+        optional: true,
+      },
+      ignore: {
+        kind: "parsed",
+        parse: String,
+        brief: "Glob pattern to exclude (gitignore-style, repeatable)",
+        optional: true,
+      },
+      "ignore-file": {
+        kind: "parsed",
+        parse: String,
+        brief: "Path to a file with gitignore-style patterns to exclude",
+        optional: true,
+      },
+      "strip-prefix": {
+        kind: "parsed",
+        parse: String,
+        brief: "Strip a prefix from uploaded file paths (e.g. 'build/')",
+        optional: true,
+      },
+      "strip-common-prefix": {
+        kind: "boolean",
+        brief:
+          "Automatically strip the longest common path prefix from all files",
+        optional: true,
+        default: false,
+      },
+      "no-rewrite": {
+        kind: "boolean",
+        brief: "Upload files as-is without injecting debug IDs",
+        optional: true,
+        default: false,
       },
       "allow-empty": {
         kind: "boolean",
@@ -116,7 +210,14 @@ export const uploadCommand = buildCommand({
     this: SentryContext,
     flags: {
       release?: string;
+      dist?: string;
       "url-prefix"?: string;
+      ext?: string;
+      ignore?: string;
+      "ignore-file"?: string;
+      "strip-prefix"?: string;
+      "strip-common-prefix"?: boolean;
+      "no-rewrite"?: boolean;
       "allow-empty"?: boolean;
     },
     dir: string
@@ -125,11 +226,25 @@ export const uploadCommand = buildCommand({
     // don't write debug IDs when the upload won't proceed (empty dir,
     // typoed path, missing credentials).
     await assertDirectoryReadable(dir);
-    const pairs = await discoverFilePairs(dir);
+
+    const extensions = flags.ext?.split(",").map((e) => e.trim());
+    const extSet = extensions
+      ? new Set(extensions.map((e) => (e.startsWith(".") ? e : `.${e}`)))
+      : undefined;
+
+    const ignorePatterns = flags.ignore
+      ? flags.ignore.split(",").map((p) => p.trim())
+      : undefined;
+    const ignoreMatcher = await buildIgnoreMatcher(
+      ignorePatterns,
+      flags["ignore-file"]
+    );
+
+    const pairs = await discoverFilePairs(dir, extSet, ignoreMatcher);
 
     if (pairs.length === 0) {
       if (!flags["allow-empty"]) {
-        const diag = await diagnoseEmptyDiscovery(dir);
+        const diag = await diagnoseEmptyDiscovery(dir, { extensions });
         throw buildEmptyDiscoveryError(dir, diag);
       }
       // --allow-empty: nothing to upload, so don't require Sentry
@@ -137,6 +252,7 @@ export const uploadCommand = buildCommand({
       // library-only / conditional-release-skip cases the docs name.
       yield new CommandOutput<UploadCommandResult>({
         release: flags.release,
+        dist: flags.dist,
         filesUploaded: 0,
       });
       return {
@@ -155,36 +271,62 @@ export const uploadCommand = buildCommand({
     }
     const { org, project } = resolved;
 
-    const results = await injectDirectory(dir);
+    const results = flags["no-rewrite"]
+      ? pairs.map((p) => ({ ...p, injected: false, debugId: "" }))
+      : await injectDirectory(dir, {
+          extensions,
+          ignoreMatcher,
+        });
 
     const urlPrefix = flags["url-prefix"] ?? "~/";
 
     // Build artifact file list with paths relative to the upload directory
     const resolvedDir = resolve(dir);
+
+    // Compute prefix to strip from relative paths (mutually exclusive)
+    if (flags["strip-prefix"] && flags["strip-common-prefix"]) {
+      throw new ValidationError(
+        "--strip-prefix and --strip-common-prefix are mutually exclusive"
+      );
+    }
+    let pathPrefixToStrip = flags["strip-prefix"] ?? "";
+    if (flags["strip-common-prefix"]) {
+      const allRelative = results.flatMap(({ jsPath, mapPath }) => [
+        relative(resolvedDir, jsPath).replaceAll("\\", "/"),
+        relative(resolvedDir, mapPath).replaceAll("\\", "/"),
+      ]);
+      pathPrefixToStrip = computeCommonPrefix(allRelative);
+    }
+
     const artifactFiles: ArtifactFile[] = results.flatMap(
       ({ jsPath, mapPath, debugId }) => {
         // Normalize to forward slashes for URLs (handles Windows backslashes)
-        const jsRelative = relative(resolvedDir, jsPath).replaceAll("\\", "/");
-        const mapRelative = relative(resolvedDir, mapPath).replaceAll(
-          "\\",
-          "/"
-        );
+        let jsRelative = relative(resolvedDir, jsPath).replaceAll("\\", "/");
+        let mapRelative = relative(resolvedDir, mapPath).replaceAll("\\", "/");
+
+        if (pathPrefixToStrip) {
+          jsRelative = stripPrefix(jsRelative, pathPrefixToStrip);
+          mapRelative = stripPrefix(mapRelative, pathPrefixToStrip);
+        }
+
         const mapBasename = basename(mapPath);
         return [
           {
             path: jsPath,
-            debugId,
+            // Empty debugId when --no-rewrite: files uploaded without debug IDs,
+            // relying on release/URL-based matching instead.
+            ...(debugId ? { debugId } : {}),
             type: "minified_source" as const,
             url: `${urlPrefix}${jsRelative}`,
             sourcemapFilename: mapBasename,
           },
           {
             path: mapPath,
-            debugId,
+            ...(debugId ? { debugId } : {}),
             type: "source_map" as const,
             url: `${urlPrefix}${mapRelative}`,
           },
-        ];
+        ] satisfies ArtifactFile[];
       }
     );
 
@@ -192,6 +334,7 @@ export const uploadCommand = buildCommand({
       org,
       project,
       release: flags.release,
+      dist: flags.dist,
       files: artifactFiles,
     });
 
@@ -199,6 +342,7 @@ export const uploadCommand = buildCommand({
       org,
       project,
       release: flags.release,
+      dist: flags.dist,
       filesUploaded: results.length,
     });
   },

--- a/src/commands/sourcemap/upload.ts
+++ b/src/commands/sourcemap/upload.ts
@@ -7,7 +7,10 @@
  */
 
 import { relative, resolve } from "node:path";
-import { dirname as posixDirname, relative as posixRelative } from "node:path/posix";
+import {
+  dirname as posixDirname,
+  relative as posixRelative,
+} from "node:path/posix";
 import type { SentryContext } from "../../context.js";
 import {
   type ArtifactFile,

--- a/src/commands/sourcemap/upload.ts
+++ b/src/commands/sourcemap/upload.ts
@@ -172,7 +172,7 @@ export const uploadCommand = buildCommand({
       ignore: {
         kind: "parsed",
         parse: String,
-        brief: "Glob pattern to exclude (gitignore-style, repeatable)",
+        brief: "Comma-separated glob patterns to exclude (gitignore-style)",
         optional: true,
       },
       "ignore-file": {

--- a/src/commands/sourcemap/upload.ts
+++ b/src/commands/sourcemap/upload.ts
@@ -6,7 +6,8 @@
  * env vars, config defaults) — no slash-separated arg parsing needed.
  */
 
-import { dirname, relative, resolve } from "node:path";
+import { relative, resolve } from "node:path";
+import { dirname as posixDirname, relative as posixRelative } from "node:path/posix";
 import type { SentryContext } from "../../context.js";
 import {
   type ArtifactFile,
@@ -310,11 +311,11 @@ export const uploadCommand = buildCommand({
         }
 
         // Sourcemap header is resolved relative to the JS file's URL.
-        // Use relative path from JS dir to map file so cross-directory
-        // maps (e.g. maps/bundle.js.map) link correctly.
-        const sourcemapRef = relative(dirname(jsPath), mapPath).replaceAll(
-          "\\",
-          "/"
+        // Compute from post-strip URL-space paths so --strip-prefix
+        // doesn't break the reference.
+        const sourcemapRef = posixRelative(
+          posixDirname(jsRelative),
+          mapRelative
         );
         return [
           {

--- a/src/lib/api/sourcemaps.ts
+++ b/src/lib/api/sourcemaps.ts
@@ -74,8 +74,8 @@ export type AssembleResponse = z.infer<typeof AssembleResponseSchema>;
 export type ArtifactFile = {
   /** Filesystem path to the file. */
   path: string;
-  /** Debug ID injected into this file (from {@link injectDebugId}). */
-  debugId: string;
+  /** Debug ID injected into this file (from {@link injectDebugId}). Omitted when uploading without rewriting. */
+  debugId?: string;
   /**
    * File type for the manifest.
    * `"minified_source"` for JS files, `"source_map"` for .map files.
@@ -101,6 +101,8 @@ export type UploadOptions = {
   project: string;
   /** Release version (optional — debug IDs can work without releases). */
   release?: string;
+  /** Distribution identifier (optional — disambiguates builds within a release). */
+  dist?: string;
   /** Files to upload (must already have debug IDs injected). */
   files: ArtifactFile[];
 };
@@ -302,6 +304,7 @@ export async function buildArtifactBundle(
     org: string;
     project: string;
     release?: string;
+    dist?: string;
     compression?: ZipCompression;
   }
 ): Promise<void> {
@@ -317,9 +320,10 @@ export async function buildArtifactBundle(
 
   for (const file of files) {
     const bundlePath = urlToBundlePath(file.url);
-    const headers: Record<string, string> = {
-      "debug-id": file.debugId,
-    };
+    const headers: Record<string, string> = {};
+    if (file.debugId) {
+      headers["debug-id"] = file.debugId;
+    }
     if (file.sourcemapFilename) {
       headers.Sourcemap = file.sourcemapFilename;
     }
@@ -335,6 +339,7 @@ export async function buildArtifactBundle(
     org: options.org,
     project: options.project,
     ...(options.release ? { release: options.release } : {}),
+    ...(options.dist ? { dist: options.dist } : {}),
     files: filesManifest,
   });
 
@@ -403,7 +408,7 @@ export async function hashChunks(
  * @throws {ApiError} If the upload or assembly fails
  */
 export async function uploadSourcemaps(options: UploadOptions): Promise<void> {
-  const { org, project, release, files } = options;
+  const { org, project, release, dist, files } = options;
 
   // Step 1: Get chunk upload configuration
   const serverOptions = await getChunkUploadOptions(org);
@@ -424,6 +429,7 @@ export async function uploadSourcemaps(options: UploadOptions): Promise<void> {
       org,
       project,
       release,
+      dist,
       compression: zipCompression,
     });
     await uploadArtifactBundle({
@@ -431,6 +437,7 @@ export async function uploadSourcemaps(options: UploadOptions): Promise<void> {
       org,
       project,
       release,
+      dist,
       serverOptions,
       encoding,
     });
@@ -454,10 +461,12 @@ async function uploadArtifactBundle(opts: {
   org: string;
   project: string;
   release: string | undefined;
+  dist: string | undefined;
   serverOptions: ChunkServerOptions;
   encoding: UploadEncoding | undefined;
 }): Promise<void> {
-  const { tmpZipPath, org, project, release, serverOptions, encoding } = opts;
+  const { tmpZipPath, org, project, release, dist, serverOptions, encoding } =
+    opts;
   // Step 3: Split into chunks, hash each chunk + compute overall checksum
   const { chunks, overallChecksum } = await hashChunks(
     tmpZipPath,
@@ -472,6 +481,7 @@ async function uploadArtifactBundle(opts: {
     chunks: chunks.map((c: ChunkInfo) => c.sha1),
     projects: [project],
     ...(release ? { version: release } : {}),
+    ...(dist ? { dist } : {}),
   };
 
   const assembleEndpoint = `organizations/${org}/artifactbundle/assemble/`;

--- a/src/lib/api/sourcemaps.ts
+++ b/src/lib/api/sourcemaps.ts
@@ -87,8 +87,8 @@ export type ArtifactFile = {
    */
   url: string;
   /**
-   * Optional associated sourcemap filename (for minified_source entries).
-   * Just the basename, e.g., `"bin.js.map"`.
+   * Optional sourcemap reference for the `Sourcemap` header (minified_source entries).
+   * Relative URL from the JS file to its map, e.g., `"bin.js.map"` or `"maps/app.js.map"`.
    */
   sourcemapFilename?: string;
 };

--- a/src/lib/sourcemap/inject.ts
+++ b/src/lib/sourcemap/inject.ts
@@ -5,12 +5,16 @@
  * then injects Sentry debug IDs into each pair.
  */
 
-import { readFile, stat } from "node:fs/promises";
-import { resolve as resolvePath } from "node:path";
+import { open, readFile, stat } from "node:fs/promises";
+import { dirname, relative, resolve as resolvePath } from "node:path";
+import ignore from "ignore";
 import { NODE_MODULES_DIRNAME } from "../constants.js";
 import { ValidationError } from "../errors.js";
+import { logger } from "../logger.js";
 import { walkFiles } from "../scan/index.js";
 import { EXISTING_DEBUGID_RE, injectDebugId } from "./debug-id.js";
+
+const log = logger.withTag("sourcemap.inject");
 
 /** Default JavaScript file extensions to scan. */
 const DEFAULT_EXTENSIONS = new Set([".js", ".cjs", ".mjs"]);
@@ -33,6 +37,10 @@ export type InjectDirectoryOptions = {
   extensions?: string[];
   /** If true, report what would be modified without writing. */
   dryRun?: boolean;
+  /** Glob patterns (gitignore-style) to exclude from processing. */
+  ignorePatterns?: string[];
+  /** Pre-built ignore matcher (takes precedence over ignorePatterns). */
+  ignoreMatcher?: ReturnType<typeof ignore>;
 };
 
 /**
@@ -53,7 +61,9 @@ export async function injectDirectory(
     ? new Set(options.extensions.map((e) => (e.startsWith(".") ? e : `.${e}`)))
     : DEFAULT_EXTENSIONS;
 
-  const filePairs = await discoverFilePairs(dir, extensions);
+  const ig =
+    options.ignoreMatcher ?? (await buildIgnoreMatcher(options.ignorePatterns));
+  const filePairs = await discoverFilePairs(dir, extensions, ig);
 
   const results: InjectResult[] = [];
   for (const { jsPath, mapPath } of filePairs) {
@@ -76,20 +86,122 @@ export async function injectDirectory(
 export type FilePair = { jsPath: string; mapPath: string };
 
 /**
- * Check if a path has a companion .map file.
+ * Regex matching `//# sourceMappingURL=<url>` or `//@ sourceMappingURL=<url>`.
  *
- * @returns The map path if the companion exists, undefined otherwise.
+ * Uses global + multiline flags so we can iterate all matches and take the
+ * **last** one — the source map spec says the last directive is authoritative.
+ * Concatenated bundles or string literals in the file tail may produce earlier
+ * false positives; only the final match matters.
+ */
+const SOURCE_MAPPING_URL_RE = /\/\/[#@]\s*sourceMappingURL\s*=\s*(\S+)\s*$/gm;
+
+/**
+ * Read the last ~512 bytes of a file efficiently.
+ *
+ * We only need the very end of the JS file to find the
+ * `sourceMappingURL` directive. Reading just the tail avoids
+ * loading multi-megabyte bundles into memory.
+ */
+async function readFileTail(filePath: string, maxBytes = 512): Promise<string> {
+  const fh = await open(filePath, "r");
+  try {
+    const fstat = await fh.stat();
+    const fileSize = fstat.size;
+    if (fileSize === 0) {
+      return "";
+    }
+    const readSize = Math.min(maxBytes, fileSize);
+    const offset = fileSize - readSize;
+    const buf = Buffer.alloc(readSize);
+    await fh.read(buf, 0, readSize, offset);
+    return buf.toString("utf-8");
+  } finally {
+    await fh.close();
+  }
+}
+
+/**
+ * Extract the **last** `sourceMappingURL` value from the tail of a JS file.
+ *
+ * The source map spec says the last directive is authoritative. Concatenated
+ * bundles may have multiple directives; we iterate all matches and return
+ * the final one.
+ *
+ * Returns `undefined` if no directive is found.
+ */
+async function extractSourceMappingUrl(
+  jsPath: string
+): Promise<string | undefined> {
+  try {
+    const tail = await readFileTail(jsPath);
+    let lastUrl: string | undefined;
+    for (const match of tail.matchAll(SOURCE_MAPPING_URL_RE)) {
+      lastUrl = match[1];
+    }
+    return lastUrl;
+  } catch {
+    return;
+  }
+}
+
+/**
+ * Check if a file exists and is a regular file.
+ */
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    const s = await stat(path);
+    return s.isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Find the companion sourcemap for a JS file.
+ *
+ * Resolution order:
+ * 1. Convention: `<jsPath>.map` on disk
+ * 2. `//# sourceMappingURL=<relative-path>` directive in the JS file
+ *    (only external file references — `data:` URLs are logged and skipped)
+ *
+ * @returns The map path if a companion exists, undefined otherwise.
  */
 async function findCompanionMap(jsPath: string): Promise<string | undefined> {
-  const mapPath = `${jsPath}.map`;
-  try {
-    const mapStat = await stat(mapPath);
-    if (mapStat.isFile()) {
-      return mapPath;
-    }
-  } catch {
-    // No companion .map file — skip
+  // Fast path: convention-based naming (most bundlers use this)
+  const conventionPath = `${jsPath}.map`;
+  if (await fileExists(conventionPath)) {
+    return conventionPath;
   }
+
+  // Slow path: parse sourceMappingURL from the file tail
+  const url = await extractSourceMappingUrl(jsPath);
+  if (!url) {
+    return;
+  }
+
+  // Skip data: URLs (inline sourcemaps) — we can't inject debug IDs
+  // into inline sourcemaps without re-encoding the entire base64 blob
+  // back into the JS file. Log and move on.
+  if (url.startsWith("data:")) {
+    log.debug(
+      `skipping inline sourcemap in ${jsPath} (data: URL not supported for injection)`
+    );
+    return;
+  }
+
+  // Skip absolute URLs (http/https) — can't inject into remote maps
+  if (url.startsWith("http://") || url.startsWith("https://")) {
+    log.debug(`skipping remote sourcemap URL in ${jsPath}: ${url}`);
+    return;
+  }
+
+  // Resolve relative path against the JS file's directory
+  const jsDir = dirname(jsPath);
+  const resolvedMapPath = resolvePath(jsDir, url);
+  if (await fileExists(resolvedMapPath)) {
+    return resolvedMapPath;
+  }
+
   return;
 }
 
@@ -115,6 +227,40 @@ async function findCompanionMap(jsPath: string): Promise<string | undefined> {
 const SOURCEMAP_SKIP_DIRS: readonly string[] = [NODE_MODULES_DIRNAME];
 
 /**
+ * Build an `ignore` matcher from user-provided patterns and/or an
+ * ignore-file path. Returns `undefined` when no patterns are active.
+ */
+export async function buildIgnoreMatcher(
+  patterns?: string[],
+  ignoreFilePath?: string
+): Promise<ReturnType<typeof ignore> | undefined> {
+  const hasPatterns = patterns && patterns.length > 0;
+  if (!(hasPatterns || ignoreFilePath)) {
+    return;
+  }
+  const ig = ignore();
+  if (hasPatterns) {
+    ig.add(patterns);
+  }
+  if (ignoreFilePath) {
+    try {
+      const content = await readFile(ignoreFilePath, "utf-8");
+      ig.add(content);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        throw new ValidationError(
+          `Ignore file '${ignoreFilePath}' does not exist.`,
+          "ignore-file"
+        );
+      }
+      throw err;
+    }
+  }
+  return ig;
+}
+
+/**
  * Read-only discovery pass — returns the list of JS + sourcemap pairs
  * without injecting debug IDs. Used as a pre-check by the upload
  * command so the directory isn't mutated when the upload won't
@@ -122,7 +268,8 @@ const SOURCEMAP_SKIP_DIRS: readonly string[] = [NODE_MODULES_DIRNAME];
  */
 export async function discoverFilePairs(
   dir: string,
-  extensions: Set<string> = DEFAULT_EXTENSIONS
+  extensions: Set<string> = DEFAULT_EXTENSIONS,
+  ignoreMatcher?: ReturnType<typeof ignore>
 ): Promise<FilePair[]> {
   // `walkFiles` requires an absolute cwd. CLI callers pass
   // user-supplied positional args like `./dist` directly through to
@@ -138,6 +285,13 @@ export async function discoverFilePairs(
     respectGitignore: false,
     maxFileSize: Number.POSITIVE_INFINITY,
   })) {
+    if (ignoreMatcher) {
+      // Use POSIX relative path for gitignore-style matching
+      const rel = relative(absDir, entry.absolutePath).replaceAll("\\", "/");
+      if (ignoreMatcher.ignores(rel)) {
+        continue;
+      }
+    }
     const mapPath = await findCompanionMap(entry.absolutePath);
     if (mapPath) {
       pairs.push({ jsPath: entry.absolutePath, mapPath });

--- a/src/lib/sourcemap/inject.ts
+++ b/src/lib/sourcemap/inject.ts
@@ -294,6 +294,15 @@ export async function discoverFilePairs(
     }
     const mapPath = await findCompanionMap(entry.absolutePath);
     if (mapPath) {
+      // Guard against sourceMappingURL directives that resolve outside the
+      // upload directory (e.g. "../../other/app.js.map"). Convention-based
+      // maps (foo.js.map) are always adjacent so they're inherently safe.
+      if (!mapPath.startsWith(absDir)) {
+        log.debug(
+          `skipping sourcemap outside directory: ${mapPath} (resolved from ${entry.absolutePath})`
+        );
+        continue;
+      }
       pairs.push({ jsPath: entry.absolutePath, mapPath });
     }
   }

--- a/src/lib/sourcemap/inject.ts
+++ b/src/lib/sourcemap/inject.ts
@@ -297,7 +297,9 @@ export async function discoverFilePairs(
       // Guard against sourceMappingURL directives that resolve outside the
       // upload directory (e.g. "../../other/app.js.map"). Convention-based
       // maps (foo.js.map) are always adjacent so they're inherently safe.
-      if (!mapPath.startsWith(absDir)) {
+      // Trailing separator prevents prefix collisions (e.g. /dist vs /dist-backup).
+      const dirPrefix = absDir.endsWith("/") ? absDir : `${absDir}/`;
+      if (!mapPath.startsWith(dirPrefix)) {
         log.debug(
           `skipping sourcemap outside directory: ${mapPath} (resolved from ${entry.absolutePath})`
         );

--- a/src/lib/sourcemap/inject.ts
+++ b/src/lib/sourcemap/inject.ts
@@ -196,8 +196,18 @@ async function findCompanionMap(jsPath: string): Promise<string | undefined> {
   }
 
   // Strip query strings and fragments (e.g. "app.js.map?v=abc123")
-  // that bundlers like Vite/Rollup may append.
-  const cleanUrl = url.split("?")[0].split("#")[0];
+  // that bundlers like Vite/Rollup may append. indexOf returns -1 when
+  // no delimiter is found, and slice(0, -1) would chop the last char —
+  // so only slice when the delimiter actually exists.
+  let cleanUrl = url;
+  const qIdx = cleanUrl.indexOf("?");
+  if (qIdx !== -1) {
+    cleanUrl = cleanUrl.slice(0, qIdx);
+  }
+  const hIdx = cleanUrl.indexOf("#");
+  if (hIdx !== -1) {
+    cleanUrl = cleanUrl.slice(0, hIdx);
+  }
 
   // Resolve relative path against the JS file's directory
   const jsDir = dirname(jsPath);

--- a/src/lib/sourcemap/inject.ts
+++ b/src/lib/sourcemap/inject.ts
@@ -6,7 +6,7 @@
  */
 
 import { open, readFile, stat } from "node:fs/promises";
-import { dirname, relative, resolve as resolvePath } from "node:path";
+import { dirname, relative, resolve as resolvePath, sep } from "node:path";
 import ignore from "ignore";
 import { NODE_MODULES_DIRNAME } from "../constants.js";
 import { ValidationError } from "../errors.js";
@@ -298,7 +298,8 @@ export async function discoverFilePairs(
       // upload directory (e.g. "../../other/app.js.map"). Convention-based
       // maps (foo.js.map) are always adjacent so they're inherently safe.
       // Trailing separator prevents prefix collisions (e.g. /dist vs /dist-backup).
-      const dirPrefix = absDir.endsWith("/") ? absDir : `${absDir}/`;
+      // Use path.sep for Windows compatibility (backslash separators).
+      const dirPrefix = absDir.endsWith(sep) ? absDir : `${absDir}${sep}`;
       if (!mapPath.startsWith(dirPrefix)) {
         log.debug(
           `skipping sourcemap outside directory: ${mapPath} (resolved from ${entry.absolutePath})`

--- a/src/lib/sourcemap/inject.ts
+++ b/src/lib/sourcemap/inject.ts
@@ -195,9 +195,13 @@ async function findCompanionMap(jsPath: string): Promise<string | undefined> {
     return;
   }
 
+  // Strip query strings and fragments (e.g. "app.js.map?v=abc123")
+  // that bundlers like Vite/Rollup may append.
+  const cleanUrl = url.split("?")[0].split("#")[0];
+
   // Resolve relative path against the JS file's directory
   const jsDir = dirname(jsPath);
-  const resolvedMapPath = resolvePath(jsDir, url);
+  const resolvedMapPath = resolvePath(jsDir, cleanUrl);
   if (await fileExists(resolvedMapPath)) {
     return resolvedMapPath;
   }

--- a/test/commands/sourcemap/upload.test.ts
+++ b/test/commands/sourcemap/upload.test.ts
@@ -29,7 +29,14 @@ type InjectFuncArgs = {
 };
 type UploadFuncArgs = {
   release?: string;
+  dist?: string;
   "url-prefix"?: string;
+  ext?: string;
+  ignore?: string;
+  "ignore-file"?: string;
+  "strip-prefix"?: string;
+  "strip-common-prefix"?: boolean;
+  "no-rewrite"?: boolean;
   "allow-empty"?: boolean;
 };
 type CmdFunc<A> = (this: unknown, flags: A, dir: string) => Promise<unknown>;
@@ -172,6 +179,54 @@ describe("sourcemap inject command — --allow-empty behavior", () => {
       func.call(ctx, { "dry-run": true, "allow-empty": true }, dir)
     ).resolves.toBeUndefined();
   });
+
+  test("sourceMappingURL: follows external map reference when convention fails", async () => {
+    // JS file with sourceMappingURL pointing to a differently-named map
+    writeFileSync(
+      join(dir, "bundle.js"),
+      "console.log(1)\n//# sourceMappingURL=bundle.abc123.js.map\n"
+    );
+    // Map file with non-convention name (no bundle.js.map exists)
+    writeFileSync(
+      join(dir, "bundle.abc123.js.map"),
+      JSON.stringify({ version: 3, sources: [], names: [], mappings: "" })
+    );
+    const ctx = makeContext();
+    await expect(func.call(ctx, {}, dir)).resolves.toBeUndefined();
+  });
+
+  test("sourceMappingURL: prefers convention naming over directive", async () => {
+    // JS file with sourceMappingURL pointing to a different file
+    writeFileSync(
+      join(dir, "app.js"),
+      "console.log(1)\n//# sourceMappingURL=other.js.map\n"
+    );
+    // Convention map exists — should be used
+    writeFileSync(
+      join(dir, "app.js.map"),
+      JSON.stringify({ version: 3, sources: [], names: [], mappings: "" })
+    );
+    // The directive target also exists
+    writeFileSync(
+      join(dir, "other.js.map"),
+      JSON.stringify({ version: 3, sources: [], names: [], mappings: "" })
+    );
+    const ctx = makeContext();
+    // Should succeed (convention-based match found first)
+    await expect(func.call(ctx, {}, dir)).resolves.toBeUndefined();
+  });
+
+  test("sourceMappingURL: skips data: URLs gracefully", async () => {
+    writeFileSync(
+      join(dir, "inline.js"),
+      "console.log(1)\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==\n"
+    );
+    // No convention map either — should fail with zero pairs
+    const ctx = makeContext();
+    await expect(func.call(ctx, {}, dir)).rejects.toBeInstanceOf(
+      ValidationError
+    );
+  });
 });
 
 describe("sourcemap upload command — --allow-empty behavior", () => {
@@ -306,6 +361,305 @@ describe("sourcemap upload command — --allow-empty behavior", () => {
       const types = callArgs?.files.map((f) => f.type);
       expect(types).toContain("minified_source");
       expect(types).toContain("source_map");
+    } finally {
+      uploadSpy.mockRestore();
+    }
+  });
+
+  test("--dist flag: passes dist to uploadSourcemaps", async () => {
+    mkdirSync(join(dir, "_astro"));
+    writeFileSync(join(dir, "_astro", "app.js"), "console.log(1)\n");
+    writeFileSync(
+      join(dir, "_astro", "app.js.map"),
+      JSON.stringify({
+        version: 3,
+        sources: ["app.ts"],
+        names: [],
+        mappings: "",
+      })
+    );
+
+    const uploadSpy = spyOn(
+      sourcemapsApi,
+      "uploadSourcemaps"
+    ).mockResolvedValue(undefined);
+    try {
+      const ctx = makeContext();
+      await func.call(ctx, { release: "1.0.0", dist: "12345" }, dir);
+      expect(uploadSpy).toHaveBeenCalledTimes(1);
+      const callArgs = uploadSpy.mock.calls[0]?.[0];
+      expect(callArgs?.dist).toBe("12345");
+      expect(callArgs?.release).toBe("1.0.0");
+    } finally {
+      uploadSpy.mockRestore();
+    }
+  });
+
+  test("--no-rewrite: uploads without injecting debug IDs", async () => {
+    mkdirSync(join(dir, "_astro"));
+    const jsPath = join(dir, "_astro", "app.js");
+    const mapPath = join(dir, "_astro", "app.js.map");
+    const originalJs = "console.log(1)\n";
+    writeFileSync(jsPath, originalJs);
+    writeFileSync(
+      mapPath,
+      JSON.stringify({
+        version: 3,
+        sources: ["app.ts"],
+        names: [],
+        mappings: "",
+      })
+    );
+
+    const uploadSpy = spyOn(
+      sourcemapsApi,
+      "uploadSourcemaps"
+    ).mockResolvedValue(undefined);
+    try {
+      const ctx = makeContext();
+      await func.call(ctx, { "no-rewrite": true }, dir);
+      expect(uploadSpy).toHaveBeenCalledTimes(1);
+      const callArgs = uploadSpy.mock.calls[0]?.[0];
+      // Files should have no debugId when --no-rewrite is used
+      for (const file of callArgs?.files ?? []) {
+        expect(file.debugId).toBeUndefined();
+      }
+      // JS file should not have been modified
+      const afterJs = await Bun.file(jsPath).text();
+      expect(afterJs).toBe(originalJs);
+      expect(afterJs).not.toContain("_sentryDebugIds");
+    } finally {
+      uploadSpy.mockRestore();
+    }
+  });
+
+  test("--ext: discovers files with custom extensions", async () => {
+    writeFileSync(join(dir, "app.ts"), "console.log(1)\n");
+    writeFileSync(
+      join(dir, "app.ts.map"),
+      JSON.stringify({
+        version: 3,
+        sources: ["app.ts"],
+        names: [],
+        mappings: "",
+      })
+    );
+    // A .js file that should NOT be discovered when --ext is .ts
+    writeFileSync(join(dir, "other.js"), "console.log(2)\n");
+
+    const uploadSpy = spyOn(
+      sourcemapsApi,
+      "uploadSourcemaps"
+    ).mockResolvedValue(undefined);
+    try {
+      const ctx = makeContext();
+      await func.call(ctx, { ext: ".ts" }, dir);
+      expect(uploadSpy).toHaveBeenCalledTimes(1);
+      const callArgs = uploadSpy.mock.calls[0]?.[0];
+      expect(callArgs?.files).toHaveLength(2);
+      const urls = callArgs?.files.map((f) => f.url);
+      expect(urls?.some((u) => u?.includes("app.ts"))).toBe(true);
+      expect(urls?.some((u) => u?.includes("other.js"))).toBe(false);
+    } finally {
+      uploadSpy.mockRestore();
+    }
+  });
+
+  test("--ignore: excludes matching files from upload", async () => {
+    mkdirSync(join(dir, "vendor"));
+    // File that should be excluded
+    writeFileSync(join(dir, "vendor", "lib.js"), "console.log(1)\n");
+    writeFileSync(
+      join(dir, "vendor", "lib.js.map"),
+      JSON.stringify({ version: 3, sources: [], names: [], mappings: "" })
+    );
+    // File that should be included
+    writeFileSync(join(dir, "app.js"), "console.log(2)\n");
+    writeFileSync(
+      join(dir, "app.js.map"),
+      JSON.stringify({ version: 3, sources: [], names: [], mappings: "" })
+    );
+
+    const uploadSpy = spyOn(
+      sourcemapsApi,
+      "uploadSourcemaps"
+    ).mockResolvedValue(undefined);
+    try {
+      const ctx = makeContext();
+      await func.call(ctx, { ignore: "vendor/**" }, dir);
+      expect(uploadSpy).toHaveBeenCalledTimes(1);
+      const callArgs = uploadSpy.mock.calls[0]?.[0];
+      // Only app.js pair should be uploaded (2 files: .js + .map)
+      expect(callArgs?.files).toHaveLength(2);
+      const urls = callArgs?.files.map((f) => f.url);
+      expect(urls?.some((u) => u?.includes("app.js"))).toBe(true);
+      expect(urls?.some((u) => u?.includes("vendor"))).toBe(false);
+    } finally {
+      uploadSpy.mockRestore();
+    }
+  });
+
+  test("--ignore-file: reads patterns from a file", async () => {
+    mkdirSync(join(dir, "vendor"));
+    writeFileSync(join(dir, "vendor", "lib.js"), "console.log(1)\n");
+    writeFileSync(
+      join(dir, "vendor", "lib.js.map"),
+      JSON.stringify({ version: 3, sources: [], names: [], mappings: "" })
+    );
+    writeFileSync(join(dir, "app.js"), "console.log(2)\n");
+    writeFileSync(
+      join(dir, "app.js.map"),
+      JSON.stringify({ version: 3, sources: [], names: [], mappings: "" })
+    );
+    // Write an ignore file
+    const ignoreFilePath = join(dir, ".sourcemapignore");
+    writeFileSync(ignoreFilePath, "vendor/\n");
+
+    const uploadSpy = spyOn(
+      sourcemapsApi,
+      "uploadSourcemaps"
+    ).mockResolvedValue(undefined);
+    try {
+      const ctx = makeContext();
+      await func.call(ctx, { "ignore-file": ignoreFilePath }, dir);
+      expect(uploadSpy).toHaveBeenCalledTimes(1);
+      const callArgs = uploadSpy.mock.calls[0]?.[0];
+      expect(callArgs?.files).toHaveLength(2);
+      const urls = callArgs?.files.map((f) => f.url);
+      expect(urls?.some((u) => u?.includes("app.js"))).toBe(true);
+      expect(urls?.some((u) => u?.includes("vendor"))).toBe(false);
+    } finally {
+      uploadSpy.mockRestore();
+    }
+  });
+
+  test("--ignore-file with non-existent file: throws ValidationError", async () => {
+    writeFileSync(join(dir, "app.js"), "console.log(1)\n");
+    writeFileSync(
+      join(dir, "app.js.map"),
+      JSON.stringify({ version: 3, sources: [], names: [], mappings: "" })
+    );
+    const ctx = makeContext();
+    try {
+      await func.call(ctx, { "ignore-file": join(dir, "nonexistent") }, dir);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as Error).message).toContain("does not exist");
+    }
+  });
+
+  test("--strip-prefix: removes explicit prefix from uploaded URLs", async () => {
+    mkdirSync(join(dir, "static", "js"), { recursive: true });
+    writeFileSync(join(dir, "static", "js", "app.js"), "console.log(1)\n");
+    writeFileSync(
+      join(dir, "static", "js", "app.js.map"),
+      JSON.stringify({ version: 3, sources: [], names: [], mappings: "" })
+    );
+
+    const uploadSpy = spyOn(
+      sourcemapsApi,
+      "uploadSourcemaps"
+    ).mockResolvedValue(undefined);
+    try {
+      const ctx = makeContext();
+      await func.call(ctx, { "strip-prefix": "static/js/" }, dir);
+      expect(uploadSpy).toHaveBeenCalledTimes(1);
+      const callArgs = uploadSpy.mock.calls[0]?.[0];
+      const urls = callArgs?.files.map((f) => f.url);
+      // Prefix stripped: "~/app.js" instead of "~/static/js/app.js"
+      expect(urls).toContain("~/app.js");
+      expect(urls).toContain("~/app.js.map");
+    } finally {
+      uploadSpy.mockRestore();
+    }
+  });
+
+  test("--strip-common-prefix: auto-strips shared directory prefix", async () => {
+    mkdirSync(join(dir, "build", "output"), { recursive: true });
+    writeFileSync(join(dir, "build", "output", "main.js"), "console.log(1)\n");
+    writeFileSync(
+      join(dir, "build", "output", "main.js.map"),
+      JSON.stringify({ version: 3, sources: [], names: [], mappings: "" })
+    );
+    writeFileSync(
+      join(dir, "build", "output", "vendor.js"),
+      "console.log(2)\n"
+    );
+    writeFileSync(
+      join(dir, "build", "output", "vendor.js.map"),
+      JSON.stringify({ version: 3, sources: [], names: [], mappings: "" })
+    );
+
+    const uploadSpy = spyOn(
+      sourcemapsApi,
+      "uploadSourcemaps"
+    ).mockResolvedValue(undefined);
+    try {
+      const ctx = makeContext();
+      await func.call(ctx, { "strip-common-prefix": true }, dir);
+      expect(uploadSpy).toHaveBeenCalledTimes(1);
+      const callArgs = uploadSpy.mock.calls[0]?.[0];
+      const urls = callArgs?.files.map((f) => f.url);
+      // Common prefix "build/output/" stripped: "~/main.js", "~/vendor.js"
+      expect(urls).toContain("~/main.js");
+      expect(urls).toContain("~/vendor.js");
+      expect(urls?.some((u) => u?.includes("build"))).toBe(false);
+    } finally {
+      uploadSpy.mockRestore();
+    }
+  });
+
+  test("--strip-prefix + --strip-common-prefix: mutually exclusive", async () => {
+    writeFileSync(join(dir, "app.js"), "console.log(1)\n");
+    writeFileSync(
+      join(dir, "app.js.map"),
+      JSON.stringify({ version: 3, sources: [], names: [], mappings: "" })
+    );
+    const ctx = makeContext();
+    await expect(
+      func.call(
+        ctx,
+        { "strip-prefix": "foo/", "strip-common-prefix": true },
+        dir
+      )
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  test("sourceMappingURL: last directive wins over earlier ones", async () => {
+    // Simulates a concatenated bundle with two directives in the tail.
+    // No convention map (concat.js.map) exists, so discovery falls back
+    // to sourceMappingURL. The last directive should win.
+    writeFileSync(
+      join(dir, "concat.js"),
+      "console.log(1)\n" +
+        "//# sourceMappingURL=wrong.js.map\n" +
+        "console.log(2)\n" +
+        "//# sourceMappingURL=correct.js.map\n"
+    );
+    writeFileSync(
+      join(dir, "correct.js.map"),
+      JSON.stringify({ version: 3, sources: [], names: [], mappings: "" })
+    );
+    // wrong.js.map also exists — but the last directive should win
+    writeFileSync(
+      join(dir, "wrong.js.map"),
+      JSON.stringify({ version: 3, sources: [], names: [], mappings: "" })
+    );
+
+    const uploadSpy = spyOn(
+      sourcemapsApi,
+      "uploadSourcemaps"
+    ).mockResolvedValue(undefined);
+    try {
+      const ctx = makeContext();
+      await func.call(ctx, {}, dir);
+      expect(uploadSpy).toHaveBeenCalledTimes(1);
+      const callArgs = uploadSpy.mock.calls[0]?.[0];
+      // Should have paired concat.js with correct.js.map (last directive)
+      const urls = callArgs?.files.map((f) => f.url);
+      expect(urls?.some((u) => u?.includes("correct.js.map"))).toBe(true);
+      expect(urls?.some((u) => u?.includes("wrong.js.map"))).toBe(false);
     } finally {
       uploadSpy.mockRestore();
     }


### PR DESCRIPTION
## Summary

Adds missing sourcemap flags for old sentry-cli parity and implements `sourceMappingURL` directive following. Ref #600.

### Sourcemap upload: 6 new flags

- **`--dist`** — Distribution identifier to disambiguate builds within a release
- **`--ext`** — Custom file extensions on upload (was only on inject)
- **`--no-rewrite`** — Upload files without injecting debug IDs
- **`--ignore` / `--ignore-file`** — Gitignore-style file exclusion (uses `ignore` npm package, already in devDeps)
- **`--strip-prefix`** — Remove explicit prefix from uploaded file URLs
- **`--strip-common-prefix`** — Auto-strip longest common directory prefix
- `--strip-prefix` and `--strip-common-prefix` are mutually exclusive (throws `ValidationError`)

### Sourcemap inject: `sourceMappingURL` following

Companion map discovery was previously strictly filename-based (`foo.js` → `foo.js.map`). Now also parses `//# sourceMappingURL=<url>`:

- Reads only the last 512 bytes of each file for efficiency
- Takes the **last** directive (spec-correct for concatenated bundles)
- Resolution order: convention naming first, then `sourceMappingURL` fallback
- Gracefully skips `data:` (inline) and `http:`/`https:` (remote) URLs

### Tests

- 13 new tests covering all flags, `sourceMappingURL` following, ignore patterns, strip-prefix, and mutual exclusion
