### PR TITLE
feat(docs): add Plausible analytics

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -197,6 +197,15 @@ export default defineConfig({
             href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap",
           },
         },
+        // Plausible analytics — defer keeps it off the critical path
+        {
+          tag: "script",
+          attrs: {
+            defer: true,
+            "data-domain": "cli.sentry.dev",
+            src: "https://plausible.io/js/script.js",
+          },
+        },
         // Open Graph images for social sharing
         {
           tag: "meta",


### PR DESCRIPTION
## Summary
- Adds Plausible analytics script to the docs site (`cli.sentry.dev`)
- Uses `defer` attribute so the script is fetched in parallel but executed after HTML parsing — zero impact on initial page load, LCP, or FCP
- No new dependencies; just a `<script>` tag in the Starlight `head` config

## Test plan
- [ ] Verify the script tag appears in the rendered HTML `<head>`
- [ ] Confirm page load performance is unaffected (Lighthouse or DevTools Network tab)
- [ ] Check Plausible dashboard receives pageviews after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)