### PR TITLE
fix(plan): only show progress from current step

### DIFF
--- a/src/lib/formatters/seer.ts
+++ b/src/lib/formatters/seer.ts
@@ -63,19 +63,18 @@ export function formatProgressLine(message: string, tick: number): string {
 /**
  * Extract the latest progress message from autofix state.
  *
+ * Only returns progress from the most recent (last) step to avoid showing
+ * stale messages from earlier phases (e.g. RCA progress during solution polling).
+ *
  * @param state - Current autofix state
  * @returns Latest progress message or default
  */
 export function getProgressMessage(state: AutofixState): string {
-  if (!state.steps) {
-    return "Processing...";
-  }
-
-  // Find the most recent progress message
-  for (let i = state.steps.length - 1; i >= 0; i--) {
-    const step = state.steps[i];
-    if (step?.progress && step.progress.length > 0) {
-      const lastProgress = step.progress.at(-1);
+  if (state.steps && state.steps.length > 0) {
+    // Only look at the last step — earlier steps belong to previous phases
+    const currentStep = state.steps.at(-1);
+    if (currentStep?.progress && currentStep.progress.length > 0) {
+      const lastProgress = currentStep.progress.at(-1);
       if (lastProgress?.message) {
         return lastProgress.message;
       }

--- a/test/lib/formatters/seer.test.ts
+++ b/test/lib/formatters/seer.test.ts
@@ -139,6 +139,77 @@ describe("getProgressMessage", () => {
     expect(getProgressMessage(completedState)).toContain("complete");
     expect(getProgressMessage(errorState)).toContain("fail");
   });
+
+  test("ignores stale progress from earlier completed steps", () => {
+    // Reproduces #950: RCA step is COMPLETED with progress, solution step
+    // has no progress yet — should NOT show stale RCA messages.
+    const state: AutofixState = {
+      run_id: 456,
+      status: "PROCESSING",
+      steps: [
+        {
+          id: "step-rca",
+          key: "root_cause_analysis",
+          status: "COMPLETED",
+          title: "Root Cause Analysis",
+          progress: [
+            {
+              message: "Looking at `src/mdx.ts` in `getsentry/sentry-docs`...",
+              timestamp: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+        {
+          id: "step-solution",
+          key: "solution",
+          status: "PROCESSING",
+          title: "Solution Planning",
+          progress: [],
+        },
+      ],
+    };
+
+    const message = getProgressMessage(state);
+    // Should NOT return the stale RCA message
+    expect(message).not.toContain("Looking at");
+    // Should return a status-based fallback
+    expect(message).toBe("Analyzing issue...");
+  });
+
+  test("returns progress from the current (last) step", () => {
+    const state: AutofixState = {
+      run_id: 789,
+      status: "PROCESSING",
+      steps: [
+        {
+          id: "step-rca",
+          key: "root_cause_analysis",
+          status: "COMPLETED",
+          title: "Root Cause Analysis",
+          progress: [
+            {
+              message: "Stale RCA message",
+              timestamp: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+        {
+          id: "step-solution",
+          key: "solution",
+          status: "PROCESSING",
+          title: "Solution Planning",
+          progress: [
+            {
+              message: "Generating solution plan...",
+              timestamp: "2025-01-01T00:01:00Z",
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(getProgressMessage(state)).toBe("Generating solution plan...");
+  });
 });
 
 describe("formatRootCauseList", () => {


### PR DESCRIPTION
`getProgressMessage()` walked backwards through all autofix steps and returned the first progress message found from any step. During solution polling after RCA completes, this surfaced stale RCA messages (e.g. "Looking at `src/mdx.ts`...") because the completed RCA step still had progress entries while the new solution step had none yet.

Now only reads progress from the last (current) step and falls back to a status-based message when it has no progress.

## Testing

`bun test test/lib/formatters/seer.test.ts` — 40 tests pass, including two new tests for the exact scenario from the issue.

Fixes #950

<!--
## Plan

Root cause: `getProgressMessage()` in `src/lib/formatters/seer.ts` iterates backwards through ALL `state.steps[].progress[]` and returns the last message from any step. When the plan command polls for a solution after RCA is COMPLETED, the solution step may have no progress yet, so the function falls back to showing stale RCA step progress.

Fix: Change `getProgressMessage()` to only look at the last step (the current phase). If the last step has no progress messages, fall back to the status-based default message instead of walking backwards into earlier completed steps.

Files changed:
- `src/lib/formatters/seer.ts` — simplified loop to only check `state.steps.at(-1)`
- `test/lib/formatters/seer.test.ts` — added two tests: one reproducing the exact bug (RCA completed + empty solution progress), one verifying correct step is used when solution has progress
-->