### PR TITLE
chore: update fossilize to 0.6.0 (V8 code cache support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "consola": "^3.4.2",
     "esbuild": "^0.25.0",
     "fast-check": "^4.5.3",
-    "fossilize": "^0.5.0",
+    "fossilize": "^0.6.0",
     "hono": "^4.12.15",
     "http-cache-semantics": "^4.2.0",
     "ignore": "^7.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
         specifier: ^4.5.3
         version: 4.8.0
       fossilize:
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       hono:
         specifier: ^4.12.15
         version: 4.12.18
@@ -1785,8 +1785,8 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
-  fossilize@0.5.0:
-    resolution: {integrity: sha512-S5ZK4HnFSeN9lcnwCuukOjLPBhTT2x9Ijpy72+dD7djw1tUPXNo/jFI2UNoECYY23mT4lnbciIk0bsHAgX7bBQ==}
+  fossilize@0.6.0:
+    resolution: {integrity: sha512-Hw+OHDmBmnXgs/mxQ4WCgEzs95+jsGwBbsSk3Md45217WHmLFrhm+7d6RfvpIJBILAZCmPr9ov0t92W8Vf2O9Q==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4625,7 +4625,7 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  fossilize@0.5.0:
+  fossilize@0.6.0:
     dependencies:
       '@stricli/auto-complete': 1.2.7
       '@stricli/core': 1.2.7(patch_hash=10f8318359902742c80029abdcec31fe4c64de89b6f2a3f5afb09f05aacc506d)


### PR DESCRIPTION
Updates fossilize to v0.6.0 which automatically enables V8 code cache for binaries matching the build host platform.

**Impact:** The linux-x64 binary (built on ubuntu-latest in CI) gets ~15% faster startup (~740ms vs ~870ms) from pre-compiled V8 bytecode. Cross-compiled binaries (darwin, windows, linux-arm64) are unaffected — code cache is CPU-architecture-specific.

See https://github.com/BYK/fossilize/pull/8 for the fossilize change.