### PR TITLE
fix(init): fall back to no-platform on 400 invalid platform from registry

### DIFF
--- a/src/lib/init/tools/create-sentry-project.ts
+++ b/src/lib/init/tools/create-sentry-project.ts
@@ -7,6 +7,7 @@
  * lack team:write.
  */
 
+import { captureException } from "@sentry/node-core/light";
 import {
   createProjectWithAutoTeam,
   createProjectWithDsn,
@@ -58,6 +59,37 @@ async function resolveProjectCreation(opts: {
   const { org, name, team, suppressFallback, slugHint } = opts;
   // Coerce null → undefined: CreateProjectBody.platform is string | undefined.
   const platform = opts.platform ?? undefined;
+
+  const withPlatformFallback = async (
+    fn: (p: string | undefined) => Promise<ProjectData>
+  ): Promise<ProjectData> => {
+    try {
+      return await fn(platform);
+    } catch (err) {
+      // The registry may include SDK keys whose derived platform slug (e.g.
+      // "javascript-hono") is not yet in the Sentry API's allowed platform
+      // list. Retry without a platform so the project is still created, and
+      // capture to track which slugs need to be added to the API allowlist.
+      if (
+        err instanceof ApiError &&
+        err.status === 400 &&
+        platform &&
+        err.detail?.includes("Invalid platform")
+      ) {
+        captureException(err, {
+          extra: {
+            attemptedPlatform: platform,
+            projectName: name,
+            apiResponseDetail: err.detail,
+            apiStatus: err.status,
+          },
+        });
+        return await fn(undefined);
+      }
+      throw err;
+    }
+  };
+
   try {
     const teamSlug = team
       ? team
@@ -67,16 +99,18 @@ async function resolveProjectCreation(opts: {
             usageHint: "sentry init",
           })
         ).slug;
-    const result = await createProjectWithDsn(org, teamSlug, {
-      name,
-      platform,
+    return await withPlatformFallback(async (p) => {
+      const result = await createProjectWithDsn(org, teamSlug, {
+        name,
+        platform: p,
+      });
+      return {
+        projectSlug: result.project.slug,
+        projectId: result.project.id,
+        dsn: result.dsn ?? "",
+        url: result.url,
+      };
     });
-    return {
-      projectSlug: result.project.slug,
-      projectId: result.project.id,
-      dsn: result.dsn ?? "",
-      url: result.url,
-    };
   } catch (innerError) {
     // Fall back to org-scoped endpoint on 403, unless the fallback is suppressed
     // (explicit --team means the 403 is meaningful feedback, not a permission gap).
@@ -92,13 +126,18 @@ async function resolveProjectCreation(opts: {
     if (innerError.detail?.includes(MEMBER_PROJECT_CREATION_DISABLED_DETAIL)) {
       throw innerError;
     }
-    const result = await createProjectWithAutoTeam(org, { name, platform });
-    return {
-      projectSlug: result.project.slug,
-      projectId: result.project.id,
-      url: result.url,
-      dsn: result.dsn ?? "",
-    };
+    return await withPlatformFallback(async (p) => {
+      const result = await createProjectWithAutoTeam(org, {
+        name,
+        platform: p,
+      });
+      return {
+        projectSlug: result.project.slug,
+        projectId: result.project.id,
+        url: result.url,
+        dsn: result.dsn ?? "",
+      };
+    });
   }
 }
 

--- a/src/lib/init/tools/create-sentry-project.ts
+++ b/src/lib/init/tools/create-sentry-project.ts
@@ -114,6 +114,9 @@ async function resolveProjectCreation(opts: {
   } catch (innerError) {
     // Fall back to org-scoped endpoint on 403, unless the fallback is suppressed
     // (explicit --team means the 403 is meaningful feedback, not a permission gap).
+    // Note: a 403 can originate from either the initial createProjectWithDsn call
+    // or from the platform-less retry inside withPlatformFallback — both mean the
+    // caller lacks team:write, so the org-scoped fallback is correct in either case.
     if (
       !(innerError instanceof ApiError && innerError.status === 403) ||
       suppressFallback


### PR DESCRIPTION
## Problem

The Sentry release registry added new JS SDK entries (sentry.javascript.hono, elysia, nitro, effect, tanstackstart-react, react-router, vercel-edge, node-core) as part of the 10.55.0 release. The platform-matcher agent now returns these keys for matching frameworks. \`getSentryPlatform()\` derives slugs like \`javascript-hono\` from them, but the Sentry project-creation API doesn't yet accept those slugs — returning \`400 {"platform":["Invalid platform"]}\` and crashing the wizard before the feature selector is shown.

The in-memory registry cache resets on every Worker restart, so there's nothing to clear — any fix has to be in code.

## Solution

When \`createProjectWithDsn\` or \`createProjectWithAutoTeam\` returns \`400\` with \`"Invalid platform"\` in the detail, retry the same call without the \`platform\` field. The project is still created; the platform tag is cosmetic and doesn't affect which SDK the codemod planner installs. Capture the exception in Sentry so we can track which slugs need to be added to the API's valid platform list.

**Before:**
```
✔ Detect platform (javascript-hono)
✖ Ensure Sentry project
  WizardError: Project ensure failed: Failed to create project: 400 Bad Request
    {"platform":["Invalid platform"]}
```

**After:**
```
✔ Detect platform (javascript-hono)
✔ Ensure Sentry project  (project created, platform tag omitted)
◆ Select features
```

## Changes

- `src/lib/init/tools/create-sentry-project.ts` — `withPlatformFallback()` helper wraps both the team-scoped path (`createProjectWithDsn`) and the 403-fallback path (`createProjectWithAutoTeam`); captures the exception with `attemptedPlatform` and `apiResponseDetail` for observability

Closes CLI-1WK