### PR TITLE
fix(auth): bake public OAuth client ID as fallback in getClientId()

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Copy this to .env.local and fill in your values
-SENTRY_CLIENT_ID=your-sentry-oauth-client-id
+# SENTRY_CLIENT_ID=your-sentry-oauth-client-id  # Only needed for self-hosted or a custom OAuth app
 # SENTRY_URL=https://sentry.io  # Uncomment for self-hosted
 
 # Test credentials (for running E2E tests)

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -44,10 +44,22 @@ function getSentryUrl(): string {
 }
 
 /**
+ * Public OAuth client ID for sentry.io.
+ *
+ * Device Authorization Grant (RFC 8628) is a public-client flow — no client
+ * secret is involved, so this value is safe to commit. It is equivalent to the
+ * `SENTRY_CLIENT_ID` repo variable used by CI.
+ *
+ * Self-hosted instances must override this via the `SENTRY_CLIENT_ID` env var
+ * or the `SENTRY_CLIENT_ID_BUILD` build-time define.
+ */
+const DEFAULT_OAUTH_CLIENT_ID =
+  "1d673b81d60ef84c951359c36296972ca6fd41bd8f45acd2d3a783a3b3c28e41";
+
+/**
  * OAuth client ID
  *
- * Build-time: Injected via esbuild define: { SENTRY_CLIENT_ID_BUILD: "..." }
- * Runtime: Can be overridden via SENTRY_CLIENT_ID env var (for self-hosted)
+ * Priority: SENTRY_CLIENT_ID env var → SENTRY_CLIENT_ID_BUILD (build-time) → committed default
  *
  * Read at call time (not module load time) so tests can override SENTRY_CLIENT_ID
  * after module initialization.
@@ -60,7 +72,7 @@ function getClientId(): string {
     getEnv().SENTRY_CLIENT_ID ??
     (typeof SENTRY_CLIENT_ID_BUILD !== "undefined"
       ? SENTRY_CLIENT_ID_BUILD
-      : "")
+      : DEFAULT_OAUTH_CLIENT_ID)
   );
 }
 

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -24,7 +24,6 @@ import { getEnv } from "./env.js";
 import {
   ApiError,
   AuthError,
-  ConfigError,
   DeviceFlowError,
   HostScopeError,
 } from "./errors.js";
@@ -174,13 +173,6 @@ function assertRefreshHostTrusted(): void {
 /** Request a device code from Sentry's device authorization endpoint */
 function requestDeviceCode() {
   const clientId = getClientId();
-  if (!clientId) {
-    throw new ConfigError(
-      "SENTRY_CLIENT_ID is required for authentication",
-      "Set SENTRY_CLIENT_ID environment variable or use a pre-built binary"
-    );
-  }
-
   return withHttpSpan("POST", "/oauth/device/code/", async () => {
     const response = await fetchWithConnectionError(
       `${getSentryUrl()}/oauth/device/code/`,
@@ -313,7 +305,6 @@ async function attemptPoll(deviceCode: string): Promise<PollResult> {
  * @param callbacks - Callbacks for UI updates during the flow
  * @param timeout - Maximum time to wait for authorization in ms (default: 10 minutes)
  * @returns The token response containing access_token and metadata
- * @throws {ConfigError} When SENTRY_CLIENT_ID is not configured
  * @throws {ApiError} When unable to connect to Sentry or API returns an error
  * @throws {DeviceFlowError} When authorization fails, is denied, or times out
  */
@@ -405,13 +396,6 @@ export function refreshAccessToken(
   refreshToken: string
 ): Promise<TokenResponse> {
   const clientId = getClientId();
-  if (!clientId) {
-    throw new ConfigError(
-      "SENTRY_CLIENT_ID is required for token refresh",
-      "Set SENTRY_CLIENT_ID environment variable or use a pre-built binary"
-    );
-  }
-
   assertRefreshHostTrusted();
 
   return withHttpSpan("POST", "/oauth/token/", async () => {


### PR DESCRIPTION
## What

Commit the sentry.io OAuth client ID directly as `DEFAULT_OAUTH_CLIENT_ID` in `oauth.ts`, used as the final fallback in `getClientId()`.

## Why this is safe

The OAuth client ID is **public by design**. Device Authorization Grant (RFC 8628) is a public-client flow — there is no client secret involved. The value is already stored as a plain repo variable (`vars.SENTRY_CLIENT_ID`) in CI, not a secret, and has always been readable by anyone with repo access.

## Why #911 was over-engineered

PR #911 addressed the same problem but introduced a separate "development" client ID, a new `RELEASE_BUILD` guard, an `ensureSentryClientIdConfigured()` function, asymmetric behaviour between `build.ts` and `bundle.ts`, and touched 10 files. The dev-vs-production distinction isn't meaningful when both IDs are equally public.

## What changes

The fallback chain in `getClientId()` is unchanged in priority:

```
SENTRY_CLIENT_ID env var → SENTRY_CLIENT_ID_BUILD (build-time define) → committed default
```

- Local dev against sentry.io: works out of the box, no `.env.local` needed
- Self-hosted: still override via `SENTRY_CLIENT_ID` env var
- Release binaries / npm bundle: still inject via `SENTRY_CLIENT_ID_BUILD` from `SENTRY_CLIENT_ID` env var at build time — no behaviour change

Closes #911