### PR TITLE
feat(auth): Add bundled dev OAuth client ID

### DIFF
--- a/.cursor/rules/bun-cli.mdc
+++ b/.cursor/rules/bun-cli.mdc
@@ -138,8 +138,11 @@ await Bun.build({
   },
   define: {
     CLI_VERSION: JSON.stringify(version),
-    // Inject secrets at build time for npm distribution
-    SENTRY_CLIENT_ID_BUILD: JSON.stringify(process.env.SENTRY_CLIENT_ID ?? ""),
+    // Inject the production OAuth client ID at build time. Local builds
+    // may fall back to the repo's committed development client ID.
+    SENTRY_CLIENT_ID_BUILD: JSON.stringify(
+      process.env.SENTRY_CLIENT_ID ?? DEVELOPMENT_SENTRY_CLIENT_ID
+    ),
   },
   sourcemap: "external",
 });
@@ -151,19 +154,24 @@ For values that need to be baked into the binary (like OAuth client IDs):
 
 1. Read from env in build script: `process.env.SENTRY_CLIENT_ID`
 2. Inject via `define`: `SENTRY_CLIENT_ID_BUILD: JSON.stringify(value)`
-3. Use in code with runtime override support:
+3. Use in code with runtime override support and the committed development fallback:
 
 ```typescript
 // Declare the build-time constant
 declare const SENTRY_CLIENT_ID_BUILD: string | undefined;
 
-// Allow runtime override (for self-hosted), fall back to build-time value
+const DEVELOPMENT_SENTRY_CLIENT_ID = "...";
+
+// Allow runtime override (for self-hosted), fall back to build-time value,
+// then use the development client ID for local unbundled runs.
 const CLIENT_ID =
   process.env.SENTRY_CLIENT_ID ??
-  (typeof SENTRY_CLIENT_ID_BUILD !== "undefined" ? SENTRY_CLIENT_ID_BUILD : "");
+  (typeof SENTRY_CLIENT_ID_BUILD !== "undefined" && SENTRY_CLIENT_ID_BUILD
+    ? SENTRY_CLIENT_ID_BUILD
+    : DEVELOPMENT_SENTRY_CLIENT_ID);
 ```
 
-**Build command with secrets:**
+**Release build command with production value:**
 ```bash
 SENTRY_CLIENT_ID=xxx bun run build:all
 ```

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Copy this to .env.local and fill in your values
-SENTRY_CLIENT_ID=your-sentry-oauth-client-id
+# Optional: override the bundled development OAuth client ID
+# SENTRY_CLIENT_ID=your-sentry-oauth-client-id
 # SENTRY_URL=https://sentry.io  # Uncomment for self-hosted
 
 # Test credentials (for running E2E tests)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,7 +3,6 @@
 ## Prerequisites
 
 - [Bun](https://bun.sh/) installed
-- A Sentry OAuth application (create one at https://sentry.io/settings/account/api/applications/)
 
 ## Setup
 
@@ -13,20 +12,20 @@
 bun install
 ```
 
-2. Create a `.env.local` file in the project root:
+2. Optional: create a `.env.local` file in the project root to override the bundled development OAuth client ID:
 
 ```
 SENTRY_CLIENT_ID=your-sentry-oauth-client-id
 ```
 
-Get the client ID from your Sentry OAuth application settings.
+Get the client ID from your Sentry OAuth application settings if you need a custom app or self-hosted instance.
 
 **Note:** No client secret is needed - the CLI uses OAuth 2.0 Device Authorization Grant (RFC 8628) which is designed for public clients.
 
 ## Running Locally
 
 ```bash
-bun run --env-file=.env.local src/bin.ts auth login
+bun run dev auth login
 ```
 
 ## Testing the Device Flow
@@ -34,7 +33,7 @@ bun run --env-file=.env.local src/bin.ts auth login
 1. Run the CLI login command:
 
 ```bash
-bun run --env-file=.env.local src/bin.ts auth login
+bun run dev auth login
 ```
 
 2. You'll see output like:
@@ -55,7 +54,7 @@ Waiting for authorization...
 
 ## Sentry OAuth App Configuration
 
-When creating your Sentry OAuth application:
+You only need to create a Sentry OAuth application when overriding the bundled development client ID or testing against self-hosted Sentry. When creating your OAuth application:
 
 - **Redirect URI**: Not required for device flow
 - **Scopes**: The CLI requests these scopes:
@@ -78,7 +77,7 @@ The table below lists the most common development variables. For the complete re
 | `SENTRY_FORCE_ENV_TOKEN` | Force env token to take priority over stored OAuth token | — |
 | `SENTRY_HOST` | Sentry instance URL (for self-hosted, takes precedence) | `https://sentry.io` |
 | `SENTRY_URL` | Alias for `SENTRY_HOST` | `https://sentry.io` |
-| `SENTRY_CLIENT_ID` | Sentry OAuth app client ID | (required for build) |
+| `SENTRY_CLIENT_ID` | Sentry OAuth app client ID | bundled development client ID |
 | `SENTRY_CONFIG_DIR` | Override credentials/cache directory | `~/.sentry/` |
 | `SENTRY_LOG_LEVEL` | Diagnostic log level (`error`, `warn`, `log`, `info`, `debug`, `trace`) | `info` |
 | `SENTRY_CLI_NO_TELEMETRY` | Disable CLI telemetry (error tracking) | — |

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ bun install
 # Run CLI in development mode
 bun run dev --help
 
-# With environment variables
+# With optional environment overrides
 bun run --env-file=.env.local src/bin.ts --help
 ```
 

--- a/script/build.ts
+++ b/script/build.ts
@@ -40,6 +40,7 @@ import { $ } from "bun";
 import { build as esbuild } from "esbuild";
 import pkg from "../package.json";
 import { uploadSourcemaps } from "../src/lib/api/sourcemaps.js";
+import { DEVELOPMENT_SENTRY_CLIENT_ID } from "../src/lib/constants.js";
 import { injectDebugId, PLACEHOLDER_DEBUG_ID } from "./debug-id.js";
 import { textImportPlugin } from "./text-import-plugin.js";
 
@@ -48,7 +49,8 @@ const gzipAsync = promisify(gzip);
 const VERSION = pkg.version;
 
 /** Build-time constants injected into the binary */
-const SENTRY_CLIENT_ID = process.env.SENTRY_CLIENT_ID ?? "";
+const explicitSentryClientId = process.env.SENTRY_CLIENT_ID?.trim() ?? "";
+const SENTRY_CLIENT_ID = explicitSentryClientId || DEVELOPMENT_SENTRY_CLIENT_ID;
 
 /** Build targets configuration */
 type BuildTarget = {
@@ -388,6 +390,26 @@ function parseTarget(targetStr: string): BuildTarget | null {
   return target ?? null;
 }
 
+function ensureSentryClientIdConfigured(): void {
+  if (explicitSentryClientId) {
+    return;
+  }
+
+  if (process.env.RELEASE_BUILD) {
+    console.error(
+      "\nError: SENTRY_CLIENT_ID environment variable is required for release builds."
+    );
+    console.error(
+      "   The CLI requires an explicit production OAuth client ID."
+    );
+    console.error("   Set it via: SENTRY_CLIENT_ID=xxx bun run build\n");
+    process.exit(1);
+  }
+
+  console.log("\nUsing bundled development SENTRY_CLIENT_ID");
+  console.log("Set SENTRY_CLIENT_ID to override it for production builds.");
+}
+
 /** Main build function */
 async function build(): Promise<void> {
   const args = process.argv.slice(2);
@@ -398,14 +420,7 @@ async function build(): Promise<void> {
   console.log(`\nSentry CLI Build v${VERSION}`);
   console.log("=".repeat(40));
 
-  if (!SENTRY_CLIENT_ID) {
-    console.error(
-      "\nError: SENTRY_CLIENT_ID environment variable is required."
-    );
-    console.error("   The CLI requires OAuth to function.");
-    console.error("   Set it via: SENTRY_CLIENT_ID=xxx bun run build\n");
-    process.exit(1);
-  }
+  ensureSentryClientIdConfigured();
 
   // Determine targets
   let targets: BuildTarget[];

--- a/script/bundle.ts
+++ b/script/bundle.ts
@@ -7,14 +7,16 @@ import { injectDebugId, PLACEHOLDER_DEBUG_ID } from "./debug-id.js";
 import { textImportPlugin } from "./text-import-plugin.js";
 
 const VERSION = pkg.version;
-const SENTRY_CLIENT_ID = process.env.SENTRY_CLIENT_ID ?? "";
+const SENTRY_CLIENT_ID = process.env.SENTRY_CLIENT_ID?.trim() ?? "";
 
 console.log(`\nBundling sentry v${VERSION} for npm`);
 console.log("=".repeat(40));
 
 if (!SENTRY_CLIENT_ID) {
   console.error("\nError: SENTRY_CLIENT_ID environment variable is required.");
-  console.error("   The CLI requires OAuth to function.");
+  console.error(
+    "   The npm bundle must inject an explicit production OAuth client ID."
+  );
   console.error("   Set it via: SENTRY_CLIENT_ID=xxx bun run bundle\n");
   process.exit(1);
 }

--- a/script/generate-docs-sections.ts
+++ b/script/generate-docs-sections.ts
@@ -338,7 +338,7 @@ function generateDevEnvVarsTable(): string {
     const desc = entry.devGuide ?? "";
     let defaultCol = "—";
     if (entry.name === "SENTRY_CLIENT_ID") {
-      defaultCol = "(required for build)";
+      defaultCol = "bundled development client ID";
     } else if (entry.defaultValue) {
       defaultCol = `\`${entry.defaultValue}\``;
     }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -25,6 +25,17 @@ export const DEFAULT_SENTRY_HOST = "sentry.io";
 export const DEFAULT_SENTRY_URL = `https://${DEFAULT_SENTRY_HOST}`;
 
 /**
+ * Public OAuth client ID for local development against sentry.io.
+ *
+ * OAuth device flow uses a public client and does not require a client secret,
+ * so this is safe to commit. Release and npm packaging still inject
+ * SENTRY_CLIENT_ID_BUILD from SENTRY_CLIENT_ID so production distributions can
+ * use a distinct OAuth application without changing runtime code.
+ */
+export const DEVELOPMENT_SENTRY_CLIENT_ID =
+  "4eeddcc5aded79ea085a30198d647ff053d7716e9b51a343d8b8d6000f474391";
+
+/**
  * Name of the JavaScript package directory — used as both a skip target
  * when walking project trees (DSN scanner, sourcemap discovery, init
  * wizard) and as a path segment when detecting how the CLI itself was

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -11,7 +11,11 @@ import {
   TokenErrorResponseSchema,
   TokenResponseSchema,
 } from "../types/index.js";
-import { DEFAULT_SENTRY_URL, getConfiguredSentryUrl } from "./constants.js";
+import {
+  DEFAULT_SENTRY_URL,
+  DEVELOPMENT_SENTRY_CLIENT_ID,
+  getConfiguredSentryUrl,
+} from "./constants.js";
 import {
   buildTlsErrorDetail,
   getCustomTlsOptions,
@@ -48,6 +52,7 @@ function getSentryUrl(): string {
  *
  * Build-time: Injected via esbuild define: { SENTRY_CLIENT_ID_BUILD: "..." }
  * Runtime: Can be overridden via SENTRY_CLIENT_ID env var (for self-hosted)
+ * Development: Falls back to a committed public client ID for sentry.io
  *
  * Read at call time (not module load time) so tests can override SENTRY_CLIENT_ID
  * after module initialization.
@@ -56,12 +61,19 @@ function getSentryUrl(): string {
  */
 declare const SENTRY_CLIENT_ID_BUILD: string | undefined;
 function getClientId(): string {
-  return (
-    getEnv().SENTRY_CLIENT_ID ??
-    (typeof SENTRY_CLIENT_ID_BUILD !== "undefined"
-      ? SENTRY_CLIENT_ID_BUILD
-      : "")
-  );
+  const envClientId = getEnv().SENTRY_CLIENT_ID?.trim();
+  if (envClientId) {
+    return envClientId;
+  }
+
+  if (typeof SENTRY_CLIENT_ID_BUILD !== "undefined") {
+    const buildClientId = SENTRY_CLIENT_ID_BUILD.trim();
+    if (buildClientId) {
+      return buildClientId;
+    }
+  }
+
+  return DEVELOPMENT_SENTRY_CLIENT_ID;
 }
 
 /** OAuth scopes requested by the CLI. Exported for doc generation. */

--- a/test/lib/security/refresh-token-poison.test.ts
+++ b/test/lib/security/refresh-token-poison.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { DEVELOPMENT_SENTRY_CLIENT_ID } from "../../../src/lib/constants.js";
 import {
   captureEnvTokenHost,
   resetEnvTokenHostForTesting,
@@ -42,6 +43,58 @@ describe("CVE defense-in-depth: refresh token", () => {
   afterEach(() => {
     resetEnvTokenHostForTesting();
     globalThis.fetch = originalFetch;
+  });
+
+  test("refreshAccessToken uses bundled development client ID when env is unset", async () => {
+    delete process.env.SENTRY_CLIENT_ID;
+    let capturedClientId: string | null = null;
+
+    globalThis.fetch = (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit
+    ) => {
+      const body = init?.body;
+      expect(body).toBeInstanceOf(URLSearchParams);
+      capturedClientId = (body as URLSearchParams).get("client_id");
+      return new Response(
+        JSON.stringify({
+          access_token: "refreshed-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }) as typeof fetch;
+
+    await refreshAccessToken("fake-refresh-token");
+
+    expect(capturedClientId).toBe(DEVELOPMENT_SENTRY_CLIENT_ID);
+  });
+
+  test("refreshAccessToken prefers SENTRY_CLIENT_ID over bundled development client ID", async () => {
+    process.env.SENTRY_CLIENT_ID = "custom-client-id";
+    let capturedClientId: string | null = null;
+
+    globalThis.fetch = (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit
+    ) => {
+      const body = init?.body;
+      expect(body).toBeInstanceOf(URLSearchParams);
+      capturedClientId = (body as URLSearchParams).get("client_id");
+      return new Response(
+        JSON.stringify({
+          access_token: "refreshed-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }) as typeof fetch;
+
+    await refreshAccessToken("fake-refresh-token");
+
+    expect(capturedClientId).toBe("custom-client-id");
   });
 
   test("refreshAccessToken throws before fetch when env.SENTRY_URL is poisoned after boot", async () => {


### PR DESCRIPTION
Bundle the public development OAuth client ID currently used in local env as the final fallback for OAuth flows. Local development and non-release binary builds no longer need a `.env.local` file just to authenticate against sentry.io, while runtime `SENTRY_CLIENT_ID` and build-time `SENTRY_CLIENT_ID_BUILD` still take precedence for self-hosted and production use.

**Packaging Guardrails**

Release binary builds and the npm bundle still require an explicit `SENTRY_CLIENT_ID`, so production distributions cannot accidentally ship the development OAuth app.

Validated locally with `bun test --timeout 15000 --isolate test/lib/security/refresh-token-poison.test.ts`, `bun run lint`, and `bun run typecheck`.