### PR TITLE
fix(init): thread existing project platform as detect-platform hint

### DIFF
--- a/src/lib/init/existing-project.ts
+++ b/src/lib/init/existing-project.ts
@@ -23,6 +23,7 @@ export async function tryGetExistingProjectData(
       projectId: project.id,
       dsn: dsn ?? "",
       url: buildProjectUrl(orgSlug, project.slug),
+      ...(project.platform ? { platform: project.platform } : {}),
     };
   } catch (error) {
     if (error instanceof ApiError && error.status === 404) {

--- a/src/lib/init/types.ts
+++ b/src/lib/init/types.ts
@@ -10,6 +10,7 @@ export type ExistingProjectData = {
   projectId: string;
   dsn: string;
   url: string;
+  platform?: string;
 };
 
 export type WizardOptions = {

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -598,6 +598,7 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
             dirListing,
             fileCache,
             existingSentry: existingSentry?.data,
+            knownPlatform: context.existingProject?.platform,
           },
           tracingOptions,
         }),
@@ -649,7 +650,13 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
       }
       activeStepId = extracted.stepId;
       ui.setStep?.(extracted.stepId, "in_progress");
-      const activeLabel = STEP_ACTIVE_LABELS[extracted.stepId];
+      let activeLabel = STEP_ACTIVE_LABELS[extracted.stepId];
+      if (
+        extracted.stepId === "detect-platform" &&
+        context.existingProject?.platform
+      ) {
+        activeLabel = `Analyzing project (existing Sentry platform: ${context.existingProject.platform})...`;
+      }
       if (activeLabel && spinState.running) {
         spin.message(activeLabel);
       }


### PR DESCRIPTION
When a user runs \`sentry init org/project\` (or has an existing Sentry project auto-detected), the CLI fetches the project from the API. That response already includes a \`platform\` field (e.g. \`"bun"\`), but \`tryGetExistingProjectData\` was discarding it — so the \`detect-platform\` step had no idea the platform was already known and ran a full ~1-min LLM analysis anyway.

This adds \`platform\` to \`ExistingProjectData\` and passes it as \`knownPlatform\` in the workflow's \`initialState\`. The server-side change feeds this as a strong hint to the AI analysis prompt. The CLI also shows a more informative spinner message when the hint is present: \`"Analyzing project (existing Sentry platform: bun)..."\` instead of the generic detecting copy.

## Testing

Run \`sentry init org/project\` where the project has a \`platform\` set in Sentry and confirm:
- spinner shows \`"Analyzing project (existing Sentry platform: <platform>)..."\`
- \`detect-platform\` completes with the correct SDK (no regression on projects without an existing platform)

Pairs with: getsentry/cli-init-api#136