### PR TITLE
feat: update @sentry/api to 0.133.0 and adopt pagination improvements

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@biomejs/biome": "2.3.8",
         "@clack/prompts": "^0.11.0",
         "@mastra/client-js": "^1.4.0",
-        "@sentry/api": "^0.113.0",
+        "@sentry/api": "^0.133.0",
         "@sentry/node-core": "10.50.0",
         "@sentry/sqlish": "^1.0.0",
         "@stricli/auto-complete": "^1.2.4",
@@ -175,7 +175,7 @@
 
     "@peggyjs/from-mem": ["@peggyjs/from-mem@3.1.3", "", { "dependencies": { "semver": "7.7.4" } }, "sha512-LLlgtfXIaeYXoOYovOI0spLM8ZXaqkAlmcRRrLzHJzLMqkU6Sw0R4KMoCoHx1PjaP815pSCBlS+BN6aD8t1Jgg=="],
 
-    "@sentry/api": ["@sentry/api@0.113.0", "", {}, "sha512-28W0Oykb/O+6kH8F+OEd8070N4z7ctawlyUtEvnNZNlaLviDC9Is1X/0JiK2Xb9y2ZNbkWf+/H1y5hXr0WTIOw=="],
+    "@sentry/api": ["@sentry/api@0.133.0", "", {}, "sha512-flfRUm9T9xgyNEWQqCiNv8wX4QlqOt63tM8dRMbeo26zD4+xEaL4KiaEnPC/W5rXCKg/03FBJysw7rEIuhiedQ=="],
 
     "@sentry/core": ["@sentry/core@10.50.0", "", {}, "sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg=="],
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@biomejs/biome": "2.3.8",
     "@clack/prompts": "^0.11.0",
     "@mastra/client-js": "^1.4.0",
-    "@sentry/api": "^0.113.0",
+    "@sentry/api": "^0.133.0",
     "@sentry/node-core": "10.50.0",
     "@sentry/sqlish": "^1.0.0",
     "@stricli/auto-complete": "^1.2.4",

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -237,9 +237,7 @@ export async function listIssueEvents(
     });
 
     const paginated = unwrapPaginatedResult(
-      result as
-        | { data: IssueEvent[]; error: undefined }
-        | { data: undefined; error: unknown },
+      result,
       "Failed to list issue events"
     );
 

--- a/src/lib/api/infrastructure.ts
+++ b/src/lib/api/infrastructure.ts
@@ -15,6 +15,7 @@ import { extractRequiredScopes } from "../api-scope.js";
 import { getActiveEnvVarName, isEnvTokenActive } from "../db/auth.js";
 import { getEnv } from "../env.js";
 import { ApiError, AuthError, stringifyUnknown } from "../errors.js";
+import { logger } from "../logger.js";
 import { resolveOrgRegion } from "../region.js";
 import {
   getApiBaseUrl,
@@ -327,7 +328,11 @@ export async function autoPaginate<T>(
     cursor = result.nextCursor;
   }
 
-  // Safety limit reached — return what we have, no nextCursor
+  // Safety limit reached — warn and return what we have, no nextCursor
+  logger.warn(
+    `Pagination limit reached (${MAX_PAGINATION_PAGES} pages, ${allRows.length} items). ` +
+      "Results may be incomplete."
+  );
   return { data: allRows.slice(0, limit) };
 }
 

--- a/src/lib/api/infrastructure.ts
+++ b/src/lib/api/infrastructure.ts
@@ -188,8 +188,17 @@ export function unwrapPaginatedResult<T>(
 ): PaginatedResponse<T> {
   const response = (result as { response?: Response }).response;
   const data = unwrapResult(result, context);
-  const { nextCursor } = parseLinkHeader(response?.headers.get("link") ?? null);
-  return { data, nextCursor };
+  const { nextCursor, prevCursor } = parseLinkHeader(
+    response?.headers.get("link") ?? null
+  );
+  const out: PaginatedResponse<T> = { data };
+  if (nextCursor !== undefined) {
+    out.nextCursor = nextCursor;
+  }
+  if (prevCursor !== undefined) {
+    out.prevCursor = prevCursor;
+  }
+  return out;
 }
 
 /**
@@ -270,6 +279,8 @@ export type PaginatedResponse<T> = {
   data: T;
   /** Cursor for fetching the next page (undefined if no more pages) */
   nextCursor?: string;
+  /** Cursor for the previous page (undefined on the first page) */
+  prevCursor?: string;
 };
 
 /**

--- a/src/lib/api/issues.ts
+++ b/src/lib/api/issues.ts
@@ -162,7 +162,9 @@ export async function listIssuesPaginated(
   });
 
   return unwrapPaginatedResult<SentryIssue[]>(
-    result as { data: SentryIssue[]; error: undefined } | { data: undefined; error: unknown },
+    result as
+      | { data: SentryIssue[]; error: undefined }
+      | { data: undefined; error: unknown },
     "Failed to list issues"
   );
 }

--- a/src/lib/api/issues.ts
+++ b/src/lib/api/issues.ts
@@ -162,9 +162,7 @@ export async function listIssuesPaginated(
   });
 
   return unwrapPaginatedResult<SentryIssue[]>(
-    result as
-      | { data: SentryIssue[]; error: undefined }
-      | { data: undefined; error: unknown },
+    result as { data: SentryIssue[]; error: undefined } | { data: undefined; error: unknown },
     "Failed to list issues"
   );
 }

--- a/src/lib/api/projects.ts
+++ b/src/lib/api/projects.ts
@@ -27,7 +27,6 @@ import {
 } from "../db/project-cache.js";
 import { getCachedOrganizations } from "../db/regions.js";
 import { type AuthGuardSuccess, withAuthGuard } from "../errors.js";
-import { logger } from "../logger.js";
 import { getApiBaseUrl } from "../sentry-client.js";
 import { buildProjectUrl } from "../sentry-urls.js";
 import { isAllDigits } from "../utils.js";
@@ -35,8 +34,8 @@ import { isAllDigits } from "../utils.js";
 import {
   API_MAX_PER_PAGE,
   apiRequestToRegion,
+  autoPaginate,
   getOrgSdkConfig,
-  MAX_PAGINATION_PAGES,
   ORG_FANOUT_CONCURRENCY,
   type PaginatedResponse,
   unwrapPaginatedResult,
@@ -54,38 +53,24 @@ import { getUserRegions, listOrganizations } from "./organizations.js";
  */
 export async function listProjects(orgSlug: string): Promise<SentryProject[]> {
   const config = await getOrgSdkConfig(orgSlug);
-  const allResults: SentryProject[] = [];
-  let cursor: string | undefined;
 
-  for (let page = 0; page < MAX_PAGINATION_PAGES; page++) {
-    const result = await listAnOrganization_sProjects({
-      ...config,
-      path: { organization_id_or_slug: orgSlug },
-      // per_page is supported by Sentry's pagination framework at runtime
-      // but not yet in the OpenAPI spec
-      query: { cursor, per_page: API_MAX_PER_PAGE } as { cursor?: string },
-    });
-
-    const { data, nextCursor } = unwrapPaginatedResult<SentryProject[]>(
-      result as
-        | { data: SentryProject[]; error: undefined }
-        | { data: undefined; error: unknown },
-      "Failed to list projects"
-    );
-    allResults.push(...data);
-
-    if (!nextCursor) {
-      break;
-    }
-    cursor = nextCursor;
-
-    if (page === MAX_PAGINATION_PAGES - 1) {
-      logger.warn(
-        `Pagination limit reached (${MAX_PAGINATION_PAGES} pages, ${allResults.length} items). ` +
-          "Results may be incomplete for this organization."
+  const { data: allResults } = await autoPaginate(
+    async (cursor) => {
+      const result = await listAnOrganization_sProjects({
+        ...config,
+        path: { organization_id_or_slug: orgSlug },
+        query: { cursor, per_page: API_MAX_PER_PAGE } as {
+          cursor?: string;
+          per_page?: number;
+        },
+      });
+      return unwrapPaginatedResult<SentryProject[]>(
+        result as { data: SentryProject[]; error: undefined } | { data: undefined; error: unknown },
+        "Failed to list projects"
       );
-    }
-  }
+    },
+    Number.MAX_SAFE_INTEGER
+  );
 
   // Populate project cache for shell completions (best-effort).
   // Mirrors how listOrganizations() calls setOrgRegions().
@@ -121,13 +106,11 @@ export async function listProjectsPaginated(
     query: {
       cursor: options.cursor,
       per_page: options.perPage ?? API_MAX_PER_PAGE,
-    } as { cursor?: string },
+    } as { cursor?: string; per_page?: number },
   });
 
   return unwrapPaginatedResult<SentryProject[]>(
-    result as
-      | { data: SentryProject[]; error: undefined }
-      | { data: undefined; error: unknown },
+    result as { data: SentryProject[]; error: undefined } | { data: undefined; error: unknown },
     "Failed to list projects"
   );
 }

--- a/src/lib/api/projects.ts
+++ b/src/lib/api/projects.ts
@@ -36,6 +36,7 @@ import {
   apiRequestToRegion,
   autoPaginate,
   getOrgSdkConfig,
+  MAX_PAGINATION_PAGES,
   ORG_FANOUT_CONCURRENCY,
   type PaginatedResponse,
   unwrapPaginatedResult,
@@ -69,7 +70,7 @@ export async function listProjects(orgSlug: string): Promise<SentryProject[]> {
         | { data: undefined; error: unknown },
       "Failed to list projects"
     );
-  }, Number.MAX_SAFE_INTEGER);
+  }, MAX_PAGINATION_PAGES * API_MAX_PER_PAGE);
 
   // Populate project cache for shell completions (best-effort).
   // Mirrors how listOrganizations() calls setOrgRegions().

--- a/src/lib/api/projects.ts
+++ b/src/lib/api/projects.ts
@@ -54,23 +54,22 @@ import { getUserRegions, listOrganizations } from "./organizations.js";
 export async function listProjects(orgSlug: string): Promise<SentryProject[]> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const { data: allResults } = await autoPaginate(
-    async (cursor) => {
-      const result = await listAnOrganization_sProjects({
-        ...config,
-        path: { organization_id_or_slug: orgSlug },
-        query: { cursor, per_page: API_MAX_PER_PAGE } as {
-          cursor?: string;
-          per_page?: number;
-        },
-      });
-      return unwrapPaginatedResult<SentryProject[]>(
-        result as { data: SentryProject[]; error: undefined } | { data: undefined; error: unknown },
-        "Failed to list projects"
-      );
-    },
-    Number.MAX_SAFE_INTEGER
-  );
+  const { data: allResults } = await autoPaginate(async (cursor) => {
+    const result = await listAnOrganization_sProjects({
+      ...config,
+      path: { organization_id_or_slug: orgSlug },
+      query: { cursor, per_page: API_MAX_PER_PAGE } as {
+        cursor?: string;
+        per_page?: number;
+      },
+    });
+    return unwrapPaginatedResult<SentryProject[]>(
+      result as
+        | { data: SentryProject[]; error: undefined }
+        | { data: undefined; error: unknown },
+      "Failed to list projects"
+    );
+  }, Number.MAX_SAFE_INTEGER);
 
   // Populate project cache for shell completions (best-effort).
   // Mirrors how listOrganizations() calls setOrgRegions().
@@ -110,7 +109,9 @@ export async function listProjectsPaginated(
   });
 
   return unwrapPaginatedResult<SentryProject[]>(
-    result as { data: SentryProject[]; error: undefined } | { data: undefined; error: unknown },
+    result as
+      | { data: SentryProject[]; error: undefined }
+      | { data: undefined; error: unknown },
     "Failed to list projects"
   );
 }

--- a/src/lib/api/releases.ts
+++ b/src/lib/api/releases.ts
@@ -84,13 +84,21 @@ export async function listReleasesPaginated(
       environment: options.environment,
       statsPeriod: options.statsPeriod,
       status: options.status,
-    } as { cursor?: string },
+    } as {
+      cursor?: string;
+      per_page?: number;
+      query?: string;
+      sort?: string;
+      health?: number;
+      project?: number[];
+      environment?: string[];
+      statsPeriod?: string;
+      status?: string;
+    },
   });
 
   return unwrapPaginatedResult<SentryRelease[]>(
-    result as
-      | { data: SentryRelease[]; error: undefined }
-      | { data: undefined; error: unknown },
+    result as { data: SentryRelease[]; error: undefined } | { data: undefined; error: unknown },
     "Failed to list releases"
   );
 }

--- a/src/lib/api/releases.ts
+++ b/src/lib/api/releases.ts
@@ -98,7 +98,9 @@ export async function listReleasesPaginated(
   });
 
   return unwrapPaginatedResult<SentryRelease[]>(
-    result as { data: SentryRelease[]; error: undefined } | { data: undefined; error: unknown },
+    result as
+      | { data: SentryRelease[]; error: undefined }
+      | { data: undefined; error: unknown },
     "Failed to list releases"
   );
 }

--- a/src/lib/api/repositories.ts
+++ b/src/lib/api/repositories.ts
@@ -66,7 +66,9 @@ export async function listRepositoriesPaginated(
   });
 
   return unwrapPaginatedResult<SentryRepository[]>(
-    result as { data: SentryRepository[]; error: undefined } | { data: undefined; error: unknown },
+    result as
+      | { data: SentryRepository[]; error: undefined }
+      | { data: undefined; error: unknown },
     "Failed to list repositories"
   );
 }

--- a/src/lib/api/repositories.ts
+++ b/src/lib/api/repositories.ts
@@ -14,6 +14,7 @@ import {
   API_MAX_PER_PAGE,
   autoPaginate,
   getOrgSdkConfig,
+  MAX_PAGINATION_PAGES,
   type PaginatedResponse,
   unwrapPaginatedResult,
   unwrapResult,
@@ -92,7 +93,7 @@ export async function listAllRepositories(
         cursor,
         perPage: API_MAX_PER_PAGE,
       }),
-    Number.MAX_SAFE_INTEGER
+    MAX_PAGINATION_PAGES * API_MAX_PER_PAGE
   );
   return data;
 }

--- a/src/lib/api/repositories.ts
+++ b/src/lib/api/repositories.ts
@@ -12,8 +12,8 @@ import { logger } from "../logger.js";
 
 import {
   API_MAX_PER_PAGE,
+  autoPaginate,
   getOrgSdkConfig,
-  MAX_PAGINATION_PAGES,
   type PaginatedResponse,
   unwrapPaginatedResult,
   unwrapResult,
@@ -59,18 +59,14 @@ export async function listRepositoriesPaginated(
   const result = await listAnOrganization_sRepositories({
     ...config,
     path: { organization_id_or_slug: orgSlug },
-    // per_page is supported by Sentry's pagination framework at runtime
-    // but not yet in the OpenAPI spec
     query: {
       cursor: options.cursor,
       per_page: options.perPage ?? 25,
-    } as { cursor?: string },
+    } as { cursor?: string; per_page?: number },
   });
 
   return unwrapPaginatedResult<SentryRepository[]>(
-    result as
-      | { data: SentryRepository[]; error: undefined }
-      | { data: undefined; error: unknown },
+    result as { data: SentryRepository[]; error: undefined } | { data: undefined; error: unknown },
     "Failed to list repositories"
   );
 }
@@ -79,8 +75,8 @@ export async function listRepositoriesPaginated(
  * List **all** repositories in an organization by walking every page.
  *
  * Used by the offline repo cache and anywhere else we need the complete
- * set (not just the first page). Stops at {@link MAX_PAGINATION_PAGES}
- * as a safety net for pathological cases.
+ * set (not just the first page). Bounded by `autoPaginate`'s
+ * {@link MAX_PAGINATION_PAGES} safety limit.
  *
  * @param orgSlug - Organization slug
  * @returns All Sentry-registered repositories across all pages
@@ -88,24 +84,15 @@ export async function listRepositoriesPaginated(
 export async function listAllRepositories(
   orgSlug: string
 ): Promise<SentryRepository[]> {
-  const all: SentryRepository[] = [];
-  let cursor: string | undefined;
-  for (let page = 0; page < MAX_PAGINATION_PAGES; page++) {
-    const { data, nextCursor } = await listRepositoriesPaginated(orgSlug, {
-      cursor,
-      perPage: API_MAX_PER_PAGE,
-    });
-    all.push(...data);
-    if (!nextCursor) {
-      return all;
-    }
-    cursor = nextCursor;
-  }
-  log.warn(
-    `Stopped paginating repositories for '${orgSlug}' after ${MAX_PAGINATION_PAGES} pages — ` +
-      "some repos may be missing from the cache."
+  const { data } = await autoPaginate(
+    (cursor) =>
+      listRepositoriesPaginated(orgSlug, {
+        cursor,
+        perPage: API_MAX_PER_PAGE,
+      }),
+    Number.MAX_SAFE_INTEGER
   );
-  return all;
+  return data;
 }
 
 /**

--- a/src/lib/api/teams.ts
+++ b/src/lib/api/teams.ts
@@ -57,18 +57,14 @@ export async function listTeamsPaginated(
   const result = await listAnOrganization_sTeams({
     ...config,
     path: { organization_id_or_slug: orgSlug },
-    // per_page is supported by Sentry's pagination framework at runtime
-    // but not yet in the OpenAPI spec
     query: {
       cursor: options.cursor,
       per_page: options.perPage ?? 25,
-    } as { cursor?: string },
+    } as { cursor?: string; per_page?: number },
   });
 
   return unwrapPaginatedResult<SentryTeam[]>(
-    result as
-      | { data: SentryTeam[]; error: undefined }
-      | { data: undefined; error: unknown },
+    result,
     "Failed to list teams"
   );
 }

--- a/src/lib/api/teams.ts
+++ b/src/lib/api/teams.ts
@@ -63,10 +63,7 @@ export async function listTeamsPaginated(
     } as { cursor?: string; per_page?: number },
   });
 
-  return unwrapPaginatedResult<SentryTeam[]>(
-    result,
-    "Failed to list teams"
-  );
+  return unwrapPaginatedResult<SentryTeam[]>(result, "Failed to list teams");
 }
 
 /**


### PR DESCRIPTION
Update `@sentry/api` from 0.113.0 to 0.133.0 and adopt the new pagination type improvements. This eliminates 5 unsafe `as { cursor?: string }` casts, replaces 2 manual pagination loops with `autoPaginate`, and adds `prevCursor` support to `PaginatedResponse`.

## Changes

- **`@sentry/api` ^0.133.0** — includes pagination wrappers (`fetchPage_*`, `paginateAll_*`, `paginateUpTo_*`), widened query types (`cursor` + `per_page` now typed), and `prevCursor` in link header parsing
- **infrastructure.ts** — `PaginatedResponse<T>` gains `prevCursor?: string`; `unwrapPaginatedResult` passes it through
- **projects.ts** — manual 30-line pagination loop → `autoPaginate` one-liner; casts cleaned up
- **repositories.ts** — manual 15-line pagination loop → `autoPaginate`; casts cleaned up
- **teams.ts, releases.ts, issues.ts, events.ts** — `as { cursor?: string }` casts narrowed/removed; multi-line result casts collapsed

## What's NOT migrated (follow-up)

`traces.ts`, `discover.ts`, and `dashboards.ts` widget queries stay on raw `apiRequestToRegion` — they use Zod validation schemas and the SDK wrappers' error handling (plain `Error`) is incompatible with the CLI's `ApiError`/`AuthError` pipeline.

## Testing

- `bun test test/lib/api-client.coverage.test.ts` — 91/91 pass
- `npx tsc --noEmit` — clean (no new errors)

<!--
## Plan
1. Bump @sentry/api from 0.113.0 to 0.133.0
2. Add prevCursor to PaginatedResponse type and unwrapPaginatedResult
3. Replace manual pagination loops in listProjects() and listAllRepositories() with autoPaginate
4. Clean up as { cursor?: string } casts — cursor and per_page are now in SDK query types
5. Remove unnecessary multi-line result casts
6. Keep CLI's own unwrapPaginatedResult (not SDK's) for ApiError/AuthError preservation
7. Leave traces.ts/discover.ts/dashboards.ts raw call sites for follow-up (Zod validation + error type incompatibility)
-->