### PR TITLE
fix(telemetry): use startSpan instead of startSpanManual for root span

### DIFF
--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -205,7 +205,7 @@ export async function withTelemetry<T>(
   }
 
   try {
-    return await Sentry.startSpanManual(
+    return await Sentry.startSpan(
       { name: "cli.command", op: "cli.command", forceTransaction: true },
       async (span) => {
         try {
@@ -219,8 +219,6 @@ export async function withTelemetry<T>(
             recordApiErrorOnSpan(span, e as ApiError);
           }
           throw e;
-        } finally {
-          span.end();
         }
       }
     );


### PR DESCRIPTION
Switch `withTelemetry` from `Sentry.startSpanManual` to `Sentry.startSpan` so the SDK manages the root span lifecycle. `startSpan` ends the span in its `.then()` chain after the callback's Promise fully resolves, ensuring the span encompasses the entire command execution — including async generator iteration in commands like `plan` and `explain`.

## Testing

`bun test test/lib/telemetry.test.ts test/lib/command.test.ts` — 168 tests pass.

Fixes #952

<!--
## Plan

The root `cli.command` span in `withTelemetry` used `Sentry.startSpanManual` with a manual `span.end()` in a `finally` block. For generator-based commands (`async *func` pattern), the span could end before all child operations settled because the `finally` block runs as part of the async function's execution, before the outer Promise resolves.

Fix: replace `startSpanManual` + `finally { span.end() }` with `startSpan`, which auto-ends the span in the SDK's `.then()` chain after the callback Promise fully resolves. This is a 3-line diff — `startSpanManual` → `startSpan` and remove the `finally` block.

The error handling for user API errors (401–499) is preserved in the `catch` block. The span reference is still passed to the callback for `setCommandSpanName` and `recordApiErrorOnSpan`.
-->