### PR TITLE
fix(install): pass through no-agent-skills flag

### DIFF
--- a/install
+++ b/install
@@ -85,6 +85,7 @@ Options:
     -v, --version <version> Install a specific version (e.g., 0.2.0) or "nightly"
         --no-modify-path    Don't modify shell config files (.zshrc, .bashrc, etc.)
         --no-completions    Don't install shell completions
+        --no-agent-skills   Don't install agent skills
 
 Environment Variables:
     SENTRY_INSTALL_DIR      Override the installation directory
@@ -104,6 +105,7 @@ EOF
 requested_version="${SENTRY_VERSION:-}"
 no_modify_path=false
 no_completions=false
+no_agent_skills=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help) usage; exit 0 ;;
@@ -121,6 +123,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-completions)
       no_completions=true
+      shift
+      ;;
+    --no-agent-skills)
+      no_agent_skills=true
       shift
       ;;
     *) shift ;;
@@ -315,6 +321,9 @@ if [[ "$no_modify_path" == "true" ]]; then
 fi
 if [[ "$no_completions" == "true" ]]; then
   setup_args="$setup_args --no-completions"
+fi
+if [[ "$no_agent_skills" == "true" ]]; then
+  setup_args="$setup_args --no-agent-skills"
 fi
 
 # Remove trap — setup will handle temp cleanup on success

--- a/test/lib/install-script.test.ts
+++ b/test/lib/install-script.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Install Script Tests
+ *
+ * Exercises the shell installer with fake download tools so argument parsing and
+ * setup delegation can be validated without network access.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..", "..");
+const installScript = join(repoRoot, "install");
+
+describe("install script", () => {
+  let testDir: string;
+  let binDir: string;
+  let argsFile: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), "sentry-install-test-"));
+    binDir = join(testDir, "bin");
+    argsFile = join(testDir, "setup-args.txt");
+    mkdirSync(binDir, { recursive: true });
+
+    const fakeCurl = `#!/usr/bin/env bash
+cat <<'SCRIPT'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$SENTRY_TEST_ARGS_FILE"
+SCRIPT
+`;
+    writeFileSync(join(binDir, "curl"), fakeCurl);
+    chmodSync(join(binDir, "curl"), 0o755);
+
+    const fakeGunzip = `#!/usr/bin/env bash
+cat
+`;
+    writeFileSync(join(binDir, "gunzip"), fakeGunzip);
+    chmodSync(join(binDir, "gunzip"), 0o755);
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("passes --no-agent-skills through to sentry cli setup", async () => {
+    const proc = Bun.spawn(
+      [
+        "bash",
+        installScript,
+        "--version",
+        "0.31.0",
+        "--no-modify-path",
+        "--no-completions",
+        "--no-agent-skills",
+      ],
+      {
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          SENTRY_TEST_ARGS_FILE: argsFile,
+          TMPDIR: testDir,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      }
+    );
+
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      Bun.readableStreamToText(proc.stdout),
+      Bun.readableStreamToText(proc.stderr),
+    ]);
+
+    expect({ exitCode, stdout, stderr }).toMatchObject({ exitCode: 0 });
+    expect(readFileSync(argsFile, "utf8").trim().split("\n")).toEqual([
+      "cli",
+      "setup",
+      "--install",
+      "--method",
+      "curl",
+      "--channel",
+      "stable",
+      "--no-modify-path",
+      "--no-completions",
+      "--no-agent-skills",
+    ]);
+  });
+});


### PR DESCRIPTION
Bit of a strange request--allow avoid installation of skills via the curl installer. Previously the install script didn't pass this flag though. My use case: I already have a much briefer skill for sentry cli and if these get autoinstalled my agents get different guidance.

## Summary
- Add `--no-agent-skills` to the curl installer arguments
- Forward the flag to `sentry cli setup` so users can skip agent skill installation during install
- Add an installer test that stubs downloads and asserts setup delegation args

## Test plan
- `bun test --timeout 15000 --isolate test/lib/install-script.test.ts`