### PR TITLE
fix(ci): replace deprecated macos-13 runner with ubuntu-latest for darwin-x64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,11 @@ jobs:
               ]}'
             else
               # main, release/**, workflow_call: full cross-platform matrix.
-              # macOS targets build natively for V8 code cache (~15% faster startup).
-              # Other targets cross-compile from ubuntu-latest via fossilize.
+              # darwin-arm64 builds natively on macOS for V8 code cache (~15% faster startup).
+              # All other targets cross-compile from ubuntu-latest via fossilize.
               echo '{"include":[
                 {"target":"darwin-arm64",  "os":"macos-latest",  "can-test":true},
-                {"target":"darwin-x64",    "os":"macos-13",      "can-test":false},
+                {"target":"darwin-x64",    "os":"ubuntu-latest", "can-test":false},
                 {"target":"linux-x64",     "os":"ubuntu-latest", "can-test":true},
                 {"target":"linux-arm64",   "os":"ubuntu-latest", "can-test":false},
                 {"target":"windows-x64",   "os":"ubuntu-latest", "can-test":false}


### PR DESCRIPTION
## Problem

The `darwin-x64` build-binary job uses `macos-13` (Intel) runners which are no longer available on GitHub Actions, causing the job to queue indefinitely on every main/release push.

## Fix

Switch `darwin-x64` from `macos-13` to `ubuntu-latest`. This target is already cross-compiled via fossilize and has `can-test: false` (can't execute an x64 binary on arm64 macOS anyway), so it matches all other cross-compiled targets.

The only darwin target that needs a native macOS runner is `darwin-arm64` (`macos-latest`) for V8 code cache and smoke testing.