### PR TITLE
fix(init): match formatError priority order for WizardError message

### DIFF
--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -869,7 +869,7 @@ export function handleFinalResult(
       setTag("wizard.exit_code", workflowCode);
     }
     throw new WizardError(
-      result.result?.message ?? result.error ?? "Workflow returned an error",
+      result.error ?? result.result?.message ?? "Workflow returned an error",
       { exitCode }
     );
   }


### PR DESCRIPTION
## Summary

The squash merge for #980 captured the first 3 commits but missed the priority-order fix that came in as a follow-up from a bot review. Main currently has `result.result?.message ?? result.error` but `formatError` (which writes to the terminal) uses the opposite: `result.error ?? inner?.message`. This makes the terminal output and the Sentry exception message inconsistent when both fields are set.

## Changes

One-line fix in `handleFinalResult` (`wizard-runner.ts`): swap the operands so the Sentry message uses `result.error ?? result.result?.message`, matching `formatError` exactly.

In practice the two fields are mutually exclusive (structured bails populate `result.result.message`; Mastra framework failures populate `result.error`), so there's no user-visible behaviour change — just consistency between what the terminal shows and what Sentry captures.

## Test Plan

Existing tests in `wizard-runner-handle-final-result.mocked.test.ts` cover both the `result.error` and `result.result.message` paths and pass unchanged.