### PR TITLE
feat(init): tag wizard.outcome:context_error for non-interactive failures

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -18,6 +18,7 @@
  */
 
 import path from "node:path";
+import { setTag } from "@sentry/node-core/light";
 import type { SentryContext } from "../context.js";
 import { findProjectsBySlug } from "../lib/api/projects.js";
 import { looksLikePath, parseOrgProjectArg } from "../lib/arg-parsing.js";
@@ -369,7 +370,12 @@ export const initCommand = buildCommand<
     // Non-TTY callers (CI/agents) must provide every interactive choice
     // needed to start setup. Fail before project lookup, org prefetch, or
     // UI creation so the error is deterministic and actionable.
-    validateNonInteractiveInit(this, flags, featuresList);
+    try {
+      validateNonInteractiveInit(this, flags, featuresList);
+    } catch (err) {
+      setTag("wizard.outcome", "context_error");
+      throw err;
+    }
 
     // 4. Resolve target → org + project
     //    Validation of user-provided slugs happens inside resolveTarget.


### PR DESCRIPTION
When `sentry init` runs in a non-TTY environment (AI agent, CI) without `--yes` and `--features`, `validateNonInteractiveInit` throws `ContextError` before `runWizard` is ever called — so `wizard.outcome` is never set on the span. `ContextError` is also silenced from Sentry exception capture, which means `cli_error.class` tags are also never written. These runs are currently invisible in any outcome-based query.

Wrapping the `validateNonInteractiveInit` call to catch and retag makes these runs queryable as `wizard.outcome:context_error`, separate from `bailed` (user Ctrl+C) and `errored` (actual wizard failures). The Init Command dashboard already has "Context Errors" KPI and "Context Error Runs" table widgets waiting for this data.