### PR TITLE
fix(init): simplify LoggingUI output for non-TTY consumers

### DIFF
--- a/src/lib/init/ui/logging-ui.ts
+++ b/src/lib/init/ui/logging-ui.ts
@@ -83,10 +83,10 @@ export class LoggingUI implements WizardUI {
 
   // ── Lifecycle ─────────────────────────────────────────────────────
 
-  banner(art: string): void {
-    // Plain stderr write, no markdown rendering — the banner already
-    // contains its own ANSI styling and shouldn't be re-processed.
-    this.stderr.write(`\n${art}\n\n`);
+  banner(_art: string): void {
+    // No-op — LoggingUI is used in non-TTY / CI contexts where the
+    // large ASCII banner wastes vertical space and adds noise for
+    // programmatic consumers (agents, scripts, piped output).
   }
 
   intro(title: string): void {
@@ -157,12 +157,12 @@ export class LoggingUI implements WizardUI {
       start: (message?: string) => {
         active = true;
         if (message) {
-          this.writeLine(this.stdout, `... ${this.renderInline(message)}`);
+          this.writeLine(this.stdout, this.renderInline(message));
         }
       },
       message: (message?: string) => {
         if (active && message) {
-          this.writeLine(this.stdout, `... ${this.renderInline(message)}`);
+          this.writeLine(this.stdout, this.renderInline(message));
         }
       },
       stop: (message?: string, code: SpinnerExitCode = 0) => {

--- a/test/lib/init/ui/logging-ui.test.ts
+++ b/test/lib/init/ui/logging-ui.test.ts
@@ -135,7 +135,7 @@ describe("LoggingUI spinner", () => {
     spinner.message("Still working");
     spinner.stop("Done", 0);
     const lines = stdout().split("\n").filter(Boolean);
-    expect(lines).toEqual(["... Working", "... Still working", "ok: Done"]);
+    expect(lines).toEqual(["Working", "Still working", "ok: Done"]);
   });
 
   test("error stop routes to stderr with error prefix", () => {
@@ -143,7 +143,7 @@ describe("LoggingUI spinner", () => {
     const spinner = ui.spinner();
     spinner.start("Working");
     spinner.stop("Boom", 1);
-    expect(stdout()).toBe("... Working\n");
+    expect(stdout()).toBe("Working\n");
     expect(stderr()).toBe("error: Boom\n");
   });
 
@@ -170,7 +170,7 @@ describe("LoggingUI spinner", () => {
     spinner.stop("Done");
     spinner.message("ignored");
     const lines = stdout().split("\n").filter(Boolean);
-    expect(lines).toEqual(["... Working", "ok: Done"]);
+    expect(lines).toEqual(["Working", "ok: Done"]);
   });
 });
 
@@ -247,14 +247,6 @@ describe("LoggingUI disposal", () => {
   });
 });
 
-describe("LoggingUI banner", () => {
-  test("writes art to stderr wrapped in newlines", () => {
-    const { ui, stdout, stderr } = createUI();
-    ui.banner("  ███ SENTRY ███");
-    expect(stdout()).toBe("");
-    expect(stderr()).toBe("\n  ███ SENTRY ███\n\n");
-  });
-});
 
 describe("LoggingUI summary", () => {
   test("empty summary (no fields, no changedFiles) is a no-op", () => {

--- a/test/lib/init/ui/logging-ui.test.ts
+++ b/test/lib/init/ui/logging-ui.test.ts
@@ -247,7 +247,6 @@ describe("LoggingUI disposal", () => {
   });
 });
 
-
 describe("LoggingUI summary", () => {
   test("empty summary (no fields, no changedFiles) is a no-op", () => {
     const { ui, stdout, stderr } = createUI();


### PR DESCRIPTION
LoggingUI is used in non-TTY / CI contexts (--yes, piped output, npm/Node distribution). Two changes to reduce noise for programmatic consumers:

- **Skip the ASCII banner** — the large SENTRY logo wastes vertical space and adds no functional value when output is consumed by agents, scripts, or CI logs. The banner was already suppressed for detected AI agents; this extends the suppression to all LoggingUI contexts.
- **Drop the `... ` prefix** from spinner status lines — `Checking prerequisites...` reads cleaner than `... Checking prerequisites...` in structured logs.

The interactive InkUI path is unaffected.

## Testing
`bun test test/lib/init/ui/logging-ui.test.ts` — all 25 tests pass.

Fixes #940

<!--
## Plan
1. Make `LoggingUI.banner()` a no-op since LoggingUI is only used in non-TTY/CI contexts where the banner is noise.
2. Remove the `... ` prefix from `spinner().start()` and `spinner().message()` in LoggingUI.
3. Update test expectations to match the new behavior.
-->