### PR TITLE
fix(feedback): prompt interactively when message is missing in TTY

### DIFF
--- a/src/commands/cli/feedback.ts
+++ b/src/commands/cli/feedback.ts
@@ -8,6 +8,7 @@
  * @example sentry cli feedback the issue view is confusing
  */
 
+import { isatty } from "node:tty";
 // biome-ignore lint/performance/noNamespaceImport: Sentry SDK recommends namespace import
 import * as Sentry from "@sentry/node-core/light";
 import type { SentryContext } from "../../context.js";
@@ -15,6 +16,7 @@ import { buildCommand } from "../../lib/command.js";
 import { ConfigError, ValidationError } from "../../lib/errors.js";
 import { formatFeedbackResult } from "../../lib/formatters/human.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
+import { logger } from "../../lib/logger.js";
 
 /** Structured result of the feedback submission */
 export type FeedbackResult = {
@@ -50,10 +52,20 @@ export const feedbackCommand = buildCommand({
     _flags: {},
     ...messageParts: string[]
   ) {
-    const message = messageParts.join(" ");
+    let message = messageParts.join(" ").trim();
 
-    if (!message.trim()) {
-      throw new ValidationError("Please provide a feedback message.");
+    if (!message) {
+      if (!isatty(0)) {
+        throw new ValidationError("Please provide a feedback message.");
+      }
+      const response = await logger.prompt("Enter your feedback message:", {
+        type: "text",
+        placeholder: "e.g. I love this tool!",
+      });
+      if (typeof response !== "string" || !response.trim()) {
+        throw new ValidationError("Please provide a feedback message.");
+      }
+      message = response.trim();
     }
 
     if (!Sentry.isEnabled()) {


### PR DESCRIPTION
When running `sentry cli feedback` without a message argument in an interactive terminal, prompt the user for their feedback message instead of throwing a `ValidationError`. The error is preserved for non-TTY contexts (piped input, CI, etc.).

Uses `isatty(0)` from `node:tty` and `logger.prompt` with `type: "text"` — matching existing patterns in the codebase (`mutate-command.ts`, `seer-trial.ts`, `cli.ts`).

Closes #922

<!--
## Plan
1. In `src/commands/cli/feedback.ts`, when `message` is empty:
   - If `isatty(0)` is false (non-TTY): throw ValidationError (existing behavior)
   - If `isatty(0)` is true (interactive TTY): use `logger.prompt()` with type "text" to ask the user for their feedback message
2. Handle Ctrl+C (Symbol(clack:cancel)) by checking `typeof response !== "string"` — matching the existing pattern in `confirmByTyping` (mutate-command.ts)
3. If the prompt response is empty or cancelled, throw ValidationError
4. Otherwise, use the prompted message for the feedback submission
-->