### PR TITLE
fix(issue): validate org/project prefix in parseWithHash slash path

### DIFF
--- a/src/lib/arg-parsing.ts
+++ b/src/lib/arg-parsing.ts
@@ -955,10 +955,11 @@ function parseWithHash(arg: string): ParsedIssueArg {
     return parseBareIssueIdentifier(fragment);
   }
 
-  // `org/project#SHORTID` → equivalent to `org/project/SHORTID`. Reconstruct the
-  // slash form so parseWithSlash/parseMultiSlashIssueArg handle org/project
-  // validation and the short-ID prefix-match logic.
+  // `org/project#SHORTID` → equivalent to `org/project/SHORTID`. Validate the
+  // org/project prefix components first — the `#` path skips the main
+  // validateResourceId guard, and parseWithSlash doesn't re-validate.
   if (prefix.includes("/")) {
+    validateResourceId(prefix.replace(/\//g, ""), "issue identifier");
     return parseWithSlash(`${prefix}/${fragment}`);
   }
 

--- a/test/lib/arg-parsing.test.ts
+++ b/test/lib/arg-parsing.test.ts
@@ -1356,6 +1356,11 @@ describe("parseIssueArg: GitHub-style # separator (CLI-1G1)", () => {
       expect(() => parseIssueArg("bad%proj#G")).toThrow(ValidationError);
     });
 
+    test("forbidden characters in org/project prefix throw", () => {
+      expect(() => parseIssueArg("bad%org/project#G")).toThrow(ValidationError);
+      expect(() => parseIssueArg("org/bad%proj#G")).toThrow(ValidationError);
+    });
+
     test("multiple # error message suggests the correct format", () => {
       expect(() => parseIssueArg("a#b#c")).toThrow(/org\/project#PROJ-123/);
     });


### PR DESCRIPTION
## Summary

Follow-up to #1048 — addresses bot review feedback from both **Cursor Bugbot** and **Sentry Seer Code Review**.

When `parseWithHash` handles the `org/project#SHORTID` form, it delegates to `parseWithSlash` without first validating the `org/project` prefix for forbidden characters. The `#` path short-circuits before `parseIssueArg`'s main `validateResourceId` guard, and `parseWithSlash` doesn't re-validate — so inputs like `bad%org/project#G` would pass forbidden characters into the org slug unchecked.

The `project#SHORTID` branch (no slash) already correctly validates its prefix, but the slash branch did not.

## Fix

Add `validateResourceId(prefix.replace(/\//g, ""), "issue identifier")` before delegating to `parseWithSlash`, consistent with how the main guard strips slashes before validating. This ensures org and project slugs are checked for `?`, `#`, `%`, whitespace, and control characters.

## Tests

Added a test case that verifies both `bad%org/project#G` and `org/bad%proj#G` throw `ValidationError`.

## Verification

- `pnpm run typecheck` ✅
- `npx vitest run test/lib/arg-parsing.test.ts test/lib/arg-parsing.property.test.ts` — 214 tests passing ✅