### PR TITLE
test(init): regression test for only-Tracing blurb bug

### DIFF
--- a/test/lib/init/formatters.test.ts
+++ b/test/lib/init/formatters.test.ts
@@ -247,6 +247,43 @@ describe("formatResult with featureBlurbs", () => {
     expect(summary?.fields.some((f) => f.label === "Features")).toBe(true);
   });
 
+  test("regression: all blurbs render when server returns canonical feature IDs", () => {
+    // Regression for the 'only Tracing' bug: the LLM was echoing human-readable
+    // labels ("Error Monitoring") in the feature field instead of canonical IDs
+    // ("errorMonitoring"). The server-side fix now maps blurbs positionally so
+    // canonical IDs are always in the feature field. This test verifies the CLI
+    // renders all blurbs when the server returns canonical IDs correctly — not
+    // just the one feature that happened to have a matching ID.
+    const { ui, calls } = createMockUI();
+    formatResult(
+      {
+        status: "success",
+        result: {
+          platform: "Next.js",
+          features: [
+            "errorMonitoring",
+            "performanceMonitoring",
+            "sessionReplay",
+          ],
+          featureBlurbs: [
+            { feature: "errorMonitoring", blurb: "Captures exceptions." },
+            { feature: "performanceMonitoring", blurb: "Traces requests." },
+            { feature: "sessionReplay", blurb: "Records sessions." },
+          ],
+        },
+      },
+      ui
+    );
+
+    const summary = summaryCall(calls);
+    expect(summary?.featureBlurbs).toHaveLength(3);
+    expect(summary?.featureBlurbs?.map((b) => b.label)).toEqual([
+      "Error Monitoring",
+      "Session Replay",
+      "Tracing",
+    ]);
+  });
+
   test("labels use canonical feature IDs — agent echoing wrong IDs omits the blurb rather than mislabelling", () => {
     const { ui, calls } = createMockUI();
     formatResult(


### PR DESCRIPTION
## Summary

After #982 landed, `sentry init` showed only "Tracing" in the blurbs table regardless of which features were enabled. The root cause was server-side (fixed in getsentry/cli-init-api#159) — the LLM was echoing human-readable labels ("Error Monitoring") in the `feature` field instead of canonical IDs ("errorMonitoring"), so the CLI Map lookup only found the one entry that happened to match (`performanceMonitoring` → "Tracing").

This PR adds a CLI-side regression test that documents the fix and guards against a recurrence: verifies all blurbs render when the server returns canonical feature IDs.

## Test Plan

`bun test test/lib/init/formatters.test.ts` — new test passes.