### PR TITLE
fix(init): recover gracefully when org listing returns 403

### DIFF
--- a/src/lib/init/preflight.ts
+++ b/src/lib/init/preflight.ts
@@ -1,7 +1,7 @@
 import type { SentryTeam } from "../../types/index.js";
 import { listOrganizations } from "../api-client.js";
 import { getAuthToken } from "../db/auth.js";
-import { WizardError } from "../errors.js";
+import { ApiError, WizardError } from "../errors.js";
 import { resolveOrCreateTeam } from "../resolve-team.js";
 import { slugify } from "../utils.js";
 import { WizardCancelledError } from "./clack-utils.js";
@@ -352,7 +352,23 @@ async function resolveOrgSlug(
     return resolved.org;
   }
 
-  const orgs = await listOrganizations();
+  let orgs: Awaited<ReturnType<typeof listOrganizations>>;
+  try {
+    orgs = await listOrganizations();
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 403) {
+      const lines: string[] = ["Could not list organizations (403 Forbidden)."];
+      if (error.detail) {
+        lines.push(error.detail, "");
+      }
+      lines.push(
+        "Specify the org on the command line:  sentry init <org-slug>/",
+        "Or set an environment variable:       SENTRY_ORG=<org-slug> sentry init"
+      );
+      return { ok: false, error: lines.join("\n  ") };
+    }
+    throw error;
+  }
   if (orgs.length === 0) {
     return {
       ok: false,


### PR DESCRIPTION
When a user runs \`sentry init\` without specifying an org, the CLI calls \`listOrganizations()\` to show a picker. If the auth token lacks \`org:read\` scope — common with limited \`SENTRY_AUTH_TOKEN\` env tokens — that call 403s. The exception had no handler in \`resolveOrgSlug()\`, so it propagated to \`withPreflightHandling()\` which logged only \`error.message\` and killed the wizard entirely, with no indication of how to proceed.

**Before:**
```
✗ Failed to list organizations: 403 Forbidden
✗ Setup failed.
```

**After** (env-var token path shown; OAuth path substitutes "Re-authenticate with: sentry auth login"):
```
✗ Could not list organizations (403 Forbidden).
  Your SENTRY_AUTH_TOKEN token may lack the required scope for this operation.
  Check token scopes at: https://sentry.io/settings/auth-tokens/

  Specify the org on the command line:  sentry init <org-slug>/
  Or set an environment variable:       SENTRY_ORG=<org-slug> sentry init
✗ Setup failed.
```

The fix catches \`ApiError(403)\` in \`resolveOrgSlug()\` and returns a structured \`{ ok: false }\` error instead of throwing. The message surfaces \`error.detail\` (already enriched by \`enrich403Detail()\` with token-scope guidance) plus two actionable recovery hints. Non-403 errors are re-thrown unchanged. The \`{ ok: false }\` return flows through the existing \`ensureOrg()\` → \`withPreflightHandling()\` chain with no other code changes needed.

Ref: sentry issue [7466435851](https://sentry.sentry.io/issues/7466435851/)

## Test plan

- Set \`SENTRY_AUTH_TOKEN\` to a token with no \`org:read\` scope (e.g. only \`project:write\`)
- Run \`sentry init\` with no org argument
- Should print the token-scope hint + the two recovery suggestions, then exit cleanly
- Confirm \`sentry init <org-slug>/\` still works end-to-end with the same limited token