### PR TITLE
feat(issue): add archive command for ignoring/archiving issues

### DIFF
--- a/docs/src/content/docs/contributing.md
+++ b/docs/src/content/docs/contributing.md
@@ -55,7 +55,7 @@ cli/
 │   │   ├── cli/         # defaults, feedback, fix, setup, upgrade
 │   │   ├── dashboard/   # list, view, create, add, edit, delete
 │   │   ├── event/       # view, list
-│   │   ├── issue/       # list, events, explain, plan, view, resolve, unresolve, merge
+│   │   ├── issue/       # list, events, explain, plan, view, resolve, unresolve, archive, merge
 │   │   ├── log/         # list, view
 │   │   ├── org/         # list, view
 │   │   ├── project/     # create, delete, list, view

--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -316,6 +316,7 @@ Manage Sentry issues
 - `sentry issue view <issue>` — View details of a specific issue
 - `sentry issue resolve <issue>` — Mark an issue as resolved
 - `sentry issue unresolve <issue>` — Reopen a resolved issue
+- `sentry issue archive <issue>` — Archive (ignore) an issue
 - `sentry issue merge <issue...>` — Merge 2+ issues into a single canonical group
 
 → Full flags and examples: `references/issue.md`

--- a/plugins/sentry-cli/skills/sentry-cli/references/issue.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/issue.md
@@ -210,6 +210,7 @@ Reopen a resolved issue
 Archive (ignore) an issue
 
 **Flags:**
+- `--until-escalating - Archive until the issue escalates (spikes in frequency)`
 - `--duration <value> - Ignore for this many minutes`
 - `--count <value> - Ignore until this many more events occur`
 - `--window <value> - Time window in minutes for --count (events must occur within this window)`

--- a/plugins/sentry-cli/skills/sentry-cli/references/issue.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/issue.md
@@ -205,6 +205,17 @@ sentry issue reopen CLI-G5   # alias
 
 Reopen a resolved issue
 
+### `sentry issue archive <issue>`
+
+Archive (ignore) an issue
+
+**Flags:**
+- `--duration <value> - Ignore for this many minutes`
+- `--count <value> - Ignore until this many more events occur`
+- `--window <value> - Time window in minutes for --count (events must occur within this window)`
+- `--users <value> - Ignore until this many more users are affected`
+- `--user-window <value> - Time window in minutes for --users (users must be affected within this window)`
+
 ### `sentry issue merge <issue...>`
 
 Merge 2+ issues into a single canonical group

--- a/src/commands/issue/archive.ts
+++ b/src/commands/issue/archive.ts
@@ -1,0 +1,126 @@
+/**
+ * sentry issue archive (aliased: ignore)
+ *
+ * Archive (ignore) an issue, suppressing alerts until an optional
+ * condition is met. This maps to the "ignored" status in the Sentry API.
+ */
+
+import type { SentryContext } from "../../context.js";
+import {
+  type IgnoreStatusDetails,
+  updateIssueStatus,
+} from "../../lib/api-client.js";
+import { buildCommand } from "../../lib/command.js";
+import { formatIssueDetails, muted } from "../../lib/formatters/index.js";
+import { CommandOutput } from "../../lib/formatters/output.js";
+import { logger } from "../../lib/logger.js";
+import type { SentryIssue } from "../../types/index.js";
+import { issueIdPositional, resolveIssue } from "./utils.js";
+
+const log = logger.withTag("issue.archive");
+
+const COMMAND = "archive";
+
+type ArchiveFlags = {
+  readonly json: boolean;
+  readonly fields?: string[];
+  readonly duration?: number;
+  readonly count?: number;
+  readonly window?: number;
+  readonly users?: number;
+  readonly "user-window"?: number;
+};
+
+function formatArchived(issue: SentryIssue): string {
+  return `${muted("Archived")}\n\n${formatIssueDetails(issue)}`;
+}
+
+export const archiveCommand = buildCommand({
+  docs: {
+    brief: "Archive (ignore) an issue",
+    fullDescription:
+      "Archive an issue, suppressing alerts until an optional condition is met.\n" +
+      "Without any duration/count flags, the issue is archived indefinitely.\n\n" +
+      "Examples:\n" +
+      "  sentry issue archive CLI-12Z\n" +
+      "  sentry issue archive CLI-12Z --duration 60\n" +
+      "  sentry issue archive CLI-12Z --count 100 --window 60\n" +
+      "  sentry issue archive CLI-12Z --users 10",
+  },
+  output: {
+    human: formatArchived,
+  },
+  parameters: {
+    positional: issueIdPositional,
+    flags: {
+      duration: {
+        kind: "parsed",
+        parse: Number,
+        brief: "Ignore for this many minutes",
+        optional: true,
+      },
+      count: {
+        kind: "parsed",
+        parse: Number,
+        brief: "Ignore until this many more events occur",
+        optional: true,
+      },
+      window: {
+        kind: "parsed",
+        parse: Number,
+        brief:
+          "Time window in minutes for --count (events must occur within this window)",
+        optional: true,
+      },
+      users: {
+        kind: "parsed",
+        parse: Number,
+        brief: "Ignore until this many more users are affected",
+        optional: true,
+      },
+      "user-window": {
+        kind: "parsed",
+        parse: Number,
+        brief:
+          "Time window in minutes for --users (users must be affected within this window)",
+        optional: true,
+      },
+    },
+  },
+  async *func(this: SentryContext, flags: ArchiveFlags, issueArg: string) {
+    const { cwd } = this;
+
+    const { org, issue } = await resolveIssue({
+      issueArg,
+      cwd,
+      command: COMMAND,
+    });
+
+    const statusDetails: IgnoreStatusDetails = {};
+    if (flags.duration !== undefined) {
+      statusDetails.ignoreDuration = flags.duration;
+    }
+    if (flags.count !== undefined) {
+      statusDetails.ignoreCount = flags.count;
+    }
+    if (flags.window !== undefined) {
+      statusDetails.ignoreWindow = flags.window;
+    }
+    if (flags.users !== undefined) {
+      statusDetails.ignoreUserCount = flags.users;
+    }
+    if (flags["user-window"] !== undefined) {
+      statusDetails.ignoreUserWindow = flags["user-window"];
+    }
+
+    const hasDetails = Object.keys(statusDetails).length > 0;
+
+    const updated = await updateIssueStatus(issue.id, "ignored", {
+      ...(hasDetails ? { statusDetails } : {}),
+      orgSlug: org,
+    });
+
+    log.debug(`Archived ${updated.shortId}`);
+    yield new CommandOutput<SentryIssue>(updated);
+  },
+});

--- a/src/commands/issue/archive.ts
+++ b/src/commands/issue/archive.ts
@@ -11,6 +11,7 @@ import {
   updateIssueStatus,
 } from "../../lib/api-client.js";
 import { buildCommand, numberParser } from "../../lib/command.js";
+import { ValidationError } from "../../lib/errors.js";
 import { formatIssueDetails, muted } from "../../lib/formatters/index.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import { logger } from "../../lib/logger.js";
@@ -89,6 +90,18 @@ export const archiveCommand = buildCommand({
   },
   async *func(this: SentryContext, flags: ArchiveFlags, issueArg: string) {
     const { cwd } = this;
+
+    // Validate dependent flag combinations
+    if (flags.window !== undefined && flags.count === undefined) {
+      throw new ValidationError(
+        "--window requires --count (time window is only meaningful with an event count threshold)"
+      );
+    }
+    if (flags["user-window"] !== undefined && flags.users === undefined) {
+      throw new ValidationError(
+        "--user-window requires --users (time window is only meaningful with a user count threshold)"
+      );
+    }
 
     const { org, issue } = await resolveIssue({
       issueArg,

--- a/src/commands/issue/archive.ts
+++ b/src/commands/issue/archive.ts
@@ -10,7 +10,7 @@ import {
   type IgnoreStatusDetails,
   updateIssueStatus,
 } from "../../lib/api-client.js";
-import { buildCommand } from "../../lib/command.js";
+import { buildCommand, numberParser } from "../../lib/command.js";
 import { formatIssueDetails, muted } from "../../lib/formatters/index.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import { logger } from "../../lib/logger.js";
@@ -55,32 +55,32 @@ export const archiveCommand = buildCommand({
     flags: {
       duration: {
         kind: "parsed",
-        parse: Number,
+        parse: numberParser,
         brief: "Ignore for this many minutes",
         optional: true,
       },
       count: {
         kind: "parsed",
-        parse: Number,
+        parse: numberParser,
         brief: "Ignore until this many more events occur",
         optional: true,
       },
       window: {
         kind: "parsed",
-        parse: Number,
+        parse: numberParser,
         brief:
           "Time window in minutes for --count (events must occur within this window)",
         optional: true,
       },
       users: {
         kind: "parsed",
-        parse: Number,
+        parse: numberParser,
         brief: "Ignore until this many more users are affected",
         optional: true,
       },
       "user-window": {
         kind: "parsed",
-        parse: Number,
+        parse: numberParser,
         brief:
           "Time window in minutes for --users (users must be affected within this window)",
         optional: true,

--- a/src/commands/issue/archive.ts
+++ b/src/commands/issue/archive.ts
@@ -10,15 +10,25 @@ import {
   type IgnoreStatusDetails,
   updateIssueStatus,
 } from "../../lib/api-client.js";
-import { buildCommand, numberParser } from "../../lib/command.js";
+import { buildCommand } from "../../lib/command.js";
 import { ValidationError } from "../../lib/errors.js";
 import { formatIssueDetails, muted } from "../../lib/formatters/index.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import { logger } from "../../lib/logger.js";
 import type { SentryIssue } from "../../types/index.js";
+import type { IssueSubstatus } from "../../types/sentry.js";
 import { issueIdPositional, resolveIssue } from "./utils.js";
 
 const log = logger.withTag("issue.archive");
+
+/** Parse a flag value as a positive integer (≥ 1). */
+function parsePositiveInt(raw: string): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new ValidationError(`expected a positive integer, got '${raw}'`);
+  }
+  return n;
+}
 
 const COMMAND = "archive";
 
@@ -39,7 +49,7 @@ function formatArchived(issue: SentryIssue): string {
 
 /** Validate flag dependencies and compute substatus + statusDetails. */
 function resolveArchiveOptions(flags: ArchiveFlags): {
-  substatus: string;
+  substatus: IssueSubstatus;
   statusDetails?: IgnoreStatusDetails;
 } {
   if (flags.window !== undefined && flags.count === undefined) {
@@ -121,32 +131,32 @@ export const archiveCommand = buildCommand({
       },
       duration: {
         kind: "parsed",
-        parse: numberParser,
+        parse: parsePositiveInt,
         brief: "Ignore for this many minutes",
         optional: true,
       },
       count: {
         kind: "parsed",
-        parse: numberParser,
+        parse: parsePositiveInt,
         brief: "Ignore until this many more events occur",
         optional: true,
       },
       window: {
         kind: "parsed",
-        parse: numberParser,
+        parse: parsePositiveInt,
         brief:
           "Time window in minutes for --count (events must occur within this window)",
         optional: true,
       },
       users: {
         kind: "parsed",
-        parse: numberParser,
+        parse: parsePositiveInt,
         brief: "Ignore until this many more users are affected",
         optional: true,
       },
       "user-window": {
         kind: "parsed",
-        parse: numberParser,
+        parse: parsePositiveInt,
         brief:
           "Time window in minutes for --users (users must be affected within this window)",
         optional: true,
@@ -163,7 +173,7 @@ export const archiveCommand = buildCommand({
     });
 
     const updated = await updateIssueStatus(issue.id, "ignored", {
-      ...(statusDetails ? { statusDetails } : {}),
+      statusDetails,
       substatus,
       orgSlug: org,
     });

--- a/src/commands/issue/archive.ts
+++ b/src/commands/issue/archive.ts
@@ -25,6 +25,7 @@ const COMMAND = "archive";
 type ArchiveFlags = {
   readonly json: boolean;
   readonly fields?: string[];
+  readonly "until-escalating"?: boolean;
   readonly duration?: number;
   readonly count?: number;
   readonly window?: number;
@@ -36,14 +37,72 @@ function formatArchived(issue: SentryIssue): string {
   return `${muted("Archived")}\n\n${formatIssueDetails(issue)}`;
 }
 
+/** Validate flag dependencies and compute substatus + statusDetails. */
+function resolveArchiveOptions(flags: ArchiveFlags): {
+  substatus: string;
+  statusDetails?: IgnoreStatusDetails;
+} {
+  if (flags.window !== undefined && flags.count === undefined) {
+    throw new ValidationError(
+      "--window requires --count (time window is only meaningful with an event count threshold)"
+    );
+  }
+  if (flags["user-window"] !== undefined && flags.users === undefined) {
+    throw new ValidationError(
+      "--user-window requires --users (time window is only meaningful with a user count threshold)"
+    );
+  }
+
+  const hasConditionFlags =
+    flags.duration !== undefined ||
+    flags.count !== undefined ||
+    flags.users !== undefined;
+
+  if (flags["until-escalating"] && hasConditionFlags) {
+    throw new ValidationError(
+      "--until-escalating cannot be combined with --duration, --count, or --users"
+    );
+  }
+
+  if (flags["until-escalating"]) {
+    return { substatus: "archived_until_escalating" };
+  }
+  if (!hasConditionFlags) {
+    return { substatus: "archived_forever" };
+  }
+
+  const details: IgnoreStatusDetails = {};
+  if (flags.duration !== undefined) {
+    details.ignoreDuration = flags.duration;
+  }
+  if (flags.count !== undefined) {
+    details.ignoreCount = flags.count;
+  }
+  if (flags.window !== undefined) {
+    details.ignoreWindow = flags.window;
+  }
+  if (flags.users !== undefined) {
+    details.ignoreUserCount = flags.users;
+  }
+  if (flags["user-window"] !== undefined) {
+    details.ignoreUserWindow = flags["user-window"];
+  }
+  return { substatus: "archived_until_condition_met", statusDetails: details };
+}
+
 export const archiveCommand = buildCommand({
   docs: {
     brief: "Archive (ignore) an issue",
     fullDescription:
-      "Archive an issue, suppressing alerts until an optional condition is met.\n" +
-      "Without any duration/count flags, the issue is archived indefinitely.\n\n" +
+      "Archive an issue, suppressing alerts until an optional condition is met.\n\n" +
+      "Archive modes:\n" +
+      "  (no flags)           Archive forever\n" +
+      "  --until-escalating   Archive until a spike in event frequency\n" +
+      "  --duration <mins>    Archive for a fixed time period\n" +
+      "  --count/--users      Archive until a threshold is reached\n\n" +
       "Examples:\n" +
       "  sentry issue archive CLI-12Z\n" +
+      "  sentry issue archive CLI-12Z --until-escalating\n" +
       "  sentry issue archive CLI-12Z --duration 60\n" +
       "  sentry issue archive CLI-12Z --count 100 --window 60\n" +
       "  sentry issue archive CLI-12Z --users 10",
@@ -54,6 +113,12 @@ export const archiveCommand = buildCommand({
   parameters: {
     positional: issueIdPositional,
     flags: {
+      "until-escalating": {
+        kind: "boolean",
+        brief: "Archive until the issue escalates (spikes in frequency)",
+        optional: true,
+        default: false,
+      },
       duration: {
         kind: "parsed",
         parse: numberParser,
@@ -89,47 +154,17 @@ export const archiveCommand = buildCommand({
     },
   },
   async *func(this: SentryContext, flags: ArchiveFlags, issueArg: string) {
-    const { cwd } = this;
-
-    // Validate dependent flag combinations
-    if (flags.window !== undefined && flags.count === undefined) {
-      throw new ValidationError(
-        "--window requires --count (time window is only meaningful with an event count threshold)"
-      );
-    }
-    if (flags["user-window"] !== undefined && flags.users === undefined) {
-      throw new ValidationError(
-        "--user-window requires --users (time window is only meaningful with a user count threshold)"
-      );
-    }
+    const { substatus, statusDetails } = resolveArchiveOptions(flags);
 
     const { org, issue } = await resolveIssue({
       issueArg,
-      cwd,
+      cwd: this.cwd,
       command: COMMAND,
     });
 
-    const statusDetails: IgnoreStatusDetails = {};
-    if (flags.duration !== undefined) {
-      statusDetails.ignoreDuration = flags.duration;
-    }
-    if (flags.count !== undefined) {
-      statusDetails.ignoreCount = flags.count;
-    }
-    if (flags.window !== undefined) {
-      statusDetails.ignoreWindow = flags.window;
-    }
-    if (flags.users !== undefined) {
-      statusDetails.ignoreUserCount = flags.users;
-    }
-    if (flags["user-window"] !== undefined) {
-      statusDetails.ignoreUserWindow = flags["user-window"];
-    }
-
-    const hasDetails = Object.keys(statusDetails).length > 0;
-
     const updated = await updateIssueStatus(issue.id, "ignored", {
-      ...(hasDetails ? { statusDetails } : {}),
+      ...(statusDetails ? { statusDetails } : {}),
+      substatus,
       orgSlug: org,
     });
 

--- a/src/commands/issue/index.ts
+++ b/src/commands/issue/index.ts
@@ -1,4 +1,5 @@
 import { buildRouteMap } from "../../lib/route-map.js";
+import { archiveCommand } from "./archive.js";
 import { eventsCommand } from "./events.js";
 import { explainCommand } from "./explain.js";
 import { listCommand } from "./list.js";
@@ -17,11 +18,11 @@ export const issueRoute = buildRouteMap({
     view: viewCommand,
     resolve: resolveCommand,
     unresolve: unresolveCommand,
+    archive: archiveCommand,
     merge: mergeCommand,
   },
-  // `reopen` is a friendlier synonym for `unresolve` — shipped as an alias
-  // so either command works identically.
-  aliases: { reopen: "unresolve" },
+  // `reopen` is a friendlier synonym for `unresolve`, `ignore` for `archive`.
+  aliases: { reopen: "unresolve", ignore: "archive" },
   defaultCommand: "view",
   docs: {
     brief: "Manage Sentry issues",
@@ -35,14 +36,16 @@ export const issueRoute = buildRouteMap({
       "  plan       Generate a solution plan using Seer AI\n" +
       "  resolve    Mark an issue as resolved (optionally in a release)\n" +
       "  unresolve  Reopen a resolved issue (alias: reopen)\n" +
+      "  archive    Archive/ignore an issue (alias: ignore)\n" +
       "  merge      Merge 2+ issues into a single group\n\n" +
-      "Magic selectors (available for view, events, explain, plan, resolve, unresolve):\n" +
+      "Magic selectors (available for view, events, explain, plan, resolve, unresolve, archive):\n" +
       "  @latest          Most recent unresolved issue\n" +
       "  @most_frequent   Issue with the highest event frequency\n\n" +
       "Examples:\n" +
       "  sentry issue view @latest\n" +
       "  sentry issue events CLI-G\n" +
       "  sentry issue resolve CLI-12Z --in 0.26.1\n" +
+      "  sentry issue archive CLI-AB --duration 60\n" +
       "  sentry issue merge CLI-K9 CLI-15H CLI-15N\n" +
       "  sentry issue explain @most_frequent\n" +
       "  sentry issue plan my-org/@latest\n\n" +

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -52,6 +52,7 @@ export {
   getIssueByShortId,
   getIssueInOrg,
   getSharedIssue,
+  type IgnoreStatusDetails,
   ISSUE_DETAIL_COLLAPSE,
   type IssueCollapseField,
   type IssueSort,

--- a/src/lib/api/issues.ts
+++ b/src/lib/api/issues.ts
@@ -535,18 +535,6 @@ export function parseResolveSpec(
 }
 
 /**
- * Update an issue's status.
- *
- * When `status === "resolved"`, optional `statusDetails` can pin the fix
- * to a release or commit (see {@link ResolveStatusDetails}). Without
- * `statusDetails`, the issue is resolved immediately with no regression
- * tracking — equivalent to clicking "Resolve" in the Sentry UI.
- *
- * When `options.orgSlug` is provided, the request is routed to that org's
- * region via the org-scoped endpoint. Without it, falls back to the legacy
- * global `/issues/{id}/` endpoint (works but not region-aware).
- */
-/**
  * Ignore/archive conditions for {@link updateIssueStatus}.
  *
  * - `ignoreDuration` — ignore for N minutes
@@ -561,6 +549,18 @@ export type IgnoreStatusDetails = {
   ignoreUserWindow?: number;
 };
 
+/**
+ * Update an issue's status.
+ *
+ * When `status === "resolved"`, optional `statusDetails` can pin the fix
+ * to a release or commit (see {@link ResolveStatusDetails}). Without
+ * `statusDetails`, the issue is resolved immediately with no regression
+ * tracking — equivalent to clicking "Resolve" in the Sentry UI.
+ *
+ * When `options.orgSlug` is provided, the request is routed to that org's
+ * region via the org-scoped endpoint. Without it, falls back to the legacy
+ * global `/issues/{id}/` endpoint (works but not region-aware).
+ */
 export async function updateIssueStatus(
   issueId: string,
   status: "resolved" | "unresolved" | "ignored",

--- a/src/lib/api/issues.ts
+++ b/src/lib/api/issues.ts
@@ -8,6 +8,7 @@ import type { ListAnOrganizationSissuesData } from "@sentry/api";
 import { listAnOrganization_sIssues } from "@sentry/api";
 
 import type { SentryIssue } from "../../types/index.js";
+import type { IssueSubstatus } from "../../types/sentry.js";
 
 import { applyCustomHeaders } from "../custom-headers.js";
 import { ApiError, ValidationError } from "../errors.js";
@@ -552,10 +553,11 @@ export type IgnoreStatusDetails = {
 /**
  * Update an issue's status.
  *
- * When `status === "resolved"`, optional `statusDetails` can pin the fix
- * to a release or commit (see {@link ResolveStatusDetails}). Without
- * `statusDetails`, the issue is resolved immediately with no regression
- * tracking — equivalent to clicking "Resolve" in the Sentry UI.
+ * - `"resolved"` — optional `statusDetails` can pin the fix to a release
+ *   or commit (see {@link ResolveStatusDetails}).
+ * - `"ignored"` — optional `substatus` controls archive granularity;
+ *   optional `statusDetails` sets conditions (see {@link IgnoreStatusDetails}).
+ * - `"unresolved"` — reopens the issue; no additional options needed.
  *
  * When `options.orgSlug` is provided, the request is routed to that org's
  * region via the org-scoped endpoint. Without it, falls back to the legacy
@@ -566,8 +568,8 @@ export async function updateIssueStatus(
   status: "resolved" | "unresolved" | "ignored",
   options?: {
     statusDetails?: ResolveStatusDetails | IgnoreStatusDetails;
-    /** Substatus for archive granularity: `archived_until_escalating`, `archived_until_condition_met`, `archived_forever`. */
-    substatus?: string;
+    /** Substatus for archive granularity. */
+    substatus?: IssueSubstatus;
     orgSlug?: string;
   }
 ): Promise<SentryIssue> {

--- a/src/lib/api/issues.ts
+++ b/src/lib/api/issues.ts
@@ -546,11 +546,26 @@ export function parseResolveSpec(
  * region via the org-scoped endpoint. Without it, falls back to the legacy
  * global `/issues/{id}/` endpoint (works but not region-aware).
  */
+/**
+ * Ignore/archive conditions for {@link updateIssueStatus}.
+ *
+ * - `ignoreDuration` — ignore for N minutes
+ * - `ignoreCount` / `ignoreWindow` — ignore until N events in M minutes
+ * - `ignoreUserCount` / `ignoreUserWindow` — ignore until N users in M minutes
+ */
+export type IgnoreStatusDetails = {
+  ignoreDuration?: number;
+  ignoreCount?: number;
+  ignoreWindow?: number;
+  ignoreUserCount?: number;
+  ignoreUserWindow?: number;
+};
+
 export async function updateIssueStatus(
   issueId: string,
   status: "resolved" | "unresolved" | "ignored",
   options?: {
-    statusDetails?: ResolveStatusDetails;
+    statusDetails?: ResolveStatusDetails | IgnoreStatusDetails;
     orgSlug?: string;
   }
 ): Promise<SentryIssue> {

--- a/src/lib/api/issues.ts
+++ b/src/lib/api/issues.ts
@@ -566,12 +566,17 @@ export async function updateIssueStatus(
   status: "resolved" | "unresolved" | "ignored",
   options?: {
     statusDetails?: ResolveStatusDetails | IgnoreStatusDetails;
+    /** Substatus for archive granularity: `archived_until_escalating`, `archived_until_condition_met`, `archived_forever`. */
+    substatus?: string;
     orgSlug?: string;
   }
 ): Promise<SentryIssue> {
   const body: Record<string, unknown> = { status };
   if (options?.statusDetails) {
     body.statusDetails = options.statusDetails;
+  }
+  if (options?.substatus) {
+    body.substatus = options.substatus;
   }
 
   if (options?.orgSlug) {

--- a/src/lib/complete.ts
+++ b/src/lib/complete.ts
@@ -95,6 +95,7 @@ export const ORG_PROJECT_COMMANDS = new Set([
   "issue plan",
   "issue resolve",
   "issue unresolve",
+  "issue archive",
   "issue merge",
   "project list",
   "project view",

--- a/test/commands/issue/archive.func.test.ts
+++ b/test/commands/issue/archive.func.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Issue Archive Command Tests
+ *
+ * Tests for `sentry issue archive` func() body — substatus selection,
+ * statusDetails construction, flag validation, and human output.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { archiveCommand } from "../../../src/commands/issue/archive.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as issueUtils from "../../../src/commands/issue/utils.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as apiClient from "../../../src/lib/api-client.js";
+import { ValidationError } from "../../../src/lib/errors.js";
+import type { SentryIssue } from "../../../src/types/sentry.js";
+
+function makeMockIssue(overrides?: Partial<SentryIssue>): SentryIssue {
+  return {
+    id: "123456789",
+    shortId: "CLI-G5",
+    title: "TypeError: boom",
+    culprit: "handler",
+    count: "10",
+    userCount: 3,
+    firstSeen: "2026-03-01T00:00:00Z",
+    lastSeen: "2026-04-03T12:00:00Z",
+    level: "error",
+    status: "ignored",
+    permalink: "https://sentry.io/organizations/test-org/issues/123456789/",
+    project: { id: "456", slug: "test-project", name: "Test Project" },
+    ...overrides,
+  } as SentryIssue;
+}
+
+function createMockContext() {
+  const stdoutWrite = mock(() => true);
+  return {
+    context: {
+      stdout: { write: stdoutWrite },
+      stderr: { write: mock(() => true) },
+      cwd: "/tmp",
+    },
+    stdoutWrite,
+  };
+}
+
+describe("archiveCommand.func()", () => {
+  let resolveIssueSpy: ReturnType<typeof spyOn>;
+  let updateSpy: ReturnType<typeof spyOn>;
+  let func: Awaited<ReturnType<typeof archiveCommand.loader>>;
+
+  beforeEach(async () => {
+    resolveIssueSpy = spyOn(issueUtils, "resolveIssue");
+    updateSpy = spyOn(apiClient, "updateIssueStatus");
+    func = await archiveCommand.loader();
+  });
+
+  afterEach(() => {
+    resolveIssueSpy.mockRestore();
+    updateSpy.mockRestore();
+  });
+
+  test("archives forever when no flags provided", async () => {
+    resolveIssueSpy.mockResolvedValue({
+      org: "test-org",
+      issue: makeMockIssue({ status: "unresolved" }),
+    });
+    updateSpy.mockResolvedValue(makeMockIssue());
+
+    const { context } = createMockContext();
+    await func.call(context, { json: false }, "CLI-G5");
+
+    expect(updateSpy).toHaveBeenCalledWith("123456789", "ignored", {
+      substatus: "archived_forever",
+      orgSlug: "test-org",
+    });
+  });
+
+  test("archives until escalating with --until-escalating", async () => {
+    resolveIssueSpy.mockResolvedValue({
+      org: "test-org",
+      issue: makeMockIssue(),
+    });
+    updateSpy.mockResolvedValue(makeMockIssue());
+
+    const { context } = createMockContext();
+    await func.call(
+      context,
+      { json: false, "until-escalating": true },
+      "CLI-G5"
+    );
+
+    expect(updateSpy).toHaveBeenCalledWith("123456789", "ignored", {
+      substatus: "archived_until_escalating",
+      orgSlug: "test-org",
+    });
+  });
+
+  test("archives with --duration sends ignoreDuration + condition substatus", async () => {
+    resolveIssueSpy.mockResolvedValue({
+      org: "test-org",
+      issue: makeMockIssue(),
+    });
+    updateSpy.mockResolvedValue(makeMockIssue());
+
+    const { context } = createMockContext();
+    await func.call(context, { json: false, duration: 60 }, "CLI-G5");
+
+    expect(updateSpy).toHaveBeenCalledWith("123456789", "ignored", {
+      statusDetails: { ignoreDuration: 60 },
+      substatus: "archived_until_condition_met",
+      orgSlug: "test-org",
+    });
+  });
+
+  test("archives with --count and --window sends both fields", async () => {
+    resolveIssueSpy.mockResolvedValue({
+      org: "test-org",
+      issue: makeMockIssue(),
+    });
+    updateSpy.mockResolvedValue(makeMockIssue());
+
+    const { context } = createMockContext();
+    await func.call(context, { json: false, count: 100, window: 60 }, "CLI-G5");
+
+    expect(updateSpy).toHaveBeenCalledWith("123456789", "ignored", {
+      statusDetails: { ignoreCount: 100, ignoreWindow: 60 },
+      substatus: "archived_until_condition_met",
+      orgSlug: "test-org",
+    });
+  });
+
+  test("archives with --users and --user-window sends both fields", async () => {
+    resolveIssueSpy.mockResolvedValue({
+      org: "test-org",
+      issue: makeMockIssue(),
+    });
+    updateSpy.mockResolvedValue(makeMockIssue());
+
+    const { context } = createMockContext();
+    await func.call(
+      context,
+      { json: false, users: 10, "user-window": 120 },
+      "CLI-G5"
+    );
+
+    expect(updateSpy).toHaveBeenCalledWith("123456789", "ignored", {
+      statusDetails: { ignoreUserCount: 10, ignoreUserWindow: 120 },
+      substatus: "archived_until_condition_met",
+      orgSlug: "test-org",
+    });
+  });
+
+  test("--count alone without --window sends only ignoreCount", async () => {
+    resolveIssueSpy.mockResolvedValue({
+      org: "test-org",
+      issue: makeMockIssue(),
+    });
+    updateSpy.mockResolvedValue(makeMockIssue());
+
+    const { context } = createMockContext();
+    await func.call(context, { json: false, count: 50 }, "CLI-G5");
+
+    expect(updateSpy).toHaveBeenCalledWith("123456789", "ignored", {
+      statusDetails: { ignoreCount: 50 },
+      substatus: "archived_until_condition_met",
+      orgSlug: "test-org",
+    });
+  });
+
+  test("human output includes 'Archived' label", async () => {
+    resolveIssueSpy.mockResolvedValue({
+      org: "test-org",
+      issue: makeMockIssue(),
+    });
+    updateSpy.mockResolvedValue(makeMockIssue());
+
+    const { context, stdoutWrite } = createMockContext();
+    await func.call(context, { json: false }, "CLI-G5");
+
+    const output = stdoutWrite.mock.calls.map((c) => c[0]).join("");
+    expect(output).toContain("Archived");
+    expect(output).toContain("CLI-G5");
+  });
+});
+
+describe("archiveCommand.func() — validation", () => {
+  let func: Awaited<ReturnType<typeof archiveCommand.loader>>;
+
+  beforeEach(async () => {
+    func = await archiveCommand.loader();
+  });
+
+  test("--window without --count throws ValidationError", async () => {
+    const { context } = createMockContext();
+    await expect(
+      func.call(context, { json: false, window: 60 }, "CLI-G5")
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  test("--user-window without --users throws ValidationError", async () => {
+    const { context } = createMockContext();
+    await expect(
+      func.call(context, { json: false, "user-window": 120 }, "CLI-G5")
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  test("--until-escalating with --duration throws ValidationError", async () => {
+    const { context } = createMockContext();
+    await expect(
+      func.call(
+        context,
+        { json: false, "until-escalating": true, duration: 60 },
+        "CLI-G5"
+      )
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  test("--until-escalating with --count throws ValidationError", async () => {
+    const { context } = createMockContext();
+    await expect(
+      func.call(
+        context,
+        { json: false, "until-escalating": true, count: 100 },
+        "CLI-G5"
+      )
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  test("--until-escalating with --users throws ValidationError", async () => {
+    const { context } = createMockContext();
+    await expect(
+      func.call(
+        context,
+        { json: false, "until-escalating": true, users: 10 },
+        "CLI-G5"
+      )
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `sentry issue archive` command (alias: `sentry issue ignore`) for archiving/ignoring issues. Ref #600.

### New command: `sentry issue archive`

Archives an issue with three modes, matching the Sentry UI's archive options:

| Mode | Flag | API substatus |
|------|------|---------------|
| Archive forever | *(no flags)* | `archived_forever` |
| Archive until escalating | `--until-escalating` | `archived_until_escalating` |
| Archive until condition | `--duration`, `--count`, `--users` | `archived_until_condition_met` |

**Condition flags:**
- `--duration <mins>` — Ignore for N minutes
- `--count <n>` / `--window <mins>` — Ignore until N events (optionally within M minutes)
- `--users <n>` / `--user-window <mins>` — Ignore until N users affected (optionally within M minutes)

**Validation:**
- `--window` requires `--count`, `--user-window` requires `--users`
- `--until-escalating` is mutually exclusive with condition flags

### Implementation details

- `updateIssueStatus()` now accepts `substatus` parameter for archive granularity
- `IgnoreStatusDetails` type added for condition parameters
- `resolveArchiveOptions()` helper extracted to keep `func()` under Biome's complexity cap

### Tests

12 tests covering:
- All three archive modes (forever, until-escalating, until-condition)
- All condition flag combinations (duration, count+window, users+user-window, count alone)
- Human output format
- All validation errors (window without count, user-window without users, until-escalating + conditions)
