### PR TITLE
fix(time-range): use UTC date methods for 90-day backfill calculation

### DIFF
--- a/src/lib/time-range.ts
+++ b/src/lib/time-range.ts
@@ -363,7 +363,7 @@ export function timeRangeToApiParams(range: TimeRange): TimeRangeApiParams {
     params.end = new Date().toISOString();
   } else if (params.end && !params.start) {
     const endDate = new Date(params.end);
-    endDate.setDate(endDate.getDate() - 90);
+    endDate.setUTCDate(endDate.getUTCDate() - 90);
     params.start = endDate.toISOString();
   }
   return params;

--- a/test/lib/time-range.test.ts
+++ b/test/lib/time-range.test.ts
@@ -297,7 +297,7 @@ describe("timeRangeToApiParams", () => {
     expect(params.start).toBeDefined();
     const startDate = new Date(params.start!);
     const expectedStart = new Date("2024-02-01T23:59:59Z");
-    expectedStart.setDate(expectedStart.getDate() - 90);
+    expectedStart.setUTCDate(expectedStart.getUTCDate() - 90);
     expect(startDate.toISOString()).toBe(expectedStart.toISOString());
   });
 });


### PR DESCRIPTION
## Summary

- Use `getUTCDate()`/`setUTCDate()` instead of `getDate()`/`setDate()` for the 90-day date backfill in `timeRangeToApiParams()`
- The input is a UTC ISO 8601 string, so date arithmetic should use UTC methods to avoid off-by-one-day errors in non-UTC timezones

Flagged by Cursor Bugbot on #892 ([comment](https://github.com/getsentry/cli/pull/892#discussion_r3170693274)).