### PR TITLE
fix: address unresolved review comments from #1058

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -7,7 +7,8 @@
     "./lint-rules/no-raw-metadata-queries.grit",
     "./lint-rules/no-manual-transactions.grit",
     "./lint-rules/no-inline-touch-cache.grit",
-    "./lint-rules/no-stderr-write-in-commands.grit"
+    "./lint-rules/no-stderr-write-in-commands.grit",
+    "./lint-rules/no-args-join-in-release.grit"
   ],
   "files": {
     // custom-ca.ts excluded: Biome's type analysis hits the 200k type limit

--- a/lint-rules/no-args-join-in-release.grit
+++ b/lint-rules/no-args-join-in-release.grit
@@ -1,0 +1,5 @@
+file($name, $body) where {
+  $name <: r".*src/commands/release/.*",
+  $body <: contains `args.join($sep)` as $call,
+  register_diagnostic(span=$call, message="Don't join variadic release args with args.join(). Declare positionals as a Stricli tuple and resolve them via resolveReleaseTarget()/parseReleaseArg() so Stricli enforces arity instead of silently swallowing extra arguments. See src/commands/release/parse.ts.")
+}

--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -389,15 +389,15 @@ Search and inspect Session Replays
 Work with Sentry releases
 
 - `sentry release list <org/project>` — List releases with adoption and health metrics
-- `sentry release view <org/version...>` — View release details with health metrics
-- `sentry release create <org/version...>` — Create a release
-- `sentry release finalize <org/version...>` — Finalize a release
-- `sentry release delete <org/version...>` — Delete a release
-- `sentry release archive <org/version...>` — Archive a release
-- `sentry release restore <org/version...>` — Restore an archived release
-- `sentry release deploy <org/version environment name...>` — Create a deploy for a release
-- `sentry release deploys <org/version...>` — List deploys for a release
-- `sentry release set-commits <org/version...>` — Set commits for a release
+- `sentry release view <org/version>` — View release details with health metrics
+- `sentry release create <org/version>` — Create a release
+- `sentry release finalize <org/version>` — Finalize a release
+- `sentry release delete <org/version>` — Delete a release
+- `sentry release archive <org/version>` — Archive a release
+- `sentry release restore <org/version>` — Restore an archived release
+- `sentry release deploy <org/version> <environment> <name>` — Create a deploy for a release
+- `sentry release deploys <org/version>` — List deploys for a release
+- `sentry release set-commits <org/version>` — Set commits for a release
 - `sentry release propose-version` — Propose a release version
 
 → Full flags and examples: `references/release.md`

--- a/plugins/sentry-cli/skills/sentry-cli/references/release.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/release.md
@@ -24,14 +24,14 @@ List releases with adoption and health metrics
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 
-### `sentry release view <org/version...>`
+### `sentry release view <org/version>`
 
 View release details with health metrics
 
 **Flags:**
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 
-### `sentry release create <org/version...>`
+### `sentry release create <org/version>`
 
 Create a release
 
@@ -42,7 +42,7 @@ Create a release
 - `--url <value> - URL to the release source`
 - `-n, --dry-run - Show what would happen without making changes`
 
-### `sentry release finalize <org/version...>`
+### `sentry release finalize <org/version>`
 
 Finalize a release
 
@@ -51,7 +51,7 @@ Finalize a release
 - `--url <value> - URL for the release`
 - `-n, --dry-run - Show what would happen without making changes`
 
-### `sentry release delete <org/version...>`
+### `sentry release delete <org/version>`
 
 Delete a release
 
@@ -60,21 +60,21 @@ Delete a release
 - `-f, --force - Force the operation without confirmation`
 - `-n, --dry-run - Show what would happen without making changes`
 
-### `sentry release archive <org/version...>`
+### `sentry release archive <org/version>`
 
 Archive a release
 
 **Flags:**
 - `-n, --dry-run - Show what would happen without making changes`
 
-### `sentry release restore <org/version...>`
+### `sentry release restore <org/version>`
 
 Restore an archived release
 
 **Flags:**
 - `-n, --dry-run - Show what would happen without making changes`
 
-### `sentry release deploy <org/version environment name...>`
+### `sentry release deploy <org/version> <environment> <name>`
 
 Create a deploy for a release
 
@@ -85,11 +85,11 @@ Create a deploy for a release
 - `-t, --time <value> - Deploy duration in seconds (sets started = now - time, finished = now)`
 - `-n, --dry-run - Show what would happen without making changes`
 
-### `sentry release deploys <org/version...>`
+### `sentry release deploys <org/version>`
 
 List deploys for a release
 
-### `sentry release set-commits <org/version...>`
+### `sentry release set-commits <org/version>`
 
 Set commits for a release
 

--- a/src/commands/release/archive.ts
+++ b/src/commands/release/archive.ts
@@ -9,7 +9,6 @@
 import type { SentryContext } from "../../context.js";
 import { updateRelease } from "../../lib/api-client.js";
 import { buildCommand } from "../../lib/command.js";
-import { ContextError } from "../../lib/errors.js";
 import {
   colorTag,
   escapeMarkdownInline,
@@ -19,9 +18,10 @@ import {
 } from "../../lib/formatters/markdown.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import { DRY_RUN_ALIASES, DRY_RUN_FLAG } from "../../lib/mutate-command.js";
-import { resolveOrg } from "../../lib/resolve-target.js";
 import type { SentryRelease } from "../../types/index.js";
-import { parseReleaseArg } from "./parse.js";
+import { resolveReleaseTarget } from "./parse.js";
+
+const USAGE_HINT = "sentry release archive [<org>/]<version>";
 
 /**
  * Render the human-readable result of archiving a release.
@@ -62,12 +62,14 @@ export const archiveCommand = buildCommand({
   },
   parameters: {
     positional: {
-      kind: "array",
-      parameter: {
-        placeholder: "org/version",
-        brief: "[<org>/]<version> - Release version to archive",
-        parse: String,
-      },
+      kind: "tuple",
+      parameters: [
+        {
+          placeholder: "org/version",
+          brief: "[<org>/]<version> - Release version to archive",
+          parse: String,
+        },
+      ],
     },
     flags: {
       "dry-run": DRY_RUN_FLAG,
@@ -81,42 +83,26 @@ export const archiveCommand = buildCommand({
       readonly json: boolean;
       readonly fields?: string[];
     },
-    ...args: string[]
+    target: string
   ) {
     const { cwd } = this;
 
-    const joined = args.join(" ").trim();
-    if (!joined) {
-      throw new ContextError(
-        "Release version",
-        "sentry release archive [<org>/]<version>",
-        []
-      );
-    }
-
-    const { version, orgSlug } = parseReleaseArg(
-      joined,
-      "sentry release archive [<org>/]<version>"
+    const { version, org, detectedFrom } = await resolveReleaseTarget(
+      target,
+      USAGE_HINT,
+      cwd
     );
-    const resolved = await resolveOrg({ org: orgSlug, cwd });
-    if (!resolved) {
-      throw new ContextError(
-        "Organization",
-        "sentry release archive [<org>/]<version>"
-      );
-    }
+
     if (flags["dry-run"]) {
-      yield new CommandOutput({ dryRun: true, version, org: resolved.org });
+      yield new CommandOutput({ dryRun: true, version, org });
       return { hint: "Dry run — release was not archived." };
     }
 
-    const release = await updateRelease(resolved.org, version, {
+    const release = await updateRelease(org, version, {
       status: "archived",
     });
     yield new CommandOutput(release);
-    const hint = resolved.detectedFrom
-      ? `Detected from ${resolved.detectedFrom}`
-      : undefined;
+    const hint = detectedFrom ? `Detected from ${detectedFrom}` : undefined;
     return { hint };
   },
 });

--- a/src/commands/release/create.ts
+++ b/src/commands/release/create.ts
@@ -7,7 +7,6 @@
 import type { SentryContext } from "../../context.js";
 import { createRelease } from "../../lib/api-client.js";
 import { buildCommand } from "../../lib/command.js";
-import { ContextError } from "../../lib/errors.js";
 import {
   colorTag,
   escapeMarkdownInline,
@@ -17,9 +16,10 @@ import {
 } from "../../lib/formatters/markdown.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import { DRY_RUN_ALIASES, DRY_RUN_FLAG } from "../../lib/mutate-command.js";
-import { resolveOrg } from "../../lib/resolve-target.js";
 import type { SentryRelease } from "../../types/index.js";
-import { parseReleaseArg } from "./parse.js";
+import { resolveReleaseTarget } from "./parse.js";
+
+const USAGE_HINT = "sentry release create [<org>/]<version>";
 
 function formatReleaseCreated(release: SentryRelease): string {
   const lines: string[] = [];
@@ -76,12 +76,14 @@ export const createCommand = buildCommand({
   },
   parameters: {
     positional: {
-      kind: "array",
-      parameter: {
-        placeholder: "org/version",
-        brief: "[<org>/]<version> - Release version to create",
-        parse: String,
-      },
+      kind: "tuple",
+      parameters: [
+        {
+          placeholder: "org/version",
+          brief: "[<org>/]<version> - Release version to create",
+          parse: String,
+        },
+      ],
     },
     flags: {
       project: {
@@ -122,30 +124,15 @@ export const createCommand = buildCommand({
       readonly json: boolean;
       readonly fields?: string[];
     },
-    ...args: string[]
+    target: string
   ) {
     const { cwd } = this;
 
-    const joined = args.join(" ").trim();
-    if (!joined) {
-      throw new ContextError(
-        "Release version",
-        "sentry release create [<org>/]<version>",
-        []
-      );
-    }
-
-    const { version, orgSlug } = parseReleaseArg(
-      joined,
-      "sentry release create [<org>/]<version>"
+    const { version, org } = await resolveReleaseTarget(
+      target,
+      USAGE_HINT,
+      cwd
     );
-    const resolved = await resolveOrg({ org: orgSlug, cwd });
-    if (!resolved) {
-      throw new ContextError(
-        "Organization",
-        "sentry release create [<org>/]<version>"
-      );
-    }
 
     const body: Parameters<typeof createRelease>[1] = { version };
     if (flags.project) {
@@ -176,7 +163,7 @@ export const createCommand = buildCommand({
       return { hint: "Dry run — no release was created." };
     }
 
-    const release = await createRelease(resolved.org, body);
+    const release = await createRelease(org, body);
     yield new CommandOutput(release);
 
     const hint = flags.finalize

--- a/src/commands/release/delete.ts
+++ b/src/commands/release/delete.ts
@@ -9,7 +9,7 @@
 
 import type { SentryContext } from "../../context.js";
 import { deleteRelease, getRelease } from "../../lib/api-client.js";
-import { ApiError, ContextError } from "../../lib/errors.js";
+import { ApiError } from "../../lib/errors.js";
 import { renderMarkdown, safeCodeSpan } from "../../lib/formatters/markdown.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import {
@@ -17,9 +17,10 @@ import {
   confirmByTyping,
   isConfirmationBypassed,
 } from "../../lib/mutate-command.js";
-import { resolveOrg } from "../../lib/resolve-target.js";
 import { buildReleaseUrl } from "../../lib/sentry-urls.js";
-import { parseReleaseArg } from "./parse.js";
+import { resolveReleaseTarget } from "./parse.js";
+
+const USAGE_HINT = "sentry release delete [<org>/]<version>";
 
 type DeleteResult = {
   deleted: boolean;
@@ -93,46 +94,33 @@ export const deleteCommand = buildDeleteCommand({
   },
   parameters: {
     positional: {
-      kind: "array",
-      parameter: {
-        placeholder: "org/version",
-        brief: "[<org>/]<version> - Release version to delete",
-        parse: String,
-      },
+      kind: "tuple",
+      parameters: [
+        {
+          placeholder: "org/version",
+          brief: "[<org>/]<version> - Release version to delete",
+          parse: String,
+        },
+      ],
     },
   },
-  async *func(this: SentryContext, flags: DeleteFlags, ...args: string[]) {
+  async *func(this: SentryContext, flags: DeleteFlags, target: string) {
     const { cwd } = this;
 
-    const joined = args.join(" ").trim();
-    if (!joined) {
-      throw new ContextError(
-        "Release version",
-        "sentry release delete [<org>/]<version>",
-        []
-      );
-    }
-
-    const { version, orgSlug } = parseReleaseArg(
-      joined,
-      "sentry release delete [<org>/]<version>"
+    const { version, org } = await resolveReleaseTarget(
+      target,
+      USAGE_HINT,
+      cwd
     );
-    const resolved = await resolveOrg({ org: orgSlug, cwd });
-    if (!resolved) {
-      throw new ContextError(
-        "Organization",
-        "sentry release delete [<org>/]<version>"
-      );
-    }
 
     // Verify the release exists before prompting for confirmation
-    const release = await getRelease(resolved.org, version);
+    const release = await getRelease(org, version);
 
     // Dry-run mode: show what would be deleted
     if (flags["dry-run"]) {
       yield new CommandOutput({
         deleted: false,
-        org: resolved.org,
+        org,
         version,
         dryRun: true,
       });
@@ -152,7 +140,7 @@ export const deleteCommand = buildDeleteCommand({
       if (!confirmed) {
         yield new CommandOutput({
           deleted: false,
-          org: resolved.org,
+          org,
           version,
         });
         return { hint: "Cancelled." };
@@ -160,10 +148,10 @@ export const deleteCommand = buildDeleteCommand({
     }
 
     try {
-      await deleteRelease(resolved.org, version);
+      await deleteRelease(org, version);
     } catch (error) {
-      throw enrichDeleteError(error, resolved.org, version);
+      throw enrichDeleteError(error, org, version);
     }
-    yield new CommandOutput({ deleted: true, org: resolved.org, version });
+    yield new CommandOutput({ deleted: true, org, version });
   },
 });

--- a/src/commands/release/deploy.ts
+++ b/src/commands/release/deploy.ts
@@ -21,6 +21,9 @@ import { resolveOrg } from "../../lib/resolve-target.js";
 import type { SentryDeploy } from "../../types/index.js";
 import { parseReleaseArg } from "./parse.js";
 
+const USAGE_HINT =
+  "sentry release deploy [<org>/]<version> <environment> [name]";
+
 function formatDeployCreated(data: Record<string, unknown>): string {
   if (data.dryRun) {
     return renderMarkdown(
@@ -49,37 +52,34 @@ function formatDeployCreated(data: Record<string, unknown>): string {
 }
 
 /**
- * Parse the deploy positional args: `[org/]version environment [name]`
+ * Parse the deploy positionals: `[org/]version`, `environment`, optional `name`.
  *
  * The first arg is parsed as the release target (version with optional org prefix).
- * The second arg is the required environment.
- * The third arg is an optional deploy name.
+ * The second arg is the required environment. The third is an optional deploy
+ * name — multi-word names must be quoted (e.g. `"Deploy #42"`), matching standard
+ * CLI conventions and avoiding the silent `args.join(" ")` defect.
+ *
+ * @param target - The `[<org>/]<version>` release target
+ * @param environment - The deploy environment
+ * @param name - Optional deploy name
  */
-function parseDeployArgs(args: string[]): {
+function parseDeployArgs(
+  target: string,
+  environment: string,
+  name?: string
+): {
   version: string;
   orgSlug?: string;
   environment: string;
   name?: string;
 } {
-  const first = args[0];
-  const second = args[1];
-  if (!(first && second)) {
-    throw new ContextError(
-      "Release version and environment",
-      "sentry release deploy [<org>/]<version> <environment> [name]",
-      []
-    );
+  if (!(target && environment)) {
+    throw new ContextError("Release version and environment", USAGE_HINT, []);
   }
 
-  const { version, orgSlug } = parseReleaseArg(
-    first,
-    "sentry release deploy [<org>/]<version> <environment>"
-  );
+  const { version, orgSlug } = parseReleaseArg(target, USAGE_HINT);
 
-  const environment = second;
-  const name = args.length > 2 ? args.slice(2).join(" ") : undefined;
-
-  return { version, orgSlug, environment, name };
+  return { version, orgSlug, environment, name: name || undefined };
 }
 
 export const deployCommand = buildCommand({
@@ -99,12 +99,26 @@ export const deployCommand = buildCommand({
   },
   parameters: {
     positional: {
-      kind: "array",
-      parameter: {
-        placeholder: "org/version environment name",
-        brief: "[<org>/]<version> <environment> [name]",
-        parse: String,
-      },
+      kind: "tuple",
+      parameters: [
+        {
+          placeholder: "org/version",
+          brief: "[<org>/]<version> - Release version",
+          parse: String,
+        },
+        {
+          placeholder: "environment",
+          brief: "Deploy environment (e.g. production)",
+          parse: String,
+        },
+        {
+          placeholder: "name",
+          brief:
+            'Optional deploy name (quote multi-word names, e.g. "Deploy #42")',
+          parse: String,
+          optional: true,
+        },
+      ],
     },
     flags: {
       url: {
@@ -136,6 +150,7 @@ export const deployCommand = buildCommand({
     },
     aliases: { ...DRY_RUN_ALIASES, t: "time" },
   },
+  // biome-ignore lint/nursery/useMaxParams: Stricli maps each `kind: "tuple"` positional to a named func param; deploy legitimately takes version + environment + optional name.
   async *func(
     this: SentryContext,
     flags: {
@@ -147,17 +162,20 @@ export const deployCommand = buildCommand({
       readonly json: boolean;
       readonly fields?: string[];
     },
-    ...args: string[]
+    target: string,
+    environmentArg: string,
+    nameArg?: string
   ) {
     const { cwd } = this;
 
-    const { version, orgSlug, environment, name } = parseDeployArgs(args);
+    const { version, orgSlug, environment, name } = parseDeployArgs(
+      target,
+      environmentArg,
+      nameArg
+    );
     const resolved = await resolveOrg({ org: orgSlug, cwd });
     if (!resolved) {
-      throw new ContextError(
-        "Organization",
-        "sentry release deploy [<org>/]<version> <environment>"
-      );
+      throw new ContextError("Organization", USAGE_HINT);
     }
 
     const body: Parameters<typeof createReleaseDeploy>[2] = { environment };

--- a/src/commands/release/deploys.ts
+++ b/src/commands/release/deploys.ts
@@ -7,13 +7,13 @@
 import type { SentryContext } from "../../context.js";
 import { listReleaseDeploys } from "../../lib/api-client.js";
 import { buildCommand } from "../../lib/command.js";
-import { ContextError } from "../../lib/errors.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import { type Column, formatTable } from "../../lib/formatters/table.js";
 import { formatRelativeTime } from "../../lib/formatters/time-utils.js";
-import { resolveOrg } from "../../lib/resolve-target.js";
 import type { SentryDeploy } from "../../types/index.js";
-import { parseReleaseArg } from "./parse.js";
+import { resolveReleaseTarget } from "./parse.js";
+
+const USAGE_HINT = "sentry release deploys [<org>/]<version>";
 
 const DEPLOY_COLUMNS: Column<SentryDeploy>[] = [
   { header: "ENVIRONMENT", value: (d) => d.environment },
@@ -46,43 +46,30 @@ export const deploysCommand = buildCommand({
   },
   parameters: {
     positional: {
-      kind: "array",
-      parameter: {
-        placeholder: "org/version",
-        brief: "[<org>/]<version> - Release version",
-        parse: String,
-      },
+      kind: "tuple",
+      parameters: [
+        {
+          placeholder: "org/version",
+          brief: "[<org>/]<version> - Release version",
+          parse: String,
+        },
+      ],
     },
   },
   async *func(
     this: SentryContext,
     _flags: { readonly json: boolean; readonly fields?: string[] },
-    ...args: string[]
+    target: string
   ) {
     const { cwd } = this;
 
-    const joined = args.join(" ").trim();
-    if (!joined) {
-      throw new ContextError(
-        "Release version",
-        "sentry release deploys [<org>/]<version>",
-        []
-      );
-    }
-
-    const { version, orgSlug } = parseReleaseArg(
-      joined,
-      "sentry release deploys [<org>/]<version>"
+    const { version, org } = await resolveReleaseTarget(
+      target,
+      USAGE_HINT,
+      cwd
     );
-    const resolved = await resolveOrg({ org: orgSlug, cwd });
-    if (!resolved) {
-      throw new ContextError(
-        "Organization",
-        "sentry release deploys [<org>/]<version>"
-      );
-    }
 
-    const deploys = await listReleaseDeploys(resolved.org, version);
+    const deploys = await listReleaseDeploys(org, version);
     yield new CommandOutput(deploys);
   },
 });

--- a/src/commands/release/finalize.ts
+++ b/src/commands/release/finalize.ts
@@ -7,7 +7,6 @@
 import type { SentryContext } from "../../context.js";
 import { updateRelease } from "../../lib/api-client.js";
 import { buildCommand } from "../../lib/command.js";
-import { ContextError } from "../../lib/errors.js";
 import {
   colorTag,
   escapeMarkdownInline,
@@ -17,9 +16,10 @@ import {
 } from "../../lib/formatters/markdown.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import { DRY_RUN_ALIASES, DRY_RUN_FLAG } from "../../lib/mutate-command.js";
-import { resolveOrg } from "../../lib/resolve-target.js";
 import type { SentryRelease } from "../../types/index.js";
-import { parseReleaseArg } from "./parse.js";
+import { resolveReleaseTarget } from "./parse.js";
+
+const USAGE_HINT = "sentry release finalize [<org>/]<version>";
 
 function formatReleaseFinalized(data: Record<string, unknown>): string {
   if (data.dryRun) {
@@ -55,12 +55,14 @@ export const finalizeCommand = buildCommand({
   },
   parameters: {
     positional: {
-      kind: "array",
-      parameter: {
-        placeholder: "org/version",
-        brief: "[<org>/]<version> - Release version to finalize",
-        parse: String,
-      },
+      kind: "tuple",
+      parameters: [
+        {
+          placeholder: "org/version",
+          brief: "[<org>/]<version> - Release version to finalize",
+          parse: String,
+        },
+      ],
     },
     flags: {
       released: {
@@ -88,35 +90,21 @@ export const finalizeCommand = buildCommand({
       readonly json: boolean;
       readonly fields?: string[];
     },
-    ...args: string[]
+    target: string
   ) {
     const { cwd } = this;
 
-    const joined = args.join(" ").trim();
-    if (!joined) {
-      throw new ContextError(
-        "Release version",
-        "sentry release finalize [<org>/]<version>",
-        []
-      );
-    }
-
-    const { version, orgSlug } = parseReleaseArg(
-      joined,
-      "sentry release finalize [<org>/]<version>"
+    const { version, org, detectedFrom } = await resolveReleaseTarget(
+      target,
+      USAGE_HINT,
+      cwd
     );
-    const resolved = await resolveOrg({ org: orgSlug, cwd });
-    if (!resolved) {
-      throw new ContextError(
-        "Organization",
-        "sentry release finalize [<org>/]<version>"
-      );
-    }
+
     if (flags["dry-run"]) {
       yield new CommandOutput({
         dryRun: true,
         version,
-        org: resolved.org,
+        org,
         released: flags.released || new Date().toISOString(),
       });
       return { hint: "Dry run — release was not finalized." };
@@ -128,11 +116,9 @@ export const finalizeCommand = buildCommand({
     if (flags.url) {
       body.url = flags.url;
     }
-    const release = await updateRelease(resolved.org, version, body);
+    const release = await updateRelease(org, version, body);
     yield new CommandOutput(release);
-    const hint = resolved.detectedFrom
-      ? `Detected from ${resolved.detectedFrom}`
-      : undefined;
+    const hint = detectedFrom ? `Detected from ${detectedFrom}` : undefined;
     return { hint };
   },
 });

--- a/src/commands/release/parse.ts
+++ b/src/commands/release/parse.ts
@@ -6,7 +6,8 @@
  * slug separators. This module provides version-aware parsing.
  */
 
-import { ValidationError } from "../../lib/errors.js";
+import { ContextError, ValidationError } from "../../lib/errors.js";
+import { resolveOrg } from "../../lib/resolve-target.js";
 
 /** Slug pattern: lowercase alphanumeric + hyphens, no leading/trailing hyphen */
 const SLUG_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/;
@@ -52,4 +53,51 @@ export function parseReleaseArg(
   }
 
   return { version: arg };
+}
+
+/** A fully-resolved release target: a concrete org plus the release version. */
+export type ResolvedReleaseTarget = {
+  /** The release version (never empty). */
+  version: string;
+  /** The resolved organization slug. */
+  org: string;
+  /** Source description when the org was auto-detected (e.g. from a DSN). */
+  detectedFrom?: string;
+};
+
+/**
+ * Resolve a single release positional argument into a concrete `{ version, org }`.
+ *
+ * Centralizes the version-only release-command boilerplate: it parses the
+ * `[<org>/]<version>` target, resolves the organization (from the parsed prefix
+ * or the surrounding project context), and raises consistent {@link ContextError}s
+ * when the version is missing or no organization can be determined.
+ *
+ * Commands pass a single required positional (Stricli `kind: "tuple"`), so callers
+ * never need to join variadic args — preventing the silent
+ * `args.join(" ")` defect where extra positionals were swallowed into the version.
+ *
+ * @param target - The raw positional argument (e.g. `1.0.0` or `my-org/1.0.0`)
+ * @param usageHint - Single-line usage example for error messages
+ * @param cwd - Current working directory, used for context-based org detection
+ * @returns The resolved version and organization
+ * @throws {ContextError} If the version is empty or the org cannot be resolved
+ */
+export async function resolveReleaseTarget(
+  target: string | undefined,
+  usageHint: string,
+  cwd: string
+): Promise<ResolvedReleaseTarget> {
+  const trimmed = target?.trim();
+  if (!trimmed) {
+    throw new ContextError("Release version", usageHint, []);
+  }
+
+  const { version, orgSlug } = parseReleaseArg(trimmed, usageHint);
+  const resolved = await resolveOrg({ org: orgSlug, cwd });
+  if (!resolved) {
+    throw new ContextError("Organization", usageHint);
+  }
+
+  return { version, org: resolved.org, detectedFrom: resolved.detectedFrom };
 }

--- a/src/commands/release/restore.ts
+++ b/src/commands/release/restore.ts
@@ -8,7 +8,6 @@
 import type { SentryContext } from "../../context.js";
 import { updateRelease } from "../../lib/api-client.js";
 import { buildCommand } from "../../lib/command.js";
-import { ContextError } from "../../lib/errors.js";
 import {
   colorTag,
   escapeMarkdownInline,
@@ -18,9 +17,10 @@ import {
 } from "../../lib/formatters/markdown.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
 import { DRY_RUN_ALIASES, DRY_RUN_FLAG } from "../../lib/mutate-command.js";
-import { resolveOrg } from "../../lib/resolve-target.js";
 import type { SentryRelease } from "../../types/index.js";
-import { parseReleaseArg } from "./parse.js";
+import { resolveReleaseTarget } from "./parse.js";
+
+const USAGE_HINT = "sentry release restore [<org>/]<version>";
 
 /**
  * Render the human-readable result of restoring a release.
@@ -60,12 +60,14 @@ export const restoreCommand = buildCommand({
   },
   parameters: {
     positional: {
-      kind: "array",
-      parameter: {
-        placeholder: "org/version",
-        brief: "[<org>/]<version> - Release version to restore",
-        parse: String,
-      },
+      kind: "tuple",
+      parameters: [
+        {
+          placeholder: "org/version",
+          brief: "[<org>/]<version> - Release version to restore",
+          parse: String,
+        },
+      ],
     },
     flags: {
       "dry-run": DRY_RUN_FLAG,
@@ -79,42 +81,26 @@ export const restoreCommand = buildCommand({
       readonly json: boolean;
       readonly fields?: string[];
     },
-    ...args: string[]
+    target: string
   ) {
     const { cwd } = this;
 
-    const joined = args.join(" ").trim();
-    if (!joined) {
-      throw new ContextError(
-        "Release version",
-        "sentry release restore [<org>/]<version>",
-        []
-      );
-    }
-
-    const { version, orgSlug } = parseReleaseArg(
-      joined,
-      "sentry release restore [<org>/]<version>"
+    const { version, org, detectedFrom } = await resolveReleaseTarget(
+      target,
+      USAGE_HINT,
+      cwd
     );
-    const resolved = await resolveOrg({ org: orgSlug, cwd });
-    if (!resolved) {
-      throw new ContextError(
-        "Organization",
-        "sentry release restore [<org>/]<version>"
-      );
-    }
+
     if (flags["dry-run"]) {
-      yield new CommandOutput({ dryRun: true, version, org: resolved.org });
+      yield new CommandOutput({ dryRun: true, version, org });
       return { hint: "Dry run — release was not restored." };
     }
 
-    const release = await updateRelease(resolved.org, version, {
+    const release = await updateRelease(org, version, {
       status: "open",
     });
     yield new CommandOutput(release);
-    const hint = resolved.detectedFrom
-      ? `Detected from ${resolved.detectedFrom}`
-      : undefined;
+    const hint = detectedFrom ? `Detected from ${detectedFrom}` : undefined;
     return { hint };
   },
 });

--- a/src/commands/release/set-commits.ts
+++ b/src/commands/release/set-commits.ts
@@ -15,7 +15,7 @@ import {
 import { buildCommand, numberParser } from "../../lib/command.js";
 import { getDatabase } from "../../lib/db/index.js";
 import { clearMetadata, getMetadata, setMetadata } from "../../lib/db/utils.js";
-import { ApiError, ContextError, ValidationError } from "../../lib/errors.js";
+import { ApiError, ValidationError } from "../../lib/errors.js";
 import {
   escapeMarkdownInline,
   mdKvTable,
@@ -29,11 +29,12 @@ import {
   isShallowRepository,
 } from "../../lib/git.js";
 import { logger } from "../../lib/logger.js";
-import { resolveOrg } from "../../lib/resolve-target.js";
 import type { SentryRelease } from "../../types/index.js";
-import { parseReleaseArg } from "./parse.js";
+import { resolveReleaseTarget } from "./parse.js";
 
 const log = logger.withTag("release.set-commits");
+
+const USAGE_HINT = "sentry release set-commits [<org>/]<version>";
 
 /** Read commits from local git history and send to the Sentry API. */
 function setCommitsFromLocal(
@@ -196,12 +197,14 @@ export const setCommitsCommand = buildCommand({
   },
   parameters: {
     positional: {
-      kind: "array",
-      parameter: {
-        placeholder: "org/version",
-        brief: "[<org>/]<version> - Release version",
-        parse: String,
-      },
+      kind: "tuple",
+      parameters: [
+        {
+          placeholder: "org/version",
+          brief: "[<org>/]<version> - Release version",
+          parse: String,
+        },
+      ],
     },
     flags: {
       auto: {
@@ -246,34 +249,19 @@ export const setCommitsCommand = buildCommand({
       readonly json: boolean;
       readonly fields?: string[];
     },
-    ...args: string[]
+    target: string
   ) {
     const { cwd } = this;
 
-    const joined = args.join(" ").trim();
-    if (!joined) {
-      throw new ContextError(
-        "Release version",
-        "sentry release set-commits [<org>/]<version> --auto",
-        []
-      );
-    }
-
-    const { version, orgSlug } = parseReleaseArg(
-      joined,
-      "sentry release set-commits [<org>/]<version>"
+    const { version, org } = await resolveReleaseTarget(
+      target,
+      USAGE_HINT,
+      cwd
     );
-    const resolved = await resolveOrg({ org: orgSlug, cwd });
-    if (!resolved) {
-      throw new ContextError(
-        "Organization",
-        "sentry release set-commits [<org>/]<version>"
-      );
-    }
 
     // Clear mode: remove all commits regardless of other flags
     if (flags.clear) {
-      const release = await updateRelease(resolved.org, version, {
+      const release = await updateRelease(org, version, {
         commits: [],
       });
       yield new CommandOutput(release);
@@ -316,7 +304,7 @@ export const setCommitsCommand = buildCommand({
         return { repository, commit: sha };
       });
 
-      const release = await setCommitsWithRefs(resolved.org, version, refs);
+      const release = await setCommitsWithRefs(org, version, refs);
       yield new CommandOutput(release);
       return;
     }
@@ -326,18 +314,18 @@ export const setCommitsCommand = buildCommand({
     if (flags.local) {
       // Explicit --local: use local git only
       release = await setCommitsFromLocal(
-        resolved.org,
+        org,
         version,
         cwd,
         flags["initial-depth"]
       );
     } else if (flags.auto) {
       // Explicit --auto: use repo integration, fail hard on error
-      release = await setCommitsAuto(resolved.org, version, cwd);
+      release = await setCommitsAuto(org, version, cwd);
     } else {
       // Default (no flag): try auto with cached fallback
       release = await setCommitsDefault(
-        resolved.org,
+        org,
         version,
         cwd,
         flags["initial-depth"]

--- a/src/commands/release/view.ts
+++ b/src/commands/release/view.ts
@@ -8,7 +8,6 @@
 import type { SentryContext } from "../../context.js";
 import { getRelease } from "../../lib/api-client.js";
 import { buildCommand } from "../../lib/command.js";
-import { ContextError } from "../../lib/errors.js";
 import {
   colorTag,
   escapeMarkdownCell,
@@ -26,9 +25,10 @@ import {
   FRESH_ALIASES,
   FRESH_FLAG,
 } from "../../lib/list-command.js";
-import { resolveOrg } from "../../lib/resolve-target.js";
 import type { SentryRelease } from "../../types/index.js";
-import { parseReleaseArg } from "./parse.js";
+import { resolveReleaseTarget } from "./parse.js";
+
+const USAGE_HINT = "sentry release view [<org>/]<version>";
 
 /** Wrap a plain "—" in muted color for consistent table styling. */
 function mutedIfDash(value: string): string {
@@ -173,12 +173,14 @@ export const viewCommand = buildCommand({
   },
   parameters: {
     positional: {
-      kind: "array",
-      parameter: {
-        placeholder: "org/version",
-        brief: "[<org>/]<version> - Release version to view",
-        parse: String,
-      },
+      kind: "tuple",
+      parameters: [
+        {
+          placeholder: "org/version",
+          brief: "[<org>/]<version> - Release version to view",
+          parse: String,
+        },
+      ],
     },
     flags: {
       fresh: FRESH_FLAG,
@@ -192,39 +194,23 @@ export const viewCommand = buildCommand({
       readonly json: boolean;
       readonly fields?: string[];
     },
-    ...args: string[]
+    target: string
   ) {
     applyFreshFlag(flags);
     const { cwd } = this;
 
-    const joined = args.join(" ").trim();
-    if (!joined) {
-      throw new ContextError(
-        "Release version",
-        "sentry release view [<org>/]<version>",
-        []
-      );
-    }
-
-    const { version, orgSlug } = parseReleaseArg(
-      joined,
-      "sentry release view [<org>/]<version>"
+    const { version, org, detectedFrom } = await resolveReleaseTarget(
+      target,
+      USAGE_HINT,
+      cwd
     );
-    const resolved = await resolveOrg({ org: orgSlug, cwd });
-    if (!resolved) {
-      throw new ContextError(
-        "Organization",
-        "sentry release view [<org>/]<version>"
-      );
-    }
-    const release = await getRelease(resolved.org, version, {
+
+    const release = await getRelease(org, version, {
       health: true,
       adoptionStages: true,
     });
     yield new CommandOutput(release);
-    const hint = resolved.detectedFrom
-      ? `Detected from ${resolved.detectedFrom}`
-      : undefined;
+    const hint = detectedFrom ? `Detected from ${detectedFrom}` : undefined;
     return { hint };
   },
 });

--- a/src/commands/sourcemap/resolve.ts
+++ b/src/commands/sourcemap/resolve.ts
@@ -194,8 +194,17 @@ export const resolveCommand = buildCommand({
       debugId: r.debugId,
     }));
 
-    const resolved = files.filter(hasSourcemap).length;
-    const withDebugId = files.filter((f) => f.debugId).length;
+    // Single pass over files to tally both counters, avoiding two full filters.
+    let resolved = 0;
+    let withDebugId = 0;
+    for (const file of files) {
+      if (hasSourcemap(file)) {
+        resolved += 1;
+      }
+      if (file.debugId) {
+        withDebugId += 1;
+      }
+    }
 
     yield new CommandOutput<ResolveCommandResult>({
       total: files.length,

--- a/src/lib/proguard.ts
+++ b/src/lib/proguard.ts
@@ -19,10 +19,21 @@
 import { createHash } from "node:crypto";
 
 /**
- * RFC 4122 DNS namespace UUID. Used as the parent namespace from which the
- * ProGuard namespace is derived.
+ * Convert a hyphenated UUID string to its 16 raw bytes.
+ *
+ * @param uuid - Hyphenated UUID string (e.g. `6ba7b810-9dad-...`)
+ * @returns 16-byte Buffer of the UUID's value
  */
-const NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+function uuidToBytes(uuid: string): Buffer {
+  return Buffer.from(uuid.replaceAll("-", ""), "hex");
+}
+
+/**
+ * RFC 4122 DNS namespace UUID, as raw bytes. Used as the parent namespace from
+ * which the ProGuard namespace is derived. Precomputed once so {@link uuidV5}
+ * never reparses it per call.
+ */
+const NAMESPACE_DNS_BYTES = uuidToBytes("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
 
 /**
  * RFC 4122 variant nibbles (`10xx`), keyed by the original hex digit at the
@@ -46,11 +57,10 @@ const VARIANT_NIBBLE = ["8", "9", "a", "b"] as const;
  * or integrity — so the "weak algorithm" warning does not apply.
  *
  * @param name - The name bytes to hash (file content or a UTF-8 string)
- * @param namespace - Hyphenated namespace UUID string
+ * @param namespaceBytes - The 16 raw namespace bytes (precomputed by callers)
  * @returns Lowercase hyphenated UUIDv5 string
  */
-function uuidV5(name: Buffer, namespace: string): string {
-  const namespaceBytes = Buffer.from(namespace.replaceAll("-", ""), "hex");
+function uuidV5(name: Buffer, namespaceBytes: Buffer): string {
   // SHA-1 is required by RFC 4122 §4.3 for name-based (v5) UUIDs and to match
   // the legacy sentry-cli mapping IDs. Not used for any security purpose.
   // codeql[js/weak-cryptographic-algorithm]
@@ -75,8 +85,15 @@ function uuidV5(name: Buffer, namespace: string): string {
  */
 export const PROGUARD_NAMESPACE = uuidV5(
   Buffer.from("guardsquare.com", "utf-8"),
-  NAMESPACE_DNS
+  NAMESPACE_DNS_BYTES
 );
+
+/**
+ * The ProGuard namespace UUID as raw bytes. Precomputed once from
+ * {@link PROGUARD_NAMESPACE} so {@link computeProguardUuid} never reparses it
+ * per call.
+ */
+const PROGUARD_NAMESPACE_BYTES = uuidToBytes(PROGUARD_NAMESPACE);
 
 /**
  * Compute the Sentry debug ID (UUID) for a ProGuard/R8 mapping file.
@@ -90,5 +107,5 @@ export const PROGUARD_NAMESPACE = uuidV5(
  * @returns Lowercase hyphenated UUID string
  */
 export function computeProguardUuid(content: Buffer): string {
-  return uuidV5(content, PROGUARD_NAMESPACE);
+  return uuidV5(content, PROGUARD_NAMESPACE_BYTES);
 }

--- a/src/lib/sourcemap/inject.ts
+++ b/src/lib/sourcemap/inject.ts
@@ -96,6 +96,12 @@ export type FilePair = { jsPath: string; mapPath: string };
 const SOURCE_MAPPING_URL_RE = /\/\/[#@]\s*sourceMappingURL\s*=\s*(\S+)\s*$/gm;
 
 /**
+ * Matches a `sourceMappingURL` that points at a remote `http(s)://` location
+ * (as opposed to an inline `data:` URL or a local companion path).
+ */
+const REMOTE_SOURCE_MAPPING_URL_RE = /^https?:\/\//i;
+
+/**
  * Read the last ~512 bytes of a file efficiently.
  *
  * We only need the very end of the JS file to find the
@@ -438,6 +444,26 @@ export type SourcemapResolution = {
 };
 
 /**
+ * Byte-wise (code-unit) comparison of two strings for `Array.prototype.sort`.
+ *
+ * Used to order discovered paths deterministically without the locale-dependent
+ * (and slower) `localeCompare`. Returns a negative, zero, or positive number.
+ *
+ * @param a - First string
+ * @param b - Second string
+ * @returns `-1` if `a < b`, `1` if `a > b`, `0` if equal
+ */
+function compareByteWise(a: string, b: string): number {
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
+  return 0;
+}
+
+/**
  * Read-only diagnostic pass over a build directory.
  *
  * For every discovered JavaScript file this reports how its sourcemap
@@ -479,8 +505,7 @@ export async function resolveDirectorySourcemaps(
     const sourceMappingUrl = await extractSourceMappingUrl(jsPath);
     const inline = sourceMappingUrl?.startsWith("data:") ?? false;
     const remote =
-      (sourceMappingUrl?.startsWith("http://") ?? false) ||
-      (sourceMappingUrl?.startsWith("https://") ?? false);
+      !!sourceMappingUrl && REMOTE_SOURCE_MAPPING_URL_RE.test(sourceMappingUrl);
     const mapPath = await findCompanionMap(jsPath);
 
     let debugId: string | undefined;
@@ -501,7 +526,10 @@ export async function resolveDirectorySourcemaps(
     });
   }
 
-  results.sort((a, b) => a.jsPath.localeCompare(b.jsPath));
+  // Byte-wise comparison is sufficient and stable for filesystem paths; the
+  // locale-aware `localeCompare` is unnecessary (and slower) here. Matches the
+  // plain `.sort()` used for paths in `upload.ts`.
+  results.sort((a, b) => compareByteWise(a.jsPath, b.jsPath));
   return results;
 }
 

--- a/test/commands/release/deploy.test.ts
+++ b/test/commands/release/deploy.test.ts
@@ -99,14 +99,8 @@ describe("release deploy", () => {
 
     const { context } = createMockContext();
     const func = await deployCommand.loader();
-    await func.call(
-      context,
-      { json: true },
-      "1.0.0",
-      "staging",
-      "Deploy",
-      "#42"
-    );
+    // Multi-word deploy names are passed as a single quoted positional.
+    await func.call(context, { json: true }, "1.0.0", "staging", "Deploy #42");
 
     expect(createRelaseDeploySpy).toHaveBeenCalledWith(
       "my-org",

--- a/test/lib/release-parse.property.test.ts
+++ b/test/lib/release-parse.property.test.ts
@@ -1,8 +1,25 @@
 import { array, constantFrom, assert as fcAssert, property } from "fast-check";
-import { describe, expect, test } from "vitest";
-import { parseReleaseArg } from "../../src/commands/release/parse.js";
-import { ValidationError } from "../../src/lib/errors.js";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  parseReleaseArg,
+  resolveReleaseTarget,
+} from "../../src/commands/release/parse.js";
+import { ContextError, ValidationError } from "../../src/lib/errors.js";
 import { DEFAULT_NUM_RUNS } from "../model-based/helpers.js";
+
+vi.mock("../../src/lib/resolve-target.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../src/lib/resolve-target.js")>();
+  return Object.fromEntries(
+    Object.entries(actual).map(([k, v]) => [
+      k,
+      typeof v === "function" ? vi.fn(v) : v,
+    ])
+  );
+});
+
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as resolveTarget from "../../src/lib/resolve-target.js";
 
 const slugChars = "abcdefghijklmnopqrstuvwxyz0123456789";
 
@@ -113,5 +130,51 @@ describe("unit: parseReleaseArg edge cases", () => {
     const result = parseReleaseArg("/1.0.0", "test");
     expect(result.version).toBe("/1.0.0");
     expect(result.orgSlug).toBeUndefined();
+  });
+});
+
+describe("unit: resolveReleaseTarget", () => {
+  let resolveOrgSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resolveOrgSpy = vi.spyOn(resolveTarget, "resolveOrg");
+  });
+
+  afterEach(() => {
+    resolveOrgSpy.mockRestore();
+  });
+
+  const USAGE = "sentry release archive [<org>/]<version>";
+
+  test("resolves version and org from a target", async () => {
+    resolveOrgSpy.mockResolvedValue({ org: "my-org" });
+    const result = await resolveReleaseTarget("my-org/1.0.0", USAGE, "/tmp");
+    expect(result).toEqual({ version: "1.0.0", org: "my-org" });
+    expect(resolveOrgSpy).toHaveBeenCalledWith({ org: "my-org", cwd: "/tmp" });
+  });
+
+  test("forwards detectedFrom from the resolved org", async () => {
+    resolveOrgSpy.mockResolvedValue({ org: "my-org", detectedFrom: "DSN" });
+    const result = await resolveReleaseTarget("1.0.0", USAGE, "/tmp");
+    expect(result.detectedFrom).toBe("DSN");
+  });
+
+  test("throws ContextError when target is undefined", async () => {
+    await expect(
+      resolveReleaseTarget(undefined, USAGE, "/tmp")
+    ).rejects.toThrow(ContextError);
+  });
+
+  test("throws ContextError when target is whitespace", async () => {
+    await expect(resolveReleaseTarget("   ", USAGE, "/tmp")).rejects.toThrow(
+      "Release version"
+    );
+  });
+
+  test("throws ContextError when org cannot be resolved", async () => {
+    resolveOrgSpy.mockResolvedValue(null);
+    await expect(resolveReleaseTarget("1.0.0", USAGE, "/tmp")).rejects.toThrow(
+      ContextError
+    );
   });
 });

--- a/test/lib/sourcemap/resolve.test.ts
+++ b/test/lib/sourcemap/resolve.test.ts
@@ -95,6 +95,7 @@ describe("resolveDirectorySourcemaps", () => {
 
     const results = await resolveDirectorySourcemaps(dir);
     const names = results.map((r) => r.jsPath);
-    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+    // Byte-wise sort, matching resolveDirectorySourcemaps' path ordering.
+    expect(names).toEqual([...names].sort());
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #1058 that addresses the review threads still **open** after the
earlier follow-ups (#1059, #1063). Each thread is mapped below.

### Release commands — eliminate the silent `args.join(" ")` defect (thread [3349270396])

The sentry bot flagged that `release restore 1.0.0 extra` silently joins extra
positionals into `"1.0.0 extra"`. This `args.join(" ").trim()` pattern was shared
by **all** release commands, so rather than a one-off guard this fixes the whole
class:

- All version-only release commands (`archive`, `restore`, `create`, `delete`,
  `deploys`, `finalize`, `view`, `set-commits`) now declare a single
  `kind: "tuple"` positional, so **Stricli enforces arity** — extra args are
  rejected instead of silently swallowed.
- `release deploy` becomes a 3-positional tuple (`<version> <environment> [name]`);
  multi-word deploy names must be quoted (e.g. `"Deploy #42"`), matching standard
  CLI conventions and the existing docs example.
- New `resolveReleaseTarget()` helper in `src/commands/release/parse.ts`
  centralizes the version-parse + org-resolution + `ContextError` boilerplate.
- **New GritQL lint rule** `lint-rules/no-args-join-in-release.grit` bans
  `args.join()` in `src/commands/release/` so the anti-pattern cannot return
  (verified it fires on a reintroduced `args.join`).

### `sourcemap resolve` — single counting loop (thread [3356439786])

Replaced two `files.filter(...)` passes with one `for...of` loop tallying both
`resolved` and `withDebugId`.

### `sourcemap inject` — remote detection + sort (threads [3356454439], [3356458605])

- Remote sourcemap detection now uses an anchored `^https?://` regex instead of
  two `startsWith` checks.
- Path sort uses byte-wise comparison instead of locale-dependent `localeCompare`
  (matching the plain `.sort()` already used in `upload.ts`).

### `proguard` — precompute namespace bytes (threads [3356471815], [3356474050])

`uuidV5()` reparsed the hyphenated namespace UUID into bytes on every call. The
namespace is fixed, so the bytes are now precomputed once at module load.
**Behavior-preserving** — golden vectors unchanged (`void\n` →
`5db7294d-87fc-5726-a5c0-4a90679657a5`, namespace `4f44f30f-...`).

### Already handled (resolving with notes)

- [3349270382] (resolved-count): the count was fixed in #1063 via `hasSourcemap()`.
  The inject-hint sub-point is a non-issue — `sourcemap inject` adds debug IDs to
  the JS file itself regardless of where its sourcemap lives, so the hint is correct.
- [3349258944] (CodeQL weak-crypto): already resolved/dismissed via #1059.

## Testing

- Full unit suite: **7449 passed / 0 failed / 13 skipped**.
- `bun run typecheck`, `bun run lint` (incl. new GritQL rule), `check:fragments`,
  `check:errors` all green.
- Added `resolveReleaseTarget` unit tests; updated the `release deploy` and
  `sourcemap resolve` tests for the new signatures.

[3349270396]: https://github.com/getsentry/cli/pull/1058#discussion_r3349270396
[3356439786]: https://github.com/getsentry/cli/pull/1058#discussion_r3356439786
[3356454439]: https://github.com/getsentry/cli/pull/1058#discussion_r3356454439
[3356458605]: https://github.com/getsentry/cli/pull/1058#discussion_r3356458605
[3356471815]: https://github.com/getsentry/cli/pull/1058#discussion_r3356471815
[3356474050]: https://github.com/getsentry/cli/pull/1058#discussion_r3356474050
[3349270382]: https://github.com/getsentry/cli/pull/1058#discussion_r3349270382
[3349258944]: https://github.com/getsentry/cli/pull/1058#discussion_r3349258944