### PR TITLE
fix(dashboard): escape author field in revision table

### DIFF
--- a/src/commands/dashboard/revisions.ts
+++ b/src/commands/dashboard/revisions.ts
@@ -72,7 +72,9 @@ function formatRevisionsHuman(result: RevisionsResult): string {
   const rows: RevisionRow[] = result.revisions.map((r) => ({
     id: r.id,
     title: escapeMarkdownCell(r.title),
-    author: r.createdBy?.name ?? r.createdBy?.email ?? r.createdBy?.id ?? "—",
+    author: escapeMarkdownCell(
+      r.createdBy?.name ?? r.createdBy?.email ?? r.createdBy?.id ?? "—"
+    ),
     created: `${escapeMarkdownCell(formatRelativeTime(r.dateCreated))}\n${colorTag("muted", r.dateCreated)}`,
   }));
 


### PR DESCRIPTION
## Summary
- wraps the `author` column in `dashboard revisions` with `escapeMarkdownCell()` to prevent markdown table breakage when a user's name or email contains `|`
- missed in #1000 — caught by sentry[bot]'s automated review

One-line change, no new dependencies.