### PR TITLE
fix(test): prevent detect-agent property test flake

### DIFF
--- a/test/lib/detect-agent.property.test.ts
+++ b/test/lib/detect-agent.property.test.ts
@@ -20,13 +20,35 @@ import { DEFAULT_NUM_RUNS } from "../model-based/helpers.js";
 /** Characters valid in agent names (lowercase alphanum + hyphens). */
 const agentNameChars = "abcdefghijklmnopqrstuvwxyz0123456789-";
 
-/** Generate valid-looking agent names (lowercase, no leading/trailing dash). */
+/**
+ * Values treated as boolean-ish garbage by normalizeAgent.
+ * Excluded from the agent name arbitrary to prevent false failures
+ * in compound tests where version/role extraction is asserted.
+ */
+const GARBAGE_NAMES = new Set([
+  "0",
+  "1",
+  "true",
+  "false",
+  "yes",
+  "no",
+  "on",
+  "off",
+]);
+
+/** Generate valid-looking agent names (lowercase, no leading/trailing dash, not garbage). */
 const agentNameArb = array(constantFrom(...agentNameChars.split("")), {
   minLength: 2,
   maxLength: 20,
 })
   .map((chars) => chars.join(""))
-  .filter((s) => /^[a-z]/.test(s) && !s.endsWith("-") && !s.includes("--"));
+  .filter(
+    (s) =>
+      /^[a-z]/.test(s) &&
+      !s.endsWith("-") &&
+      !s.includes("--") &&
+      !GARBAGE_NAMES.has(s)
+  );
 
 /** Generate semver-ish version strings. */
 const versionArb = tuple(


### PR DESCRIPTION
## Summary

- Excludes boolean-ish garbage names (`no`, `on`, `off`, `yes`, `true`, `false`, `0`, `1`) from `agentNameArb` in `detect-agent.property.test.ts`

## Problem

Follow-up to #896. The `agentNameArb` arbitrary could randomly generate short strings like `"no"` or `"on"` that match `FALSY_GARBAGE_RE` / `TRUTHY_GARBAGE_RE`. When these appeared in compound property tests (e.g. `"no/1.2.3/agent"`), `normalizeAgent` would short-circuit without extracting version/role, causing the unconditional `expect(result!.version).toBe(version)` assertion to fail.

Caught by [Cursor BugBot](https://github.com/getsentry/cli/pull/896#discussion_r3170767059).