### PR TITLE
fix(init): tighten feedback banner copy

### DIFF
--- a/src/lib/init/ui/ink-app.tsx
+++ b/src/lib/init/ui/ink-app.tsx
@@ -17,7 +17,7 @@
  *   │                           │  ╰────────────────────────╯ │
  *   │  ● Status   Files                                       │
  *   │  ←→ switch tab                                          │
- *   │  Sentry                         For feedback run: ...   │
+ *   │  Sentry                         $ sentry cli feedback... │
  *   └─────────────────────────────────────────────────────────┘
  *
  * Tab 1 (Status): Banner + logs + spinner + prompts + summary
@@ -112,8 +112,7 @@ const DEFAULT_WELCOME_OPTIONS = {
   ],
   punchline: "Continue to let Sentry use AI for setup.",
 };
-const FEEDBACK_BANNER_TEXT =
-  'For feedback run: sentry cli feedback "what worked or broke"';
+const FEEDBACK_BANNER_TEXT = '$ sentry cli feedback "what worked or broke"';
 const FEEDBACK_BANNER_FG = "#FFFFFF";
 
 function getIntroTopPadding(rows: number): number {
@@ -134,7 +133,8 @@ function formatBannerBrand(cliVersion: string | null): string {
   return cliVersion ? `Sentry v${cliVersion}` : "Sentry";
 }
 
-function formatFeedbackBanner(
+/** @internal Exported for testing. */
+export function formatFeedbackBanner(
   width: number,
   cliVersion: string | null
 ): string {
@@ -144,14 +144,18 @@ function formatFeedbackBanner(
     return left.slice(0, Math.max(0, width));
   }
 
-  const maxRight = Math.max(0, width - left.length - 1);
+  const rightPadding = 1;
+  const maxRight = Math.max(0, width - left.length - rightPadding - 1);
   const clippedRight = truncateForBanner(FEEDBACK_BANNER_TEXT, maxRight);
   if (clippedRight.length === 0) {
     return left.padEnd(width, " ");
   }
 
-  const spacerWidth = Math.max(1, width - left.length - clippedRight.length);
-  return `${left}${" ".repeat(spacerWidth)}${clippedRight}`;
+  const spacerWidth = Math.max(
+    1,
+    width - left.length - clippedRight.length - rightPadding
+  );
+  return `${left}${" ".repeat(spacerWidth)}${clippedRight}${" ".repeat(rightPadding)}`;
 }
 
 // ────────────────────────────── App entry ─────────────────────────────

--- a/test/lib/init/ui/ink-app.snapshot.test.tsx
+++ b/test/lib/init/ui/ink-app.snapshot.test.tsx
@@ -12,7 +12,10 @@ import { describe, expect, test } from "bun:test";
 import { Readable, Writable } from "node:stream";
 import { render } from "ink";
 import { createElement } from "react";
-import { App } from "../../../../src/lib/init/ui/ink-app.js";
+import {
+  App,
+  formatFeedbackBanner,
+} from "../../../../src/lib/init/ui/ink-app.js";
 import { WizardStore } from "../../../../src/lib/init/ui/wizard-store.js";
 
 const LEARN_HEADER_RE = /How Sentry Works/;
@@ -34,8 +37,7 @@ const ANSI_CSI_RE = /\u001B\[[0-9;?]*[ -/]*[@-~]/g;
 const ANSI_OSC_RE = /\u001B\][^\u0007]*(?:\u0007|\u001B\\)/g;
 const LINE_SPLIT_RE = /\r?\n/;
 const RIGHT_ARROW = "\u001B[C";
-const FEEDBACK_BANNER_TEXT =
-  'For feedback run: sentry cli feedback "what worked or broke"';
+const FEEDBACK_BANNER_TEXT = '$ sentry cli feedback "what worked or broke"';
 
 const FRAME_SETTLE_MS = 80;
 const TEST_BANNER_ROWS = [
@@ -173,6 +175,15 @@ function makeReadFiles(count: number): string[] {
 }
 
 describe("Ink App snapshot", () => {
+  test("feedback banner reserves padding on both edges", () => {
+    const banner = formatFeedbackBanner(120, "0.32.0-test.0");
+
+    expect(banner.length).toBe(120);
+    expect(banner.startsWith(" Sentry v0.32.0-test.0")).toBe(true);
+    expect(banner).toContain(FEEDBACK_BANNER_TEXT);
+    expect(banner.endsWith(" ")).toBe(true);
+  });
+
   test("renders full-screen layout at 120 cols", async () => {
     const store = new WizardStore();
     store.appendLog("info", "Hello world");
@@ -271,7 +282,7 @@ describe("Ink App snapshot", () => {
       .find((line) => line.includes("Sentry v") && line.includes("feedback"));
     expect(bannerLine).toBeDefined();
     expect(bannerLine?.indexOf("Sentry v0.32.0-test.0")).toBeLessThan(
-      bannerLine?.indexOf("For feedback run") ?? 0
+      bannerLine?.indexOf("$ sentry cli feedback") ?? 0
     );
   });
 


### PR DESCRIPTION
## Summary

Shortens the persistent init footer feedback prompt so it reads like a copyable command. The banner now uses `$ sentry cli feedback "what worked or broke"` and keeps padding on both edges of the purple footer.

## Fix

Reserve a right-padding column when formatting the feedback banner, then update the footer copy to the shorter command-style text. The formatter is exported for a small regression test that checks the banner width and edge padding directly.

## Test Plan

```bash
bun test test/lib/init/ui/ink-app.snapshot.test.tsx
bunx ultracite check src/lib/init/ui/ink-app.tsx test/lib/init/ui/ink-app.snapshot.test.tsx
bun run typecheck
```