### PR TITLE
feat(init): tag wizard.outcome on cli.command span

### DIFF
--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -14,7 +14,11 @@
 import { randomBytes } from "node:crypto";
 
 import { MastraClient } from "@mastra/client-js";
-import { captureException, getTraceData } from "@sentry/node-core/light";
+import {
+  captureException,
+  getTraceData,
+  setTag,
+} from "@sentry/node-core/light";
 import { formatBanner } from "../banner.js";
 import { CLI_VERSION } from "../constants.js";
 import { detectAgent } from "../detect-agent.js";
@@ -699,6 +703,7 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
       // failed; the post-dispose report shows the cancel message
       // instead.
       captureException(err);
+      setTag("wizard.outcome", "bailed");
       showCancelledFeedback(ui);
       process.exitCode = 0;
       return;
@@ -708,10 +713,12 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     }
     if (err instanceof WizardError) {
       showFailedFeedback(ui);
+      setTag("wizard.outcome", "errored");
       throw err;
     }
     ui.log.error(errorMessage(err));
     showFailedFeedback(ui);
+    setTag("wizard.outcome", "errored");
     throw new WizardError(errorMessage(err));
   }
 
@@ -725,6 +732,16 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
   }
 
   handleFinalResult(result, spin, spinState, ui);
+  setTag("wizard.outcome", "completed");
+  if (result.result?.platform)
+    setTag("wizard.platform", String(result.result.platform));
+  if (result.result?.features) {
+    const features = result.result.features;
+    setTag(
+      "wizard.features",
+      Array.isArray(features) ? features.join(",") : String(features)
+    );
+  }
 }
 
 function handleFinalResult(
@@ -745,6 +762,7 @@ function handleFinalResult(
     // Map workflow-internal exit codes to semantic EXIT.* constants
     const workflowCode = result.result?.exitCode;
     const exitCode = mapWorkflowExitCode(workflowCode);
+    setTag("wizard.outcome", "errored");
     throw new WizardError("Workflow returned an error", { exitCode });
   }
 

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -733,13 +733,16 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
 
   handleFinalResult(result, spin, spinState, ui);
   setTag("wizard.outcome", "completed");
-  if (result.result?.platform)
+  if (result.result?.platform) {
     setTag("wizard.platform", String(result.result.platform));
+  }
   if (result.result?.features) {
-    const features = result.result.features;
+    const resultFeatures = result.result.features;
     setTag(
       "wizard.features",
-      Array.isArray(features) ? features.join(",") : String(features)
+      Array.isArray(resultFeatures)
+        ? resultFeatures.join(",")
+        : String(resultFeatures)
     );
   }
 }


### PR DESCRIPTION
`span.status` is `unknown` on every `sentry init` run, so there was no way to distinguish completed, bailed, and failed runs in the Init Command dashboard — you just got a sea of identical spans.

Adds `wizard.outcome` (`completed` / `bailed` / `errored`) as a Sentry scope tag at the three exit paths in `runWizard`. On a successful completion also tags `wizard.platform` and `wizard.features` from the final step result, so the CLI span carries the same platform/feature context as the server-side metrics.

This unlocks span-level filtering in Explore and dashboards — e.g. `wizard.outcome:errored` for a "Failed Runs" table, `wizard.outcome:completed` for reach-out to successful users.

Companion change adding the same tags on the server side: getsentry/cli-init-api#136