### PR TITLE
feat(init): show AI-generated feature blurbs in setup summary

### DIFF
--- a/src/lib/formatters/plain-detect.ts
+++ b/src/lib/formatters/plain-detect.ts
@@ -73,22 +73,29 @@ export function isPlainOutput(): boolean {
 }
 
 /**
- * Strip ANSI escape sequences from a string.
+ * Strip ANSI/VT escape sequences from a string.
  *
- * Handles all CSI sequences (`\x1b[...LETTER` — covers SGR colour codes,
- * cursor movement, screen-clear, and other control sequences) and OSC 8
- * terminal hyperlink sequences (`\x1b]8;;url\x07text\x1b]8;;\x07`).
+ * Covers the four escape-sequence families that can reach a terminal:
+ *   - CSI (`\x1b[`): SGR colour codes, cursor movement, screen-clear, etc.
+ *   - OSC (`\x1b]`): window-title changes, hyperlinks, etc.
+ *   - DCS (`\x1bP`): device-control strings.
+ *   - Two-character C1 ESC: single-byte sequences like `\x1bc` (terminal reset).
  */
 export function stripAnsi(text: string): string {
   return (
     text
-      // Full CSI spec: \x1b[ + parameter bytes (0x30-0x3F) + intermediate
-      // bytes (0x20-0x2F, e.g. space, !, ") + final byte (0x40-0x7E).
-      // The narrower [0-9;?]*[A-Za-z] missed sequences with intermediate
-      // bytes like \x1b[!p (Soft Terminal Reset) or \x1b[1 q (cursor style).
+      // CSI: \x1b[ + param bytes (0x30-0x3F) + intermediate bytes (0x20-0x2F) + final byte (0x40-0x7E)
       // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape detection requires matching \x1b
       .replace(/\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g, "")
-      // biome-ignore lint/suspicious/noControlCharactersInRegex: OSC 8 hyperlink sequences use \x1b and \x07
-      .replace(/\x1b\]8;;[^\x07]*\x07/g, "")
+      // OSC: \x1b] ... terminated by BEL (\x07) or ST (\x1b\)
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: OSC sequences use \x1b and \x07
+      .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
+      // DCS: \x1bP ... terminated by ST (\x1b\)
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: DCS sequences use \x1b
+      .replace(/\x1bP[^\x1b]*\x1b\\/g, "")
+      // Two-character ESC sequences (C1: 0x40-0x5F, Fs: 0x60-0x7E), e.g. \x1bc (terminal reset).
+      // Applied last so CSI/OSC/DCS introducers (\x1b[, \x1b], \x1bP) are already stripped.
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: ESC sequence detection requires matching \x1b
+      .replace(/\x1b[@-~]/g, "")
   );
 }

--- a/src/lib/formatters/plain-detect.ts
+++ b/src/lib/formatters/plain-detect.ts
@@ -82,8 +82,12 @@ export function isPlainOutput(): boolean {
 export function stripAnsi(text: string): string {
   return (
     text
+      // Full CSI spec: \x1b[ + parameter bytes (0x30-0x3F) + intermediate
+      // bytes (0x20-0x2F, e.g. space, !, ") + final byte (0x40-0x7E).
+      // The narrower [0-9;?]*[A-Za-z] missed sequences with intermediate
+      // bytes like \x1b[!p (Soft Terminal Reset) or \x1b[1 q (cursor style).
       // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape detection requires matching \x1b
-      .replace(/\x1b\[[0-9;?]*[A-Za-z]/g, "")
+      .replace(/\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g, "")
       // biome-ignore lint/suspicious/noControlCharactersInRegex: OSC 8 hyperlink sequences use \x1b and \x07
       .replace(/\x1b\]8;;[^\x07]*\x07/g, "")
   );

--- a/src/lib/formatters/plain-detect.ts
+++ b/src/lib/formatters/plain-detect.ts
@@ -75,14 +75,15 @@ export function isPlainOutput(): boolean {
 /**
  * Strip ANSI escape sequences from a string.
  *
- * Handles SGR codes (`\x1b[...m`) and OSC 8 terminal hyperlink sequences
- * (`\x1b]8;;url\x07text\x1b]8;;\x07`).
+ * Handles all CSI sequences (`\x1b[...LETTER` — covers SGR colour codes,
+ * cursor movement, screen-clear, and other control sequences) and OSC 8
+ * terminal hyperlink sequences (`\x1b]8;;url\x07text\x1b]8;;\x07`).
  */
 export function stripAnsi(text: string): string {
   return (
     text
-      // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape detection requires matching \x1b and \x07
-      .replace(/\x1b\[[0-9;]*m/g, "")
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape detection requires matching \x1b
+      .replace(/\x1b\[[0-9;?]*[A-Za-z]/g, "")
       // biome-ignore lint/suspicious/noControlCharactersInRegex: OSC 8 hyperlink sequences use \x1b and \x07
       .replace(/\x1b\]8;;[^\x07]*\x07/g, "")
   );

--- a/src/lib/init/feedback.ts
+++ b/src/lib/init/feedback.ts
@@ -7,9 +7,7 @@ const FEEDBACK_COMMANDS: Record<InitFeedbackOutcome, string> = {
 };
 
 const FEEDBACK_COPY: Record<InitFeedbackOutcome, string[]> = {
-  success: [
-    "Tell us what felt great or rough:",
-  ],
+  success: ["Tell us what felt great or rough:"],
   cancelled: [
     "Sad to see setup stop. Was something going sideways?",
     "Tell us so we can fix it:",

--- a/src/lib/init/feedback.ts
+++ b/src/lib/init/feedback.ts
@@ -8,7 +8,6 @@ const FEEDBACK_COMMANDS: Record<InitFeedbackOutcome, string> = {
 
 const FEEDBACK_COPY: Record<InitFeedbackOutcome, string[]> = {
   success: [
-    "Nice, setup made it through.",
     "Tell us what felt great or rough:",
   ],
   cancelled: [

--- a/src/lib/init/formatters.ts
+++ b/src/lib/init/formatters.ts
@@ -16,7 +16,7 @@
  */
 
 import { terminalLink } from "../formatters/colors.js";
-import { featureLabel } from "./clack-utils.js";
+import { featureLabel, sortFeatures } from "./clack-utils.js";
 import {
   EXIT_DEPENDENCY_INSTALL_FAILED,
   EXIT_PLATFORM_NOT_DETECTED,
@@ -41,7 +41,7 @@ function buildSummary(output: WizardOutput): WizardSummary | null {
   if (output.projectDir) {
     fields.push({ label: "Directory", value: output.projectDir });
   }
-  if (output.features?.length) {
+  if (output.features?.length && !output.featureBlurbs?.length) {
     fields.push({
       label: "Features",
       value: output.features.map(featureLabel).join(", "),
@@ -62,6 +62,15 @@ function buildSummary(output: WizardOutput): WizardSummary | null {
 
   const changedFiles = output.changedFiles ?? [];
 
+  const featureBlurbs = sortFeatures(
+    (output.featureBlurbs ?? []).map((b) => b.feature)
+  )
+    .map((feature) => {
+      const match = output.featureBlurbs?.find((b) => b.feature === feature);
+      return match ? { label: featureLabel(feature), blurb: match.blurb } : null;
+    })
+    .filter((b): b is { label: string; blurb: string } => b !== null);
+
   if (fields.length === 0 && changedFiles.length === 0) {
     return null;
   }
@@ -69,6 +78,7 @@ function buildSummary(output: WizardOutput): WizardSummary | null {
   return {
     fields,
     ...(changedFiles.length > 0 ? { changedFiles } : {}),
+    ...(featureBlurbs.length > 0 ? { featureBlurbs } : {}),
   };
 }
 

--- a/src/lib/init/formatters.ts
+++ b/src/lib/init/formatters.ts
@@ -62,12 +62,13 @@ function buildSummary(output: WizardOutput): WizardSummary | null {
 
   const changedFiles = output.changedFiles ?? [];
 
-  const featureBlurbs = sortFeatures(
-    (output.featureBlurbs ?? []).map((b) => b.feature)
-  )
+  const blurbMap = new Map(
+    (output.featureBlurbs ?? []).map(({ feature, blurb }) => [feature, blurb])
+  );
+  const featureBlurbs = sortFeatures([...blurbMap.keys()])
     .map((feature) => {
-      const match = output.featureBlurbs?.find((b) => b.feature === feature);
-      return match ? { label: featureLabel(feature), blurb: match.blurb } : null;
+      const blurb = blurbMap.get(feature);
+      return blurb ? { label: featureLabel(feature), blurb } : null;
     })
     .filter((b): b is { label: string; blurb: string } => b !== null);
 

--- a/src/lib/init/formatters.ts
+++ b/src/lib/init/formatters.ts
@@ -62,12 +62,15 @@ function buildSummary(output: WizardOutput): WizardSummary | null {
 
   const changedFiles = output.changedFiles ?? [];
 
-  const blurbMap = new Map(
-    (output.featureBlurbs ?? []).map(({ feature, blurb }) => [feature, blurb])
-  );
-  const featureBlurbs = sortFeatures([...blurbMap.keys()])
+  // output.features is the canonical ordered list of selected feature IDs.
+  // Pair blurbs positionally so labels are always correct regardless of what
+  // the agent echoes back in the feature field.
+  const blurbsInOrder = output.featureBlurbs ?? [];
+  const canonicalFeatures = output.features ?? [];
+  const featureBlurbs = sortFeatures(canonicalFeatures)
     .map((feature) => {
-      const blurb = blurbMap.get(feature);
+      const pos = canonicalFeatures.indexOf(feature);
+      const blurb = blurbsInOrder[pos]?.blurb;
       return blurb ? { label: featureLabel(feature), blurb } : null;
     })
     .filter((b): b is { label: string; blurb: string } => b !== null);

--- a/src/lib/init/formatters.ts
+++ b/src/lib/init/formatters.ts
@@ -75,7 +75,11 @@ function buildSummary(output: WizardOutput): WizardSummary | null {
     })
     .filter((b): b is { label: string; blurb: string } => b !== null);
 
-  if (fields.length === 0 && changedFiles.length === 0 && featureBlurbs.length === 0) {
+  if (
+    fields.length === 0 &&
+    changedFiles.length === 0 &&
+    featureBlurbs.length === 0
+  ) {
     return null;
   }
 

--- a/src/lib/init/formatters.ts
+++ b/src/lib/init/formatters.ts
@@ -16,6 +16,7 @@
  */
 
 import { terminalLink } from "../formatters/colors.js";
+import { stripAnsi } from "../formatters/plain-detect.js";
 import { featureLabel, sortFeatures } from "./clack-utils.js";
 import {
   EXIT_DEPENDENCY_INSTALL_FAILED,
@@ -62,15 +63,19 @@ function buildSummary(output: WizardOutput): WizardSummary | null {
 
   const changedFiles = output.changedFiles ?? [];
 
-  // output.features is the canonical ordered list of selected feature IDs.
-  // Pair blurbs positionally so labels are always correct regardless of what
-  // the agent echoes back in the feature field.
-  const blurbsInOrder = output.featureBlurbs ?? [];
-  const canonicalFeatures = output.features ?? [];
-  const featureBlurbs = sortFeatures(canonicalFeatures)
+  // Build a Map keyed by the feature ID the agent echoed back. Labels always
+  // come from featureLabel(canonicalId) so they are correct regardless of what
+  // the agent put in the feature field. If the agent omits or misspells a
+  // feature ID the blurb is simply absent for that feature — never misassigned.
+  const blurbMap = new Map(
+    (output.featureBlurbs ?? []).map(({ feature, blurb }) => [
+      feature,
+      stripAnsi(blurb),
+    ])
+  );
+  const featureBlurbs = sortFeatures(output.features ?? [])
     .map((feature) => {
-      const pos = canonicalFeatures.indexOf(feature);
-      const blurb = blurbsInOrder[pos]?.blurb;
+      const blurb = blurbMap.get(feature);
       return blurb ? { label: featureLabel(feature), blurb } : null;
     })
     .filter((b): b is { label: string; blurb: string } => b !== null);

--- a/src/lib/init/formatters.ts
+++ b/src/lib/init/formatters.ts
@@ -75,7 +75,7 @@ function buildSummary(output: WizardOutput): WizardSummary | null {
     })
     .filter((b): b is { label: string; blurb: string } => b !== null);
 
-  if (fields.length === 0 && changedFiles.length === 0) {
+  if (fields.length === 0 && changedFiles.length === 0 && featureBlurbs.length === 0) {
     return null;
   }
 

--- a/src/lib/init/formatters.ts
+++ b/src/lib/init/formatters.ts
@@ -34,6 +34,22 @@ import type { WizardSummary, WizardUI } from "./ui/types.js";
  * appear.
  */
 function buildSummary(output: WizardOutput): WizardSummary | null {
+  // Resolve blurbs first so the Features row can check the *resolved* length.
+  // If the agent returns blurbs with wrong IDs they all drop out here, and
+  // the Features row falls back to showing correctly.
+  const blurbMap = new Map(
+    (output.featureBlurbs ?? []).map(({ feature, blurb }) => [
+      feature,
+      stripAnsi(blurb),
+    ])
+  );
+  const featureBlurbs = sortFeatures(output.features ?? [])
+    .map((feature) => {
+      const blurb = blurbMap.get(feature);
+      return blurb ? { label: featureLabel(feature), blurb } : null;
+    })
+    .filter((b): b is { label: string; blurb: string } => b !== null);
+
   const fields: WizardSummary["fields"] = [];
 
   if (output.platform) {
@@ -42,7 +58,7 @@ function buildSummary(output: WizardOutput): WizardSummary | null {
   if (output.projectDir) {
     fields.push({ label: "Directory", value: output.projectDir });
   }
-  if (output.features?.length && !output.featureBlurbs?.length) {
+  if (output.features?.length && !featureBlurbs.length) {
     fields.push({
       label: "Features",
       value: output.features.map(featureLabel).join(", "),
@@ -62,23 +78,6 @@ function buildSummary(output: WizardOutput): WizardSummary | null {
   }
 
   const changedFiles = output.changedFiles ?? [];
-
-  // Build a Map keyed by the feature ID the agent echoed back. Labels always
-  // come from featureLabel(canonicalId) so they are correct regardless of what
-  // the agent put in the feature field. If the agent omits or misspells a
-  // feature ID the blurb is simply absent for that feature — never misassigned.
-  const blurbMap = new Map(
-    (output.featureBlurbs ?? []).map(({ feature, blurb }) => [
-      feature,
-      stripAnsi(blurb),
-    ])
-  );
-  const featureBlurbs = sortFeatures(output.features ?? [])
-    .map((feature) => {
-      const blurb = blurbMap.get(feature);
-      return blurb ? { label: featureLabel(feature), blurb } : null;
-    })
-    .filter((b): b is { label: string; blurb: string } => b !== null);
 
   if (
     fields.length === 0 &&

--- a/src/lib/init/types.ts
+++ b/src/lib/init/types.ts
@@ -229,6 +229,7 @@ export type WizardOutput = {
   docsUrl?: string;
   sentryProjectUrl?: string;
   message?: string;
+  featureBlurbs?: Array<{ feature: string; blurb: string }>;
 };
 
 // Interactive payloads

--- a/src/lib/init/ui/ink-app.tsx
+++ b/src/lib/init/ui/ink-app.tsx
@@ -1173,9 +1173,6 @@ function SummaryPanel({
           ))}
         </Box>
       ) : null}
-      {summary.changedFiles !== undefined && summary.changedFiles.length > 0 ? (
-        <ChangedFilesTree files={summary.changedFiles} />
-      ) : null}
       {summary.featureBlurbs !== undefined &&
       summary.featureBlurbs.length > 0 ? (
         <Box flexDirection="column" flexShrink={0} marginTop={1}>
@@ -1197,6 +1194,9 @@ function SummaryPanel({
             </Box>
           ))}
         </Box>
+      ) : null}
+      {summary.changedFiles !== undefined && summary.changedFiles.length > 0 ? (
+        <ChangedFilesTree files={summary.changedFiles} />
       ) : null}
     </Box>
   );

--- a/src/lib/init/ui/ink-app.tsx
+++ b/src/lib/init/ui/ink-app.tsx
@@ -1182,7 +1182,7 @@ function SummaryPanel({
             Here&apos;s what we set up
           </Text>
           {summary.featureBlurbs.map(({ label, blurb }) => (
-            <Box flexDirection="row" flexShrink={0} key={label} marginTop={0}>
+            <Box flexDirection="row" flexShrink={0} key={label}>
               <Box flexShrink={0} width={22}>
                 <Text bold color={PRIMARY}>
                   {label}

--- a/src/lib/init/ui/ink-app.tsx
+++ b/src/lib/init/ui/ink-app.tsx
@@ -1176,7 +1176,8 @@ function SummaryPanel({
       {summary.changedFiles !== undefined && summary.changedFiles.length > 0 ? (
         <ChangedFilesTree files={summary.changedFiles} />
       ) : null}
-      {summary.featureBlurbs !== undefined && summary.featureBlurbs.length > 0 ? (
+      {summary.featureBlurbs !== undefined &&
+      summary.featureBlurbs.length > 0 ? (
         <Box flexDirection="column" flexShrink={0} marginTop={1}>
           <Text bold color={MUTED}>
             Here&apos;s what we set up

--- a/src/lib/init/ui/ink-app.tsx
+++ b/src/lib/init/ui/ink-app.tsx
@@ -1176,6 +1176,27 @@ function SummaryPanel({
       {summary.changedFiles !== undefined && summary.changedFiles.length > 0 ? (
         <ChangedFilesTree files={summary.changedFiles} />
       ) : null}
+      {summary.featureBlurbs !== undefined && summary.featureBlurbs.length > 0 ? (
+        <Box flexDirection="column" flexShrink={0} marginTop={1}>
+          <Text bold color={MUTED}>
+            Here&apos;s what we set up
+          </Text>
+          {summary.featureBlurbs.map(({ label, blurb }) => (
+            <Box flexDirection="row" flexShrink={0} key={label} marginTop={0}>
+              <Box flexShrink={0} width={22}>
+                <Text bold color={PRIMARY}>
+                  {label}
+                </Text>
+              </Box>
+              <Box flexShrink={1}>
+                <Text color={MUTED} wrap="wrap">
+                  {blurb}
+                </Text>
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      ) : null}
     </Box>
   );
 }

--- a/src/lib/init/ui/ink-report.ts
+++ b/src/lib/init/ui/ink-report.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import { renderTextTable } from "../../formatters/text-table.js";
 import { buildFileTree, flattenTree } from "./file-tree.js";
 import type { WizardSummary } from "./types.js";
 
@@ -66,6 +67,20 @@ export function formatSuccessReport(
     const tree = buildFileTree(summary.changedFiles);
     for (const row of flattenTree(tree)) {
       lines.push(formatTreeRowChalk(row));
+    }
+  }
+  if (summary?.featureBlurbs && summary.featureBlurbs.length > 0) {
+    lines.push("");
+    lines.push(`   ${chalk.hex(REPORT_MUTED).bold("Here's what we set up")}`);
+    const tableRows = summary.featureBlurbs.map(({ label, blurb }) => [
+      chalk.bold(label),
+      chalk.hex(REPORT_MUTED)(blurb),
+    ]);
+    const table = renderTextTable(["", ""], tableRows, {
+      shrinkable: [false, true],
+    });
+    for (const line of table.trimEnd().split("\n")) {
+      lines.push(`   ${line}`);
     }
   }
   appendFeedbackHint(lines, feedbackHint);

--- a/src/lib/init/ui/ink-report.ts
+++ b/src/lib/init/ui/ink-report.ts
@@ -61,14 +61,6 @@ export function formatSuccessReport(
       lines.push(`   ${label}  ${field.value}`);
     }
   }
-  if (summary?.changedFiles && summary.changedFiles.length > 0) {
-    lines.push("");
-    lines.push(`   ${chalk.hex(REPORT_MUTED).bold("Changed files")}`);
-    const tree = buildFileTree(summary.changedFiles);
-    for (const row of flattenTree(tree)) {
-      lines.push(formatTreeRowChalk(row));
-    }
-  }
   if (summary?.featureBlurbs && summary.featureBlurbs.length > 0) {
     lines.push("");
     lines.push(`   ${chalk.hex(REPORT_MUTED).bold("Here's what we set up")}`);
@@ -81,6 +73,14 @@ export function formatSuccessReport(
     });
     for (const line of table.trimEnd().split("\n")) {
       lines.push(`   ${line}`);
+    }
+  }
+  if (summary?.changedFiles && summary.changedFiles.length > 0) {
+    lines.push("");
+    lines.push(`   ${chalk.hex(REPORT_MUTED).bold("Changed files")}`);
+    const tree = buildFileTree(summary.changedFiles);
+    for (const row of flattenTree(tree)) {
+      lines.push(formatTreeRowChalk(row));
     }
   }
   appendFeedbackHint(lines, feedbackHint);

--- a/src/lib/init/ui/logging-ui.ts
+++ b/src/lib/init/ui/logging-ui.ts
@@ -18,6 +18,7 @@
  * logs deterministic and free of carriage returns.
  */
 
+import { renderTextTable } from "../../formatters/text-table.js";
 import {
   renderInlineMarkdown,
   renderMarkdown,
@@ -117,6 +118,20 @@ export class LoggingUI implements WizardUI {
       const tree = buildFileTree(summary.changedFiles);
       for (const row of flattenTree(tree)) {
         this.writeLine(this.stdout, `    ${formatTreeRowPlain(row)}`);
+      }
+    }
+    if (summary.featureBlurbs && summary.featureBlurbs.length > 0) {
+      this.writeLine(this.stdout, "");
+      this.writeLine(this.stdout, "  Here's what we set up:");
+      const tableRows = summary.featureBlurbs.map(({ label, blurb }) => [
+        label,
+        blurb,
+      ]);
+      const table = renderTextTable(["", ""], tableRows, {
+        shrinkable: [false, true],
+      });
+      for (const line of table.trimEnd().split("\n")) {
+        this.writeLine(this.stdout, `  ${line}`);
       }
     }
   }

--- a/src/lib/init/ui/logging-ui.ts
+++ b/src/lib/init/ui/logging-ui.ts
@@ -18,11 +18,11 @@
  * logs deterministic and free of carriage returns.
  */
 
-import { renderTextTable } from "../../formatters/text-table.js";
 import {
   renderInlineMarkdown,
   renderMarkdown,
 } from "../../formatters/markdown.js";
+import { renderTextTable } from "../../formatters/text-table.js";
 import { formatFeedbackHint, type InitFeedbackOutcome } from "../feedback.js";
 import { buildFileTree, flattenTree } from "./file-tree.js";
 import type {
@@ -95,7 +95,11 @@ export class LoggingUI implements WizardUI {
   }
 
   summary(summary: WizardSummary): void {
-    if (summary.fields.length === 0 && !summary.changedFiles?.length) {
+    if (
+      summary.fields.length === 0 &&
+      !summary.changedFiles?.length &&
+      !summary.featureBlurbs?.length
+    ) {
       return;
     }
     // Compact two-column key/value listing — one line per field. The

--- a/src/lib/init/ui/logging-ui.ts
+++ b/src/lib/init/ui/logging-ui.ts
@@ -122,7 +122,7 @@ export class LoggingUI implements WizardUI {
     }
     if (summary.featureBlurbs && summary.featureBlurbs.length > 0) {
       this.writeLine(this.stdout, "");
-      this.writeLine(this.stdout, "  Here's what we set up:");
+      this.writeLine(this.stdout, "  Here's what we set up");
       const tableRows = summary.featureBlurbs.map(({ label, blurb }) => [
         label,
         blurb,

--- a/src/lib/init/ui/logging-ui.ts
+++ b/src/lib/init/ui/logging-ui.ts
@@ -114,16 +114,6 @@ export class LoggingUI implements WizardUI {
       const padded = field.label.padEnd(labelWidth);
       this.writeLine(this.stdout, `  ${padded}  ${field.value}`);
     }
-    if (summary.changedFiles && summary.changedFiles.length > 0) {
-      this.writeLine(this.stdout, "");
-      this.writeLine(this.stdout, "  Changed files:");
-      // Render as a directory tree so collapsed common prefixes match
-      // what the InkUI panel + post-dispose summary report show.
-      const tree = buildFileTree(summary.changedFiles);
-      for (const row of flattenTree(tree)) {
-        this.writeLine(this.stdout, `    ${formatTreeRowPlain(row)}`);
-      }
-    }
     if (summary.featureBlurbs && summary.featureBlurbs.length > 0) {
       this.writeLine(this.stdout, "");
       this.writeLine(this.stdout, "  Here's what we set up");
@@ -136,6 +126,16 @@ export class LoggingUI implements WizardUI {
       });
       for (const line of table.trimEnd().split("\n")) {
         this.writeLine(this.stdout, `  ${line}`);
+      }
+    }
+    if (summary.changedFiles && summary.changedFiles.length > 0) {
+      this.writeLine(this.stdout, "");
+      this.writeLine(this.stdout, "  Changed files:");
+      // Render as a directory tree so collapsed common prefixes match
+      // what the InkUI panel + post-dispose summary report show.
+      const tree = buildFileTree(summary.changedFiles);
+      for (const row of flattenTree(tree)) {
+        this.writeLine(this.stdout, `    ${formatTreeRowPlain(row)}`);
       }
     }
   }

--- a/src/lib/init/ui/types.ts
+++ b/src/lib/init/ui/types.ts
@@ -143,6 +143,8 @@ export type WizardSummary = {
   fields: { label: string; value: string }[];
   /** Optional list of files the wizard added/edited/removed. */
   changedFiles?: { action: string; path: string }[];
+  /** AI-generated per-feature blurbs personalised to the analysed project. */
+  featureBlurbs?: { label: string; blurb: string }[];
 };
 
 /**

--- a/test/lib/init/feedback.test.ts
+++ b/test/lib/init/feedback.test.ts
@@ -5,7 +5,6 @@ describe("formatFeedbackHint", () => {
   test("maps init outcomes to copy-paste feedback commands", () => {
     expect(formatFeedbackHint("success")).toBe(
       [
-        "Nice, setup made it through.",
         "Tell us what felt great or rough:",
         '$ sentry cli feedback "sentry init worked well"',
       ].join("\n")

--- a/test/lib/init/formatters.test.ts
+++ b/test/lib/init/formatters.test.ts
@@ -247,7 +247,7 @@ describe("formatResult with featureBlurbs", () => {
     expect(summary?.fields.some((f) => f.label === "Features")).toBe(true);
   });
 
-  test("uses output.features for labels regardless of what the agent echoed in feature field", () => {
+  test("labels use canonical feature IDs — agent echoing wrong IDs omits the blurb rather than mislabelling", () => {
     const { ui, calls } = createMockUI();
     formatResult(
       {
@@ -255,7 +255,7 @@ describe("formatResult with featureBlurbs", () => {
         result: {
           platform: "Next.js",
           features: ["errorMonitoring", "sessionReplay"],
-          // Agent echoed back wrong IDs
+          // Agent echoed back wrong IDs — neither matches a canonical feature
           featureBlurbs: [
             { feature: "error_monitoring", blurb: "Blurb A." },
             { feature: "session-replay", blurb: "Blurb B." },
@@ -266,12 +266,11 @@ describe("formatResult with featureBlurbs", () => {
     );
 
     const summary = summaryCall(calls);
-    // Labels come from output.features positionally, not blurb.feature
-    expect(summary?.featureBlurbs?.[0]?.label).toBe("Error Monitoring");
-    expect(summary?.featureBlurbs?.[1]?.label).toBe("Session Replay");
+    // Wrong IDs → no match → blurbs omitted entirely; safe fallback
+    expect(summary?.featureBlurbs).toBeUndefined();
   });
 
-  test("drops entries when blurbs array is shorter than features", () => {
+  test("drops blurb for feature the agent omitted — remaining blurbs stay correctly labelled", () => {
     const { ui, calls } = createMockUI();
     formatResult(
       {
@@ -283,10 +282,10 @@ describe("formatResult with featureBlurbs", () => {
             "performanceMonitoring",
             "sessionReplay",
           ],
-          // Only 2 blurbs for 3 features — third has no blurb
+          // Agent returned 2 of 3; skipped performanceMonitoring
           featureBlurbs: [
             { feature: "errorMonitoring", blurb: "Captures." },
-            { feature: "performanceMonitoring", blurb: "Traces." },
+            { feature: "sessionReplay", blurb: "Records." },
           ],
         },
       },
@@ -297,8 +296,28 @@ describe("formatResult with featureBlurbs", () => {
     expect(summary?.featureBlurbs).toHaveLength(2);
     expect(summary?.featureBlurbs?.map((b) => b.label)).toEqual([
       "Error Monitoring",
-      "Tracing",
+      "Session Replay",
     ]);
+  });
+
+  test("stripAnsi sanitizes ANSI sequences in server-supplied blurbs", () => {
+    const { ui, calls } = createMockUI();
+    formatResult(
+      {
+        status: "success",
+        result: {
+          platform: "Next.js",
+          features: ["errorMonitoring"],
+          featureBlurbs: [
+            { feature: "errorMonitoring", blurb: "\x1b[31mCaptures.\x1b[0m" },
+          ],
+        },
+      },
+      ui
+    );
+
+    const summary = summaryCall(calls);
+    expect(summary?.featureBlurbs?.[0]?.blurb).toBe("Captures.");
   });
 
   test("sorts featureBlurbs by canonical display order", () => {

--- a/test/lib/init/formatters.test.ts
+++ b/test/lib/init/formatters.test.ts
@@ -300,7 +300,7 @@ describe("formatResult with featureBlurbs", () => {
     ]);
   });
 
-  test("stripAnsi sanitizes ANSI sequences in server-supplied blurbs", () => {
+  test("stripAnsi strips SGR colour codes from server-supplied blurbs", () => {
     const { ui, calls } = createMockUI();
     formatResult(
       {
@@ -310,6 +310,30 @@ describe("formatResult with featureBlurbs", () => {
           features: ["errorMonitoring"],
           featureBlurbs: [
             { feature: "errorMonitoring", blurb: "\x1b[31mCaptures.\x1b[0m" },
+          ],
+        },
+      },
+      ui
+    );
+
+    const summary = summaryCall(calls);
+    expect(summary?.featureBlurbs?.[0]?.blurb).toBe("Captures.");
+  });
+
+  test("stripAnsi strips non-SGR CSI sequences (cursor movement, screen-clear) from blurbs", () => {
+    const { ui, calls } = createMockUI();
+    formatResult(
+      {
+        status: "success",
+        result: {
+          platform: "Next.js",
+          features: ["errorMonitoring"],
+          featureBlurbs: [
+            // \x1b[2J = clear screen, \x1b[1A = cursor up — non-SGR CSI
+            {
+              feature: "errorMonitoring",
+              blurb: "\x1b[2JCaptures.\x1b[1A",
+            },
           ],
         },
       },

--- a/test/lib/init/formatters.test.ts
+++ b/test/lib/init/formatters.test.ts
@@ -278,7 +278,11 @@ describe("formatResult with featureBlurbs", () => {
         status: "success",
         result: {
           platform: "Next.js",
-          features: ["errorMonitoring", "performanceMonitoring", "sessionReplay"],
+          features: [
+            "errorMonitoring",
+            "performanceMonitoring",
+            "sessionReplay",
+          ],
           // Only 2 blurbs for 3 features — third has no blurb
           featureBlurbs: [
             { feature: "errorMonitoring", blurb: "Captures." },

--- a/test/lib/init/formatters.test.ts
+++ b/test/lib/init/formatters.test.ts
@@ -271,6 +271,32 @@ describe("formatResult with featureBlurbs", () => {
     expect(summary?.featureBlurbs?.[1]?.label).toBe("Session Replay");
   });
 
+  test("drops entries when blurbs array is shorter than features", () => {
+    const { ui, calls } = createMockUI();
+    formatResult(
+      {
+        status: "success",
+        result: {
+          platform: "Next.js",
+          features: ["errorMonitoring", "performanceMonitoring", "sessionReplay"],
+          // Only 2 blurbs for 3 features — third has no blurb
+          featureBlurbs: [
+            { feature: "errorMonitoring", blurb: "Captures." },
+            { feature: "performanceMonitoring", blurb: "Traces." },
+          ],
+        },
+      },
+      ui
+    );
+
+    const summary = summaryCall(calls);
+    expect(summary?.featureBlurbs).toHaveLength(2);
+    expect(summary?.featureBlurbs?.map((b) => b.label)).toEqual([
+      "Error Monitoring",
+      "Tracing",
+    ]);
+  });
+
   test("sorts featureBlurbs by canonical display order", () => {
     const { ui, calls } = createMockUI();
     formatResult(

--- a/test/lib/init/formatters.test.ts
+++ b/test/lib/init/formatters.test.ts
@@ -345,6 +345,51 @@ describe("formatResult with featureBlurbs", () => {
     expect(summary?.featureBlurbs?.[0]?.blurb).toBe("Captures.");
   });
 
+  test("stripAnsi strips arbitrary OSC sequences (e.g. window title change) from blurbs", () => {
+    const { ui, calls } = createMockUI();
+    formatResult(
+      {
+        status: "success",
+        result: {
+          platform: "Next.js",
+          features: ["errorMonitoring"],
+          featureBlurbs: [
+            // \x1b]0;title\x07 = set window title — OSC command, not OSC 8
+            {
+              feature: "errorMonitoring",
+              blurb: "\x1b]0;injected title\x07Captures.",
+            },
+          ],
+        },
+      },
+      ui
+    );
+
+    const summary = summaryCall(calls);
+    expect(summary?.featureBlurbs?.[0]?.blurb).toBe("Captures.");
+  });
+
+  test("stripAnsi strips single-char C1 ESC sequences (e.g. terminal reset) from blurbs", () => {
+    const { ui, calls } = createMockUI();
+    formatResult(
+      {
+        status: "success",
+        result: {
+          platform: "Next.js",
+          features: ["errorMonitoring"],
+          featureBlurbs: [
+            // \x1bc = RIS (Reset to Initial State) — two-char ESC sequence
+            { feature: "errorMonitoring", blurb: "\x1bcCaptures." },
+          ],
+        },
+      },
+      ui
+    );
+
+    const summary = summaryCall(calls);
+    expect(summary?.featureBlurbs?.[0]?.blurb).toBe("Captures.");
+  });
+
   test("stripAnsi strips non-SGR CSI sequences (cursor movement, screen-clear) from blurbs", () => {
     const { ui, calls } = createMockUI();
     formatResult(

--- a/test/lib/init/formatters.test.ts
+++ b/test/lib/init/formatters.test.ts
@@ -184,6 +184,120 @@ describe("formatResult", () => {
   });
 });
 
+describe("formatResult with featureBlurbs", () => {
+  test("populates featureBlurbs from output.featureBlurbs paired positionally with output.features", () => {
+    const { ui, calls } = createMockUI();
+    formatResult(
+      {
+        status: "success",
+        result: {
+          platform: "Next.js",
+          projectDir: "/app",
+          features: ["errorMonitoring", "performanceMonitoring"],
+          featureBlurbs: [
+            { feature: "errorMonitoring", blurb: "Captures exceptions." },
+            { feature: "performanceMonitoring", blurb: "Traces requests." },
+          ],
+        },
+      },
+      ui
+    );
+
+    const summary = summaryCall(calls);
+    expect(summary?.featureBlurbs).toEqual([
+      { label: "Error Monitoring", blurb: "Captures exceptions." },
+      { label: "Tracing", blurb: "Traces requests." },
+    ]);
+  });
+
+  test("suppresses the Features row when featureBlurbs are present", () => {
+    const { ui, calls } = createMockUI();
+    formatResult(
+      {
+        status: "success",
+        result: {
+          platform: "Next.js",
+          features: ["errorMonitoring"],
+          featureBlurbs: [
+            { feature: "errorMonitoring", blurb: "Captures exceptions." },
+          ],
+        },
+      },
+      ui
+    );
+
+    const summary = summaryCall(calls);
+    expect(summary?.fields.some((f) => f.label === "Features")).toBe(false);
+  });
+
+  test("shows the Features row when featureBlurbs are absent", () => {
+    const { ui, calls } = createMockUI();
+    formatResult(
+      {
+        status: "success",
+        result: {
+          platform: "Next.js",
+          features: ["errorMonitoring", "sessionReplay"],
+        },
+      },
+      ui
+    );
+
+    const summary = summaryCall(calls);
+    expect(summary?.fields.some((f) => f.label === "Features")).toBe(true);
+  });
+
+  test("uses output.features for labels regardless of what the agent echoed in feature field", () => {
+    const { ui, calls } = createMockUI();
+    formatResult(
+      {
+        status: "success",
+        result: {
+          platform: "Next.js",
+          features: ["errorMonitoring", "sessionReplay"],
+          // Agent echoed back wrong IDs
+          featureBlurbs: [
+            { feature: "error_monitoring", blurb: "Blurb A." },
+            { feature: "session-replay", blurb: "Blurb B." },
+          ],
+        },
+      },
+      ui
+    );
+
+    const summary = summaryCall(calls);
+    // Labels come from output.features positionally, not blurb.feature
+    expect(summary?.featureBlurbs?.[0]?.label).toBe("Error Monitoring");
+    expect(summary?.featureBlurbs?.[1]?.label).toBe("Session Replay");
+  });
+
+  test("sorts featureBlurbs by canonical display order", () => {
+    const { ui, calls } = createMockUI();
+    formatResult(
+      {
+        status: "success",
+        result: {
+          platform: "Next.js",
+          // Server returned performanceMonitoring before errorMonitoring
+          features: ["performanceMonitoring", "errorMonitoring"],
+          featureBlurbs: [
+            { feature: "performanceMonitoring", blurb: "Traces." },
+            { feature: "errorMonitoring", blurb: "Captures." },
+          ],
+        },
+      },
+      ui
+    );
+
+    const summary = summaryCall(calls);
+    // errorMonitoring comes before performanceMonitoring in FEATURE_DISPLAY_ORDER
+    expect(summary?.featureBlurbs?.map((b) => b.label)).toEqual([
+      "Error Monitoring",
+      "Tracing",
+    ]);
+  });
+});
+
 describe("formatError", () => {
   test("logs the error message", () => {
     const { ui, calls } = createMockUI();

--- a/test/lib/init/formatters.test.ts
+++ b/test/lib/init/formatters.test.ts
@@ -320,6 +320,31 @@ describe("formatResult with featureBlurbs", () => {
     expect(summary?.featureBlurbs?.[0]?.blurb).toBe("Captures.");
   });
 
+  test("stripAnsi strips CSI sequences with intermediate bytes (e.g. soft reset, cursor style)", () => {
+    const { ui, calls } = createMockUI();
+    formatResult(
+      {
+        status: "success",
+        result: {
+          platform: "Next.js",
+          features: ["errorMonitoring"],
+          featureBlurbs: [
+            // \x1b[!p = Soft Terminal Reset (intermediate byte !)
+            // \x1b[1 q = Set Cursor Style (intermediate byte space)
+            {
+              feature: "errorMonitoring",
+              blurb: "\x1b[!pCaptures.\x1b[1 q",
+            },
+          ],
+        },
+      },
+      ui
+    );
+
+    const summary = summaryCall(calls);
+    expect(summary?.featureBlurbs?.[0]?.blurb).toBe("Captures.");
+  });
+
   test("stripAnsi strips non-SGR CSI sequences (cursor movement, screen-clear) from blurbs", () => {
     const { ui, calls } = createMockUI();
     formatResult(

--- a/test/lib/init/ui/ink-app.snapshot.test.tsx
+++ b/test/lib/init/ui/ink-app.snapshot.test.tsx
@@ -514,6 +514,24 @@ describe("Ink App snapshot", () => {
     expect(frame).not.toMatch(FILES_HEADER_UNPINNED_RE);
   });
 
+  test("SummaryPanel renders featureBlurbs as Here's what we set up section", async () => {
+    const store = new WizardStore({ bannerRows: [] });
+    store.setSummary({
+      fields: [{ label: "Platform", value: "javascript.nextjs" }],
+      featureBlurbs: [
+        { label: "Error Monitoring", blurb: "Captures every unhandled exception." },
+        { label: "Tracing", blurb: "Traces requests end-to-end." },
+      ],
+    });
+
+    const frame = stripAnsi((await renderApp(store, 120)).allOutput());
+    expect(frame).toContain("Here's what we set up");
+    expect(frame).toContain("Error Monitoring");
+    expect(frame).toContain("Captures every unhandled exception.");
+    expect(frame).toContain("Tracing");
+    expect(frame).toContain("Traces requests end-to-end.");
+  });
+
   test("Ctrl+C path uses requestCancel via store, never bare process.exit", () => {
     let cancels = 0;
     const store = new WizardStore();

--- a/test/lib/init/ui/ink-app.snapshot.test.tsx
+++ b/test/lib/init/ui/ink-app.snapshot.test.tsx
@@ -519,7 +519,10 @@ describe("Ink App snapshot", () => {
     store.setSummary({
       fields: [{ label: "Platform", value: "javascript.nextjs" }],
       featureBlurbs: [
-        { label: "Error Monitoring", blurb: "Captures every unhandled exception." },
+        {
+          label: "Error Monitoring",
+          blurb: "Captures every unhandled exception.",
+        },
         { label: "Tracing", blurb: "Traces requests end-to-end." },
       ],
     });

--- a/test/lib/init/ui/ink-report.test.ts
+++ b/test/lib/init/ui/ink-report.test.ts
@@ -49,6 +49,37 @@ describe("formatSuccessReport with summary fields", () => {
   });
 });
 
+describe("formatSuccessReport with featureBlurbs", () => {
+  test("renders Here's what we set up heading and blurb content", () => {
+    const output = stripAnsi(
+      formatSuccessReport("Done!", {
+        fields: [],
+        featureBlurbs: [
+          { label: "Error Monitoring", blurb: "Captures exceptions." },
+          { label: "Tracing", blurb: "Traces requests end-to-end." },
+        ],
+      })
+    );
+    expect(output).toContain("Here's what we set up");
+    expect(output).toContain("Error Monitoring");
+    expect(output).toContain("Captures exceptions.");
+    expect(output).toContain("Tracing");
+    expect(output).toContain("Traces requests end-to-end.");
+  });
+
+  test("no blurbs section when featureBlurbs is absent", () => {
+    const output = stripAnsi(formatSuccessReport("Done!", { fields: [] }));
+    expect(output).not.toContain("Here's what we set up");
+  });
+
+  test("no blurbs section when featureBlurbs is empty", () => {
+    const output = stripAnsi(
+      formatSuccessReport("Done!", { fields: [], featureBlurbs: [] })
+    );
+    expect(output).not.toContain("Here's what we set up");
+  });
+});
+
 describe("formatSuccessReport with changedFiles", () => {
   test("shows Changed files heading and file paths", () => {
     const output = stripAnsi(

--- a/test/lib/init/ui/logging-ui.test.ts
+++ b/test/lib/init/ui/logging-ui.test.ts
@@ -307,4 +307,27 @@ describe("LoggingUI summary", () => {
     expect(lines.some((l) => l.includes("−") && l.includes("b.ts"))).toBe(true);
     expect(lines.some((l) => l.includes("~") && l.includes("c.ts"))).toBe(true);
   });
+
+  test("featureBlurbs renders Here's what we set up table with label and blurb", () => {
+    const { ui, stdout } = createUI();
+    ui.summary({
+      fields: [],
+      featureBlurbs: [
+        { label: "Error Monitoring", blurb: "Captures exceptions." },
+        { label: "Tracing", blurb: "Traces requests." },
+      ],
+    });
+    const out = stdout();
+    expect(out).toContain("Here's what we set up");
+    expect(out).toContain("Error Monitoring");
+    expect(out).toContain("Captures exceptions.");
+    expect(out).toContain("Tracing");
+    expect(out).toContain("Traces requests.");
+  });
+
+  test("no featureBlurbs section when featureBlurbs is absent", () => {
+    const { ui, stdout } = createUI();
+    ui.summary({ fields: [{ label: "Platform", value: "Next.js" }] });
+    expect(stdout()).not.toContain("Here's what we set up");
+  });
 });


### PR DESCRIPTION
## Summary

Ends the wizard with a \"Here's what we set up\" two-column table — one row per enabled feature with a sentence specific to the project that was just instrumented. The blurbs come from a new server-side agent that uses the tech-stack description already captured during platform detection (e.g. \"Next.js 14 with Drizzle ORM and Cloudflare D1\") to produce context-aware copy rather than generic marketing text.

Depends on getsentry/cli-init-api#156 for the server-side agent.

## Changes

- `WizardSummary` and `WizardOutput` gain an optional `featureBlurbs` field
- `buildSummary()` populates it from the workflow output and suppresses the plain \"Features\" row when blurbs are present (the table makes it redundant)
- Both `ink-report.ts` (post-dispose chalk output) and `logging-ui.ts` render the blurbs as a proper two-column table via `renderTextTable` — same renderer used by `sentry issue list` / `sentry project list`, so wrapping and column fitting are handled automatically
- `SummaryPanel` in `ink-app.tsx` renders the live Ink variant with flex layout
- Removed \"Nice, setup made it through.\" preamble so the feedback prompt follows the summary directly

## Test Plan

- Start `bun run dev` in `cli-init-api`, then run `MASTRA_API_URL=http://localhost:8787 bun run src/bin.ts init` against a real project
- Confirm the blurbs table appears after the key/value fields and before changed files
- Run with `--no-tui` and confirm the plain-text table renders the same content
- If the blurb agent fails, wizard completes normally with no blurbs shown (try/catch in `open-sentry-ui.ts`)