### PR TITLE
fix(init): improve multi-org error message for agentic use

### DIFF
--- a/src/lib/init/preflight.ts
+++ b/src/lib/init/preflight.ts
@@ -404,7 +404,11 @@ async function resolveOrgSlug(
     const slugs = orgs.map((org) => org.slug).join(", ");
     return {
       ok: false,
-      error: `Multiple organizations found (${slugs}). Set SENTRY_ORG to specify which one.`,
+      error: [
+        `Multiple organizations found (${slugs}).`,
+        "Specify one with: sentry init <org-slug>/ [directory]",
+        "  or set SENTRY_ORG=<org-slug>",
+      ].join("\n"),
     };
   }
 


### PR DESCRIPTION
When `--yes` is set and the user has multiple orgs, the wizard currently hard-fails with:

```
Multiple organizations found (...). Set SENTRY_ORG to specify which one.
```

That's a dead-end for agents — they read stderr and retry, but the message doesn't tell them *how* to retry. This adds the positional syntax to the hint so agents can act on it immediately:

```
Multiple organizations found (bete-dev, sentry-eu, ...).
Specify one with: sentry init <org-slug>/ [directory]
  or set SENTRY_ORG=<org-slug>
```

All 7 occurrences in CLI-Z1 are the same user running `sentry init` via claude-code/cursor/codex with `--yes` and 8 orgs. No interactive users have hit this.

## Test plan

- Run `sentry init --yes` as a user with 2+ orgs and no existing Sentry config → see updated message
- Run `sentry init <org-slug>/ --yes` → succeeds (unchanged)
- Run `SENTRY_ORG=<org-slug> sentry init --yes` → succeeds (unchanged)

Fixes CLI-Z1