### PR TITLE
fix: handle with { type: "file" } import attributes in tsx dev mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Setup codesign dependencies
         env:
-          APPLE_CERT_DATA: ${{ secrets.CSC_LINK }}
+          APPLE_CERT_DATA: ${{ secrets.APPLE_CERT_DATA }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
         run: |
           curl -L 'https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F0.29.0/apple-codesign-0.29.0-x86_64-unknown-linux-musl.tar.gz' -o 'rcodesign.tar.gz'
@@ -297,8 +297,8 @@ jobs:
           RELEASE_BUILD: ${{ github.event_name != 'pull_request' && '1' || '' }}
           # Codesigning: only on main/release pushes (fork PRs lack secrets)
           FOSSILIZE_SIGN: ${{ github.event_name == 'push' && (github.ref_name == 'main' || startsWith(github.ref_name, 'release/')) && 'y' || 'n' }}
-          APPLE_CERT_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: pnpm run build -- --target ${{ matrix.target }}
       - name: Smoke test
         if: matrix.can-test

--- a/script/require-shim.mjs
+++ b/script/require-shim.mjs
@@ -1,5 +1,6 @@
 /**
- * ESM preload shim that provides `require` in ESM modules.
+ * ESM preload shim that provides `require` in ESM modules and handles
+ * `with { type: "file" }` import attributes in tsx dev mode.
  *
  * The source code uses bare `require()` for lazy loading (circular dependency
  * breaking, optional features). This works natively in Bun and in the CJS
@@ -13,14 +14,38 @@
  * must use a file-local `createRequire(import.meta.url)` instead of relying
  * on this global shim.
  *
+ * `with { type: "file" }` import attributes are used to embed sidecar files
+ * (e.g. the Ink UI app). Bun supports this natively; esbuild's
+ * text-import-plugin handles it at build time. In tsx dev mode neither
+ * applies, so we register a loader hook that returns the file path as a
+ * string — matching Bun's native behaviour.
+ *
  * Usage: NODE_OPTIONS="--import ./script/require-shim.mjs" tsx script/...
  * Or in package.json scripts via the `pnpm tsx` alias.
  */
 
-import { createRequire } from "node:module";
+import { createRequire, registerHooks } from "node:module";
 
 if (typeof globalThis.require === "undefined") {
   globalThis.require = createRequire(
     new URL("../package.json", import.meta.url)
   );
 }
+
+// Handle `with { type: "file" }` import attributes in Node.js dev mode.
+// Bun supports this natively; esbuild's text-import-plugin handles it at
+// build time. In tsx dev mode neither applies, so we register a synchronous
+// hook that returns the file path as a string — matching Bun's behaviour.
+// registerHooks() is available from Node 22.15+ (our minimum).
+registerHooks({
+  load(url, context, nextLoad) {
+    if (context.importAttributes?.type === "file") {
+      return {
+        format: "module",
+        shortCircuit: true,
+        source: `export default ${JSON.stringify(new URL(url).pathname)};`,
+      };
+    }
+    return nextLoad(url, context);
+  },
+});


### PR DESCRIPTION
Depends on #1008.

## Problem

`ink-ui.ts` imports the Ink app sidecar using a `with { type: "file" }` import attribute:

```typescript
import inkAppPath from "./ink-app.tsx" with { type: "file" };
```

This is a static module-level import, so Node.js evaluates it when `ink-ui.ts` is first loaded. Node.js only supports `with { type: "json" }` — everything else throws `ERR_IMPORT_ATTRIBUTE_UNSUPPORTED`. The factory catches the error and falls back to `LoggingUI`, but `LoggingUI` can't do interactive prompts, so the wizard fails with:

```
Error: The interactive UI failed to load. Run with --yes for non-interactive mode.
```

This affected anyone running `pnpm cli init` or `pnpm tsx /path/to/bin.ts init` in a real terminal — the interactive wizard UI was never reachable in dev mode.

**Why it worked before:** Bun supports `with { type: "file" }` natively. In esbuild builds, `text-import-plugin` transforms the attribute away before Node.js ever sees it.

## Fix

Register a synchronous Node.js module hook in `require-shim.mjs` using `registerHooks()` (available from Node 22.15, our minimum). When a module is imported with `with { type: "file" }`, the hook returns a synthetic ESM module that exports the file's absolute path as a string — the same behaviour Bun provides natively.

```js
registerHooks({
  load(url, context, nextLoad) {
    if (context.importAttributes?.type === "file") {
      return {
        format: "module",
        shortCircuit: true,
        source: `export default ${JSON.stringify(new URL(url).pathname)};`,
      };
    }
    return nextLoad(url, context);
  },
});
```

## Test plan

```
# Before
pnpm tsx /path/to/bin.ts init
→ Error: The interactive UI failed to load. Run with --yes for non-interactive mode.

# After
pnpm tsx /path/to/bin.ts init
→ Launches the Ink wizard UI
```

Note: tsx v4.20.6 itself emits a `[DEP0205]` deprecation warning for `module.register()` — that's a tsx bug unrelated to this change.