### PR TITLE
feat: show upgrade nudge when command fails and newer version exists

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -164,8 +164,10 @@ export async function runCli(cliArgs: string[]): Promise<void> {
     AuthError,
     ContextError,
     ConfigError,
+    HostScopeError,
     OutputError,
     ResolutionError,
+    SeerError,
     ValidationError,
     formatError,
     getExitCode,
@@ -189,8 +191,9 @@ export async function runCli(cliArgs: string[]): Promise<void> {
   /**
    * Write an update notification to stderr after a command failure.
    *
-   * User-input errors (missing context, bad config, validation) get the
-   * standard "update available" banner — upgrading won't fix those.
+   * User-input errors (missing context, bad config, validation, auth,
+   * host scope, Seer billing) get the standard "update available" banner
+   * — upgrading won't fix those.
    * Unexpected errors (bugs, API failures) get a contextual nudge
    * suggesting the upgrade may resolve the issue.
    */
@@ -205,7 +208,10 @@ export async function runCli(cliArgs: string[]): Promise<void> {
       err instanceof ContextError ||
       err instanceof ConfigError ||
       err instanceof ValidationError ||
-      err instanceof ResolutionError;
+      err instanceof ResolutionError ||
+      err instanceof AuthError ||
+      err instanceof HostScopeError ||
+      err instanceof SeerError;
     const notification = isUserError
       ? getUpdateNotification()
       : getErrorUpdateNotification();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -160,9 +160,16 @@ export async function runCli(cliArgs: string[]): Promise<void> {
   const { app } = await import("./app.js");
   const { hoistGlobalFlags } = await import("./lib/argv-hoist.js");
   const { buildContext } = await import("./context.js");
-  const { AuthError, OutputError, formatError, getExitCode } = await import(
-    "./lib/errors.js"
-  );
+  const {
+    AuthError,
+    ContextError,
+    ConfigError,
+    OutputError,
+    ResolutionError,
+    ValidationError,
+    formatError,
+    getExitCode,
+  } = await import("./lib/errors.js");
   const { error, warning } = await import("./lib/formatters/colors.js");
   const { runInteractiveLogin } = await import("./lib/interactive-login.js");
   const { getEnvLogLevel, setLogLevel } = await import("./lib/logger.js");
@@ -173,10 +180,39 @@ export async function runCli(cliArgs: string[]): Promise<void> {
   const { startCleanupOldBinary } = await import("./lib/upgrade.js");
   const {
     abortPendingVersionCheck,
+    getErrorUpdateNotification,
     getUpdateNotification,
     maybeCheckForUpdateInBackground,
     shouldSuppressNotification,
   } = await import("./lib/version-check.js");
+
+  /**
+   * Write an update notification to stderr after a command failure.
+   *
+   * User-input errors (missing context, bad config, validation) get the
+   * standard "update available" banner — upgrading won't fix those.
+   * Unexpected errors (bugs, API failures) get a contextual nudge
+   * suggesting the upgrade may resolve the issue.
+   */
+  function maybeWriteErrorNotification(
+    err: unknown,
+    suppressed: boolean
+  ): void {
+    if (suppressed) {
+      return;
+    }
+    const isUserError =
+      err instanceof ContextError ||
+      err instanceof ConfigError ||
+      err instanceof ValidationError ||
+      err instanceof ResolutionError;
+    const notification = isUserError
+      ? getUpdateNotification()
+      : getErrorUpdateNotification();
+    if (notification) {
+      process.stderr.write(notification);
+    }
+  }
 
   // Move global flags (--verbose, -v, --log-level, --json, --fields) from any
   // position to the end of argv, where Stricli's leaf-command parser can
@@ -439,6 +475,7 @@ export async function runCli(cliArgs: string[]): Promise<void> {
     }
     process.stderr.write(`${error("Error:")} ${formatError(err)}\n`);
     process.exitCode = getExitCode(err);
+    maybeWriteErrorNotification(err, suppressNotification);
     return;
   } finally {
     // Abort any pending version check to allow clean exit

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -160,18 +160,9 @@ export async function runCli(cliArgs: string[]): Promise<void> {
   const { app } = await import("./app.js");
   const { hoistGlobalFlags } = await import("./lib/argv-hoist.js");
   const { buildContext } = await import("./context.js");
-  const {
-    AuthError,
-    ContextError,
-    ConfigError,
-    HostScopeError,
-    OutputError,
-    ResolutionError,
-    SeerError,
-    ValidationError,
-    formatError,
-    getExitCode,
-  } = await import("./lib/errors.js");
+  const { AuthError, OutputError, formatError, getExitCode } = await import(
+    "./lib/errors.js"
+  );
   const { error, warning } = await import("./lib/formatters/colors.js");
   const { runInteractiveLogin } = await import("./lib/interactive-login.js");
   const { getEnvLogLevel, setLogLevel } = await import("./lib/logger.js");
@@ -187,38 +178,6 @@ export async function runCli(cliArgs: string[]): Promise<void> {
     maybeCheckForUpdateInBackground,
     shouldSuppressNotification,
   } = await import("./lib/version-check.js");
-
-  /**
-   * Write an update notification to stderr after a command failure.
-   *
-   * User-input errors (missing context, bad config, validation, auth,
-   * host scope, Seer billing) get the standard "update available" banner
-   * — upgrading won't fix those.
-   * Unexpected errors (bugs, API failures) get a contextual nudge
-   * suggesting the upgrade may resolve the issue.
-   */
-  function maybeWriteErrorNotification(
-    err: unknown,
-    suppressed: boolean
-  ): void {
-    if (suppressed) {
-      return;
-    }
-    const isUserError =
-      err instanceof ContextError ||
-      err instanceof ConfigError ||
-      err instanceof ValidationError ||
-      err instanceof ResolutionError ||
-      err instanceof AuthError ||
-      err instanceof HostScopeError ||
-      err instanceof SeerError;
-    const notification = isUserError
-      ? getUpdateNotification()
-      : getErrorUpdateNotification();
-    if (notification) {
-      process.stderr.write(notification);
-    }
-  }
 
   // Move global flags (--verbose, -v, --log-level, --json, --fields) from any
   // position to the end of argv, where Stricli's leaf-command parser can
@@ -481,7 +440,10 @@ export async function runCli(cliArgs: string[]): Promise<void> {
     }
     process.stderr.write(`${error("Error:")} ${formatError(err)}\n`);
     process.exitCode = getExitCode(err);
-    maybeWriteErrorNotification(err, suppressNotification);
+    const notification = getErrorUpdateNotification(err, hoistedArgs);
+    if (notification) {
+      process.stderr.write(notification);
+    }
     return;
   } finally {
     // Abort any pending version check to allow clean exit

--- a/src/commands/issue/merge.ts
+++ b/src/commands/issue/merge.ts
@@ -25,7 +25,6 @@ import { type MergeIssuesResult, mergeIssues } from "../../lib/api-client.js";
 import { buildCommand } from "../../lib/command.js";
 import {
   ApiError,
-  CliError,
   ResolutionError,
   ValidationError,
 } from "../../lib/errors.js";
@@ -126,7 +125,7 @@ async function resolveAllIssues(
   if (!org) {
     // Unreachable — resolved.length >= 1 (callers guard for <2) and we
     // just asserted every entry has a non-empty org.
-    throw new CliError("Internal error: resolved issue missing org slug.");
+    throw new Error("Internal error: resolved issue missing org slug.");
   }
 
   // Dedupe on resolved numeric ID: a user may pass the same issue in

--- a/src/commands/issue/merge.ts
+++ b/src/commands/issue/merge.ts
@@ -25,6 +25,7 @@ import { type MergeIssuesResult, mergeIssues } from "../../lib/api-client.js";
 import { buildCommand } from "../../lib/command.js";
 import {
   ApiError,
+  CliError,
   ResolutionError,
   ValidationError,
 } from "../../lib/errors.js";
@@ -125,7 +126,7 @@ async function resolveAllIssues(
   if (!org) {
     // Unreachable — resolved.length >= 1 (callers guard for <2) and we
     // just asserted every entry has a non-empty org.
-    throw new Error("Internal error: resolved issue missing org slug.");
+    throw new CliError("Internal error: resolved issue missing org slug.");
   }
 
   // Dedupe on resolved numeric ID: a user may pass the same issue in

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -764,8 +764,12 @@ export function getExitCode(error: unknown): number {
  */
 export function isUserError(error: unknown): boolean {
   if (error instanceof ApiError) {
-    // 400 usually means the CLI constructed a bad request. Other 4xx statuses
-    // are user/account/API-state problems: no access, missing entity, etc.
+    // Status 0 = network-level failure (DNS, ECONNREFUSED) — user environment,
+    // not a CLI bug. 400 usually means the CLI constructed a bad request.
+    // Other 4xx statuses are user/account/API-state problems.
+    if (error.status === 0) {
+      return true;
+    }
     return error.status > 400 && error.status < 500;
   }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -754,6 +754,47 @@ export function getExitCode(error: unknown): number {
   return 1;
 }
 
+/**
+ * Classify errors caused by user input, configuration, auth state, or account
+ * settings. These errors already tell the user what to fix, so upgrade nudges
+ * should use the neutral update banner instead of implying a CLI bug fix.
+ *
+ * Generic {@link CliError} instances are treated as user-facing by default.
+ * Explicit non-user subclasses must be checked before that fallback.
+ */
+export function isUserError(error: unknown): boolean {
+  if (error instanceof ApiError) {
+    // 400 usually means the CLI constructed a bad request. Other 4xx statuses
+    // are user/account/API-state problems: no access, missing entity, etc.
+    return error.status > 400 && error.status < 500;
+  }
+
+  if (
+    error instanceof AbortError ||
+    error instanceof TimeoutError ||
+    error instanceof UpgradeError
+  ) {
+    return false;
+  }
+
+  if (
+    error instanceof AuthError ||
+    error instanceof HostScopeError ||
+    error instanceof ConfigError ||
+    error instanceof ContextError ||
+    error instanceof ResolutionError ||
+    error instanceof ValidationError ||
+    error instanceof DeviceFlowError ||
+    error instanceof SeerError ||
+    error instanceof OutputError ||
+    error instanceof WizardError
+  ) {
+    return true;
+  }
+
+  return error instanceof CliError;
+}
+
 /** Result when the guarded operation succeeded */
 export type AuthGuardSuccess<T> = { ok: true; value: T };
 

--- a/src/lib/version-check.ts
+++ b/src/lib/version-check.ts
@@ -343,3 +343,71 @@ export function getUpdateNotification(): string | null {
   }
   return getUpdateNotificationImpl();
 }
+
+/**
+ * Get a contextual upgrade nudge for the error path.
+ *
+ * Shown when a command fails with an unexpected error and a newer CLI version
+ * exists. The copy suggests upgrading may resolve the issue, which is more
+ * actionable than the standard "update available" banner.
+ *
+ * Shares the same gates as {@link getUpdateNotification} (TTY, rate-limit,
+ * once-per-process) so the two never double-emit.
+ *
+ * Returns null when no nudge should be shown (disabled, up-to-date, non-TTY,
+ * rate-limited, or on error).
+ */
+export function getErrorUpdateNotification(): string | null {
+  if (isUpdateCheckDisabled()) {
+    return null;
+  }
+  return getErrorUpdateNotificationImpl();
+}
+
+/**
+ * Build the contextual upgrade nudge shown after unexpected command failures.
+ *
+ * Same gating logic as {@link getUpdateNotificationImpl} (TTY, once-per-process,
+ * daily rate limit) but with copy that frames the upgrade as a potential fix.
+ */
+function getErrorUpdateNotificationImpl(): string | null {
+  if (!isStderrTTY()) {
+    return null;
+  }
+
+  if (notifiedThisProcess) {
+    return null;
+  }
+
+  try {
+    const { latestVersion, lastNotified } = getVersionCheckInfo();
+
+    if (!latestVersion) {
+      return null;
+    }
+
+    if (Bun.semver.order(latestVersion, CLI_VERSION) !== 1) {
+      return null;
+    }
+
+    if (!canNotifyAgain(lastNotified)) {
+      return null;
+    }
+
+    try {
+      markUpdateNotified();
+    } catch (error) {
+      Sentry.captureException(error);
+    }
+    notifiedThisProcess = true;
+
+    return (
+      `\n${muted("A new version of sentry-cli is available")} (${cyan(latestVersion)})${muted(".")} ` +
+      `${muted("Upgrading may resolve this — we fix a lot of bugs in every release.")} ` +
+      `${muted("Run")} ${cyan('"sentry cli upgrade"')} ${muted("to update.")}\n`
+    );
+  } catch (error) {
+    Sentry.captureException(error);
+    return null;
+  }
+}

--- a/src/lib/version-check.ts
+++ b/src/lib/version-check.ts
@@ -21,6 +21,7 @@ import {
   prefetchStablePatches,
 } from "./delta-upgrade.js";
 import { getEnv } from "./env.js";
+import { isUserError } from "./errors.js";
 import { cyan, muted } from "./formatters/colors.js";
 import { cleanupPatchCache } from "./patch-cache.js";
 import { fetchLatestFromGitHub, fetchLatestNightlyVersion } from "./upgrade.js";
@@ -240,7 +241,7 @@ function canNotifyAgain(lastNotified: number | null): boolean {
 }
 
 /**
- * Get the update notification message if a new version is available.
+ * Build an update notification when a newer version is available.
  * Returns null if up-to-date, no cached version info, rate-limited, on a
  * non-TTY stderr, or on error. Never throws — errors are caught and
  * reported to Sentry.
@@ -249,7 +250,9 @@ function canNotifyAgain(lastNotified: number | null): boolean {
  * persists `last_notified = now` via {@link markUpdateNotified} so
  * subsequent invocations within the rate-limit window return null.
  */
-function getUpdateNotificationImpl(): string | null {
+function getUpdateNotificationWithCopy(
+  formatNotification: (latestVersion: string) => string
+): string | null {
   // Gate 1: non-TTY stderr (scripts, CI, pipes).
   if (!isStderrTTY()) {
     return null;
@@ -278,9 +281,7 @@ function getUpdateNotificationImpl(): string | null {
       return null;
     }
 
-    const channel = getReleaseChannel();
-    const label =
-      channel === "nightly" ? "New nightly available:" : "Update available:";
+    const notification = formatNotification(latestVersion);
 
     // Record that we're about to print the banner so repeat invocations
     // within the rate-limit window stay silent. Failures here are
@@ -293,12 +294,28 @@ function getUpdateNotificationImpl(): string | null {
     }
     notifiedThisProcess = true;
 
-    return `\n${muted(label)} ${cyan(CLI_VERSION)} -> ${cyan(latestVersion)}  Run ${cyan('"sentry cli upgrade"')} to update.\n`;
+    return notification;
   } catch (error) {
     // DB access failed - report to Sentry but don't crash CLI
     Sentry.captureException(error);
     return null;
   }
+}
+
+function formatStandardUpdateNotification(latestVersion: string): string {
+  const channel = getReleaseChannel();
+  const label =
+    channel === "nightly" ? "New nightly available:" : "Update available:";
+
+  return `\n${muted(label)} ${cyan(CLI_VERSION)} -> ${cyan(latestVersion)}  Run ${cyan('"sentry cli upgrade"')} to update.\n`;
+}
+
+function formatContextualUpdateNotification(latestVersion: string): string {
+  return (
+    `\n${muted("A new version of sentry-cli is available")} (${cyan(latestVersion)})${muted(".")} ` +
+    `${muted("Upgrading may resolve this — we fix a lot of bugs in every release.")} ` +
+    `${muted("Run")} ${cyan('"sentry cli upgrade"')} ${muted("to update.")}\n`
+  );
 }
 
 /**
@@ -341,73 +358,35 @@ export function getUpdateNotification(): string | null {
   if (isUpdateCheckDisabled()) {
     return null;
   }
-  return getUpdateNotificationImpl();
+  return getUpdateNotificationWithCopy(formatStandardUpdateNotification);
 }
 
 /**
- * Get a contextual upgrade nudge for the error path.
+ * Get an update notification for the error path.
  *
- * Shown when a command fails with an unexpected error and a newer CLI version
- * exists. The copy suggests upgrading may resolve the issue, which is more
- * actionable than the standard "update available" banner.
+ * User errors get the standard neutral banner. Non-user errors get a
+ * contextual nudge suggesting an upgrade may resolve the failure.
  *
  * Shares the same gates as {@link getUpdateNotification} (TTY, rate-limit,
  * once-per-process) so the two never double-emit.
  *
- * Returns null when no nudge should be shown (disabled, up-to-date, non-TTY,
- * rate-limited, or on error).
+ * Returns null when no notification should be shown (suppressed command,
+ * disabled, up-to-date, non-TTY, rate-limited, or on error).
  */
-export function getErrorUpdateNotification(): string | null {
+export function getErrorUpdateNotification(
+  error: unknown,
+  args: string[]
+): string | null {
+  if (shouldSuppressNotification(args)) {
+    return null;
+  }
+
+  if (isUserError(error)) {
+    return getUpdateNotification();
+  }
+
   if (isUpdateCheckDisabled()) {
     return null;
   }
-  return getErrorUpdateNotificationImpl();
-}
-
-/**
- * Build the contextual upgrade nudge shown after unexpected command failures.
- *
- * Same gating logic as {@link getUpdateNotificationImpl} (TTY, once-per-process,
- * daily rate limit) but with copy that frames the upgrade as a potential fix.
- */
-function getErrorUpdateNotificationImpl(): string | null {
-  if (!isStderrTTY()) {
-    return null;
-  }
-
-  if (notifiedThisProcess) {
-    return null;
-  }
-
-  try {
-    const { latestVersion, lastNotified } = getVersionCheckInfo();
-
-    if (!latestVersion) {
-      return null;
-    }
-
-    if (Bun.semver.order(latestVersion, CLI_VERSION) !== 1) {
-      return null;
-    }
-
-    if (!canNotifyAgain(lastNotified)) {
-      return null;
-    }
-
-    try {
-      markUpdateNotified();
-    } catch (error) {
-      Sentry.captureException(error);
-    }
-    notifiedThisProcess = true;
-
-    return (
-      `\n${muted("A new version of sentry-cli is available")} (${cyan(latestVersion)})${muted(".")} ` +
-      `${muted("Upgrading may resolve this — we fix a lot of bugs in every release.")} ` +
-      `${muted("Run")} ${cyan('"sentry cli upgrade"')} ${muted("to update.")}\n`
-    );
-  } catch (error) {
-    Sentry.captureException(error);
-    return null;
-  }
+  return getUpdateNotificationWithCopy(formatContextualUpdateNotification);
 }

--- a/test/lib/errors.test.ts
+++ b/test/lib/errors.test.ts
@@ -497,6 +497,7 @@ describe("isUserError", () => {
     ["DeviceFlowError", new DeviceFlowError("slow_down"), true],
     ["SeerError", new SeerError("not_enabled"), true],
     ["WizardError", new WizardError("wizard failed"), true],
+    ["ApiError 0 (network)", new ApiError("network error", 0), true],
     ["ApiError 400", new ApiError("bad request", 400), false],
     ["ApiError 401", new ApiError("unauthorized", 401), true],
     ["ApiError 418", new ApiError("teapot", 418), true],

--- a/test/lib/errors.test.ts
+++ b/test/lib/errors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  AbortError,
   ApiError,
   AuthError,
   CliError,
@@ -10,6 +11,7 @@ import {
   formatError,
   getExitCode,
   HostScopeError,
+  isUserError,
   OutputError,
   ResolutionError,
   SeerError,
@@ -475,6 +477,39 @@ describe("getExitCode", () => {
   test("returns 1 for non-errors", () => {
     expect(getExitCode("string")).toBe(1);
     expect(getExitCode(null)).toBe(1);
+  });
+});
+
+describe("isUserError", () => {
+  test.each([
+    ["generic CliError", new CliError("message"), true],
+    ["HostScopeError", new HostScopeError("blocked"), true],
+    ["AuthError", new AuthError("invalid"), true],
+    ["ConfigError", new ConfigError("bad config"), true],
+    ["OutputError", new OutputError({ error: "not found" }), true],
+    ["ContextError", new ContextError("Organization", "sentry org list"), true],
+    [
+      "ResolutionError",
+      new ResolutionError("Project 'x'", "not found", "sentry project list"),
+      true,
+    ],
+    ["ValidationError", new ValidationError("bad input"), true],
+    ["DeviceFlowError", new DeviceFlowError("slow_down"), true],
+    ["SeerError", new SeerError("not_enabled"), true],
+    ["WizardError", new WizardError("wizard failed"), true],
+    ["ApiError 400", new ApiError("bad request", 400), false],
+    ["ApiError 401", new ApiError("unauthorized", 401), true],
+    ["ApiError 418", new ApiError("teapot", 418), true],
+    ["ApiError 499", new ApiError("client closed", 499), true],
+    ["ApiError 500", new ApiError("server error", 500), false],
+    ["TimeoutError", new TimeoutError("timed out"), false],
+    ["UpgradeError", new UpgradeError("network_error"), false],
+    ["AbortError", new AbortError(), false],
+    ["standard Error", new Error("boom"), false],
+    ["string throw", "boom", false],
+    ["null", null, false],
+  ])("classifies %s", (_label, errorValue, expected) => {
+    expect(isUserError(errorValue)).toBe(expected);
   });
 });
 

--- a/test/lib/version-check.test.ts
+++ b/test/lib/version-check.test.ts
@@ -9,6 +9,11 @@ import {
   setVersionCheckInfo,
 } from "../../src/lib/db/version-check.js";
 import {
+  ApiError,
+  ContextError,
+  ValidationError,
+} from "../../src/lib/errors.js";
+import {
   abortPendingVersionCheck,
   getErrorUpdateNotification,
   getUpdateNotification,
@@ -213,6 +218,7 @@ describe("getUpdateNotification", () => {
 
 describe("getErrorUpdateNotification", () => {
   useTestConfigDir("test-version-error-notif-");
+  const defaultArgs = ["issue", "list"];
   let savedNoUpdateCheck: string | undefined;
   let restoreTTY: (() => void) | undefined;
 
@@ -232,17 +238,24 @@ describe("getErrorUpdateNotification", () => {
   });
 
   test("returns null when no version info is cached", () => {
-    expect(getErrorUpdateNotification()).toBeNull();
+    expect(
+      getErrorUpdateNotification(new Error("boom"), defaultArgs)
+    ).toBeNull();
   });
 
   test("returns null when cached version is same as current", () => {
     setVersionCheckInfo("0.0.0-dev");
-    expect(getErrorUpdateNotification()).toBeNull();
+    expect(
+      getErrorUpdateNotification(new Error("boom"), defaultArgs)
+    ).toBeNull();
   });
 
-  test("returns contextual message when newer version is available", () => {
+  test("returns contextual message for unexpected errors when newer version is available", () => {
     setVersionCheckInfo("99.0.0");
-    const notification = getErrorUpdateNotification();
+    const notification = getErrorUpdateNotification(
+      new Error("boom"),
+      defaultArgs
+    );
 
     expect(notification).not.toBeNull();
     expect(notification).toContain("99.0.0");
@@ -252,10 +265,49 @@ describe("getErrorUpdateNotification", () => {
 
   test("does not contain standard 'Update available:' label", () => {
     setVersionCheckInfo("99.0.0");
-    const notification = getErrorUpdateNotification();
+    const notification = getErrorUpdateNotification(
+      new Error("boom"),
+      defaultArgs
+    );
 
     expect(notification).not.toBeNull();
     expect(notification).not.toContain("Update available:");
+  });
+
+  test.each([
+    ["ContextError", new ContextError("Organization", "sentry org list")],
+    ["ValidationError", new ValidationError("bad input")],
+    ["ApiError 404", new ApiError("not found", 404)],
+  ])("returns standard update copy for user error %s", (_label, errorValue) => {
+    setVersionCheckInfo("99.0.0");
+    const notification = getErrorUpdateNotification(errorValue, defaultArgs);
+
+    expect(notification).not.toBeNull();
+    expect(notification).toContain("Update available:");
+    expect(notification).not.toContain("Upgrading may resolve this");
+  });
+
+  test.each([
+    ["ApiError 400", new ApiError("bad request", 400)],
+    ["ApiError 500", new ApiError("server error", 500)],
+    ["generic Error", new Error("boom")],
+  ])("returns contextual update copy for non-user error %s", (_label, errorValue) => {
+    setVersionCheckInfo("99.0.0");
+    const notification = getErrorUpdateNotification(errorValue, defaultArgs);
+
+    expect(notification).not.toBeNull();
+    expect(notification).toContain("Upgrading may resolve this");
+    expect(notification).not.toContain("Update available:");
+  });
+
+  test.each([
+    ["json flag", ["issue", "list", "--json"]],
+    ["init", ["init"]],
+    ["upgrade", ["upgrade"]],
+    ["cli setup", ["cli", "setup"]],
+  ])("returns null for suppressed args: %s", (_label, args) => {
+    setVersionCheckInfo("99.0.0");
+    expect(getErrorUpdateNotification(new Error("boom"), args)).toBeNull();
   });
 
   test("returns null when stderr is not a TTY", () => {
@@ -263,14 +315,16 @@ describe("getErrorUpdateNotification", () => {
     restoreTTY = withStderrTTY(false);
 
     setVersionCheckInfo("99.0.0");
-    expect(getErrorUpdateNotification()).toBeNull();
+    expect(
+      getErrorUpdateNotification(new Error("boom"), defaultArgs)
+    ).toBeNull();
   });
 
   test("shares once-per-process latch with getUpdateNotification", () => {
     setVersionCheckInfo("99.0.0");
 
     // Error notification fires first
-    const first = getErrorUpdateNotification();
+    const first = getErrorUpdateNotification(new Error("boom"), defaultArgs);
     expect(first).not.toBeNull();
 
     // Standard notification is suppressed (same latch)
@@ -284,21 +338,21 @@ describe("getErrorUpdateNotification", () => {
     const first = getUpdateNotification();
     expect(first).not.toBeNull();
 
-    const second = getErrorUpdateNotification();
+    const second = getErrorUpdateNotification(new Error("boom"), defaultArgs);
     expect(second).toBeNull();
   });
 
   test("rate-limits across CLI invocations", () => {
     setVersionCheckInfo("99.0.0");
 
-    const first = getErrorUpdateNotification();
+    const first = getErrorUpdateNotification(new Error("boom"), defaultArgs);
     expect(first).not.toBeNull();
 
     // Simulate fresh invocation
     resetUpdateNotificationState();
 
     // Still within 24h window
-    const second = getErrorUpdateNotification();
+    const second = getErrorUpdateNotification(new Error("boom"), defaultArgs);
     expect(second).toBeNull();
   });
 });

--- a/test/lib/version-check.test.ts
+++ b/test/lib/version-check.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../src/lib/db/version-check.js";
 import {
   abortPendingVersionCheck,
+  getErrorUpdateNotification,
   getUpdateNotification,
   maybeCheckForUpdateInBackground,
   resetUpdateNotificationState,
@@ -206,6 +207,98 @@ describe("getUpdateNotification", () => {
 
     // Still within the 24h window → no banner.
     const second = getUpdateNotification();
+    expect(second).toBeNull();
+  });
+});
+
+describe("getErrorUpdateNotification", () => {
+  useTestConfigDir("test-version-error-notif-");
+  let savedNoUpdateCheck: string | undefined;
+  let restoreTTY: (() => void) | undefined;
+
+  beforeEach(() => {
+    savedNoUpdateCheck = process.env.SENTRY_CLI_NO_UPDATE_CHECK;
+    delete process.env.SENTRY_CLI_NO_UPDATE_CHECK;
+    resetUpdateNotificationState();
+    restoreTTY = withStderrTTY(true);
+  });
+
+  afterEach(() => {
+    if (savedNoUpdateCheck !== undefined) {
+      process.env.SENTRY_CLI_NO_UPDATE_CHECK = savedNoUpdateCheck;
+    }
+    restoreTTY?.();
+    restoreTTY = undefined;
+  });
+
+  test("returns null when no version info is cached", () => {
+    expect(getErrorUpdateNotification()).toBeNull();
+  });
+
+  test("returns null when cached version is same as current", () => {
+    setVersionCheckInfo("0.0.0-dev");
+    expect(getErrorUpdateNotification()).toBeNull();
+  });
+
+  test("returns contextual message when newer version is available", () => {
+    setVersionCheckInfo("99.0.0");
+    const notification = getErrorUpdateNotification();
+
+    expect(notification).not.toBeNull();
+    expect(notification).toContain("99.0.0");
+    expect(notification).toContain("Upgrading may resolve this");
+    expect(notification).toContain("sentry cli upgrade");
+  });
+
+  test("does not contain standard 'Update available:' label", () => {
+    setVersionCheckInfo("99.0.0");
+    const notification = getErrorUpdateNotification();
+
+    expect(notification).not.toBeNull();
+    expect(notification).not.toContain("Update available:");
+  });
+
+  test("returns null when stderr is not a TTY", () => {
+    restoreTTY?.();
+    restoreTTY = withStderrTTY(false);
+
+    setVersionCheckInfo("99.0.0");
+    expect(getErrorUpdateNotification()).toBeNull();
+  });
+
+  test("shares once-per-process latch with getUpdateNotification", () => {
+    setVersionCheckInfo("99.0.0");
+
+    // Error notification fires first
+    const first = getErrorUpdateNotification();
+    expect(first).not.toBeNull();
+
+    // Standard notification is suppressed (same latch)
+    const second = getUpdateNotification();
+    expect(second).toBeNull();
+  });
+
+  test("standard notification suppresses error notification too", () => {
+    setVersionCheckInfo("99.0.0");
+
+    const first = getUpdateNotification();
+    expect(first).not.toBeNull();
+
+    const second = getErrorUpdateNotification();
+    expect(second).toBeNull();
+  });
+
+  test("rate-limits across CLI invocations", () => {
+    setVersionCheckInfo("99.0.0");
+
+    const first = getErrorUpdateNotification();
+    expect(first).not.toBeNull();
+
+    // Simulate fresh invocation
+    resetUpdateNotificationState();
+
+    // Still within 24h window
+    const second = getErrorUpdateNotification();
     expect(second).toBeNull();
   });
 });


### PR DESCRIPTION
Wire the version check into the error path so users who hit unexpected errors see a contextual "upgrading may resolve this" message when a newer CLI version is available. User-input errors (ContextError, ConfigError, etc.) get the standard "update available" banner instead.

## Testing
`bun test test/lib/version-check.test.ts` — 32 tests pass, including 8 new tests for `getErrorUpdateNotification`.

Closes #956

<!--
## Plan
1. Add `getErrorUpdateNotification()` to `src/lib/version-check.ts` — same gating (TTY, rate-limit, once-per-process) as `getUpdateNotification()` but with contextual copy: "A new version of sentry-cli is available (x.y.z). Upgrading may resolve this — we fix a lot of bugs in every release."
2. In `src/cli.ts` catch block, call the new function after writing the error. Classify errors: ContextError/ConfigError/ValidationError/ResolutionError are "user errors" → standard banner. Everything else (ApiError, generic errors, SeerError, etc.) → contextual nudge.
3. Extract `maybeWriteErrorNotification()` helper to keep `runCli` under Biome's cognitive complexity limit of 15.
4. Tests verify: null when no version cached, null when same version, contextual message content, no "Update available:" label, TTY gating, shared once-per-process latch with standard notification, and rate limiting across invocations.
-->