### PR TITLE
fix(init): extend workflow API timeout

### DIFF
--- a/src/lib/init/constants.ts
+++ b/src/lib/init/constants.ts
@@ -9,7 +9,7 @@ export const SENTRY_DOCS_URL = "https://docs.sentry.io/platforms/";
 export const MAX_FILE_BYTES = 262_144; // 256KB per file
 export const MAX_OUTPUT_BYTES = 65_536; // 64KB stdout/stderr truncation
 export const DEFAULT_COMMAND_TIMEOUT_MS = 120_000; // 2 minutes
-export const API_TIMEOUT_MS = 120_000; // 2 minutes timeout for Mastra API calls
+export const API_TIMEOUT_MS = 180_000; // 3 minutes timeout for Mastra API calls
 
 // Exit codes returned by the remote workflow.
 // These are internal to the workflow protocol — they're mapped to EXIT.*


### PR DESCRIPTION
## Summary

The docs-MCP `get-docs` timeout is being raised to 100s in the server, but the CLI still had a 120s outer timeout for workflow start/resume calls. A slow-but-successful docs tailoring run plus the codemod planner could run past that and surface as a CLI workflow timeout instead.

This gives init workflow API calls a 3 minute budget so the outer client stays above the new server-side docs budget.

## Changes

- raise `API_TIMEOUT_MS` from 120s to 180s
- leave local command execution timeout unchanged at 120s

## Test Plan

```bash
bun test test/lib/init/wizard-runner.test.ts
bunx ultracite check src/lib/init/constants.ts
git diff --check
```

Note: `bunx ultracite check src/lib/init/constants.ts` exits 0, but Biome still prints an existing internal warning about `src/lib/custom-ca.ts` exceeding its type limit.

## Companion PR

Server-side timeout change: https://github.com/getsentry/cli-init-api/pull/129
