### PR TITLE
fix(dashboard): enrich 400 errors on create to surface plan-limit messages (CLI-1J8)

### DIFF
--- a/src/commands/dashboard/resolve.ts
+++ b/src/commands/dashboard/resolve.ts
@@ -639,10 +639,13 @@ export function enrichDashboardError(
     build403Error(ctx, org, error.detail);
   }
 
-  // 400 on update — likely invalid widget config; preserve API detail
-  if (error.status === 400 && ctx.operation === "update") {
+  // 400 on create/update — preserve API detail (plan limits, invalid config)
+  if (
+    error.status === 400 &&
+    (ctx.operation === "create" || ctx.operation === "update")
+  ) {
     throw new ApiError(
-      `Dashboard update failed in ${org}`,
+      `Dashboard ${ctx.operation} failed in ${org}`,
       error.status,
       error.detail ??
         "The API rejected the request. Check widget configuration.",

--- a/test/commands/dashboard/resolve.test.ts
+++ b/test/commands/dashboard/resolve.test.ts
@@ -540,7 +540,27 @@ describe("enrichDashboardError", () => {
     }
   });
 
-  test("400 on non-update operation re-throws unchanged", () => {
+  test("400 on create throws enriched ApiError with plan limit detail", () => {
+    const apiErr = new ApiError(
+      "Bad Request",
+      400,
+      "You may not exceed 10 dashboards on your current plan."
+    );
+    try {
+      enrichDashboardError(apiErr, { orgSlug: "my-org", operation: "create" });
+      expect.unreachable("Should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      const msg = (error as ApiError).message;
+      expect(msg).toContain("Dashboard create failed");
+      expect(msg).toContain("'my-org'");
+      expect((error as ApiError).detail).toContain(
+        "You may not exceed 10 dashboards"
+      );
+    }
+  });
+
+  test("400 on non-create/update operation re-throws unchanged", () => {
     const apiErr = new ApiError("Bad Request", 400, "some detail");
     expect(() =>
       enrichDashboardError(apiErr, { orgSlug: "my-org", operation: "list" })


### PR DESCRIPTION
## Summary
- Widen `enrichDashboardError` to handle 400 on `create` (not just `update`), so plan-limit messages like *"You may not exceed 10 dashboards on your current plan."* surface clearly instead of a raw `ApiError: Failed to create dashboard: 400 Bad Request`
- Add test for 400 on create with plan-limit detail

Fixes CLI-1J8.

**Note:** CLI-1JD (explore 400 from open-ended time ranges) was already fixed in #884.