### PR TITLE
fix(init): replace confusing classifyArgs errors with specific ValidationError messages

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -41,8 +41,6 @@ const FEATURE_DELIMITER = /[,+ ]+/;
 const NON_INTERACTIVE_USAGE_HINT =
   "sentry init --yes --features errors,tracing,replay [target] [directory]";
 
-const USAGE_HINT = "sentry init <org>/<project> [directory]";
-
 const FEATURE_ALIASES = {
   errors: "errorMonitoring",
   errorMonitoring: "errorMonitoring",
@@ -123,16 +121,26 @@ function classifyArgs(
 
   // Two paths → error
   if (firstIsPath && secondIsPath) {
-    throw new ContextError("Arguments", USAGE_HINT, [
-      "Two directory paths provided. Only one directory is allowed.",
-    ]);
+    throw new ValidationError(
+      [
+        `"${first}" and "${second}" are both directory paths — only one directory is allowed.`,
+        "",
+        "Provide a single directory:",
+        `  sentry init [<org>/<project>] ${first}`,
+      ].join("\n")
+    );
   }
 
   // Two targets → error
   if (!(firstIsPath || secondIsPath)) {
-    throw new ContextError("Arguments", USAGE_HINT, [
-      "Two targets provided. Use <org>/<project> for the target and a path (e.g., ./dir) for the directory.",
-    ]);
+    throw new ValidationError(
+      [
+        `"${first}" and "${second}" are both treated as targets — only one is allowed.`,
+        "",
+        "Pair a target with a directory path:",
+        `  sentry init ${first} ./my-project`,
+      ].join("\n")
+    );
   }
 
   // (TARGET, PATH) — correct order

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -452,18 +452,22 @@ describe("init command func", () => {
   // ── Error cases ───────────────────────────────────────────────────────
 
   describe("error cases", () => {
-    test("two paths throws ContextError", async () => {
+    test("two paths throws ValidationError with specific message", async () => {
       const ctx = makeContext();
-      await expect(
-        func.call(ctx, DEFAULT_FLAGS, "./dir1", "./dir2")
-      ).rejects.toThrow(ContextError);
+      const promise = func.call(ctx, DEFAULT_FLAGS, "./dir1", "./dir2");
+      await expect(promise).rejects.toThrow(ValidationError);
+      await expect(promise).rejects.toThrow(
+        '"./dir1" and "./dir2" are both directory paths'
+      );
     });
 
-    test("two targets throws ContextError", async () => {
+    test("two targets throws ValidationError with specific message", async () => {
       const ctx = makeContext();
-      await expect(
-        func.call(ctx, DEFAULT_FLAGS, "acme/", "other/")
-      ).rejects.toThrow(ContextError);
+      const promise = func.call(ctx, DEFAULT_FLAGS, "acme/", "other/");
+      await expect(promise).rejects.toThrow(ValidationError);
+      await expect(promise).rejects.toThrow(
+        '"acme/" and "other/" are both treated as targets'
+      );
     });
 
     test("org slug with whitespace is rejected by validateResourceId", async () => {


### PR DESCRIPTION
`classifyArgs` was throwing `ContextError` for two invalid-input cases, which produced the nonsensical headline **"Arguments is required."** The root cause ("Two targets provided") was buried in the "Or:" alternatives section — exactly where a user's eye goes last.

Three problems fixed:
- **Wrong error class.** `ContextError` is for missing required values. These are invalid-input cases → `ValidationError`.
- **Meaningless headline.** `ContextError("Arguments", ...)` → `"Arguments is required."` makes no sense when the user did provide args.
- **Diagnosis buried.** The actual explanation was an "Or:" bullet instead of the lead line.

Before (e.g. `sentry init acme/ other/`):
```
Arguments is required.

Specify it using:
  sentry init <org>/<project> [directory]

Or:
  - Two targets provided. Use <org>/<project> for the target and a path (e.g., ./dir) for the directory.
```

After:
```
"acme/" and "other/" are both treated as targets — only one is allowed.

Pair a target with a directory path:
  sentry init acme/ ./my-project
```

Closes https://sentry.sentry.io/issues/7485819399/