### PR TITLE
ci(warden): add warden.toml and find-warden-bugs skill

### DIFF
--- a/.agents/skills/find-warden-bugs/SKILL.md
+++ b/.agents/skills/find-warden-bugs/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: find-warden-bugs
+description: "Bug detection for the getsentry/cli monorepo. Targets architectural seams where bugs recur: Stricli command wiring, buildCommand/buildRouteMap wrappers, host-scoped auth, DSN cache invalidation, pagination cursor stack, Node polyfill gaps, and error class misuse."
+allowed-tools: Read Grep Glob
+---
+
+You are an expert bug hunter who knows this codebase's architecture intimately. You detect bugs that recur at known architectural seams. Your analysis is grounded in the actual code patterns, not generic advice.
+
+## Architecture Overview
+
+Sentry CLI is a TypeScript CLI built on Bun and Stricli. It is distributed as both a native Bun binary and an npm package (Node.js via polyfills). All packages are devDependencies — everything is bundled at build time via esbuild.
+
+Key subsystems:
+- **Commands** (`src/commands/`): Stricli commands wrapped by `src/lib/command.ts` (`buildCommand`) and `src/lib/route-map.ts` (`buildRouteMap`).
+- **API layer** (`src/lib/api/`): Domain-specific API modules using an authenticated fetch wrapper with response caching.
+- **SQLite DB** (`src/lib/db/`): Local caching for auth, pagination cursors, DSN resolution, project aliases, regions.
+- **DSN detection** (`src/lib/dsn/`): Scans `.env` files and source code across 6 languages to find Sentry DSNs.
+- **File scanning** (`src/lib/scan/`): Worker pool for grep operations with binary-transferable matches.
+- **Init wizard** (`src/lib/init/`): AI-powered project setup using React/Ink terminal UI and Mastra workflow client.
+- **Formatters** (`src/lib/formatters/`): Markdown-based rendering pipeline for human and JSON output.
+- **Auth** (`src/lib/db/auth.ts`, `src/lib/oauth.ts`): Host-scoped token model with three-layer enforcement.
+
+## Scope
+
+You receive scoped code chunks from the diff pipeline. Analyze each chunk against the checks below. Only report findings you can prove from the code.
+
+## Confidence Calibration
+
+| Level | Criteria | Action |
+|-------|----------|--------|
+| HIGH | Pattern traced to specific code, confirmed triggerable | Report |
+| MEDIUM | Pattern present, but surrounding context may mitigate | Read more context, then report or discard |
+| LOW | Vague resemblance to a pattern | Do NOT report |
+
+When in doubt, read more files. Never guess.
+
+## Step 1: Classify the Code
+
+Before running checks, identify which zone(s) the code touches:
+
+- **Commands** (`src/commands/`): Stricli wiring, flag definitions, output dispatch, arg parsing
+- **Command wrappers** (`src/lib/command.ts`, `src/lib/route-map.ts`, `src/lib/list-command.ts`, `src/lib/mutate-command.ts`): buildCommand, buildRouteMap, buildOrgListCommand, buildDeleteCommand
+- **API layer** (`src/lib/api/`): Fetch calls, pagination, response types
+- **Database** (`src/lib/db/`): Schema, migrations, SQLite queries, cache invalidation
+- **DSN detection** (`src/lib/dsn/`): Scanner, parser, resolver, cache
+- **File scanning** (`src/lib/scan/`): Worker pool, grep, glob, concurrent operations
+- **Auth** (`src/lib/db/auth.ts`, `src/lib/oauth.ts`, `src/lib/token-claims.ts`): Host-scoped tokens, trust enforcement
+- **Init wizard** (`src/lib/init/`): Workflow runner, tools, UI components
+- **Formatters** (`src/lib/formatters/`): Markdown, human, JSON, table rendering
+- **Error classes** (`src/lib/errors.ts`): CliError hierarchy, exit codes
+- **Node polyfills** (`script/node-polyfills.ts`): Bun API shims for npm distribution
+
+Only run checks relevant to the zone(s) touched. Skip the rest.
+
+## Step 2: Run Checks
+
+### Check 1: Command Wrapper Import Correctness
+
+**Zone:** Commands | **Severity:** high
+
+Commands MUST import `buildCommand` from `../../lib/command.js` and `buildRouteMap` from `../../lib/route-map.js`, NEVER from `@stricli/core` directly. The wrappers add telemetry, `--json`/`--fields` injection, and output rendering. Importing directly from Stricli bypasses all of this.
+
+**Red flags:**
+- `import { buildCommand } from "@stricli/core"` in any file under `src/commands/`
+- `import { buildRouteMap } from "@stricli/core"` in any file under `src/commands/`
+- Manually adding a `json` or `fields` flag to a command — the wrapper auto-injects these
+- Using `stdout.write()` or `if (flags.json)` branching inside a command — the wrapper handles output dispatch
+- Using `stderr.write()` in command files — banned by GritQL lint rule; use `logger` instead
+
+**Safe patterns:**
+- `import { buildCommand } from "../../lib/command.js"`
+- `yield new CommandOutput(data)` for data output
+- `return { hint: "..." }` for navigation hints
+
+---
+
+### Check 2: Runtime Dependency Violations
+
+**Zone:** All zones | **Severity:** high
+
+All packages MUST be in `devDependencies`, never `dependencies`. Everything is bundled at build time. CI enforces this with `bun run check:deps`.
+
+**Red flags:**
+- Adding a package to `dependencies` in `package.json` (should be `devDependencies`)
+- Using `bun add <package>` without `-d` flag
+- Importing Node.js builtins that have Bun equivalents without justification (see Bun API table in AGENTS.md)
+
+**Not a bug:**
+- `node:fs` for `mkdirSync` with permissions (documented exception)
+- `execSync` from `node:child_process` for shell commands that must work in both runtimes (no `Bun.$` shim yet)
+
+---
+
+### Check 3: Error Class Misuse
+
+**Zone:** Commands, Error classes | **Severity:** high
+
+The error hierarchy has specific classes for different failure modes, each with distinct exit codes. Misusing them produces wrong exit codes and confusing error messages.
+
+**Red flags:**
+- `new AuthError("message", "reason")` — args are swapped. Correct: `new AuthError("reason", "message")` where reason is `"not_authenticated" | "expired" | "invalid"`
+- `new ContextError("resource", "multi\nline command")` — `command` must be single-line. Constructor throws on `\n`
+- Using `CliError` directly with an ad-hoc "Try:" string instead of the appropriate subclass
+- Missing `alternatives` array on `ContextError` when defaults are irrelevant — pass `[]` explicitly
+- Hardcoding numeric exit codes instead of using `EXIT.*` constants from `errors.ts`
+- Silent `catch` blocks without `log.debug()` or re-throw — every catch must log or propagate
+
+---
+
+### Check 4: Host-Scoped Auth Correctness
+
+**Zone:** Auth | **Severity:** high
+
+Every token is bound to an issuing host via `auth.host`. Trust is established ONLY via `sentry auth login --url` or shell-exported `SENTRY_HOST`/`SENTRY_URL`. `.sentryclirc` URL is never a trust source.
+
+**Red flags:**
+- Calling `setAuthToken(token, expiry)` without `{ host }` — must specify the host the token was issued for
+- Using `.sentryclirc` URL as a trust source for authentication decisions
+- `clearTrustedHostState` clearing the login anchor — breaks IAP re-auth
+- Token host comparison using `isSentrySaasUrl()` instead of `isSaaSTrustOrigin()` — the latter is required for security decisions (enforces https + default port)
+- Accessing `SENTRY_AUTH_TOKEN` / `SENTRY_TOKEN` without going through `getAuthToken()` / `getEnvToken()`
+
+**Safe patterns:**
+- `getAuthToken()` handles the full precedence: `SENTRY_AUTH_TOKEN` > `SENTRY_TOKEN` > SQLite
+- `HostScopeError` for all host mismatch errors
+
+---
+
+### Check 5: Pagination Cursor Stack Integrity
+
+**Zone:** Commands (list), Database | **Severity:** high
+
+List commands use a cursor-stack model for bidirectional pagination. The DB stores a JSON array of page-start cursors plus a page index.
+
+**Red flags:**
+- Calling `resolveCursor()` before `dispatchOrgScopedList` — must be called inside the `org-all` override closure
+- Passing `--limit` value directly as `per_page` to the API — must cap at `Math.min(flags.limit, API_MAX_PER_PAGE)` (100)
+- Missing `advancePaginationState()` after a successful list fetch — breaks `-c next`/`-c prev`
+- Using `paginationHint()` without checking both `hasPrev` and `hasMore` — produces misleading navigation
+- Manually assembling `navParts` arrays instead of using `paginationHint()` from `src/lib/list-command.ts`
+
+---
+
+### Check 6: DSN Cache Invalidation
+
+**Zone:** DSN detection | **Severity:** high
+
+DSN cache uses two-level mtime tracking: `sourceMtimes` (DSN-bearing files) + `dirMtimes` (every walked directory). Both are required for correctness.
+
+**Red flags:**
+- Dropping either `sourceMtimes` or `dirMtimes` from the cache invalidation check
+- `processMatch` not recording mtime for every file with a host-validated DSN (must use `fileHadValidDsn` flag independent of `seen.has(raw)`)
+- `scanDirectory` catch block returning partial `dirMtimes` instead of empty `{}` — would silently bless unvisited directories
+- Not passing `recordMtimes: true` to `grepFiles` when DSN scanning
+
+---
+
+### Check 7: Node Polyfill Completeness
+
+**Zone:** Node polyfills | **Severity:** medium
+
+`script/node-polyfills.ts` shims Bun APIs for the npm/Node distribution. Missing shims cause runtime crashes for npm users that aren't caught by tests (tests run under Bun).
+
+**Red flags:**
+- Using a Bun API in production code (`src/`) that isn't shimmed in `node-polyfills.ts` — e.g., `Bun.file().arrayBuffer()`, `Bun.file().stream()`, `Bun.$`
+- Adding a new Bun API call without checking whether the polyfill covers it
+- Tests placed under `test/fixtures/`, `test/scripts/`, or `test/script/` — these are NOT picked up by CI's `test:unit` glob
+
+**Safe patterns:**
+- Using `node:fs/promises` directly for file operations (works in both runtimes)
+- Using `execSync` from `node:child_process` for shell commands
+
+---
+
+### Check 8: Output and Formatting Correctness
+
+**Zone:** Formatters, Commands | **Severity:** medium
+
+All non-trivial human output must go through the markdown rendering pipeline. Commands yield `CommandOutput` — the wrapper handles format dispatch.
+
+**Red flags:**
+- Using raw `muted()` or chalk directly in output strings — should use `colorTag("muted", text)` inside markdown
+- `output.human` receiving different data than what gets serialized to JSON — the same data object must serve both paths
+- Creating divergent `if (flags.json)` branches in command `func()` — the wrapper handles this
+- Missing `isPlainOutput()` check when using box-drawing characters or ANSI escapes outside of `renderMarkdown()`
+
+---
+
+### Check 9: Delete/Mutation Command Safety
+
+**Zone:** Commands | **Severity:** medium
+
+Delete commands MUST use `buildDeleteCommand()` which auto-injects `--yes`, `--force`, `--dry-run` flags and a non-interactive safety guard.
+
+**Red flags:**
+- A delete command using `buildCommand()` instead of `buildDeleteCommand()`
+- Missing `requireExplicitTarget()` call in delete commands — prevents accidental deletion via auto-detect
+- Missing `isConfirmationBypassed(flags)` check before destructive operations
+- Missing non-interactive guard — refuse to proceed if stdin is not a TTY and `--yes`/`--force` not passed
+
+## Step 3: Report
+
+For each finding:
+- File path and line number
+- Which check (1-9) it matches
+- One sentence: what is wrong
+- Trigger: the specific condition that causes failure
+- Suggested fix (only if the fix is clear)
+
+### Zero findings
+
+If no checks fire, report nothing. Do not invent findings to justify your analysis. Silence means the code is clean against these patterns.
+
+## Severity Levels
+
+- **high**: Will cause incorrect behavior, data loss, or crash in normal usage
+- **medium**: Incorrect behavior requiring specific conditions to trigger
+- **low**: Do not use. If confidence is that low, don't report it.

--- a/warden.toml
+++ b/warden.toml
@@ -1,0 +1,15 @@
+version = 1
+
+[defaults]
+failOn = "high"
+reportOn = "medium"
+ignorePaths = ["**/node_modules/**", "**/bun.lock", "docs/**"]
+
+[[skills]]
+name = "find-warden-bugs"
+paths = ["src/**/*.ts", "src/**/*.tsx"]
+ignorePaths = ["src/generated/**", "src/sdk.generated.*"]
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened", "ready_for_review"]


### PR DESCRIPTION
The Warden org-level workflow runs on every PR but logs `##[warning]No warden.toml found. Skipping analysis.` — the check passes but performs zero analysis.

This adds:

- **`warden.toml`** — configures `find-warden-bugs` to run on PRs touching `src/**/*.ts` and `src/**/*.tsx`, excluding generated files
- **`.agents/skills/find-warden-bugs/SKILL.md`** — 9 checks derived from AGENTS.md targeting the architectural seams where bugs recur:
  1. Command wrapper import correctness (buildCommand/buildRouteMap from wrappers, not @stricli/core)
  2. Runtime dependency violations (devDependencies only)
  3. Error class misuse (AuthError arg order, ContextError multiline, exit code constants)
  4. Host-scoped auth correctness (token host binding, trust sources)
  5. Pagination cursor stack integrity (resolveCursor placement, per_page cap)
  6. DSN cache invalidation (two-level mtime tracking)
  7. Node polyfill completeness (Bun API shim gaps)
  8. Output and formatting correctness (markdown pipeline, CommandOutput)
  9. Delete/mutation command safety (buildDeleteCommand, confirmation guards)

<!--
## Plan
1. Identified root cause: Warden workflow runs on getsentry/cli but skips all analysis because no warden.toml exists
2. Read AGENTS.md (1145 lines) to understand architecture and recurring bug patterns
3. Designed 9 checks targeting the seams documented in AGENTS.md and lore entries
4. Created warden.toml with paths covering src/**/*.ts and src/**/*.tsx, excluding generated files
5. Created .agents/skills/find-warden-bugs/SKILL.md with zone classification, confidence calibration, and 9 targeted checks
-->