### PR TITLE
fix(archive): accept 'forever' as a valid --until value

### DIFF
--- a/plugins/sentry-cli/skills/sentry-cli/references/issue.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/issue.md
@@ -210,7 +210,7 @@ Reopen a resolved issue
 Archive (ignore) an issue
 
 **Flags:**
-- `-u, --until <value> - Condition for unarchival: auto, 30m, 10x, 10u, 10x/5m, etc.`
+- `-u, --until <value> - Condition for unarchival: forever, auto, 30m, 10x, 10u, 10x/5m, etc.`
 
 **Examples:**
 

--- a/src/commands/issue/archive.ts
+++ b/src/commands/issue/archive.ts
@@ -53,6 +53,7 @@ const NUMERIC_WORD_RE = /^(\d+)\s*([a-z]+)$/i;
 
 /** Parsed result of a --until value. */
 export type UntilSpec =
+  | { kind: "forever" }
   | { kind: "escalating" }
   | { kind: "duration"; minutes: number }
   | { kind: "count"; count: number; windowMinutes?: number }
@@ -217,6 +218,7 @@ function throwUnrecognizedUntil(raw: string): never {
   throw new ValidationError(
     `invalid --until value: '${raw}'\n\n` +
       "Expected one of:\n" +
+      "  forever           Archive forever (same as omitting --until)\n" +
       "  auto             Archive until Sentry detects a spike\n" +
       "  30m, 1h, 7d      Archive for a duration\n" +
       "  2026-05-15        Archive until a date\n" +
@@ -240,6 +242,10 @@ function throwUnrecognizedUntil(raw: string): never {
 export function parseUntilSpec(raw: string): UntilSpec {
   const trimmed = raw.trim();
   const lower = trimmed.toLowerCase();
+
+  if (lower === "forever") {
+    return { kind: "forever" };
+  }
 
   if (lower === "auto" || lower === "escalating") {
     return { kind: "escalating" };
@@ -281,6 +287,8 @@ function specToApiOptions(spec: UntilSpec): {
   statusDetails?: IgnoreStatusDetails;
 } {
   switch (spec.kind) {
+    case "forever":
+      return { substatus: "archived_forever" };
     case "escalating":
       return { substatus: "archived_until_escalating" };
     case "duration":
@@ -355,7 +363,8 @@ export const archiveCommand = buildCommand({
       until: {
         kind: "parsed",
         parse: String,
-        brief: "Condition for unarchival: auto, 30m, 10x, 10u, 10x/5m, etc.",
+        brief:
+          "Condition for unarchival: forever, auto, 30m, 10x, 10u, 10x/5m, etc.",
         optional: true,
       },
     },

--- a/test/commands/issue/archive.func.test.ts
+++ b/test/commands/issue/archive.func.test.ts
@@ -58,6 +58,14 @@ function createMockContext() {
 // ── parseUntilSpec unit tests ──────────────────────────────────────
 
 describe("parseUntilSpec", () => {
+  test("'forever' → forever", () => {
+    expect(parseUntilSpec("forever")).toEqual({ kind: "forever" });
+  });
+
+  test("'Forever' (case-insensitive) → forever", () => {
+    expect(parseUntilSpec("Forever")).toEqual({ kind: "forever" });
+  });
+
   test("'auto' → escalating", () => {
     expect(parseUntilSpec("auto")).toEqual({ kind: "escalating" });
   });
@@ -222,6 +230,23 @@ describe("archiveCommand.func()", () => {
 
     const { context } = createMockContext();
     await func.call(context, { json: false }, "CLI-G5");
+
+    expect(updateSpy).toHaveBeenCalledWith("123456789", "ignored", {
+      statusDetails: undefined,
+      substatus: "archived_forever",
+      orgSlug: "test-org",
+    });
+  });
+
+  test("--until forever → archives forever (same as no --until)", async () => {
+    resolveIssueSpy.mockResolvedValue({
+      org: "test-org",
+      issue: makeMockIssue({ status: "unresolved" }),
+    });
+    updateSpy.mockResolvedValue(makeMockIssue());
+
+    const { context } = createMockContext();
+    await func.call(context, { json: false, until: "forever" }, "CLI-G5");
 
     expect(updateSpy).toHaveBeenCalledWith("123456789", "ignored", {
       statusDetails: undefined,


### PR DESCRIPTION
## Summary

Fixes CLI-1MD: users passing `--until forever` to `sentry issue archive` received a `ValidationError`. Since omitting `--until` already archives forever, `forever` is a natural and discoverable alias.

## Changes

- Adds `{ kind: "forever" }` to the `UntilSpec` union
- Recognizes `"forever"` (case-insensitive) in `parseUntilSpec`
- Maps `{ kind: "forever" }` to `{ substatus: "archived_forever" }` in `specToApiOptions` — identical to the no-`--until` path
- Adds `forever` to the `--until` flag brief and the unrecognized-value error hint
- Adds 3 tests: `parseUntilSpec("forever")`, `parseUntilSpec("Forever")` (case-insensitive), and a `func()` integration test

## Before / After

```
# Before
$ sentry issue archive CLI-1MD --until forever
ValidationError: invalid --until value: 'forever'

# After
$ sentry issue archive CLI-1MD --until forever
# Archives forever — same as omitting --until
```
