### PR TITLE
fix(init): correct step display order in progress checklist

### DIFF
--- a/src/lib/init/clack-utils.ts
+++ b/src/lib/init/clack-utils.ts
@@ -145,9 +145,9 @@ export const CANONICAL_STEP_ORDER: readonly string[] = [
   "detect-platform",
   "ensure-sentry-project",
   "select-features",
-  "install-deps",
   "plan-codemods",
   "apply-codemods",
+  "install-deps",
   "verify-changes",
   "open-sentry-ui",
 ];
@@ -169,9 +169,9 @@ export const CHECKLIST_VISIBLE_STEPS: readonly string[] = [
   "detect-platform",
   "ensure-sentry-project",
   "select-features",
-  "install-deps",
   "plan-codemods",
   "apply-codemods",
+  "install-deps",
   "verify-changes",
   "open-sentry-ui",
 ];


### PR DESCRIPTION
`CANONICAL_STEP_ORDER` and `CHECKLIST_VISIBLE_STEPS` in `clack-utils.ts` had `install-deps` before `plan-codemods`. The actual Mastra workflow runs them in the opposite order: `planCodemods → applyCodemods → installDeps`.

The back-fill logic in `WizardStore.setStepStatus()` uses canonical indices to auto-skip any pending steps that were bypassed. With the wrong order, activating `plan-codemods` (index 8) would back-fill `install-deps` (index 7) as skipped — crossing it out in the sidebar before it had run. Then when `install-deps` actually activated later, its canonical position had already been passed.

Fix: swap the two entries so both arrays match the real workflow chain.

## Testing

- `pnpm test -- wizard-store` — existing back-fill tests pass
- Manually: run `sentry init` and confirm the sidebar shows "Planning changes" → "Applying changes" → "Installing deps" in that activation order