### PR TITLE
ci: add warden.toml to enable Warden analysis on PRs

### DIFF
--- a/warden.toml
+++ b/warden.toml
@@ -1,0 +1,51 @@
+# Warden Configuration
+# https://github.com/getsentry/warden
+#
+# Warden reviews code using AI-powered skills triggered by GitHub events.
+# Skills live in .agents/skills/ or .claude/skills/
+#
+# Add skills with: warden add <skill-name>
+
+version = 1
+
+# Default settings inherited by all skills
+[defaults]
+# Severity levels: critical, high, medium, low, info
+# failOn: minimum severity that fails the check
+failOn = "high"
+# reportOn: minimum severity that creates PR annotations
+reportOn = "medium"
+
+# Skills define what to analyze and when to run
+# Add skills with: warden add <skill-name>
+#
+# Example skill with path filters and triggers:
+#
+# [[skills]]
+# name = "security-review"
+# paths = ["src/**/*.ts", "src/**/*.tsx"]
+# ignorePaths = ["**/*.test.ts", "**/__fixtures__/**"]
+#
+# [[skills.triggers]]
+# type = "pull_request"
+# actions = ["opened", "synchronize", "reopened"]
+
+[[skills]]
+name = "find-bugs"
+remote = "getsentry/skills"
+paths = ["src/**/*.ts", "src/**/*.tsx", "script/**/*.ts"]
+ignorePaths = ["src/generated/**", "src/sdk.generated.*"]
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]
+
+[[skills]]
+name = "security-review"
+remote = "getsentry/skills"
+paths = ["src/**/*.ts", "src/**/*.tsx"]
+ignorePaths = ["src/generated/**", "src/sdk.generated.*"]
+
+[[skills.triggers]]
+type = "pull_request"
+actions = ["opened", "synchronize", "reopened"]


### PR DESCRIPTION
The org-level Warden workflow runs on every PR but logs `No warden.toml found. Skipping analysis.` — the check passes but performs zero analysis.

Generated via `npx @sentry/warden init` and `warden add`, with path filters scoped to `src/` and `script/` TypeScript files.

Skills added from `getsentry/skills`:
- **find-bugs** — general bug detection on changed source files
- **security-review** — security vulnerability scanning (relevant given the CLI handles auth tokens, OAuth flows, and host-scoped credentials)