### PR TITLE
fix(local): re-emit SIGINT/SIGTERM after cleanup in verify mode

### DIFF
--- a/src/commands/local/run.ts
+++ b/src/commands/local/run.ts
@@ -406,8 +406,15 @@ async function* runWithVerify(
     );
   }
 
-  const onSigint = () => child.kill("SIGINT");
-  const onSigterm = () => child.kill("SIGTERM");
+  let signalReceived: NodeJS.Signals | null = null;
+  const onSigint = () => {
+    signalReceived = "SIGINT";
+    child.kill("SIGINT");
+  };
+  const onSigterm = () => {
+    signalReceived = "SIGTERM";
+    child.kill("SIGTERM");
+  };
   process.once("SIGINT", onSigint);
   process.once("SIGTERM", onSigterm);
 
@@ -463,6 +470,13 @@ async function* runWithVerify(
     process.removeListener("SIGINT", onSigint);
     process.removeListener("SIGTERM", onSigterm);
     await shutdownServer(server);
+  }
+
+  // Re-emit the signal after cleanup so the default handler terminates the
+  // process instead of continuing with the outcome switch below.
+  if (signalReceived) {
+    process.kill(process.pid, signalReceived);
+    return;
   }
 
   switch (outcome.kind) {

--- a/src/lib/init/verify-setup.ts
+++ b/src/lib/init/verify-setup.ts
@@ -282,6 +282,9 @@ export async function verifySetup(
     return;
   }
 
+  // Track whether the user sent an interrupt so we can re-emit it after
+  // cleanup instead of silently continuing the wizard.
+  let signalReceived: NodeJS.Signals | null = null;
   const safeKill = (sig: NodeJS.Signals) => {
     try {
       child.kill(sig);
@@ -289,8 +292,14 @@ export async function verifySetup(
       logger.debug(`Child already exited when forwarding ${sig}`);
     }
   };
-  const onSigint = () => safeKill("SIGINT");
-  const onSigterm = () => safeKill("SIGTERM");
+  const onSigint = () => {
+    signalReceived = "SIGINT";
+    safeKill("SIGINT");
+  };
+  const onSigterm = () => {
+    signalReceived = "SIGTERM";
+    safeKill("SIGTERM");
+  };
   process.once("SIGINT", onSigint);
   process.once("SIGTERM", onSigterm);
 
@@ -332,6 +341,14 @@ export async function verifySetup(
   process.removeListener("SIGINT", onSigint);
   process.removeListener("SIGTERM", onSigterm);
   await shutdownServer(server);
+
+  // Re-emit the signal after cleanup so the default handler terminates the
+  // process. Without this, Ctrl+C during verification would be swallowed and
+  // the wizard would continue as if nothing happened.
+  if (signalReceived) {
+    process.kill(process.pid, signalReceived);
+    return;
+  }
 
   // If the child crashed (non-zero exit) but the startup watcher resolved
   // first as "started" or "silent", correct to "exited" so the crash is


### PR DESCRIPTION
## Summary

SIGINT/SIGTERM during `--verify` mode or post-init verification was forwarded to the child process but never re-emitted afterward. After cleanup completed, the CLI continued normally instead of terminating — the user's Ctrl+C was silently swallowed.

This fix tracks the received signal and re-emits it via `process.kill(process.pid, signal)` after all cleanup (child kill, server shutdown, listener removal) completes, so the default handler terminates the process with the correct exit code.

Fixes both `src/commands/local/run.ts` (`runWithVerify`) and `src/lib/init/verify-setup.ts` (`verifySetup`).

## Testing

- `vitest run test/commands/local/run.test.ts` — 12 tests pass
- `vitest run test/lib/init/wizard-runner.test.ts test/lib/dev-script.test.ts test/lib/dev-script.property.test.ts` — 57 tests pass
- `pnpm run lint` — clean
- `tsc --noEmit` — no errors (excluding pre-existing generated-file issues)

Addresses warden findings from #998.

<!--
## Plan

### Problem
Warden flagged (twice, across commits 5c40365 and fc94462) that SIGINT is swallowed
in verify-setup.ts: signal handlers forward SIGINT to the child but don't re-emit or
exit, so the wizard continues after verifySetup returns. The same pattern exists in
runWithVerify in run.ts.

### Fix (2 files)

1. `src/lib/init/verify-setup.ts`
   - Add `signalReceived: NodeJS.Signals | null` variable
   - Update onSigint/onSigterm to set signalReceived before forwarding
   - After cleanup, check signalReceived and re-emit via process.kill(process.pid, signal)

2. `src/commands/local/run.ts` (runWithVerify function)
   - Same pattern: track signal, re-emit after cleanup

### Verification
- PR #1034's CLIENT_SPOTLIGHT_PREFIXES work confirmed intact on main
- All existing tests pass
- Lint and typecheck clean
-->