### PR TITLE
fix(explore): use tracemetrics dataset instead of metricsEnhanced

### DIFF
--- a/src/commands/dashboard/resolve.ts
+++ b/src/commands/dashboard/resolve.ts
@@ -818,8 +818,7 @@ const DATASET_ALIASES: Record<string, string> = {
   transactions: "transaction-like",
   log: "logs",
   // `metrics` and `metricsEnhanced` both alias to the canonical `tracemetrics`.
-  // `metricsEnhanced` is the value surfaced by the events API dataset param
-  // (see WIDGET_TYPE_TO_DATASET in types/dashboard.ts) and may appear in docs.
+  // `metricsEnhanced` is a legacy API synonym and may appear in older docs.
   metrics: "tracemetrics",
   metricsenhanced: "tracemetrics",
 };

--- a/src/commands/explore.ts
+++ b/src/commands/explore.ts
@@ -85,7 +85,7 @@ const DATASET_ALIASES: Record<string, string> = {
   error: "errors",
   spans: "spans",
   span: "spans",
-  metrics: "metricsEnhanced",
+  metrics: "tracemetrics",
   logs: "logs",
   log: "logs",
   replays: "replays",
@@ -113,7 +113,7 @@ const VALID_DATASETS = new Set([
 
 /**
  * Reverse map from API-level dataset name → canonical user-facing name.
- * Used by pagination hints so they emit `--dataset metrics` not `--dataset metricsEnhanced`.
+ * Used by pagination hints so they emit `--dataset metrics` not `--dataset tracemetrics`.
  */
 const API_TO_USER_DATASET = new Map(
   Array.from(VALID_DATASETS, (name) => [DATASET_ALIASES[name] ?? name, name])
@@ -363,7 +363,7 @@ function appendFlagHints(
   const defaultSort =
     flags.dataset === "replays" ? DEFAULT_REPLAY_SORT : undefined;
   if (flags.dataset !== DEFAULT_DATASET) {
-    // Emit user-facing name, not API-level name (e.g. "metrics" not "metricsEnhanced")
+    // Emit user-facing name, not API-level name (e.g. "metrics" not "tracemetrics")
     const displayDataset =
       API_TO_USER_DATASET.get(flags.dataset) ?? flags.dataset;
     parts.push(`--dataset ${displayDataset}`);
@@ -412,7 +412,7 @@ function isTracemetricsAggregate(aggregate: string): boolean {
 
 /**
  * Validate that aggregate fields use the tracemetrics format when querying
- * the `metricsEnhanced` dataset. Standard aggregates like `count()` or
+ * the `tracemetrics` dataset. Standard aggregates like `count()` or
  * `avg(measurements.fcp)` are invalid — the API requires the four-part
  * comma-separated format: `aggregation(value,metric_name,metric_type,unit)`.
  */
@@ -720,9 +720,9 @@ export const exploreCommand = buildListCommand("explore", {
 
     // --metric auto mode: resolve metric name → tracemetrics aggregate
     if (flags.metric) {
-      if (dataset !== "metricsEnhanced") {
+      if (dataset !== "tracemetrics") {
         log.warn("--metric implies --dataset metrics; switching dataset.");
-        dataset = "metricsEnhanced";
+        dataset = "tracemetrics";
       }
 
       // Use the user's --period for metadata discovery so older metrics are found
@@ -745,7 +745,7 @@ export const exploreCommand = buildListCommand("explore", {
         ? fieldList.filter((f) => !isAggregate(f))
         : [];
       fieldList = [...groupByFields, aggField];
-    } else if (dataset === "metricsEnhanced") {
+    } else if (dataset === "tracemetrics") {
       if (!userSuppliedFields) {
         throw new ValidationError(
           "The metrics dataset requires --metric or explicit --field flags.\n\n" +

--- a/src/lib/api/discover.ts
+++ b/src/lib/api/discover.ts
@@ -96,7 +96,7 @@ export type MetricMeta = {
 /**
  * Discover available metrics for an org via the Events API.
  *
- * Queries `dataset=metricsEnhanced` with meta-fields (`metric.name`, etc.)
+ * Queries `dataset=tracemetrics` with meta-fields (`metric.name`, etc.)
  * — the same technique the Sentry Explore Metrics UI uses.
  *
  * Auto-paginates to collect all available metrics (bounded by
@@ -116,7 +116,7 @@ export async function queryMetricsMeta(
 
   const baseOptions: ExploreQueryOptions = {
     fields: ["metric.name", "metric.type", "metric.unit"],
-    dataset: "metricsEnhanced",
+    dataset: "tracemetrics",
     query,
     statsPeriod:
       options?.start || options?.end

--- a/src/lib/metrics-transform.ts
+++ b/src/lib/metrics-transform.ts
@@ -3,7 +3,7 @@
  *
  * Transforms user-friendly metric names (e.g., `llm.token_usage`) into the
  * four-part tracemetrics format required by the Sentry Events API when
- * querying `dataset=metricsEnhanced`: `aggregation(value,name,type,unit)`.
+ * querying `dataset=tracemetrics`: `aggregation(value,name,type,unit)`.
  */
 
 import type { MetricMeta } from "./api/discover.js";

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1002,7 +1002,7 @@ const WIDGET_TYPE_TO_DATASET: Record<string, string> = {
   "error-events": "errors",
   "transaction-like": "transactions",
   logs: "logs",
-  tracemetrics: "metricsEnhanced",
+  tracemetrics: "tracemetrics",
 };
 
 /**

--- a/test/commands/explore.test.ts
+++ b/test/commands/explore.test.ts
@@ -510,7 +510,7 @@ describe("sentry explore", () => {
         context,
         {
           ...DEFAULT_FLAGS,
-          dataset: "metricsEnhanced",
+          dataset: "tracemetrics",
           field: ["title", "count()"],
         },
         "test-org/"
@@ -528,7 +528,7 @@ describe("sentry explore", () => {
         context,
         {
           ...DEFAULT_FLAGS,
-          dataset: "metricsEnhanced",
+          dataset: "tracemetrics",
           field: [
             "gen_ai.request.model",
             "sum(value,llm.token_usage,distribution,none)",
@@ -539,7 +539,7 @@ describe("sentry explore", () => {
 
       expect(queryEventsSpy).toHaveBeenCalledWith(
         "test-org",
-        expect.objectContaining({ dataset: "metricsEnhanced" })
+        expect.objectContaining({ dataset: "tracemetrics" })
       );
     });
 
@@ -549,7 +549,7 @@ describe("sentry explore", () => {
 
       const promise = func.call(
         context,
-        { ...DEFAULT_FLAGS, dataset: "metricsEnhanced" },
+        { ...DEFAULT_FLAGS, dataset: "tracemetrics" },
         "test-org/"
       );
 
@@ -567,7 +567,7 @@ describe("sentry explore", () => {
         context,
         {
           ...DEFAULT_FLAGS,
-          dataset: "metricsEnhanced",
+          dataset: "tracemetrics",
           field: ["gen_ai.request.model"],
         },
         "test-org/"
@@ -584,7 +584,7 @@ describe("sentry explore", () => {
         context,
         {
           ...DEFAULT_FLAGS,
-          dataset: "metricsEnhanced",
+          dataset: "tracemetrics",
           metric: "llm.token_usage",
         },
         "test-org/"
@@ -598,7 +598,7 @@ describe("sentry explore", () => {
         "test-org",
         expect.objectContaining({
           fields: ["sum(value,llm.token_usage,distribution,none)"],
-          dataset: "metricsEnhanced",
+          dataset: "tracemetrics",
         })
       );
     });
@@ -611,7 +611,7 @@ describe("sentry explore", () => {
         context,
         {
           ...DEFAULT_FLAGS,
-          dataset: "metricsEnhanced",
+          dataset: "tracemetrics",
           metric: "llm.token_usage",
           field: ["gen_ai.request.model"],
         },
@@ -637,7 +637,7 @@ describe("sentry explore", () => {
         context,
         {
           ...DEFAULT_FLAGS,
-          dataset: "metricsEnhanced",
+          dataset: "tracemetrics",
           metric: "cache.hit_rate",
           agg: "avg",
         },
@@ -652,7 +652,7 @@ describe("sentry explore", () => {
       );
     });
 
-    test("--metric without --dataset metrics auto-switches to metricsEnhanced", async () => {
+    test("--metric without --dataset metrics auto-switches to tracemetrics", async () => {
       resolveTargetSpy.mockResolvedValue({ org: "test-org" });
       const { context } = createContext();
 
@@ -669,7 +669,7 @@ describe("sentry explore", () => {
       expect(queryEventsSpy).toHaveBeenCalledWith(
         "test-org",
         expect.objectContaining({
-          dataset: "metricsEnhanced",
+          dataset: "tracemetrics",
           fields: ["sum(value,llm.token_usage,distribution,none)"],
         })
       );

--- a/test/types/dashboard.test.ts
+++ b/test/types/dashboard.test.ts
@@ -950,7 +950,7 @@ describe("mapWidgetTypeToDataset", () => {
     expect(mapWidgetTypeToDataset("error-events")).toBe("errors");
     expect(mapWidgetTypeToDataset("transaction-like")).toBe("transactions");
     expect(mapWidgetTypeToDataset("logs")).toBe("logs");
-    expect(mapWidgetTypeToDataset("tracemetrics")).toBe("metricsEnhanced");
+    expect(mapWidgetTypeToDataset("tracemetrics")).toBe("tracemetrics");
   });
 
   test("returns null for unsupported widget types", () => {


### PR DESCRIPTION
`--dataset metrics` and `--metric` auto-resolver were sending `dataset=metricsEnhanced` to the Events API, which routes to the legacy `metrics_enhanced_performance` backend. SDK v10 trace metrics live in the `tracemetrics` dataset (backed by `TraceMetrics`), which is what the Sentry Explore Metrics UI uses. Switched all metrics-related API calls to `tracemetrics`.

## Testing

`bun test test/commands/explore.test.ts` — 37/38 pass (1 pre-existing failure from missing `api-schema.json`).
`bun test test/types/dashboard.test.ts` — 96/96 pass.
`bun test test/commands/dashboard/resolve.test.ts` — 76/76 pass.
`bun test test/lib/metrics-transform.test.ts` — 10/10 pass.

Fixes #994

<!--
## Plan

Root cause: the Sentry Events API has two distinct dataset values for metrics:
- `metricsEnhanced` → `metrics_enhanced_performance` (legacy DDM/release-health)
- `tracemetrics` → `TraceMetrics` (SDK v10 trace metrics, used by Explore Metrics UI)

The CLI was sending `metricsEnhanced` everywhere, which can't find SDK v10 metrics.

Changes:
1. `src/commands/explore.ts` — DATASET_ALIASES maps `metrics` → `"tracemetrics"`, all internal comparisons updated
2. `src/lib/api/discover.ts` — `queryMetricsMeta` uses `dataset: "tracemetrics"`
3. `src/types/dashboard.ts` — `WIDGET_TYPE_TO_DATASET` maps `tracemetrics` → `"tracemetrics"`
4. Comments and tests updated to match
-->