### PR TITLE
ci: require conventional commit PR titles via changelog-preview

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -11,4 +11,6 @@ permissions:
 jobs:
   changelog-preview:
     uses: getsentry/craft/.github/workflows/changelog-preview.yml@v2
+    with:
+      require-conventional-title: true
     secrets: inherit


### PR DESCRIPTION
## Summary

Opts into the new `require-conventional-title` enforcement added in getsentry/craft#812.

When a PR title doesn't start with a recognized conventional commit prefix (`feat:`, `fix:`, `docs:`, `chore:`, `ci:`, `refactor:`, `test:`, `perf:`, `build:`, `style:`, `meta:`, `ref:`, `security:`), the Changelog Preview check will **fail** and block merge.

PRs with the `skip-changelog` label or `#skip-changelog` in the body are exempt.

## Dependency

Requires getsentry/craft#812 to be merged and the `v2` tag updated before this takes effect. Until then, the `require-conventional-title` input is unknown to the workflow and will be silently ignored (reusable workflows ignore unknown inputs).