### PR TITLE
feat: add release archive/restore, sourcemap resolve, proguard uuid

### DIFF
--- a/docs/src/content/docs/contributing.md
+++ b/docs/src/content/docs/contributing.md
@@ -60,11 +60,12 @@ cli/
 │   │   ├── local/       # serve, run
 │   │   ├── log/         # list, view
 │   │   ├── org/         # list, view
+│   │   ├── proguard/    # uuid
 │   │   ├── project/     # create, delete, list, view
-│   │   ├── release/     # list, view, create, finalize, delete, deploy, deploys, set-commits, propose-version
+│   │   ├── release/     # list, view, create, finalize, delete, archive, restore, deploy, deploys, set-commits, propose-version
 │   │   ├── replay/      # list, view
 │   │   ├── repo/        # list
-│   │   ├── sourcemap/   # inject, upload
+│   │   ├── sourcemap/   # inject, upload, resolve
 │   │   ├── span/        # list, view
 │   │   ├── team/        # list
 │   │   ├── trace/       # list, view, logs

--- a/docs/src/fragments/commands/proguard.md
+++ b/docs/src/fragments/commands/proguard.md
@@ -1,0 +1,19 @@
+
+
+## Examples
+
+```bash
+# Compute the UUID for a ProGuard/R8 mapping file
+sentry proguard uuid ./app/build/outputs/mapping/release/mapping.txt
+
+# Output as JSON (includes the file path)
+sentry proguard uuid mapping.txt --json
+```
+
+## Important Notes
+
+- The UUID is **deterministically derived from the mapping file contents** —
+  identical files always produce the same UUID. This is the same value
+  Sentry uses to associate a mapping with obfuscated Android stack traces.
+- This matches the UUID computed by the legacy `sentry-cli proguard uuid`
+  command byte-for-byte.

--- a/docs/src/fragments/commands/release.md
+++ b/docs/src/fragments/commands/release.md
@@ -35,6 +35,14 @@ sentry release create $(sentry release propose-version)
 sentry release deploys 1.0.0
 sentry release deploys my-org/1.0.0
 
+# Archive a release (hide it from the default list, but keep it)
+sentry release archive 1.0.0
+sentry release archive my-org/1.0.0 --dry-run   # Preview without archiving
+
+# Restore a previously archived release
+sentry release restore 1.0.0
+sentry release restore my-org/1.0.0
+
 # Delete a release
 sentry release delete my-org/1.0.0
 sentry release delete my-org/1.0.0 --yes        # Skip confirmation

--- a/docs/src/fragments/commands/sourcemap.md
+++ b/docs/src/fragments/commands/sourcemap.md
@@ -28,6 +28,23 @@ sentry sourcemap upload ./dist --release 1.0.0
 sentry sourcemap upload ./dist --url-prefix '~/static/js/'
 ```
 
+### Resolve sourcemap linkage
+
+```bash
+# Report how each JS file's sourcemap resolves and whether a debug ID
+# has been injected (read-only — never modifies files)
+sentry sourcemap resolve ./dist
+
+# Machine-readable output
+sentry sourcemap resolve ./dist --json
+```
+
+Use `sentry sourcemap resolve` to debug why `sentry sourcemap upload` may
+not find the expected sourcemaps. It reports, for each JavaScript file,
+whether the companion `.map` was located (by convention or via a
+`sourceMappingURL` directive), whether the map is inline (`data:` URL) or
+remote, and whether a Sentry debug ID is present.
+
 ## Error handling
 
 Both `sentry sourcemap inject` and `sentry sourcemap upload` exit with an

--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -367,6 +367,14 @@ Manage Sentry dashboards
 
 → Full flags and examples: `references/dashboard.md`
 
+### Proguard
+
+Work with ProGuard/R8 mapping files
+
+- `sentry proguard uuid <path>` — Compute the UUID for a ProGuard mapping file
+
+→ Full flags and examples: `references/proguard.md`
+
 ### Replay
 
 Search and inspect Session Replays
@@ -385,6 +393,8 @@ Work with Sentry releases
 - `sentry release create <org/version...>` — Create a release
 - `sentry release finalize <org/version...>` — Finalize a release
 - `sentry release delete <org/version...>` — Delete a release
+- `sentry release archive <org/version...>` — Archive a release
+- `sentry release restore <org/version...>` — Restore an archived release
 - `sentry release deploy <org/version environment name...>` — Create a deploy for a release
 - `sentry release deploys <org/version...>` — List deploys for a release
 - `sentry release set-commits <org/version...>` — Set commits for a release
@@ -431,6 +441,7 @@ Manage sourcemaps
 
 - `sentry sourcemap inject <directory>` — Inject debug IDs into JavaScript files and sourcemaps
 - `sentry sourcemap upload <directory>` — Upload sourcemaps to Sentry
+- `sentry sourcemap resolve <directory>` — Resolve and report sourcemap linkage for JavaScript files
 
 → Full flags and examples: `references/sourcemap.md`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/proguard.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/proguard.md
@@ -1,0 +1,28 @@
+---
+name: sentry-cli-proguard
+version: 0.36.0-dev.0
+description: Work with ProGuard/R8 mapping files
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Proguard Commands
+
+Work with ProGuard/R8 mapping files
+
+### `sentry proguard uuid <path>`
+
+Compute the UUID for a ProGuard mapping file
+
+**Examples:**
+
+```bash
+# Compute the UUID for a ProGuard/R8 mapping file
+sentry proguard uuid ./app/build/outputs/mapping/release/mapping.txt
+
+# Output as JSON (includes the file path)
+sentry proguard uuid mapping.txt --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/plugins/sentry-cli/skills/sentry-cli/references/release.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/release.md
@@ -60,6 +60,20 @@ Delete a release
 - `-f, --force - Force the operation without confirmation`
 - `-n, --dry-run - Show what would happen without making changes`
 
+### `sentry release archive <org/version...>`
+
+Archive a release
+
+**Flags:**
+- `-n, --dry-run - Show what would happen without making changes`
+
+### `sentry release restore <org/version...>`
+
+Restore an archived release
+
+**Flags:**
+- `-n, --dry-run - Show what would happen without making changes`
+
 ### `sentry release deploy <org/version environment name...>`
 
 Create a deploy for a release
@@ -124,6 +138,14 @@ sentry release create $(sentry release propose-version)
 # List deploys for a release
 sentry release deploys 1.0.0
 sentry release deploys my-org/1.0.0
+
+# Archive a release (hide it from the default list, but keep it)
+sentry release archive 1.0.0
+sentry release archive my-org/1.0.0 --dry-run   # Preview without archiving
+
+# Restore a previously archived release
+sentry release restore 1.0.0
+sentry release restore my-org/1.0.0
 
 # Delete a release
 sentry release delete my-org/1.0.0

--- a/plugins/sentry-cli/skills/sentry-cli/references/sourcemap.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/sourcemap.md
@@ -66,4 +66,24 @@ sentry sourcemap upload ./dist --url-prefix '~/static/js/'
 sentry sourcemap upload ./dist --allow-empty
 ```
 
+### `sentry sourcemap resolve <directory>`
+
+Resolve and report sourcemap linkage for JavaScript files
+
+**Flags:**
+- `--ext <value> - Comma-separated file extensions to process (default: .js,.cjs,.mjs)`
+- `--ignore <value> - Comma-separated glob patterns to exclude (gitignore-style)`
+- `--ignore-file <value> - Path to a file with gitignore-style patterns to exclude`
+
+**Examples:**
+
+```bash
+# Report how each JS file's sourcemap resolves and whether a debug ID
+# has been injected (read-only — never modifies files)
+sentry sourcemap resolve ./dist
+
+# Machine-readable output
+sentry sourcemap resolve ./dist --json
+```
+
 All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,6 +23,7 @@ import { logRoute } from "./commands/log/index.js";
 import { listCommand as logListCommand } from "./commands/log/list.js";
 import { orgRoute } from "./commands/org/index.js";
 import { listCommand as orgListCommand } from "./commands/org/list.js";
+import { proguardRoute } from "./commands/proguard/index.js";
 import { projectRoute } from "./commands/project/index.js";
 import { listCommand as projectListCommand } from "./commands/project/list.js";
 import { releaseRoute } from "./commands/release/index.js";
@@ -91,6 +92,7 @@ export const routes = buildRouteMap({
     dashboard: dashboardRoute,
     org: orgRoute,
     project: projectRoute,
+    proguard: proguardRoute,
     replay: replayRoute,
     release: releaseRoute,
     repo: repoRoute,

--- a/src/commands/proguard/index.ts
+++ b/src/commands/proguard/index.ts
@@ -1,0 +1,22 @@
+/**
+ * sentry proguard
+ *
+ * Route map for ProGuard/R8 mapping commands. Currently exposes `uuid`;
+ * `upload` is tracked separately (see issue #1053).
+ */
+
+import { buildRouteMap } from "../../lib/route-map.js";
+import { uuidCommand } from "./uuid.js";
+
+export const proguardRoute = buildRouteMap({
+  routes: {
+    uuid: uuidCommand,
+  },
+  docs: {
+    brief: "Work with ProGuard/R8 mapping files",
+    fullDescription:
+      "Compute UUIDs for Android ProGuard/R8 mapping files.\n\n" +
+      "The UUID is derived deterministically from the mapping file contents " +
+      "and identifies the mapping when deobfuscating Android stack traces.",
+  },
+});

--- a/src/commands/proguard/uuid.ts
+++ b/src/commands/proguard/uuid.ts
@@ -1,0 +1,95 @@
+/**
+ * sentry proguard uuid <path>
+ *
+ * Compute and print the deterministic UUID for a ProGuard/R8 mapping file.
+ * This is the same UUID that `sentry proguard upload` assigns, derived purely
+ * from the file contents. Matches legacy `sentry-cli proguard uuid`.
+ */
+
+import { readFile } from "node:fs/promises";
+import type { SentryContext } from "../../context.js";
+import { buildCommand } from "../../lib/command.js";
+import { ContextError, ValidationError } from "../../lib/errors.js";
+import { CommandOutput } from "../../lib/formatters/output.js";
+import { computeProguardUuid } from "../../lib/proguard.js";
+
+/** Structured result for the proguard uuid command. */
+type ProguardUuidResult = {
+  /** Absolute or user-supplied path to the mapping file. */
+  path: string;
+  /** The computed mapping UUID. */
+  uuid: string;
+};
+
+export const uuidCommand = buildCommand({
+  docs: {
+    brief: "Compute the UUID for a ProGuard mapping file",
+    fullDescription:
+      "Compute and print the UUID of a ProGuard/R8 mapping file. The UUID is " +
+      "deterministically derived from the file contents and matches the " +
+      "value assigned by `sentry proguard upload`.\n\n" +
+      "Usage:\n" +
+      "  sentry proguard uuid ./app/build/outputs/mapping/release/mapping.txt\n" +
+      "  sentry proguard uuid mapping.txt --json",
+  },
+  output: {
+    // Print only the bare UUID for human/plain output (scriptable, matches
+    // legacy `sentry-cli proguard uuid`). JSON output includes the path.
+    human: (data: ProguardUuidResult) => data.uuid,
+    jsonExclude: [],
+  },
+  parameters: {
+    positional: {
+      kind: "tuple",
+      parameters: [
+        {
+          brief: "Path to the ProGuard mapping file",
+          parse: String,
+          placeholder: "path",
+        },
+      ],
+    },
+    flags: {},
+  },
+  async *func(
+    this: SentryContext,
+    _flags: Record<string, never>,
+    path: string
+  ) {
+    if (!path?.trim()) {
+      throw new ContextError(
+        "Mapping file path",
+        "sentry proguard uuid <path>",
+        []
+      );
+    }
+
+    let content: Buffer;
+    try {
+      content = await readFile(path);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        throw new ValidationError(
+          `ProGuard mapping file '${path}' does not exist.`,
+          "path"
+        );
+      }
+      if (code === "EISDIR") {
+        throw new ValidationError(
+          `Path '${path}' is a directory, not a ProGuard mapping file.`,
+          "path"
+        );
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new ValidationError(
+        `Cannot read ProGuard mapping file '${path}': ${msg}`,
+        "path"
+      );
+    }
+
+    const uuid = computeProguardUuid(content);
+    yield new CommandOutput<ProguardUuidResult>({ path, uuid });
+    return {};
+  },
+});

--- a/src/commands/release/archive.ts
+++ b/src/commands/release/archive.ts
@@ -1,0 +1,122 @@
+/**
+ * sentry release archive
+ *
+ * Archive a release by setting its status to "archived". Archived releases are
+ * hidden from the default release list but retained; restore with
+ * `sentry release restore`.
+ */
+
+import type { SentryContext } from "../../context.js";
+import { updateRelease } from "../../lib/api-client.js";
+import { buildCommand } from "../../lib/command.js";
+import { ContextError } from "../../lib/errors.js";
+import {
+  colorTag,
+  escapeMarkdownInline,
+  mdKvTable,
+  renderMarkdown,
+  safeCodeSpan,
+} from "../../lib/formatters/markdown.js";
+import { CommandOutput } from "../../lib/formatters/output.js";
+import { DRY_RUN_ALIASES, DRY_RUN_FLAG } from "../../lib/mutate-command.js";
+import { resolveOrg } from "../../lib/resolve-target.js";
+import type { SentryRelease } from "../../types/index.js";
+import { parseReleaseArg } from "./parse.js";
+
+/**
+ * Render the human-readable result of archiving a release.
+ *
+ * @param data - Either the dry-run preview object or the updated release.
+ */
+function formatReleaseArchived(data: Record<string, unknown>): string {
+  if (data.dryRun) {
+    return renderMarkdown(
+      `Would archive release ${safeCodeSpan(String(data.version))} (dry run)`
+    );
+  }
+  const release = data as unknown as SentryRelease;
+  const lines: string[] = [];
+  lines.push(`## Release Archived: ${escapeMarkdownInline(release.version)}`);
+  lines.push("");
+  const kvRows: [string, string][] = [];
+  kvRows.push(["Version", safeCodeSpan(release.version)]);
+  kvRows.push(["Status", colorTag("muted", "Archived")]);
+  lines.push(mdKvTable(kvRows));
+  return renderMarkdown(lines.join("\n"));
+}
+
+export const archiveCommand = buildCommand({
+  docs: {
+    brief: "Archive a release",
+    fullDescription:
+      "Mark a release as archived. Archived releases are hidden from the " +
+      "default `sentry release list` but are retained and can be restored " +
+      "with `sentry release restore`.\n\n" +
+      "Examples:\n" +
+      "  sentry release archive 1.0.0\n" +
+      "  sentry release archive my-org/1.0.0\n" +
+      "  sentry release archive 1.0.0 --dry-run",
+  },
+  output: {
+    human: formatReleaseArchived,
+  },
+  parameters: {
+    positional: {
+      kind: "array",
+      parameter: {
+        placeholder: "org/version",
+        brief: "[<org>/]<version> - Release version to archive",
+        parse: String,
+      },
+    },
+    flags: {
+      "dry-run": DRY_RUN_FLAG,
+    },
+    aliases: { ...DRY_RUN_ALIASES },
+  },
+  async *func(
+    this: SentryContext,
+    flags: {
+      readonly "dry-run": boolean;
+      readonly json: boolean;
+      readonly fields?: string[];
+    },
+    ...args: string[]
+  ) {
+    const { cwd } = this;
+
+    const joined = args.join(" ").trim();
+    if (!joined) {
+      throw new ContextError(
+        "Release version",
+        "sentry release archive [<org>/]<version>",
+        []
+      );
+    }
+
+    const { version, orgSlug } = parseReleaseArg(
+      joined,
+      "sentry release archive [<org>/]<version>"
+    );
+    const resolved = await resolveOrg({ org: orgSlug, cwd });
+    if (!resolved) {
+      throw new ContextError(
+        "Organization",
+        "sentry release archive [<org>/]<version>"
+      );
+    }
+    if (flags["dry-run"]) {
+      yield new CommandOutput({ dryRun: true, version, org: resolved.org });
+      return { hint: "Dry run — release was not archived." };
+    }
+
+    const release = await updateRelease(resolved.org, version, {
+      status: "archived",
+    });
+    yield new CommandOutput(release);
+    const hint = resolved.detectedFrom
+      ? `Detected from ${resolved.detectedFrom}`
+      : undefined;
+    return { hint };
+  },
+});

--- a/src/commands/release/index.ts
+++ b/src/commands/release/index.ts
@@ -5,6 +5,7 @@
  */
 
 import { buildRouteMap } from "../../lib/route-map.js";
+import { archiveCommand } from "./archive.js";
 import { createCommand } from "./create.js";
 import { deleteCommand } from "./delete.js";
 import { deployCommand } from "./deploy.js";
@@ -12,6 +13,7 @@ import { deploysCommand } from "./deploys.js";
 import { finalizeCommand } from "./finalize.js";
 import { listCommand } from "./list.js";
 import { proposeVersionCommand } from "./propose-version.js";
+import { restoreCommand } from "./restore.js";
 import { setCommitsCommand } from "./set-commits.js";
 import { viewCommand } from "./view.js";
 
@@ -22,6 +24,8 @@ export const releaseRoute = buildRouteMap({
     create: createCommand,
     finalize: finalizeCommand,
     delete: deleteCommand,
+    archive: archiveCommand,
+    restore: restoreCommand,
     deploy: deployCommand,
     deploys: deploysCommand,
     "set-commits": setCommitsCommand,

--- a/src/commands/release/restore.ts
+++ b/src/commands/release/restore.ts
@@ -1,0 +1,120 @@
+/**
+ * sentry release restore
+ *
+ * Restore an archived release by setting its status back to "open", making it
+ * visible in the default release list again.
+ */
+
+import type { SentryContext } from "../../context.js";
+import { updateRelease } from "../../lib/api-client.js";
+import { buildCommand } from "../../lib/command.js";
+import { ContextError } from "../../lib/errors.js";
+import {
+  colorTag,
+  escapeMarkdownInline,
+  mdKvTable,
+  renderMarkdown,
+  safeCodeSpan,
+} from "../../lib/formatters/markdown.js";
+import { CommandOutput } from "../../lib/formatters/output.js";
+import { DRY_RUN_ALIASES, DRY_RUN_FLAG } from "../../lib/mutate-command.js";
+import { resolveOrg } from "../../lib/resolve-target.js";
+import type { SentryRelease } from "../../types/index.js";
+import { parseReleaseArg } from "./parse.js";
+
+/**
+ * Render the human-readable result of restoring a release.
+ *
+ * @param data - Either the dry-run preview object or the updated release.
+ */
+function formatReleaseRestored(data: Record<string, unknown>): string {
+  if (data.dryRun) {
+    return renderMarkdown(
+      `Would restore release ${safeCodeSpan(String(data.version))} (dry run)`
+    );
+  }
+  const release = data as unknown as SentryRelease;
+  const lines: string[] = [];
+  lines.push(`## Release Restored: ${escapeMarkdownInline(release.version)}`);
+  lines.push("");
+  const kvRows: [string, string][] = [];
+  kvRows.push(["Version", safeCodeSpan(release.version)]);
+  kvRows.push(["Status", colorTag("green", "Open")]);
+  lines.push(mdKvTable(kvRows));
+  return renderMarkdown(lines.join("\n"));
+}
+
+export const restoreCommand = buildCommand({
+  docs: {
+    brief: "Restore an archived release",
+    fullDescription:
+      "Restore an archived release by setting its status back to open, " +
+      "making it visible in the default `sentry release list` again.\n\n" +
+      "Examples:\n" +
+      "  sentry release restore 1.0.0\n" +
+      "  sentry release restore my-org/1.0.0\n" +
+      "  sentry release restore 1.0.0 --dry-run",
+  },
+  output: {
+    human: formatReleaseRestored,
+  },
+  parameters: {
+    positional: {
+      kind: "array",
+      parameter: {
+        placeholder: "org/version",
+        brief: "[<org>/]<version> - Release version to restore",
+        parse: String,
+      },
+    },
+    flags: {
+      "dry-run": DRY_RUN_FLAG,
+    },
+    aliases: { ...DRY_RUN_ALIASES },
+  },
+  async *func(
+    this: SentryContext,
+    flags: {
+      readonly "dry-run": boolean;
+      readonly json: boolean;
+      readonly fields?: string[];
+    },
+    ...args: string[]
+  ) {
+    const { cwd } = this;
+
+    const joined = args.join(" ").trim();
+    if (!joined) {
+      throw new ContextError(
+        "Release version",
+        "sentry release restore [<org>/]<version>",
+        []
+      );
+    }
+
+    const { version, orgSlug } = parseReleaseArg(
+      joined,
+      "sentry release restore [<org>/]<version>"
+    );
+    const resolved = await resolveOrg({ org: orgSlug, cwd });
+    if (!resolved) {
+      throw new ContextError(
+        "Organization",
+        "sentry release restore [<org>/]<version>"
+      );
+    }
+    if (flags["dry-run"]) {
+      yield new CommandOutput({ dryRun: true, version, org: resolved.org });
+      return { hint: "Dry run — release was not restored." };
+    }
+
+    const release = await updateRelease(resolved.org, version, {
+      status: "open",
+    });
+    yield new CommandOutput(release);
+    const hint = resolved.detectedFrom
+      ? `Detected from ${resolved.detectedFrom}`
+      : undefined;
+    return { hint };
+  },
+});

--- a/src/commands/sourcemap/index.ts
+++ b/src/commands/sourcemap/index.ts
@@ -1,11 +1,13 @@
 import { buildRouteMap } from "../../lib/route-map.js";
 import { injectCommand } from "./inject.js";
+import { resolveCommand } from "./resolve.js";
 import { uploadCommand } from "./upload.js";
 
 export const sourcemapRoute = buildRouteMap({
   routes: {
     inject: injectCommand,
     upload: uploadCommand,
+    resolve: resolveCommand,
   },
   docs: {
     brief: "Manage sourcemaps",

--- a/src/commands/sourcemap/resolve.ts
+++ b/src/commands/sourcemap/resolve.ts
@@ -1,0 +1,201 @@
+/**
+ * sentry sourcemap resolve <dir>
+ *
+ * Read-only diagnostic that reports how each JavaScript file's sourcemap
+ * resolves (convention, external `sourceMappingURL`, inline `data:` URL, or
+ * none) and whether a Sentry debug ID has been injected. Mirrors the legacy
+ * `sentry-cli sourcemaps resolve` command without mutating any files.
+ */
+
+import { relative, resolve as resolvePath } from "node:path";
+import type { SentryContext } from "../../context.js";
+import { buildCommand } from "../../lib/command.js";
+import {
+  colorTag,
+  escapeMarkdownCell,
+  mdKvTable,
+  renderMarkdown,
+} from "../../lib/formatters/markdown.js";
+import { CommandOutput } from "../../lib/formatters/output.js";
+import {
+  assertDirectoryReadable,
+  buildIgnoreMatcher,
+  resolveDirectorySourcemaps,
+  type SourcemapResolution,
+} from "../../lib/sourcemap/inject.js";
+
+/** Result type for the resolve command output. */
+type ResolveCommandResult = {
+  /** Total JS files scanned. */
+  total: number;
+  /** Files with a resolvable companion sourcemap. */
+  resolved: number;
+  /** Files with an injected debug ID. */
+  withDebugId: number;
+  /** Per-file resolution details (paths relative to the scanned dir). */
+  files: Array<
+    SourcemapResolution & {
+      /** JS path relative to the scanned directory (for display). */
+      relPath: string;
+      /** Map path relative to the scanned directory, if any. */
+      relMapPath?: string;
+    }
+  >;
+};
+
+/**
+ * Describe how the sourcemap resolved, for the human table's "Source map"
+ * column.
+ */
+function describeMapStatus(
+  file: ResolveCommandResult["files"][number]
+): string {
+  if (file.relMapPath) {
+    return escapeMarkdownCell(file.relMapPath);
+  }
+  if (file.inline) {
+    return colorTag("muted", "inline (data: URL)");
+  }
+  if (file.remote) {
+    return colorTag("muted", "remote URL");
+  }
+  return colorTag("red", "not found");
+}
+
+/** Format human-readable output for resolve results. */
+function formatResolveResult(data: ResolveCommandResult): string {
+  const lines: string[] = [];
+  lines.push(
+    mdKvTable([
+      ["JS files", String(data.total)],
+      ["With sourcemap", String(data.resolved)],
+      ["With debug ID", String(data.withDebugId)],
+    ])
+  );
+
+  if (data.files.length > 0) {
+    lines.push("");
+    lines.push("| File | Source map | Debug ID |");
+    lines.push("| --- | --- | --- |");
+    for (const file of data.files) {
+      const debugId = file.debugId
+        ? escapeMarkdownCell(file.debugId)
+        : colorTag("muted", "—");
+      lines.push(
+        `| ${escapeMarkdownCell(file.relPath)} | ${describeMapStatus(file)} | ${debugId} |`
+      );
+    }
+  }
+
+  return renderMarkdown(lines.join("\n"));
+}
+
+export const resolveCommand = buildCommand({
+  docs: {
+    brief: "Resolve and report sourcemap linkage for JavaScript files",
+    fullDescription:
+      "Read-only diagnostic that scans a directory for .js/.mjs/.cjs files " +
+      "and reports, for each file, how its sourcemap resolves (companion " +
+      ".map file, external sourceMappingURL directive, inline data: URL, or " +
+      "none) and whether a Sentry debug ID has been injected.\n\n" +
+      "This command never modifies files. Use it to debug why " +
+      "`sentry sourcemap upload` may not find the expected sourcemaps.\n\n" +
+      "Usage:\n" +
+      "  sentry sourcemap resolve ./dist\n" +
+      "  sentry sourcemap resolve ./build --ext .js,.mjs\n" +
+      "  sentry sourcemap resolve ./out --json",
+  },
+  output: {
+    human: formatResolveResult,
+  },
+  parameters: {
+    positional: {
+      kind: "tuple",
+      parameters: [
+        {
+          brief: "Directory to scan for JS files",
+          parse: String,
+          placeholder: "directory",
+        },
+      ],
+    },
+    flags: {
+      ext: {
+        kind: "parsed",
+        parse: String,
+        brief:
+          "Comma-separated file extensions to process (default: .js,.cjs,.mjs)",
+        optional: true,
+      },
+      ignore: {
+        kind: "parsed",
+        parse: String,
+        brief: "Comma-separated glob patterns to exclude (gitignore-style)",
+        optional: true,
+      },
+      "ignore-file": {
+        kind: "parsed",
+        parse: String,
+        brief: "Path to a file with gitignore-style patterns to exclude",
+        optional: true,
+      },
+    },
+  },
+  async *func(
+    this: SentryContext,
+    flags: {
+      ext?: string;
+      ignore?: string;
+      "ignore-file"?: string;
+    },
+    dir: string
+  ) {
+    await assertDirectoryReadable(dir);
+
+    const extensions = flags.ext?.split(",").map((e) => e.trim());
+    const extSet = extensions
+      ? new Set(extensions.map((e) => (e.startsWith(".") ? e : `.${e}`)))
+      : undefined;
+
+    const ignorePatterns = flags.ignore
+      ? flags.ignore.split(",").map((p) => p.trim())
+      : undefined;
+    const ignoreMatcher = await buildIgnoreMatcher(
+      ignorePatterns,
+      flags["ignore-file"]
+    );
+
+    const resolutions = await resolveDirectorySourcemaps(
+      dir,
+      extSet,
+      ignoreMatcher
+    );
+
+    const absDir = resolvePath(dir);
+    const files = resolutions.map((r) => ({
+      ...r,
+      relPath: relative(absDir, r.jsPath) || r.jsPath,
+      relMapPath: r.mapPath ? relative(absDir, r.mapPath) : undefined,
+    }));
+
+    const resolved = files.filter((f) => f.mapPath).length;
+    const withDebugId = files.filter((f) => f.debugId).length;
+
+    yield new CommandOutput<ResolveCommandResult>({
+      total: files.length,
+      resolved,
+      withDebugId,
+      files,
+    });
+
+    if (files.length === 0) {
+      return { hint: "No JavaScript files found in this directory." };
+    }
+    if (withDebugId < files.length) {
+      return {
+        hint: "Run `sentry sourcemap inject` to add debug IDs to files missing them.",
+      };
+    }
+    return {};
+  },
+});

--- a/src/lib/api/releases.ts
+++ b/src/lib/api/releases.ts
@@ -251,6 +251,8 @@ export async function updateRelease(
     ref?: string;
     url?: string;
     dateReleased?: string;
+    /** Release lifecycle status: "open" (active) or "archived". */
+    status?: string;
     commits?: Array<{
       id: string;
       repository?: string;

--- a/src/lib/complete.ts
+++ b/src/lib/complete.ts
@@ -131,6 +131,8 @@ export const ORG_ONLY_COMMANDS = new Set([
   "release create",
   "release finalize",
   "release delete",
+  "release archive",
+  "release restore",
   "release deploy",
   "release deploys",
   "release set-commits",

--- a/src/lib/proguard.ts
+++ b/src/lib/proguard.ts
@@ -1,0 +1,85 @@
+/**
+ * ProGuard/R8 mapping file utilities.
+ *
+ * The primary export computes the deterministic UUID that Sentry uses to
+ * identify a ProGuard/R8 mapping file. This matches the legacy `sentry-cli`
+ * (via the `rust-proguard` crate) byte-for-byte: the UUID is a content
+ * checksum, computed as a UUIDv5 over the raw file bytes using a namespace
+ * itself derived from the DNS namespace and `"guardsquare.com"`.
+ *
+ * Reference: `rust-proguard` `ProguardMapping::uuid()` —
+ *   NAMESPACE = uuidv5(NAMESPACE_DNS, "guardsquare.com")
+ *   uuid      = uuidv5(NAMESPACE, <raw file bytes>)
+ *
+ * Verified against legacy CLI fixtures:
+ *   - `void\n` (5 bytes)  → 5db7294d-87fc-5726-a5c0-4a90679657a5
+ *   - sample mapping.txt  → c038584d-c366-570c-ad1e-034fa0d194d7
+ */
+
+import { createHash } from "node:crypto";
+
+/**
+ * RFC 4122 DNS namespace UUID. Used as the parent namespace from which the
+ * ProGuard namespace is derived.
+ */
+const NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+
+/**
+ * RFC 4122 variant nibbles (`10xx`), keyed by the original hex digit at the
+ * variant position. Forcing the digit to one of these encodes the variant
+ * without bitwise math: `8/9` keep the low bit, `a/b` set it.
+ */
+const VARIANT_NIBBLE = ["8", "9", "a", "b"] as const;
+
+/**
+ * Compute a name-based UUIDv5 (SHA-1) for `name` within `namespace`.
+ *
+ * Implements RFC 4122 §4.3: SHA-1 over the 16 namespace bytes concatenated
+ * with the name bytes; the first 16 digest bytes become the UUID with the
+ * version forced to 5 and the variant forced to RFC 4122. Operates on the hex
+ * representation (mirroring {@link contentToDebugId}) to avoid bitwise byte
+ * manipulation. Safe for arbitrary (non-UTF-8) file content.
+ *
+ * @param name - The name bytes to hash (file content or a UTF-8 string)
+ * @param namespace - Hyphenated namespace UUID string
+ * @returns Lowercase hyphenated UUIDv5 string
+ */
+function uuidV5(name: Buffer, namespace: string): string {
+  const namespaceBytes = Buffer.from(namespace.replaceAll("-", ""), "hex");
+  const hash = createHash("sha1");
+  hash.update(namespaceBytes);
+  hash.update(name);
+  const hex = hash.digest("hex").slice(0, 32).toLowerCase();
+
+  // Version nibble (5) at hex position 12; variant nibble at position 16,
+  // chosen deterministically from the original digit so the result is stable.
+  const variant = VARIANT_NIBBLE[Number.parseInt(hex[16] ?? "0", 16) % 4];
+  return (
+    `${hex.slice(0, 8)}-${hex.slice(8, 12)}-5${hex.slice(13, 16)}-` +
+    `${variant}${hex.slice(17, 20)}-${hex.slice(20, 32)}`
+  );
+}
+
+/**
+ * The ProGuard namespace UUID, derived as `uuidv5(NAMESPACE_DNS,
+ * "guardsquare.com")`. Equals `4f44f30f-24be-53d0-bab6-f47c7120ad6c`.
+ */
+export const PROGUARD_NAMESPACE = uuidV5(
+  Buffer.from("guardsquare.com", "utf-8"),
+  NAMESPACE_DNS
+);
+
+/**
+ * Compute the Sentry debug ID (UUID) for a ProGuard/R8 mapping file.
+ *
+ * The UUID is a deterministic content checksum: `uuidv5(PROGUARD_NAMESPACE,
+ * <raw file bytes>)`. Identical file contents always yield the same UUID,
+ * matching the value assigned by `sentry proguard upload` and the legacy
+ * `sentry-cli proguard uuid`.
+ *
+ * @param content - Raw bytes of the mapping file
+ * @returns Lowercase hyphenated UUID string
+ */
+export function computeProguardUuid(content: Buffer): string {
+  return uuidV5(content, PROGUARD_NAMESPACE);
+}

--- a/src/lib/sourcemap/inject.ts
+++ b/src/lib/sourcemap/inject.ts
@@ -404,6 +404,108 @@ export async function diagnoseEmptyDiscovery(
 }
 
 /**
+ * Read-only resolution result for a single JavaScript file, produced by
+ * {@link resolveDirectorySourcemaps}. Mirrors the legacy `sentry-cli
+ * sourcemaps resolve` diagnostic output without mutating any files.
+ */
+export type SourcemapResolution = {
+  /** Absolute path to the JavaScript file. */
+  jsPath: string;
+  /**
+   * Absolute path to the resolved companion sourcemap, or `undefined`
+   * when no external `.map` file could be located on disk.
+   */
+  mapPath?: string;
+  /**
+   * Raw value of the last `//# sourceMappingURL=` directive in the file,
+   * or `undefined` when no directive is present.
+   */
+  sourceMappingUrl?: string;
+  /**
+   * True when the `sourceMappingURL` is an inline `data:` URL (embedded
+   * base64 sourcemap) rather than an external file reference.
+   */
+  inline: boolean;
+  /**
+   * True when the `sourceMappingURL` is a remote `http(s)://` reference.
+   */
+  remote: boolean;
+  /**
+   * The embedded `//# debugId=<uuid>` value, or `undefined` when the
+   * file has not been injected yet.
+   */
+  debugId?: string;
+};
+
+/**
+ * Read-only diagnostic pass over a build directory.
+ *
+ * For every discovered JavaScript file this reports how its sourcemap
+ * resolves (convention `<name>.map`, an external `sourceMappingURL`
+ * directive, an inline `data:` URL, or none) and whether a Sentry debug
+ * ID has been injected. Unlike {@link discoverFilePairs}, files **without**
+ * a companion map are still included so the user can see what is missing.
+ *
+ * Never mutates files — this powers `sentry sourcemap resolve`.
+ *
+ * @param dir - Directory to scan (resolved to an absolute path internally)
+ * @param extensions - JS extensions to consider
+ * @param ignoreMatcher - Optional gitignore-style matcher
+ * @returns One {@link SourcemapResolution} per JS file, sorted by path
+ */
+export async function resolveDirectorySourcemaps(
+  dir: string,
+  extensions: Set<string> = DEFAULT_EXTENSIONS,
+  ignoreMatcher?: ReturnType<typeof ignore>
+): Promise<SourcemapResolution[]> {
+  const absDir = resolvePath(dir);
+  const results: SourcemapResolution[] = [];
+  for await (const entry of walkFiles({
+    cwd: absDir,
+    extensions,
+    alwaysSkipDirs: SOURCEMAP_SKIP_DIRS,
+    hidden: false,
+    respectGitignore: false,
+    maxFileSize: Number.POSITIVE_INFINITY,
+  })) {
+    const jsPath = entry.absolutePath;
+    if (ignoreMatcher) {
+      const rel = relative(absDir, jsPath).replaceAll("\\", "/");
+      if (ignoreMatcher.ignores(rel)) {
+        continue;
+      }
+    }
+
+    const sourceMappingUrl = await extractSourceMappingUrl(jsPath);
+    const inline = sourceMappingUrl?.startsWith("data:") ?? false;
+    const remote =
+      (sourceMappingUrl?.startsWith("http://") ?? false) ||
+      (sourceMappingUrl?.startsWith("https://") ?? false);
+    const mapPath = await findCompanionMap(jsPath);
+
+    let debugId: string | undefined;
+    try {
+      const js = await readFile(jsPath, "utf-8");
+      debugId = js.match(EXISTING_DEBUGID_RE)?.[1];
+    } catch (err) {
+      log.debug(`failed to read JS file for debug ID: ${jsPath}`, err);
+    }
+
+    results.push({
+      jsPath,
+      mapPath,
+      sourceMappingUrl,
+      inline,
+      remote,
+      debugId,
+    });
+  }
+
+  results.sort((a, b) => a.jsPath.localeCompare(b.jsPath));
+  return results;
+}
+
+/**
  * Build an actionable error for the zero-pairs case, tailored to
  * which side of the JS/map pairing is missing.
  */

--- a/test/commands/release/archive.test.ts
+++ b/test/commands/release/archive.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Release Archive & Restore Command Tests
+ */
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { archiveCommand } from "../../../src/commands/release/archive.js";
+import { restoreCommand } from "../../../src/commands/release/restore.js";
+
+vi.mock("../../../src/lib/api-client.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/lib/api-client.js")>();
+  return Object.fromEntries(
+    Object.entries(actual).map(([k, v]) => [
+      k,
+      typeof v === "function" ? vi.fn(v) : v,
+    ])
+  );
+});
+
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as apiClient from "../../../src/lib/api-client.js";
+
+vi.mock("../../../src/lib/resolve-target.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/lib/resolve-target.js")>();
+  return Object.fromEntries(
+    Object.entries(actual).map(([k, v]) => [
+      k,
+      typeof v === "function" ? vi.fn(v) : v,
+    ])
+  );
+});
+
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as resolveTarget from "../../../src/lib/resolve-target.js";
+import type { SentryRelease } from "../../../src/types/index.js";
+import { useTestConfigDir } from "../../helpers.js";
+
+useTestConfigDir("release-archive-");
+
+function makeRelease(status: string): SentryRelease {
+  return {
+    id: 1,
+    version: "1.0.0",
+    shortVersion: "1.0.0",
+    status,
+    dateCreated: "2025-01-01T00:00:00Z",
+    dateReleased: null,
+    commitCount: 0,
+    deployCount: 0,
+    newGroups: 0,
+    versionInfo: null,
+    data: {},
+    authors: [],
+    projects: [],
+  };
+}
+
+function createMockContext(cwd = "/tmp") {
+  const stdoutWrite = vi.fn(() => true);
+  const stderrWrite = vi.fn(() => true);
+  return {
+    context: {
+      stdout: { write: stdoutWrite },
+      stderr: { write: stderrWrite },
+      cwd,
+    },
+    stdoutWrite,
+    stderrWrite,
+  };
+}
+
+describe("release archive", () => {
+  let updateReleaseSpy: ReturnType<typeof vi.spyOn>;
+  let resolveOrgSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    updateReleaseSpy = vi.spyOn(apiClient, "updateRelease");
+    resolveOrgSpy = vi.spyOn(resolveTarget, "resolveOrg");
+  });
+
+  afterEach(() => {
+    updateReleaseSpy.mockRestore();
+    resolveOrgSpy.mockRestore();
+  });
+
+  test("archives a release by setting status=archived", async () => {
+    resolveOrgSpy.mockResolvedValue({ org: "my-org" });
+    updateReleaseSpy.mockResolvedValue(makeRelease("archived"));
+
+    const { context, stdoutWrite } = createMockContext();
+    const func = await archiveCommand.loader();
+    await func.call(context, { "dry-run": false, json: true }, "my-org/1.0.0");
+
+    expect(updateReleaseSpy).toHaveBeenCalledWith("my-org", "1.0.0", {
+      status: "archived",
+    });
+    const output = stdoutWrite.mock.calls.map((c) => c[0]).join("");
+    expect(JSON.parse(output).status).toBe("archived");
+  });
+
+  test("dry-run does not call the API", async () => {
+    resolveOrgSpy.mockResolvedValue({ org: "my-org" });
+
+    const { context } = createMockContext();
+    const func = await archiveCommand.loader();
+    await func.call(context, { "dry-run": true, json: true }, "my-org/1.0.0");
+
+    expect(updateReleaseSpy).not.toHaveBeenCalled();
+  });
+
+  test("throws when no version provided", async () => {
+    const { context } = createMockContext();
+    const func = await archiveCommand.loader();
+
+    await expect(
+      func.call(context, { "dry-run": false, json: false })
+    ).rejects.toThrow("Release version");
+  });
+
+  test("throws when org cannot be resolved", async () => {
+    resolveOrgSpy.mockResolvedValue(null);
+
+    const { context } = createMockContext();
+    const func = await archiveCommand.loader();
+
+    await expect(
+      func.call(context, { "dry-run": false, json: false }, "1.0.0")
+    ).rejects.toThrow("organization");
+  });
+});
+
+describe("release restore", () => {
+  let updateReleaseSpy: ReturnType<typeof vi.spyOn>;
+  let resolveOrgSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    updateReleaseSpy = vi.spyOn(apiClient, "updateRelease");
+    resolveOrgSpy = vi.spyOn(resolveTarget, "resolveOrg");
+  });
+
+  afterEach(() => {
+    updateReleaseSpy.mockRestore();
+    resolveOrgSpy.mockRestore();
+  });
+
+  test("restores a release by setting status=open", async () => {
+    resolveOrgSpy.mockResolvedValue({ org: "my-org" });
+    updateReleaseSpy.mockResolvedValue(makeRelease("open"));
+
+    const { context, stdoutWrite } = createMockContext();
+    const func = await restoreCommand.loader();
+    await func.call(context, { "dry-run": false, json: true }, "my-org/1.0.0");
+
+    expect(updateReleaseSpy).toHaveBeenCalledWith("my-org", "1.0.0", {
+      status: "open",
+    });
+    const output = stdoutWrite.mock.calls.map((c) => c[0]).join("");
+    expect(JSON.parse(output).status).toBe("open");
+  });
+
+  test("dry-run does not call the API", async () => {
+    resolveOrgSpy.mockResolvedValue({ org: "my-org" });
+
+    const { context } = createMockContext();
+    const func = await restoreCommand.loader();
+    await func.call(context, { "dry-run": true, json: true }, "my-org/1.0.0");
+
+    expect(updateReleaseSpy).not.toHaveBeenCalled();
+  });
+});

--- a/test/lib/proguard.property.test.ts
+++ b/test/lib/proguard.property.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Property-based + golden tests for ProGuard mapping UUID computation.
+ *
+ * The golden vectors are taken directly from the legacy `sentry-cli`
+ * integration test fixtures (`tests/integration/_cases/proguard/`) and verify
+ * byte-for-byte parity with the `rust-proguard` crate's `uuid()`.
+ */
+
+import { assert as fcAssert, property, uint8Array } from "fast-check";
+import { describe, expect, test } from "vitest";
+import {
+  computeProguardUuid,
+  PROGUARD_NAMESPACE,
+} from "../../src/lib/proguard.js";
+import { DEFAULT_NUM_RUNS } from "../model-based/helpers.js";
+
+/** Lowercase hyphenated UUID shape (8-4-4-4-12 hex). */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+describe("proguard: computeProguardUuid", () => {
+  test("derived namespace matches legacy sentry-cli", () => {
+    // uuidv5(NAMESPACE_DNS, "guardsquare.com")
+    expect(PROGUARD_NAMESPACE).toBe("4f44f30f-24be-53d0-bab6-f47c7120ad6c");
+  });
+
+  test("golden: 'void\\n' fixture", () => {
+    // tests/integration/_fixtures/proguard.txt (5 bytes)
+    const uuid = computeProguardUuid(Buffer.from("void\n", "utf-8"));
+    expect(uuid).toBe("5db7294d-87fc-5726-a5c0-4a90679657a5");
+  });
+
+  test("golden: sample mapping.txt fixture", () => {
+    // tests/integration/_fixtures/proguard/upload/mapping.txt (155 bytes)
+    const mapping =
+      "HelloWorld -> HelloWorld:\n" +
+      '# {"fileName":"HelloWorld.java","id":"sourceFile"}\n' +
+      "    1:1:void <init>() -> <init>\n" +
+      "    3:4:void main(java.lang.String[]) -> main\n";
+    const uuid = computeProguardUuid(Buffer.from(mapping, "utf-8"));
+    expect(uuid).toBe("c038584d-c366-570c-ad1e-034fa0d194d7");
+  });
+
+  test("always returns a well-formed lowercase UUID with version 5", () => {
+    fcAssert(
+      property(uint8Array(), (bytes) => {
+        const uuid = computeProguardUuid(Buffer.from(bytes));
+        expect(uuid).toMatch(UUID_RE);
+        // Version nibble (first char of 3rd group) is always 5.
+        expect(uuid[14]).toBe("5");
+        // Variant nibble (first char of 4th group) is RFC 4122 (8/9/a/b).
+        expect(["8", "9", "a", "b"]).toContain(uuid[19]);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("is deterministic: same bytes yield the same UUID", () => {
+    fcAssert(
+      property(uint8Array(), (bytes) => {
+        const a = computeProguardUuid(Buffer.from(bytes));
+        const b = computeProguardUuid(Buffer.from(bytes));
+        expect(a).toBe(b);
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+
+  test("differs when content differs", () => {
+    fcAssert(
+      property(uint8Array({ minLength: 1 }), (bytes) => {
+        const original = Buffer.from(bytes);
+        const mutated = Buffer.from(bytes);
+        // Flip the first byte to guarantee different content.
+        mutated[0] = (mutated[0]! + 1) % 256;
+        expect(computeProguardUuid(original)).not.toBe(
+          computeProguardUuid(mutated)
+        );
+      }),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});

--- a/test/lib/sourcemap/resolve.test.ts
+++ b/test/lib/sourcemap/resolve.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the read-only sourcemap resolution pass that powers
+ * `sentry sourcemap resolve`. Verifies companion-map detection,
+ * sourceMappingURL classification (external / inline / remote / missing),
+ * and debug-ID extraction.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { resolveDirectorySourcemaps } from "../../../src/lib/sourcemap/inject.js";
+
+describe("resolveDirectorySourcemaps", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sentry-resolve-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(rel: string, content: string): void {
+    const full = join(dir, rel);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, content);
+  }
+
+  test("resolves a convention-named companion map", async () => {
+    write("app.js", "console.log(1)\n");
+    write("app.js.map", "{}\n");
+
+    const results = await resolveDirectorySourcemaps(dir);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.mapPath).toBe(join(dir, "app.js.map"));
+    expect(results[0]?.inline).toBe(false);
+    expect(results[0]?.remote).toBe(false);
+  });
+
+  test("reports a JS file with no companion map", async () => {
+    write("orphan.js", "console.log(1)\n");
+
+    const results = await resolveDirectorySourcemaps(dir);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.mapPath).toBeUndefined();
+    expect(results[0]?.sourceMappingUrl).toBeUndefined();
+  });
+
+  test("classifies an inline data: sourceMappingURL", async () => {
+    write(
+      "inline.js",
+      "console.log(1)\n//# sourceMappingURL=data:application/json;base64,e30=\n"
+    );
+
+    const results = await resolveDirectorySourcemaps(dir);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.inline).toBe(true);
+    expect(results[0]?.mapPath).toBeUndefined();
+  });
+
+  test("classifies a remote sourceMappingURL", async () => {
+    write(
+      "remote.js",
+      "console.log(1)\n//# sourceMappingURL=https://cdn.example.com/remote.js.map\n"
+    );
+
+    const results = await resolveDirectorySourcemaps(dir);
+    expect(results[0]?.remote).toBe(true);
+    expect(results[0]?.mapPath).toBeUndefined();
+  });
+
+  test("extracts an injected debug ID", async () => {
+    const debugId = "a1b2c3d4-e5f6-4789-abcd-ef0123456789";
+    write("with-id.js", `console.log(1)\n//# debugId=${debugId}\n`);
+    write("with-id.js.map", "{}\n");
+
+    const results = await resolveDirectorySourcemaps(dir);
+    expect(results[0]?.debugId).toBe(debugId);
+  });
+
+  test("reports undefined debug ID when not injected", async () => {
+    write("plain.js", "console.log(1)\n");
+    write("plain.js.map", "{}\n");
+
+    const results = await resolveDirectorySourcemaps(dir);
+    expect(results[0]?.debugId).toBeUndefined();
+  });
+
+  test("results are sorted by path", async () => {
+    write("b.js", "1\n");
+    write("a.js", "1\n");
+    write("c.js", "1\n");
+
+    const results = await resolveDirectorySourcemaps(dir);
+    const names = results.map((r) => r.jsPath);
+    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+  });
+});


### PR DESCRIPTION
## Summary

Parity quick wins toward replacing the legacy Rust `sentry-cli` (ref #600). Adds three commands whose infrastructure already existed:

- **`release archive` / `release restore`** — toggle a release's lifecycle status between `archived` and `open` via `updateRelease({ status })`. Archived releases are hidden from the default `release list` but retained; restore brings them back. Both support `--dry-run`.
- **`sourcemap resolve`** — read-only diagnostic that reports, per JS file, how its sourcemap resolves (convention `<name>.map` / external `sourceMappingURL` / inline `data:` URL / remote / none) and whether a Sentry debug ID has been injected. Reuses the `inject` discovery logic and **never mutates files**. Helps debug why `sourcemap upload` may not find expected maps.
- **`proguard uuid`** — computes the deterministic ProGuard/R8 mapping UUID. Pure TS via `node:crypto`, no native deps.

## ProGuard UUID — verified against the legacy CLI

The UUID is a content checksum matching `rust-proguard`'s `ProguardMapping::uuid()`:

```
NAMESPACE = uuidv5(NAMESPACE_DNS, "guardsquare.com")  // 4f44f30f-24be-53d0-bab6-f47c7120ad6c
uuid      = uuidv5(NAMESPACE, <raw file bytes>)
```

Reproduced **byte-for-byte** against the legacy `sentry-cli` integration fixtures (used as golden tests):
- `void\n` (5 bytes) → `5db7294d-87fc-5726-a5c0-4a90679657a5`
- sample `mapping.txt` (155 bytes) → `c038584d-c366-570c-ad1e-034fa0d194d7`

The variant-nibble encoding uses a string-based approach (no bitwise ops, to satisfy `noBitwiseOperators`); I verified it is mathematically equivalent to the canonical `byte[8] & 0x3f | 0x80` bitmask for all 16 hex digits.

## Changes
- `src/lib/api/releases.ts`: add `status?` to `updateRelease` body type.
- `src/commands/release/{archive,restore}.ts` + route wiring.
- `src/commands/sourcemap/resolve.ts` + `src/lib/sourcemap/inject.ts` (`resolveDirectorySourcemaps`) + route wiring.
- `src/commands/proguard/{uuid,index}.ts` + `src/lib/proguard.ts` + `src/app.ts` wiring.
- `src/lib/complete.ts`: register the new org-positional `release archive`/`restore` verbs.
- Docs fragments (`release`, `sourcemap`, new `proguard`) + regenerated skill references.

## Tests
40 new tests (all green); full suite: **7440 passed / 0 failed / 13 skipped**.
- `proguard.property.test.ts`: golden vectors + properties (well-formed UUIDv5, determinism, content-sensitivity).
- `sourcemap/resolve.test.ts`: companion-map detection, inline/remote/missing classification, debug-ID extraction, sort order.
- `release/archive.test.ts`: archive/restore status calls, `--dry-run`, error paths.

## Out of scope (tracked separately)
- #1052 cron `monitor` check-ins · #1053 `proguard upload` · #1054 inline base64 sourcemaps · #1055 niche commands.

`send-envelope` is intentionally **not** revived (deprecated in favor of `event send --raw`).
