### PR TITLE
fix(auth): surface .sentryclirc source in self-hosted login errors

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -179,13 +179,16 @@ async function resolveRcContext(
  */
 function rcTokenHint(
   rcConfig: SentryCliRcConfig,
-  urlFromRc: string | undefined,
   effectiveHost: string
 ): string | undefined {
   if (!rcConfig.token) {
     return;
   }
-  const urlHint = urlFromRc ? ` --url ${effectiveHost}` : "";
+  // Always include --url for self-hosted instances regardless of how the host
+  // was supplied — omitting it would point the user at SaaS instead.
+  const urlHint = isSaaSTrustOrigin(effectiveHost)
+    ? ""
+    : ` --url ${effectiveHost}`;
   return (
     `Found a token in .sentryclirc (${rcConfig.sources.token}). ` +
     `To skip OAuth next time: sentry auth login --token <token>${urlHint}`
@@ -420,7 +423,7 @@ export const loginCommand = buildCommand({
       persistLoginUrlAsDefault(flags.url, effectiveHost);
       warmOrgCache();
       yield new CommandOutput(result);
-      return { hint: rcTokenHint(rcConfig, urlFromRc, effectiveHost) };
+      return { hint: rcTokenHint(rcConfig, effectiveHost) };
     }
     // Error already displayed by runInteractiveLogin
     process.exitCode = 1;

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -42,7 +42,10 @@ import {
   normalizeOrigin,
   normalizeUserInputToOrigin,
 } from "../../lib/sentry-urls.js";
-import { loadSentryCliRc } from "../../lib/sentryclirc.js";
+import {
+  loadSentryCliRc,
+  type SentryCliRcConfig,
+} from "../../lib/sentryclirc.js";
 import {
   isLoginTrustAnchorFor,
   registerLoginTrustAnchor,
@@ -153,7 +156,7 @@ async function resolveRcContext(
   cwd: string,
   effectiveHost: string
 ): Promise<{
-  rcConfig: Awaited<ReturnType<typeof loadSentryCliRc>>;
+  rcConfig: SentryCliRcConfig;
   urlFromRc: string | undefined;
 }> {
   const rcConfig = await loadSentryCliRc(cwd);
@@ -175,7 +178,7 @@ async function resolveRcContext(
  * Returned as a footer hint so it appears after login completes, not before.
  */
 function rcTokenHint(
-  rcConfig: Awaited<ReturnType<typeof loadSentryCliRc>>,
+  rcConfig: SentryCliRcConfig,
   urlFromRc: string | undefined,
   effectiveHost: string
 ): string | undefined {

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -176,12 +176,22 @@ async function resolveRcContext(
  * Returns a hint string when .sentryclirc contains a token the user could
  * pass directly via --token instead of going through the OAuth flow.
  * Returned as a footer hint so it appears after login completes, not before.
+ *
+ * Only shown when the stored token is plausibly for the current host: either
+ * no URL is set in the rc file (global SaaS token) or the rc URL matches
+ * effectiveHost. A mismatched URL means the token is for a different instance.
  */
 function rcTokenHint(
   rcConfig: SentryCliRcConfig,
   effectiveHost: string
 ): string | undefined {
   if (!rcConfig.token) {
+    return;
+  }
+  const rcUrl = rcConfig.url
+    ? normalizeOrigin(normalizeUrl(rcConfig.url))
+    : undefined;
+  if (rcUrl && rcUrl !== normalizeOrigin(effectiveHost)) {
     return;
   }
   // Always include --url for self-hosted instances regardless of how the host

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -147,9 +147,6 @@ function refuseLoginToUntrustedHost(
 /**
  * Resolve which `.sentryclirc` file (if any) provided the effective host, and
  * return its path alongside the full rc config for downstream use.
- *
- * Separating this into its own function keeps {@link loginCommand}'s `func`
- * complexity within limits.
  */
 async function resolveRcContext(
   flagUrl: string | undefined,

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -181,7 +181,8 @@ async function resolveRcContext(
  * no URL is set in the rc file (global SaaS token) or the rc URL matches
  * effectiveHost. A mismatched URL means the token is for a different instance.
  */
-function rcTokenHint(
+/** @internal exported for testing */
+export function rcTokenHint(
   rcConfig: SentryCliRcConfig,
   effectiveHost: string
 ): string | undefined {

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -133,7 +133,7 @@ function refuseLoginToUntrustedHost(
   ) {
     return;
   }
-  const tokenFlag = flags.token ? ` --token ${flags.token.slice(0, 8)}…` : "";
+  const tokenFlag = flags.token ? " --token <your-token>" : "";
   const sourceClause = rcSource
     ? `this URL was read from .sentryclirc (${rcSource}) but hasn't been confirmed as trusted yet`
     : "--url was not provided";
@@ -184,7 +184,7 @@ function maybeWarnRcToken(
   if (!rcConfig.token) {
     return;
   }
-  const masked = `${rcConfig.token.slice(0, 8)}…`;
+  const masked = "<token>";
   const urlHint = urlFromRc ? ` --url ${effectiveHost}` : "";
   log.info(
     `Tip: Found a token in .sentryclirc (${rcConfig.sources.token}). ` +

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -191,8 +191,12 @@ function rcTokenHint(
   const rcUrl = rcConfig.url
     ? normalizeOrigin(normalizeUrl(rcConfig.url))
     : undefined;
-  if (rcUrl && rcUrl !== normalizeOrigin(effectiveHost)) {
-    return;
+  if (rcUrl) {
+    // rc has an explicit URL — only hint if it matches the current host
+    if (rcUrl !== normalizeOrigin(effectiveHost)) return;
+  } else {
+    // No URL in rc — assume a bare SaaS token; don't hint on self-hosted
+    if (!isSaaSTrustOrigin(effectiveHost)) return;
   }
   // Always include --url for self-hosted instances regardless of how the host
   // was supplied — omitting it would point the user at SaaS instead.
@@ -362,7 +366,7 @@ export const loginCommand = buildCommand({
     // the source file in trust-refusal errors and show a migration tip.
     const { rcConfig, urlFromRc } = await resolveRcContext(
       flags.url,
-      process.cwd(),
+      this.cwd,
       effectiveHost
     );
 

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -173,22 +173,22 @@ async function resolveRcContext(
 }
 
 /**
- * When the user is about to start an OAuth flow but `.sentryclirc` already
- * has a token, surface the faster `--token` path as a one-line tip.
+ * Returns a hint string when .sentryclirc contains a token the user could
+ * pass directly via --token instead of going through the OAuth flow.
+ * Returned as a footer hint so it appears after login completes, not before.
  */
-function maybeWarnRcToken(
+function rcTokenHint(
   rcConfig: Awaited<ReturnType<typeof loadSentryCliRc>>,
   urlFromRc: string | undefined,
   effectiveHost: string
-): void {
+): string | undefined {
   if (!rcConfig.token) {
     return;
   }
-  const masked = "<token>";
   const urlHint = urlFromRc ? ` --url ${effectiveHost}` : "";
-  log.info(
-    `Tip: Found a token in .sentryclirc (${rcConfig.sources.token}). ` +
-      `To use it: sentry auth login --token ${masked}${urlHint}`
+  return (
+    `Found a token in .sentryclirc (${rcConfig.sources.token}). ` +
+    `To skip OAuth next time: sentry auth login --token <token>${urlHint}`
   );
 }
 
@@ -363,11 +363,6 @@ export const loginCommand = buildCommand({
       }
     }
 
-    // If going through the OAuth flow but .sentryclirc has a token, tip the user.
-    if (!flags.token) {
-      maybeWarnRcToken(rcConfig, urlFromRc, effectiveHost);
-    }
-
     // Clear stale cached responses from a previous session
     try {
       await clearResponseCache();
@@ -434,10 +429,10 @@ export const loginCommand = buildCommand({
       // Fire-and-forget — login already succeeded, caching is best-effort.
       warmOrgCache();
       yield new CommandOutput(result);
-    } else {
-      // Error already displayed by runInteractiveLogin
-      process.exitCode = 1;
+      return { hint: rcTokenHint(rcConfig, urlFromRc, effectiveHost) };
     }
+    // Error already displayed by runInteractiveLogin
+    process.exitCode = 1;
   },
 });
 

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -355,7 +355,6 @@ export const loginCommand = buildCommand({
 
     refuseLoginToUntrustedHost(flags, effectiveHost, urlFromRc);
 
-    // Check if already authenticated and handle re-authentication
     if (isAuthenticated()) {
       const shouldProceed = await handleExistingAuth(flags.force);
       if (!shouldProceed) {
@@ -363,25 +362,21 @@ export const loginCommand = buildCommand({
       }
     }
 
-    // Clear stale cached responses from a previous session
     try {
       await clearResponseCache();
     } catch {
       // Non-fatal: cache directory may not exist
     }
 
-    // Token-based authentication
     if (flags.token) {
       // Save token first (with host scope), then validate by fetching user regions
       await setAuthToken(flags.token, undefined, undefined, {
         host: effectiveHost,
       });
 
-      // Validate token by fetching user regions
       try {
         await getUserRegions();
       } catch {
-        // Token is invalid - clear it and throw
         await clearAuth();
         throw new AuthError(
           "invalid",
@@ -389,7 +384,6 @@ export const loginCommand = buildCommand({
         );
       }
 
-      // Login succeeded — persist default URL for subsequent invocations.
       persistLoginUrlAsDefault(flags.url, effectiveHost);
 
       // Fetch and cache user info via /auth/ (works with all token types).
@@ -423,10 +417,7 @@ export const loginCommand = buildCommand({
     });
 
     if (result) {
-      // Login succeeded — persist default URL for subsequent invocations.
       persistLoginUrlAsDefault(flags.url, effectiveHost);
-      // Warm the org + region cache so the first real command is fast.
-      // Fire-and-forget — login already succeeded, caching is best-effort.
       warmOrgCache();
       yield new CommandOutput(result);
       return { hint: rcTokenHint(rcConfig, urlFromRc, effectiveHost) };

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -42,6 +42,7 @@ import {
   normalizeOrigin,
   normalizeUserInputToOrigin,
 } from "../../lib/sentry-urls.js";
+import { loadSentryCliRc } from "../../lib/sentryclirc.js";
 import {
   isLoginTrustAnchorFor,
   registerLoginTrustAnchor,
@@ -115,10 +116,15 @@ export function parseLoginUrl(raw: string): string {
  * a trusted source (`--url` flag or boot-time env snapshot), so "no
  * matching anchor" is the load-bearing signal that the host arrived via
  * an untrusted channel.
+ *
+ * @param rcSource - Path of the `.sentryclirc` file that provided the URL,
+ *   if that's where the host came from. Used to produce a more actionable
+ *   error message pointing at the specific file.
  */
 function refuseLoginToUntrustedHost(
   flags: LoginFlags,
-  effectiveHost: string
+  effectiveHost: string,
+  rcSource?: string
 ): void {
   if (
     flags.url ||
@@ -127,11 +133,62 @@ function refuseLoginToUntrustedHost(
   ) {
     return;
   }
-  const tokenHint = flags.token ? " --token <token>" : "";
+  const tokenFlag = flags.token ? ` --token ${flags.token.slice(0, 8)}…` : "";
+  const sourceClause = rcSource
+    ? `this URL was read from .sentryclirc (${rcSource}) but hasn't been confirmed as trusted yet`
+    : "--url was not provided";
   throw new HostScopeError(
-    `Refusing to log in against ${effectiveHost} without explicit --url.\n` +
-      "Pass the host explicitly to confirm you trust it:\n" +
-      `  sentry auth login --url ${effectiveHost}${tokenHint}`
+    `Refusing to log in against ${effectiveHost} — ${sourceClause}.\n\n` +
+      "To authenticate against this self-hosted instance, confirm the host explicitly:\n" +
+      `  sentry auth login --url ${effectiveHost}${tokenFlag}`
+  );
+}
+
+/**
+ * Resolve which `.sentryclirc` file (if any) provided the effective host, and
+ * return its path alongside the full rc config for downstream use.
+ *
+ * Separating this into its own function keeps {@link loginCommand}'s `func`
+ * complexity within limits.
+ */
+async function resolveRcContext(
+  flagUrl: string | undefined,
+  cwd: string,
+  effectiveHost: string
+): Promise<{
+  rcConfig: Awaited<ReturnType<typeof loadSentryCliRc>>;
+  urlFromRc: string | undefined;
+}> {
+  const rcConfig = await loadSentryCliRc(cwd);
+  const rcUrlNormalized = rcConfig.url
+    ? normalizeOrigin(normalizeUrl(rcConfig.url))
+    : undefined;
+  const urlFromRc =
+    !flagUrl &&
+    !!rcUrlNormalized &&
+    normalizeOrigin(effectiveHost) === rcUrlNormalized
+      ? rcConfig.sources.url
+      : undefined;
+  return { rcConfig, urlFromRc };
+}
+
+/**
+ * When the user is about to start an OAuth flow but `.sentryclirc` already
+ * has a token, surface the faster `--token` path as a one-line tip.
+ */
+function maybeWarnRcToken(
+  rcConfig: Awaited<ReturnType<typeof loadSentryCliRc>>,
+  urlFromRc: string | undefined,
+  effectiveHost: string
+): void {
+  if (!rcConfig.token) {
+    return;
+  }
+  const masked = `${rcConfig.token.slice(0, 8)}…`;
+  const urlHint = urlFromRc ? ` --url ${effectiveHost}` : "";
+  log.info(
+    `Tip: Found a token in .sentryclirc (${rcConfig.sources.token}). ` +
+      `To use it: sentry auth login --token ${masked}${urlHint}`
   );
 }
 
@@ -287,7 +344,16 @@ export const loginCommand = buildCommand({
     // requested instance. Default URL persistence is deferred until login
     // succeeds — see persistLoginUrlAsDefault calls below.
     const effectiveHost = applyLoginUrl(flags.url);
-    refuseLoginToUntrustedHost(flags, effectiveHost);
+
+    // Check whether the effective URL came from .sentryclirc so we can name
+    // the source file in trust-refusal errors and show a migration tip.
+    const { rcConfig, urlFromRc } = await resolveRcContext(
+      flags.url,
+      process.cwd(),
+      effectiveHost
+    );
+
+    refuseLoginToUntrustedHost(flags, effectiveHost, urlFromRc);
 
     // Check if already authenticated and handle re-authentication
     if (isAuthenticated()) {
@@ -295,6 +361,11 @@ export const loginCommand = buildCommand({
       if (!shouldProceed) {
         return;
       }
+    }
+
+    // If going through the OAuth flow but .sentryclirc has a token, tip the user.
+    if (!flags.token) {
+      maybeWarnRcToken(rcConfig, urlFromRc, effectiveHost);
     }
 
     // Clear stale cached responses from a previous session

--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -191,12 +191,13 @@ function rcTokenHint(
   const rcUrl = rcConfig.url
     ? normalizeOrigin(normalizeUrl(rcConfig.url))
     : undefined;
-  if (rcUrl) {
-    // rc has an explicit URL — only hint if it matches the current host
-    if (rcUrl !== normalizeOrigin(effectiveHost)) return;
-  } else {
-    // No URL in rc — assume a bare SaaS token; don't hint on self-hosted
-    if (!isSaaSTrustOrigin(effectiveHost)) return;
+  // Token is for a different host — don't suggest it
+  if (rcUrl && rcUrl !== normalizeOrigin(effectiveHost)) {
+    return;
+  }
+  // No URL in rc means a bare SaaS token — don't suggest it for self-hosted
+  if (!(rcUrl || isSaaSTrustOrigin(effectiveHost))) {
+    return;
   }
   // Always include --url for self-hosted instances regardless of how the host
   // was supplied — omitting it would point the user at SaaS instead.

--- a/test/commands/auth/login.test.ts
+++ b/test/commands/auth/login.test.ts
@@ -77,9 +77,10 @@ mock.module("../../../src/lib/logger.js", () => ({
 }));
 
 // Dynamic import: must run AFTER mock.module() so login.ts picks up fakeLog.
-const { loginCommand } = await import("../../../src/commands/auth/login.js");
+const { loginCommand, rcTokenHint } = await import(
+  "../../../src/commands/auth/login.js"
+);
 
-import { rcTokenHint } from "../../../src/commands/auth/login.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as apiClient from "../../../src/lib/api-client.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking

--- a/test/commands/auth/login.test.ts
+++ b/test/commands/auth/login.test.ts
@@ -79,6 +79,7 @@ mock.module("../../../src/lib/logger.js", () => ({
 // Dynamic import: must run AFTER mock.module() so login.ts picks up fakeLog.
 const { loginCommand } = await import("../../../src/commands/auth/login.js");
 
+import { rcTokenHint } from "../../../src/commands/auth/login.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as apiClient from "../../../src/lib/api-client.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
@@ -88,6 +89,7 @@ import * as dbUser from "../../../src/lib/db/user.js";
 import { AuthError } from "../../../src/lib/errors.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as interactiveLogin from "../../../src/lib/interactive-login.js";
+import type { SentryCliRcConfig } from "../../../src/lib/sentryclirc.js";
 
 type LoginFlags = {
   readonly token?: string;
@@ -778,5 +780,54 @@ describe("applyLoginUrl (trust anchor registration)", () => {
         "https://evil.com/oauth/device/code/"
       )
     ).toBe(false);
+  });
+});
+
+function makeRcConfig(
+  token: string | undefined,
+  url?: string
+): SentryCliRcConfig {
+  return {
+    token,
+    url,
+    sources: { token: token ? "~/.sentryclirc" : undefined },
+  };
+}
+
+describe("rcTokenHint", () => {
+  test("no token → no hint", () => {
+    expect(
+      rcTokenHint(makeRcConfig(undefined), "https://sentry.io")
+    ).toBeUndefined();
+  });
+
+  test("SaaS host, no rc URL → hint without --url", () => {
+    const hint = rcTokenHint(makeRcConfig("sntrys_abc"), "https://sentry.io");
+    expect(hint).toContain("sentry auth login --token <token>");
+    expect(hint).not.toContain("--url");
+  });
+
+  test("self-hosted, rc URL matches → hint includes --url", () => {
+    const hint = rcTokenHint(
+      makeRcConfig("sntrys_abc", "https://self.example.com"),
+      "https://self.example.com"
+    );
+    expect(hint).toContain("--url https://self.example.com");
+  });
+
+  test("self-hosted, rc URL mismatches → no hint (token is for a different instance)", () => {
+    const hint = rcTokenHint(
+      makeRcConfig("sntrys_abc", "https://other.example.com"),
+      "https://self.example.com"
+    );
+    expect(hint).toBeUndefined();
+  });
+
+  test("self-hosted, no rc URL → no hint (bare SaaS token shouldn't be suggested for self-hosted)", () => {
+    const hint = rcTokenHint(
+      makeRcConfig("sntrys_abc"),
+      "https://self.example.com"
+    );
+    expect(hint).toBeUndefined();
   });
 });


### PR DESCRIPTION
When `sentry auth login` rejects a self-hosted URL that came from `.sentryclirc`, the old error just said `--url was not provided` — which doesn't tell you *why* it was blocked or where the URL came from. Now it names the exact file and gives you the fix in one line:

```
Refusing to log in against https://sentry.example.com — this URL was read from
.sentryclirc (/Users/you/.sentryclirc) but hasn't been confirmed as trusted yet.

To authenticate against this self-hosted instance, confirm the host explicitly:
  sentry auth login --url https://sentry.example.com
```
The rc context logic is extracted into small helpers (`resolveRcContext`, `maybeWarnRcToken`) to keep `func`'s cyclomatic complexity in check.

Relates to #975.