### PR TITLE
chore: remove dead isBunRuntime() export

### DIFF
--- a/src/lib/init/ui/factory.ts
+++ b/src/lib/init/ui/factory.ts
@@ -53,18 +53,6 @@ export type UIFactoryOptions = {
 };
 
 /**
- * Detect whether the CLI is running inside the Bun-compiled binary
- * vs. the npm/Node distribution. The `Bun` global only exists in
- * the Bun runtime.
- */
-export function isBunRuntime(): boolean {
-  return (
-    typeof globalThis.Bun !== "undefined" &&
-    typeof process.versions.bun === "string"
-  );
-}
-
-/**
  * Detect whether the current process can run an interactive prompt.
  * Both stdin (read keystrokes) and stdout (render the prompt) must be
  * TTYs. Piped input or output disqualifies us.

--- a/test/lib/init/ui/factory.test.ts
+++ b/test/lib/init/ui/factory.test.ts
@@ -12,13 +12,10 @@
  *     bundle into our CJS npm distribution).
  *
  * We patch the env and `process.stdin.isTTY` / `process.stdout.isTTY`
- * around each test so the assertions are deterministic. The
- * Bun-runtime branch is exercised by leaving `isBunRuntime()` to its
- * real return value — the test runner is invoked via `bun test` so
- * the Bun global is present and `getUIAsync` can attempt the Ink
- * path. To keep tests fast and TTY-independent we use the
- * `forceLegacy` / non-TTY / `--yes` paths to assert `LoggingUI` is
- * returned without ever spinning up a real renderer.
+ * around each test so the assertions are deterministic. To keep tests
+ * fast and TTY-independent we use the `forceLegacy` / non-TTY / `--yes`
+ * paths to assert `LoggingUI` is returned without ever spinning up a
+ * real renderer.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";


### PR DESCRIPTION
## Summary

- removes the exported `isBunRuntime()` function from `src/lib/init/ui/factory.ts` — it lost its only caller in #938 when `shouldUseLogging()` stopped gating on the Bun runtime
- updates stale comment in the test file that referenced it

Flagged by Cursor Bugbot in https://github.com/getsentry/cli/pull/938#pullrequestreview-4257969335.