### PR TITLE
fix(init): recover from member project-creation restriction

### DIFF
--- a/src/lib/api/infrastructure.ts
+++ b/src/lib/api/infrastructure.ts
@@ -26,16 +26,27 @@ import {
 /**
  * Enrich a 403 Forbidden error detail with actionable guidance.
  *
- * For env-var tokens (SENTRY_AUTH_TOKEN / SENTRY_TOKEN): extracts the specific
- * missing scope from the API response when available, otherwise suggests
- * checking token scopes. Includes a link to the token settings page.
+ * "Your organization has disabled this feature for members" is an org-level
+ * policy (Organization.flags.disable_member_project_creation), not a token
+ * scope or auth problem. We return targeted guidance and skip the generic
+ * scope/re-auth enrichment entirely — suggesting re-authentication for this
+ * error would be actively wrong and has caused user confusion (CLI-SERVER-E).
  *
- * For OAuth tokens: suggests the user may lack access and should re-authenticate.
- *
- * @param rawDetail - The original detail string from the API 403 response
- * @returns Enriched detail string with actionable suggestions
+ * All other 403s fall through to the existing logic:
+ * - env-var tokens → suggest checking token scopes
+ * - OAuth tokens → suggest re-authentication
  */
 function enrich403Detail(rawDetail: string | undefined): string {
+  // Org-level policy — re-auth and token scope advice do not apply here.
+  if (rawDetail?.includes("disabled this feature")) {
+    return [
+      rawDetail,
+      "",
+      "This is an org-level policy setting, not an auth issue.",
+      "You need org:admin/manager/owner role, or team:admin role on the team.",
+    ].join("\n  ");
+  }
+
   const lines: string[] = [];
   if (rawDetail) {
     lines.push(rawDetail, "");

--- a/src/lib/init/tools/create-sentry-project.ts
+++ b/src/lib/init/tools/create-sentry-project.ts
@@ -1,7 +1,6 @@
-import { createProjectWithDsn, listTeams } from "../../api-client.js";
+import { createProjectWithDsn } from "../../api-client.js";
 import { ApiError } from "../../errors.js";
 import { resolveOrCreateTeam } from "../../resolve-team.js";
-import { getSentryBaseUrl } from "../../sentry-urls.js";
 import { slugify } from "../../utils.js";
 import { tryGetExistingProjectData } from "../existing-project.js";
 import type {
@@ -12,76 +11,17 @@ import type {
 import { formatToolError } from "./shared.js";
 import type { InitToolDefinition, ToolContext } from "./types.js";
 
-/** True when the API returned the org-level member project-creation restriction. */
-function isMemberCreationDenied(error: unknown): error is ApiError {
-  return (
-    error instanceof ApiError &&
-    error.status === 403 &&
-    error.detail?.includes("disabled this feature") === true
-  );
-}
-
-/**
- * Attempt project creation on any team where the user holds team:admin.
- *
- * Called after a 403 "disabled this feature" on the auto-resolved team.
- * team:admin bypasses the org-level member-creation restriction even for
- * plain org members (team_projects.py:228–233).
- *
- * Returns the successful ToolResult, null if no admin team exists, or a
- * failed ToolResult if the retry encountered a different error (so that
- * a 5xx or 409 slug conflict is not masked by the original 403).
- */
-async function retryWithAdminTeam(
-  org: string,
-  name: string,
-  platform: string
-): Promise<ToolResult | null> {
-  try {
-    const allTeams = await listTeams(org);
-    const adminTeam = allTeams.find(
-      (t) => t.isMember === true && t.teamRole === "admin"
-    );
-    if (!adminTeam) {
-      return null;
-    }
-
-    const { project, dsn, url } = await createProjectWithDsn(
-      org,
-      adminTeam.slug,
-      { name, platform }
-    );
-    return {
-      ok: true,
-      data: {
-        orgSlug: org,
-        projectSlug: project.slug,
-        projectId: project.id,
-        dsn: dsn ?? "",
-        url,
-      },
-    };
-  } catch (retryError) {
-    if (!isMemberCreationDenied(retryError)) {
-      // Surface failures unrelated to the same org-policy restriction —
-      // a 409 slug conflict or 5xx should not be masked by the original 403.
-      return { ok: false, error: formatToolError(retryError) };
-    }
-    return null;
-  }
-}
-
 /**
  * Create a new Sentry project using the org that preflight already resolved.
  * Team creation is deferred here for empty-org init flows so the final project
  * slug can be reused as the team slug.
  *
  * New Sentry orgs have member project creation disabled by default
- * (Organization.flags.disable_member_project_creation = true). When the
- * auto-resolved team doesn't grant project-creation rights, we retry once
- * via {@link retryWithAdminTeam}. If no admin team exists we surface a clear
- * error rather than the generic "re-authenticate" advice that 403 enrichment
- * would otherwise produce.
+ * (Organization.flags.disable_member_project_creation = true). When the org
+ * restricts project creation for members, we surface a clear error with an
+ * escape hatch: the user can pass `sentry init <org>/<project-slug>` once an
+ * admin creates the project, which resolves to an existing project and skips
+ * creation entirely (preflight.ts:261).
  */
 export async function createSentryProject(
   payload: CreateSentryProjectPayload | EnsureSentryProjectPayload,
@@ -106,11 +46,6 @@ export async function createSentryProject(
       data: context.existingProject,
     };
   }
-
-  // Hoisted before the try so the catch can read it without a scoping issue.
-  // When the user passed --team explicitly we must not silently swap teams on a
-  // 403 — their intent is clear and we should surface the error as-is.
-  const teamWasExplicit = !!context.team;
 
   try {
     const existingProject = await tryGetExistingProjectData(context.org, slug);
@@ -165,28 +100,26 @@ export async function createSentryProject(
       },
     };
   } catch (error) {
-    // Guard: pass through immediately for explicit teams or non-policy errors.
-    if (teamWasExplicit || !isMemberCreationDenied(error)) {
-      return { ok: false, error: formatToolError(error) };
+    // Org-level policy: members cannot create projects. The generic 403
+    // enrichment would suggest re-authentication, which is wrong here.
+    // Surface a clear message with the escape hatch: once an admin creates
+    // the project, `sentry init <org>/<slug>` resolves to the existing
+    // project and skips creation entirely.
+    if (
+      error instanceof ApiError &&
+      error.status === 403 &&
+      error.detail?.includes("disabled this feature")
+    ) {
+      return {
+        ok: false,
+        error:
+          `Project creation is disabled for members in "${context.org}".\n` +
+          "Ask an org owner to either enable project creation for members\n" +
+          "or create the project for you. Once the project exists, run:\n" +
+          `  sentry init ${context.org}/<project-slug>`,
+      };
     }
-
-    const retryResult = await retryWithAdminTeam(
-      context.org,
-      name,
-      payload.params.platform
-    );
-    if (retryResult) {
-      return retryResult;
-    }
-
-    return {
-      ok: false,
-      error:
-        `Project creation is disabled for members in "${context.org}".\n` +
-        "You need org:admin/manager/owner role, or team:admin role on a team.\n" +
-        "Ask an org owner, or manage access at: " +
-        `${getSentryBaseUrl()}/settings/${context.org}/members/`,
-    };
+    return { ok: false, error: formatToolError(error) };
   }
 }
 

--- a/src/lib/init/tools/create-sentry-project.ts
+++ b/src/lib/init/tools/create-sentry-project.ts
@@ -1,5 +1,7 @@
-import { createProjectWithDsn } from "../../api-client.js";
+import { createProjectWithDsn, listTeams } from "../../api-client.js";
+import { ApiError } from "../../errors.js";
 import { resolveOrCreateTeam } from "../../resolve-team.js";
+import { getSentryBaseUrl } from "../../sentry-urls.js";
 import { slugify } from "../../utils.js";
 import { tryGetExistingProjectData } from "../existing-project.js";
 import type {
@@ -10,10 +12,76 @@ import type {
 import { formatToolError } from "./shared.js";
 import type { InitToolDefinition, ToolContext } from "./types.js";
 
+/** True when the API returned the org-level member project-creation restriction. */
+function isMemberCreationDenied(error: unknown): error is ApiError {
+  return (
+    error instanceof ApiError &&
+    error.status === 403 &&
+    error.detail?.includes("disabled this feature") === true
+  );
+}
+
+/**
+ * Attempt project creation on any team where the user holds team:admin.
+ *
+ * Called after a 403 "disabled this feature" on the auto-resolved team.
+ * team:admin bypasses the org-level member-creation restriction even for
+ * plain org members (team_projects.py:228–233).
+ *
+ * Returns the successful ToolResult, null if no admin team exists, or a
+ * failed ToolResult if the retry encountered a different error (so that
+ * a 5xx or 409 slug conflict is not masked by the original 403).
+ */
+async function retryWithAdminTeam(
+  org: string,
+  name: string,
+  platform: string
+): Promise<ToolResult | null> {
+  try {
+    const allTeams = await listTeams(org);
+    const adminTeam = allTeams.find(
+      (t) => t.isMember === true && t.teamRole === "admin"
+    );
+    if (!adminTeam) {
+      return null;
+    }
+
+    const { project, dsn, url } = await createProjectWithDsn(
+      org,
+      adminTeam.slug,
+      { name, platform }
+    );
+    return {
+      ok: true,
+      data: {
+        orgSlug: org,
+        projectSlug: project.slug,
+        projectId: project.id,
+        dsn: dsn ?? "",
+        url,
+      },
+    };
+  } catch (retryError) {
+    if (!isMemberCreationDenied(retryError)) {
+      // Surface failures unrelated to the same org-policy restriction —
+      // a 409 slug conflict or 5xx should not be masked by the original 403.
+      return { ok: false, error: formatToolError(retryError) };
+    }
+    return null;
+  }
+}
+
 /**
  * Create a new Sentry project using the org that preflight already resolved.
  * Team creation is deferred here for empty-org init flows so the final project
  * slug can be reused as the team slug.
+ *
+ * New Sentry orgs have member project creation disabled by default
+ * (Organization.flags.disable_member_project_creation = true). When the
+ * auto-resolved team doesn't grant project-creation rights, we retry once
+ * via {@link retryWithAdminTeam}. If no admin team exists we surface a clear
+ * error rather than the generic "re-authenticate" advice that 403 enrichment
+ * would otherwise produce.
  */
 export async function createSentryProject(
   payload: CreateSentryProjectPayload | EnsureSentryProjectPayload,
@@ -38,6 +106,11 @@ export async function createSentryProject(
       data: context.existingProject,
     };
   }
+
+  // Hoisted before the try so the catch can read it without a scoping issue.
+  // When the user passed --team explicitly we must not silently swap teams on a
+  // 403 — their intent is clear and we should surface the error as-is.
+  const teamWasExplicit = !!context.team;
 
   try {
     const existingProject = await tryGetExistingProjectData(context.org, slug);
@@ -92,7 +165,28 @@ export async function createSentryProject(
       },
     };
   } catch (error) {
-    return { ok: false, error: formatToolError(error) };
+    // Guard: pass through immediately for explicit teams or non-policy errors.
+    if (teamWasExplicit || !isMemberCreationDenied(error)) {
+      return { ok: false, error: formatToolError(error) };
+    }
+
+    const retryResult = await retryWithAdminTeam(
+      context.org,
+      name,
+      payload.params.platform
+    );
+    if (retryResult) {
+      return retryResult;
+    }
+
+    return {
+      ok: false,
+      error:
+        `Project creation is disabled for members in "${context.org}".\n` +
+        "You need org:admin/manager/owner role, or team:admin role on a team.\n" +
+        "Ask an org owner, or manage access at: " +
+        `${getSentryBaseUrl()}/settings/${context.org}/members/`,
+    };
   }
 }
 

--- a/src/types/sentry.ts
+++ b/src/types/sentry.ts
@@ -40,11 +40,21 @@ import { z } from "zod";
  * Based on the `@sentry/api` list-organizations response type.
  * Core identifiers are required; other SDK fields are available but optional,
  * allowing test mocks and list-endpoint responses to omit them.
+ *
+ * `allowMemberProjectCreation` and `orgRole` are present in detail responses
+ * (GET /api/0/organizations/{slug}/) but absent from list responses, hence
+ * optional. `allowMemberProjectCreation` being false means
+ * Organization.flags.disable_member_project_creation is set — project creation
+ * requires org:write scope or team:admin on the target team.
  */
 export type SentryOrganization = Partial<SdkOrganizationList[number]> & {
   id: string;
   slug: string;
   name: string;
+  /** False when org admins have restricted project creation to owners/managers/team-admins. Default for new orgs. */
+  allowMemberProjectCreation?: boolean;
+  /** The authenticated user's role in this org ("member", "admin", "manager", "owner"). */
+  orgRole?: string;
 };
 
 // Project

--- a/test/lib/api/infrastructure.test.ts
+++ b/test/lib/api/infrastructure.test.ts
@@ -122,6 +122,29 @@ describe("throwApiError", () => {
     // Test preload sets SENTRY_AUTH_TOKEN, so isEnvTokenActive() returns true
     // by default in these tests.
 
+    test("does not suggest token scopes for org-policy disabled-feature 403s", () => {
+      const mockResponse = new Response("", {
+        status: 403,
+        statusText: "Forbidden",
+      });
+
+      try {
+        throwApiError(
+          {
+            detail: "Your organization has disabled this feature for members.",
+          },
+          mockResponse,
+          "Failed to create project"
+        );
+      } catch (error) {
+        const apiError = error as ApiError;
+        expect(apiError.enriched403).toBe(true);
+        expect(apiError.detail).toContain("disabled this feature");
+        expect(apiError.detail).toContain("org-level policy");
+        expect(apiError.detail).not.toContain("SENTRY_AUTH_TOKEN");
+      }
+    });
+
     test("enriches 403 with env-var token hints", () => {
       const mockResponse = new Response("", {
         status: 403,
@@ -258,6 +281,31 @@ describe("throwApiError", () => {
           process.env.SENTRY_TOKEN = savedToken;
         } else {
           delete process.env.SENTRY_TOKEN;
+        }
+      });
+
+      test("does not suggest re-authentication for org-policy disabled-feature 403s", () => {
+        const mockResponse = new Response("", {
+          status: 403,
+          statusText: "Forbidden",
+        });
+
+        try {
+          throwApiError(
+            {
+              detail:
+                "Your organization has disabled this feature for members.",
+            },
+            mockResponse,
+            "Failed to create project"
+          );
+        } catch (error) {
+          const apiError = error as ApiError;
+          expect(apiError.enriched403).toBe(true);
+          expect(apiError.detail).toContain("disabled this feature");
+          expect(apiError.detail).toContain("org-level policy");
+          expect(apiError.detail).not.toContain("Re-authenticate");
+          expect(apiError.detail).not.toContain("sentry auth login");
         }
       });
 

--- a/test/lib/init/tools/create-sentry-project.test.ts
+++ b/test/lib/init/tools/create-sentry-project.test.ts
@@ -39,6 +39,7 @@ let createProjectWithDsnSpy: ReturnType<typeof spyOn>;
 let getProjectSpy: ReturnType<typeof spyOn>;
 let tryGetPrimaryDsnSpy: ReturnType<typeof spyOn>;
 let resolveOrCreateTeamSpy: ReturnType<typeof spyOn>;
+let listTeamsSpy: ReturnType<typeof spyOn>;
 
 beforeEach(() => {
   createProjectWithDsnSpy = spyOn(
@@ -72,6 +73,7 @@ beforeEach(() => {
     slug: "generated-team",
     source: "auto-created",
   } as any);
+  listTeamsSpy = spyOn(apiClient, "listTeams").mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -79,6 +81,7 @@ afterEach(() => {
   getProjectSpy.mockRestore();
   tryGetPrimaryDsnSpy.mockRestore();
   resolveOrCreateTeamSpy.mockRestore();
+  listTeamsSpy.mockRestore();
 });
 
 describe("createSentryProject", () => {
@@ -220,6 +223,109 @@ describe("createSentryProject", () => {
         platform: "javascript-react",
       })
     );
+  });
+
+  test("retries project creation with a team:admin team when org disables member creation", async () => {
+    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
+    createProjectWithDsnSpy
+      .mockRejectedValueOnce(
+        new ApiError(
+          "Failed to create project: 403 Forbidden",
+          403,
+          "Your organization has disabled this feature for members.",
+          undefined,
+          true
+        )
+      )
+      .mockResolvedValueOnce({
+        project: {
+          id: "99",
+          slug: "my-app",
+          name: "my-app",
+          platform: "javascript-react",
+          dateCreated: "2026-01-01T00:00:00Z",
+        } as any,
+        dsn: "https://xyz@o1.ingest.sentry.io/99",
+        url: "https://sentry.io/settings/acme/projects/my-app/",
+      });
+    listTeamsSpy.mockResolvedValue([
+      {
+        slug: "contributor-team",
+        isMember: true,
+        teamRole: "contributor",
+      } as any,
+      { slug: "admin-team", isMember: true, teamRole: "admin" } as any,
+    ]);
+
+    const result = await createSentryProject(makePayload(), {
+      dryRun: false,
+      org: "acme",
+      team: undefined,
+      project: undefined,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(createProjectWithDsnSpy).toHaveBeenCalledTimes(2);
+    expect(createProjectWithDsnSpy).toHaveBeenLastCalledWith(
+      "acme",
+      "admin-team",
+      expect.anything()
+    );
+  });
+
+  test("returns actionable error when org disables member creation and no admin team exists", async () => {
+    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
+    createProjectWithDsnSpy.mockRejectedValueOnce(
+      new ApiError(
+        "Failed to create project: 403 Forbidden",
+        403,
+        "Your organization has disabled this feature for members.",
+        undefined,
+        true
+      )
+    );
+    listTeamsSpy.mockResolvedValue([
+      {
+        slug: "contributor-team",
+        isMember: true,
+        teamRole: "contributor",
+      } as any,
+    ]);
+
+    const result = await createSentryProject(makePayload(), {
+      dryRun: false,
+      org: "acme",
+      team: undefined,
+      project: undefined,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("disabled for members");
+    expect(result.error).toContain("org:admin");
+    expect(result.error).not.toContain("Re-authenticate");
+  });
+
+  test("does not retry when --team was specified explicitly", async () => {
+    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
+    createProjectWithDsnSpy.mockRejectedValueOnce(
+      new ApiError(
+        "Failed to create project: 403 Forbidden",
+        403,
+        "Your organization has disabled this feature for members.",
+        undefined,
+        true
+      )
+    );
+
+    const result = await createSentryProject(makePayload(), {
+      dryRun: false,
+      org: "acme",
+      team: "explicit-team",
+      project: undefined,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(listTeamsSpy).not.toHaveBeenCalled();
   });
 
   test("uses the final project slug for deferred team resolution in dry-run mode", async () => {

--- a/test/lib/init/tools/create-sentry-project.test.ts
+++ b/test/lib/init/tools/create-sentry-project.test.ts
@@ -39,7 +39,6 @@ let createProjectWithDsnSpy: ReturnType<typeof spyOn>;
 let getProjectSpy: ReturnType<typeof spyOn>;
 let tryGetPrimaryDsnSpy: ReturnType<typeof spyOn>;
 let resolveOrCreateTeamSpy: ReturnType<typeof spyOn>;
-let listTeamsSpy: ReturnType<typeof spyOn>;
 
 beforeEach(() => {
   createProjectWithDsnSpy = spyOn(
@@ -73,7 +72,6 @@ beforeEach(() => {
     slug: "generated-team",
     source: "auto-created",
   } as any);
-  listTeamsSpy = spyOn(apiClient, "listTeams").mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -81,7 +79,6 @@ afterEach(() => {
   getProjectSpy.mockRestore();
   tryGetPrimaryDsnSpy.mockRestore();
   resolveOrCreateTeamSpy.mockRestore();
-  listTeamsSpy.mockRestore();
 });
 
 describe("createSentryProject", () => {
@@ -225,55 +222,7 @@ describe("createSentryProject", () => {
     );
   });
 
-  test("retries project creation with a team:admin team when org disables member creation", async () => {
-    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
-    createProjectWithDsnSpy
-      .mockRejectedValueOnce(
-        new ApiError(
-          "Failed to create project: 403 Forbidden",
-          403,
-          "Your organization has disabled this feature for members.",
-          undefined,
-          true
-        )
-      )
-      .mockResolvedValueOnce({
-        project: {
-          id: "99",
-          slug: "my-app",
-          name: "my-app",
-          platform: "javascript-react",
-          dateCreated: "2026-01-01T00:00:00Z",
-        } as any,
-        dsn: "https://xyz@o1.ingest.sentry.io/99",
-        url: "https://sentry.io/settings/acme/projects/my-app/",
-      });
-    listTeamsSpy.mockResolvedValue([
-      {
-        slug: "contributor-team",
-        isMember: true,
-        teamRole: "contributor",
-      } as any,
-      { slug: "admin-team", isMember: true, teamRole: "admin" } as any,
-    ]);
-
-    const result = await createSentryProject(makePayload(), {
-      dryRun: false,
-      org: "acme",
-      team: undefined,
-      project: undefined,
-    });
-
-    expect(result.ok).toBe(true);
-    expect(createProjectWithDsnSpy).toHaveBeenCalledTimes(2);
-    expect(createProjectWithDsnSpy).toHaveBeenLastCalledWith(
-      "acme",
-      "admin-team",
-      expect.anything()
-    );
-  });
-
-  test("returns actionable error when org disables member creation and no admin team exists", async () => {
+  test("returns clear error with sentry-init guidance when org disables member creation", async () => {
     getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
     createProjectWithDsnSpy.mockRejectedValueOnce(
       new ApiError(
@@ -284,13 +233,6 @@ describe("createSentryProject", () => {
         true
       )
     );
-    listTeamsSpy.mockResolvedValue([
-      {
-        slug: "contributor-team",
-        isMember: true,
-        teamRole: "contributor",
-      } as any,
-    ]);
 
     const result = await createSentryProject(makePayload(), {
       dryRun: false,
@@ -301,31 +243,8 @@ describe("createSentryProject", () => {
 
     expect(result.ok).toBe(false);
     expect(result.error).toContain("disabled for members");
-    expect(result.error).toContain("org:admin");
+    expect(result.error).toContain("sentry init acme/");
     expect(result.error).not.toContain("Re-authenticate");
-  });
-
-  test("does not retry when --team was specified explicitly", async () => {
-    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
-    createProjectWithDsnSpy.mockRejectedValueOnce(
-      new ApiError(
-        "Failed to create project: 403 Forbidden",
-        403,
-        "Your organization has disabled this feature for members.",
-        undefined,
-        true
-      )
-    );
-
-    const result = await createSentryProject(makePayload(), {
-      dryRun: false,
-      org: "acme",
-      team: "explicit-team",
-      project: undefined,
-    });
-
-    expect(result.ok).toBe(false);
-    expect(listTeamsSpy).not.toHaveBeenCalled();
   });
 
   test("uses the final project slug for deferred team resolution in dry-run mode", async () => {

--- a/test/lib/init/tools/create-sentry-project.test.ts
+++ b/test/lib/init/tools/create-sentry-project.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as apiClient from "../../../../src/lib/api-client.js";
 import { ApiError } from "../../../../src/lib/errors.js";
-import { createSentryProject } from "../../../../src/lib/init/tools/create-sentry-project.js";
+import {
+  createSentryProject,
+  createSentryProjectTool,
+} from "../../../../src/lib/init/tools/create-sentry-project.js";
 import type {
   CreateSentryProjectPayload,
   EnsureSentryProjectPayload,
@@ -120,6 +123,19 @@ describe("createSentryProject", () => {
 
     expect(result.ok).toBe(true);
     expect(result.message).toContain("Using existing project");
+    expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
+  });
+
+  test("returns error when project name produces an empty slug", async () => {
+    const result = await createSentryProject(makePayload({ name: "---" }), {
+      dryRun: false,
+      org: "acme",
+      team: undefined,
+      project: undefined,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("produces an empty slug");
     expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
   });
 
@@ -245,6 +261,17 @@ describe("createSentryProject", () => {
     expect(result.error).toContain("disabled for members");
     expect(result.error).toContain("sentry init acme/");
     expect(result.error).not.toContain("Re-authenticate");
+  });
+
+  test("tool describe uses payload.detail when provided", () => {
+    const payload = { ...makePayload(), detail: "Setting up my-app..." };
+    expect(createSentryProjectTool.describe(payload)).toBe(
+      "Setting up my-app..."
+    );
+  });
+
+  test("tool describe falls back to project name and platform", () => {
+    expect(createSentryProjectTool.describe(makePayload())).toContain("my-app");
   });
 
   test("uses the final project slug for deferred team resolution in dry-run mode", async () => {


### PR DESCRIPTION
When the wizard tries to create a Sentry project, it fails with a 403 if the org has \`disable_member_project_creation\` set — which is **the default for every new org** (\`organization.py:256\`). The error message then appended "Re-authenticate with: \`sentry auth login\`", which is completely wrong advice for an org policy issue.

Tracked in CLI-SERVER-E (21 events, 11 users including internal).

## What changes

**Clear error with an escape hatch** (\`create-sentry-project.ts\`) — when the org rejects project creation for members, surface the actual problem and tell the user what to do:

\`\`\`
Project creation is disabled for members in "acme".
Ask an org owner to either enable project creation for members
or create the project for you. Once the project exists, run:
  sentry init acme/<project-slug>
\`\`\`

The \`sentry init <org>/<slug>\` escape hatch is real — preflight resolves the positional arg to an existing project and \`createSentryProject\` short-circuits before touching the create API.

A previous iteration retried with a \`team:admin\` team, but that was wrong: the user chose that org and we shouldn't alter its structure silently. It also only paginated the first page of teams, missing admin memberships on large orgs. The right answer is a clear error, not a silent workaround.

**Fix misleading 403 enrichment** (\`infrastructure.ts\`) — \`enrich403Detail\` now short-circuits on \`"disabled this feature"\` before the scope/re-auth branches, so the wrong advice never reaches the user from any command.

**Type the org fields** (\`sentry.ts\`) — adds \`allowMemberProjectCreation?\` and \`orgRole?\` to \`SentryOrganization\` for future use.

## Testing

- 1 new test in \`create-sentry-project.test.ts\`: clear error with \`sentry init\` guidance, no re-auth text
- 2 new tests in \`infrastructure.test.ts\`: no re-auth advice for org-policy 403s, no token-scope advice for org-policy 403s
- All 23 tests pass; baseline failure count unchanged

Fixes CLI-SERVER-E.