### PR TITLE
feat(proguard): add 'proguard upload' command (chunk-upload of R8/ProGuard mappings)

### DIFF
--- a/docs/src/content/docs/contributing.md
+++ b/docs/src/content/docs/contributing.md
@@ -62,7 +62,7 @@ cli/
 │   │   ├── log/         # list, view
 │   │   ├── monitor/     # list, run
 │   │   ├── org/         # list, view
-│   │   ├── proguard/    # uuid
+│   │   ├── proguard/    # upload, uuid
 │   │   ├── project/     # create, delete, list, view
 │   │   ├── release/     # archive, create, delete, deploy, deploys, finalize, list, propose-version, restore, set-commits, view
 │   │   ├── replay/      # list, view

--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -408,6 +408,7 @@ Manage Sentry dashboards
 
 Work with ProGuard/R8 mapping files
 
+- `sentry proguard upload <path...>` — Upload ProGuard/R8 mapping files to Sentry
 - `sentry proguard uuid <path>` — Compute the UUID for a ProGuard mapping file
 
 → Full flags and examples: `references/proguard.md`

--- a/plugins/sentry-cli/skills/sentry-cli/references/proguard.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/proguard.md
@@ -11,6 +11,16 @@ requires:
 
 Work with ProGuard/R8 mapping files
 
+### `sentry proguard upload <path...>`
+
+Upload ProGuard/R8 mapping files to Sentry
+
+**Flags:**
+- `--uuid <value> - Force a specific UUID instead of computing from file content (only valid with a single file)`
+- `--no-upload - Compute and print UUIDs without uploading (dry-run)`
+- `--require-one - Require at least one mapping file (error if none provided)`
+- `--no-reprocessing - Don't trigger event reprocessing after upload`
+
 ### `sentry proguard uuid <path>`
 
 Compute the UUID for a ProGuard mapping file

--- a/plugins/sentry-cli/skills/sentry-cli/references/proguard.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/proguard.md
@@ -19,7 +19,6 @@ Upload ProGuard/R8 mapping files to Sentry
 - `--uuid <value> - Force a specific UUID instead of computing from file content (only valid with a single file)`
 - `--no-upload - Compute and print UUIDs without uploading (dry-run)`
 - `--require-one - Require at least one mapping file (error if none provided)`
-- `--no-reprocessing - Don't trigger event reprocessing after upload`
 
 ### `sentry proguard uuid <path>`
 

--- a/src/commands/proguard/index.ts
+++ b/src/commands/proguard/index.ts
@@ -1,21 +1,22 @@
 /**
  * sentry proguard
  *
- * Route map for ProGuard/R8 mapping commands. Currently exposes `uuid`;
- * `upload` is tracked separately (see issue #1053).
+ * Route map for ProGuard/R8 mapping commands.
  */
 
 import { buildRouteMap } from "../../lib/route-map.js";
+import { uploadCommand } from "./upload.js";
 import { uuidCommand } from "./uuid.js";
 
 export const proguardRoute = buildRouteMap({
   routes: {
+    upload: uploadCommand,
     uuid: uuidCommand,
   },
   docs: {
     brief: "Work with ProGuard/R8 mapping files",
     fullDescription:
-      "Compute UUIDs for Android ProGuard/R8 mapping files.\n\n" +
+      "Upload and manage Android ProGuard/R8 mapping files.\n\n" +
       "The UUID is derived deterministically from the mapping file contents " +
       "and identifies the mapping when deobfuscating Android stack traces.",
   },

--- a/src/commands/proguard/upload.ts
+++ b/src/commands/proguard/upload.ts
@@ -1,0 +1,263 @@
+/**
+ * sentry proguard upload <path>...
+ *
+ * Upload ProGuard/R8 mapping files to Sentry using the DIF
+ * chunk-upload protocol. Each mapping file is bundled as
+ * `proguard/<uuid>.txt` where UUID is derived from the file content.
+ * Org/project resolved via standard cascade (DSN auto-detection,
+ * env vars, config defaults).
+ */
+
+import { readFile } from "node:fs/promises";
+import type { SentryContext } from "../../context.js";
+import type { ProguardMapping } from "../../lib/api/proguard.js";
+import { uploadProguardMappings } from "../../lib/api/proguard.js";
+import { buildCommand } from "../../lib/command.js";
+import { ContextError, ValidationError } from "../../lib/errors.js";
+import { mdKvTable, renderMarkdown } from "../../lib/formatters/markdown.js";
+import { CommandOutput } from "../../lib/formatters/output.js";
+import { computeProguardUuid } from "../../lib/proguard.js";
+import { resolveOrgAndProject } from "../../lib/resolve-target.js";
+
+// ── Types ───────────────────────────────────────────────────────────
+
+/** Structured result for the proguard upload command. */
+type ProguardUploadResult = {
+  /** Organization slug. Omitted when --no-upload short-circuits before
+   * org/project resolution. */
+  org?: string;
+  /** Project slug. Omitted in the same short-circuit case. */
+  project?: string;
+  /** Per-file upload results. */
+  mappings: Array<{
+    /** Path to the mapping file. */
+    path: string;
+    /** Mapping UUID (computed or forced). */
+    uuid: string;
+  }>;
+  /** Number of mapping files uploaded. */
+  filesUploaded: number;
+};
+
+// ── Formatter ───────────────────────────────────────────────────────
+
+const USAGE_HINT = "sentry proguard upload <path>...";
+
+/** Format human-readable output for upload results. */
+function formatUploadResult(data: ProguardUploadResult): string {
+  const rows: [string, string][] = [];
+  if (data.org) {
+    rows.push(["Organization", data.org]);
+  }
+  if (data.project) {
+    rows.push(["Project", data.project]);
+  }
+  rows.push(["Files uploaded", String(data.filesUploaded)]);
+  for (const m of data.mappings) {
+    rows.push(["UUID", `${m.uuid}  (${m.path})`]);
+  }
+  return renderMarkdown(mdKvTable(rows));
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/** UUID format: 8-4-4-4-12 hex with hyphens. */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Validate that a user-provided UUID string is well-formed.
+ *
+ * @param uuid - The UUID string to validate
+ * @throws {ValidationError} If the UUID is malformed
+ */
+function validateUuidFormat(uuid: string): void {
+  if (!UUID_RE.test(uuid)) {
+    throw new ValidationError(
+      `Invalid UUID format: '${uuid}'. Expected format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`,
+      "uuid"
+    );
+  }
+}
+
+/**
+ * Read a mapping file from disk with descriptive error handling.
+ *
+ * @param path - Path to the mapping file
+ * @returns File content as a Buffer
+ * @throws {ValidationError} On ENOENT, EISDIR, or other read failures
+ */
+async function readMappingFile(path: string): Promise<Buffer> {
+  try {
+    return await readFile(path);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      throw new ValidationError(
+        `ProGuard mapping file '${path}' does not exist.`,
+        "path"
+      );
+    }
+    if (code === "EISDIR") {
+      throw new ValidationError(
+        `Path '${path}' is a directory, not a ProGuard mapping file.`,
+        "path"
+      );
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new ValidationError(
+      `Cannot read ProGuard mapping file '${path}': ${msg}`,
+      "path"
+    );
+  }
+}
+
+// ── Command ─────────────────────────────────────────────────────────
+
+export const uploadCommand = buildCommand({
+  docs: {
+    brief: "Upload ProGuard/R8 mapping files to Sentry",
+    fullDescription:
+      "Upload one or more ProGuard/R8 mapping files to Sentry using " +
+      "the chunk-upload protocol. Each mapping is identified by a " +
+      "deterministic UUID derived from its content.\n\n" +
+      "Org/project are auto-detected from DSN, env vars, or config defaults.\n\n" +
+      "Usage:\n" +
+      "  sentry proguard upload mapping.txt\n" +
+      "  sentry proguard upload build/mapping1.txt build/mapping2.txt\n" +
+      "  sentry proguard upload mapping.txt --uuid 5db7294d-87fc-5726-a5c0-4a90679657a5\n" +
+      "  sentry proguard upload mapping.txt --no-upload\n" +
+      "  sentry proguard upload mapping.txt --no-reprocessing\n" +
+      "  sentry proguard upload mapping.txt --json",
+  },
+  output: {
+    human: formatUploadResult,
+  },
+  parameters: {
+    positional: {
+      kind: "array",
+      parameter: {
+        brief: "Paths to ProGuard/R8 mapping files",
+        parse: String,
+        placeholder: "path",
+      },
+    },
+    flags: {
+      uuid: {
+        kind: "parsed",
+        parse: String,
+        brief:
+          "Force a specific UUID instead of computing from file content " +
+          "(only valid with a single file)",
+        optional: true,
+      },
+      "no-upload": {
+        kind: "boolean",
+        brief: "Compute and print UUIDs without uploading (dry-run)",
+        optional: true,
+        default: false,
+      },
+      "require-one": {
+        kind: "boolean",
+        brief: "Require at least one mapping file (error if none provided)",
+        optional: true,
+        default: false,
+      },
+      "no-reprocessing": {
+        kind: "boolean",
+        brief: "Don't trigger event reprocessing after upload",
+        optional: true,
+        default: false,
+      },
+    },
+  },
+  async *func(
+    this: SentryContext,
+    flags: {
+      uuid?: string;
+      "no-upload"?: boolean;
+      "require-one"?: boolean;
+      "no-reprocessing"?: boolean;
+    },
+    ...paths: string[]
+  ) {
+    // 1. Validate at least one path is provided
+    if (paths.length === 0) {
+      if (flags["require-one"]) {
+        throw new ValidationError(
+          "No mapping files provided (--require-one is set)",
+          "path"
+        );
+      }
+      throw new ContextError("Mapping file path(s)", USAGE_HINT, []);
+    }
+
+    // 2. Validate --uuid with multiple files is ambiguous
+    if (flags.uuid && paths.length > 1) {
+      throw new ValidationError(
+        "--uuid cannot be used with multiple files (each file needs a unique UUID)",
+        "uuid"
+      );
+    }
+
+    // 3. Validate UUID format if provided
+    if (flags.uuid) {
+      validateUuidFormat(flags.uuid);
+    }
+
+    // 4. Read each file and compute UUID
+    const mappings: ProguardMapping[] = [];
+    for (const path of paths) {
+      const content = await readMappingFile(path);
+      const uuid = flags.uuid ?? computeProguardUuid(content);
+      mappings.push({ path, uuid, content });
+    }
+
+    // 5. --no-upload: just print UUIDs and return (no auth needed)
+    if (flags["no-upload"]) {
+      yield new CommandOutput<ProguardUploadResult>({
+        mappings: mappings.map((m) => ({ path: m.path, uuid: m.uuid })),
+        filesUploaded: 0,
+      });
+      return {
+        hint:
+          mappings.length === 1
+            ? `UUID: ${mappings[0]?.uuid}`
+            : `Computed UUIDs for ${mappings.length} mapping files`,
+      };
+    }
+
+    // 6. Resolve org/project
+    const resolved = await resolveOrgAndProject({
+      cwd: this.cwd,
+      usageHint: USAGE_HINT,
+    });
+    if (!resolved) {
+      throw new ContextError("Organization and project", USAGE_HINT);
+    }
+    const { org, project } = resolved;
+
+    // 7. Upload
+    await uploadProguardMappings({
+      org,
+      project,
+      mappings,
+      noReprocessing: flags["no-reprocessing"],
+    });
+
+    // 8. Yield result
+    yield new CommandOutput<ProguardUploadResult>({
+      org,
+      project,
+      mappings: mappings.map((m) => ({ path: m.path, uuid: m.uuid })),
+      filesUploaded: mappings.length,
+    });
+
+    return {
+      hint:
+        mappings.length === 1
+          ? `Uploaded mapping ${mappings[0]?.uuid}`
+          : `Uploaded ${mappings.length} mapping files`,
+    };
+  },
+});

--- a/src/commands/proguard/upload.ts
+++ b/src/commands/proguard/upload.ts
@@ -16,8 +16,11 @@ import { buildCommand } from "../../lib/command.js";
 import { ContextError, ValidationError } from "../../lib/errors.js";
 import { mdKvTable, renderMarkdown } from "../../lib/formatters/markdown.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
+import { logger } from "../../lib/logger.js";
 import { computeProguardUuid } from "../../lib/proguard.js";
 import { resolveOrgAndProject } from "../../lib/resolve-target.js";
+
+const log = logger.withTag("proguard.upload");
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -88,8 +91,9 @@ function validateUuidFormat(uuid: string): void {
  * @throws {ValidationError} On ENOENT, EISDIR, or other read failures
  */
 async function readMappingFile(path: string): Promise<Buffer> {
+  let content: Buffer;
   try {
-    return await readFile(path);
+    content = await readFile(path);
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === "ENOENT") {
@@ -110,11 +114,42 @@ async function readMappingFile(path: string): Promise<Buffer> {
       "path"
     );
   }
+  if (content.length === 0) {
+    throw new ValidationError(
+      `ProGuard mapping file '${path}' is empty.`,
+      "path"
+    );
+  }
+  return content;
+}
+
+/**
+ * Deduplicate mappings with identical content (same UUID = same content).
+ * Logs a warning for each skipped duplicate.
+ */
+function deduplicateMappings(mappings: ProguardMapping[]): ProguardMapping[] {
+  const seen = new Map<string, string>();
+  const unique: ProguardMapping[] = [];
+  for (const m of mappings) {
+    const existing = seen.get(m.uuid);
+    if (existing) {
+      log.warn(
+        `Skipping '${m.path}': identical content as '${existing}' (UUID ${m.uuid})`
+      );
+      continue;
+    }
+    seen.set(m.uuid, m.path);
+    unique.push(m);
+  }
+  return unique;
 }
 
 // ── Command ─────────────────────────────────────────────────────────
 
 export const uploadCommand = buildCommand({
+  // Auth is not required for --no-upload (dry-run mode).
+  // The upload path calls resolveOrgAndProject which triggers auth.
+  auth: false,
   docs: {
     brief: "Upload ProGuard/R8 mapping files to Sentry",
     fullDescription:
@@ -205,21 +240,24 @@ export const uploadCommand = buildCommand({
       mappings.push({ path, uuid, content });
     }
 
-    // 5. --no-upload: just print UUIDs and return (no auth needed)
+    // 5. Deduplicate mappings with identical content (same UUID = same content)
+    const uniqueMappings = deduplicateMappings(mappings);
+
+    // 6. --no-upload: just print UUIDs and return (no auth needed)
     if (flags["no-upload"]) {
       yield new CommandOutput<ProguardUploadResult>({
-        mappings: mappings.map((m) => ({ path: m.path, uuid: m.uuid })),
+        mappings: uniqueMappings.map((m) => ({ path: m.path, uuid: m.uuid })),
         filesUploaded: 0,
       });
       return {
         hint:
-          mappings.length === 1
-            ? `UUID: ${mappings[0]?.uuid}`
-            : `Computed UUIDs for ${mappings.length} mapping files`,
+          uniqueMappings.length === 1
+            ? `UUID: ${uniqueMappings[0]?.uuid}`
+            : `Computed UUIDs for ${uniqueMappings.length} mapping files`,
       };
     }
 
-    // 6. Resolve org/project
+    // 7. Resolve org/project
     const resolved = await resolveOrgAndProject({
       cwd: this.cwd,
       usageHint: USAGE_HINT,
@@ -229,26 +267,26 @@ export const uploadCommand = buildCommand({
     }
     const { org, project } = resolved;
 
-    // 7. Upload
+    // 8. Upload
     await uploadProguardMappings({
       org,
       project,
-      mappings,
+      mappings: uniqueMappings,
     });
 
-    // 8. Yield result
+    // 9. Yield result
     yield new CommandOutput<ProguardUploadResult>({
       org,
       project,
-      mappings: mappings.map((m) => ({ path: m.path, uuid: m.uuid })),
-      filesUploaded: mappings.length,
+      mappings: uniqueMappings.map((m) => ({ path: m.path, uuid: m.uuid })),
+      filesUploaded: uniqueMappings.length,
     });
 
     return {
       hint:
-        mappings.length === 1
-          ? `Uploaded mapping ${mappings[0]?.uuid}`
-          : `Uploaded ${mappings.length} mapping files`,
+        uniqueMappings.length === 1
+          ? `Uploaded mapping ${uniqueMappings[0]?.uuid}`
+          : `Uploaded ${uniqueMappings.length} mapping files`,
     };
   },
 });

--- a/src/commands/proguard/upload.ts
+++ b/src/commands/proguard/upload.ts
@@ -127,7 +127,6 @@ export const uploadCommand = buildCommand({
       "  sentry proguard upload build/mapping1.txt build/mapping2.txt\n" +
       "  sentry proguard upload mapping.txt --uuid 5db7294d-87fc-5726-a5c0-4a90679657a5\n" +
       "  sentry proguard upload mapping.txt --no-upload\n" +
-      "  sentry proguard upload mapping.txt --no-reprocessing\n" +
       "  sentry proguard upload mapping.txt --json",
   },
   output: {
@@ -163,12 +162,6 @@ export const uploadCommand = buildCommand({
         optional: true,
         default: false,
       },
-      "no-reprocessing": {
-        kind: "boolean",
-        brief: "Don't trigger event reprocessing after upload",
-        optional: true,
-        default: false,
-      },
     },
   },
   async *func(
@@ -177,7 +170,6 @@ export const uploadCommand = buildCommand({
       uuid?: string;
       "no-upload"?: boolean;
       "require-one"?: boolean;
-      "no-reprocessing"?: boolean;
     },
     ...paths: string[]
   ) {
@@ -242,7 +234,6 @@ export const uploadCommand = buildCommand({
       org,
       project,
       mappings,
-      noReprocessing: flags["no-reprocessing"],
     });
 
     // 8. Yield result

--- a/src/lib/api/chunk-upload.ts
+++ b/src/lib/api/chunk-upload.ts
@@ -368,7 +368,7 @@ async function uploadBufferChunk(params: {
   const { chunk, content, encoding, fetch: authFetch, url } = params;
 
   const buf = content.subarray(chunk.offset, chunk.offset + chunk.size);
-  const payload = await encodeChunk(Buffer.from(buf), encoding);
+  const payload = await encodeChunk(buf, encoding);
 
   const fieldName = encoding === "gzip" ? "file_gzip" : "file";
   const form = new FormData();
@@ -388,7 +388,10 @@ async function uploadBufferChunk(params: {
     throw new ApiError(
       `Chunk upload failed: ${response.status} ${response.statusText}`,
       response.status,
-      await response.text().catch(() => ""),
+      await response.text().catch((err) => {
+        log.debug("Failed to read chunk upload error response body", err);
+        return "";
+      }),
       url
     );
   }

--- a/src/lib/api/chunk-upload.ts
+++ b/src/lib/api/chunk-upload.ts
@@ -1,0 +1,389 @@
+/**
+ * Shared chunk-upload protocol infrastructure.
+ *
+ * Implements the Sentry chunk-upload + assemble protocol used by
+ * artifact bundle (sourcemap) and DIF (proguard) uploads. Callers
+ * build their own ZIP and choose the appropriate assemble endpoint;
+ * this module handles chunking, hashing, codec selection, chunk
+ * upload, and assembly polling.
+ *
+ * Protocol overview:
+ * 1. GET  chunk-upload options (chunk size, concurrency, compression)
+ * 2. (Caller builds the ZIP)
+ * 3. Split ZIP into chunks, compute SHA-1 checksums
+ * 4. POST assemble request -> server reports missing chunks
+ * 5. Upload missing chunks in parallel as multipart/form-data
+ * 6. Poll assemble endpoint until complete
+ */
+
+import { createHash } from "node:crypto";
+import { open, stat } from "node:fs/promises";
+import { promisify } from "node:util";
+import {
+  gzip as gzipCb,
+  constants as zlibConstants,
+  zstdCompress as zstdCompressCb,
+} from "node:zlib";
+import pLimit from "p-limit";
+import { z } from "zod";
+import { ApiError } from "../errors.js";
+import { logger } from "../logger.js";
+import { resolveOrgRegion } from "../region.js";
+import { getSdkConfig } from "../sentry-client.js";
+import { apiRequestToRegion } from "./infrastructure.js";
+
+const gzipAsync = promisify(gzipCb);
+const zstdCompressAsync = promisify(zstdCompressCb);
+const log = logger.withTag("api.chunk-upload");
+
+// ── Schemas ─────────────────────────────────────────────────────────
+
+/** Server-provided chunk upload configuration. */
+export const ChunkServerOptionsSchema = z.object({
+  /** Absolute URL to upload chunks to. */
+  url: z.string(),
+  /** Maximum size of a single chunk in bytes. */
+  chunkSize: z.number(),
+  /** Maximum number of chunks per upload request. */
+  chunksPerRequest: z.number(),
+  /** Maximum total request body size in bytes. */
+  maxRequestSize: z.number(),
+  /** Hash algorithm for chunk checksums (always "sha1"). */
+  hashAlgorithm: z.string(),
+  /** Maximum concurrent upload requests. */
+  concurrency: z.number(),
+  /** Supported compression methods (e.g., ["gzip"]). */
+  compression: z.array(z.string()),
+});
+
+export type ChunkServerOptions = z.infer<typeof ChunkServerOptionsSchema>;
+
+/** Response from an assemble endpoint (shared by artifact bundle and DIF). */
+export const AssembleResponseSchema = z.object({
+  state: z.enum(["not_found", "created", "assembling", "ok", "error"]),
+  missingChunks: z.array(z.string()).optional(),
+  detail: z.string().nullable().optional(),
+});
+
+export type AssembleResponse = z.infer<typeof AssembleResponseSchema>;
+
+// ── Types ───────────────────────────────────────────────────────────
+
+/** Chunk metadata after splitting the ZIP for upload. */
+export type ChunkInfo = {
+  /** SHA-1 checksum of this chunk. */
+  sha1: string;
+  /** Byte offset in the ZIP file. */
+  offset: number;
+  /** Byte size of this chunk. */
+  size: number;
+};
+
+// ── Constants ───────────────────────────────────────────────────────
+
+/** Interval between assemble poll requests. */
+export const ASSEMBLE_POLL_INTERVAL_MS = 1000;
+
+/** Maximum time to wait for assembly. */
+export const ASSEMBLE_MAX_WAIT_MS = 300_000;
+
+/**
+ * Codecs the CLI knows how to emit, in order of preference.
+ *
+ * `zstd` is the forward-looking codec: advertised only by servers that
+ * implement `Content-Encoding`-based detection. `gzip` is the legacy
+ * codec supported by every Sentry server since forever; we still send
+ * it under the original `file_gzip` multipart field name so that
+ * pre-zstd servers -- which ignore `Content-Encoding` -- keep working.
+ */
+const UPLOAD_CODECS = ["zstd", "gzip"] as const;
+export type UploadEncoding = (typeof UPLOAD_CODECS)[number];
+
+// ── API Functions ───────────────────────────────────────────────────
+
+/**
+ * Get chunk upload configuration for an organization.
+ *
+ * @param orgSlug - Organization slug
+ * @returns Server-provided upload options (chunk size, concurrency, etc.)
+ */
+export async function getChunkUploadOptions(
+  orgSlug: string
+): Promise<ChunkServerOptions> {
+  const regionUrl = await resolveOrgRegion(orgSlug);
+  const { data } = await apiRequestToRegion<ChunkServerOptions>(
+    regionUrl,
+    `organizations/${orgSlug}/chunk-upload/`,
+    { schema: ChunkServerOptionsSchema }
+  );
+  return data;
+}
+
+/**
+ * Select the most efficient upload codec the server advertises, or
+ * `undefined` for plain (uncompressed) uploads when the server opts out
+ * of compression (e.g. the `chunk-upload.no-compression` kill-switch)
+ * or advertises only codecs we don't implement.
+ *
+ * Exported for testing.
+ */
+export function pickUploadEncoding(
+  compression: string[]
+): UploadEncoding | undefined {
+  for (const codec of UPLOAD_CODECS) {
+    if (compression.includes(codec)) {
+      return codec;
+    }
+  }
+  if (compression.length > 0) {
+    log.debug(
+      `server advertised unsupported codecs [${compression.join(", ")}]; falling back to plain upload`
+    );
+  }
+  return;
+}
+
+/**
+ * Compress a chunk buffer with the chosen codec. Exported for testing.
+ *
+ * Both codecs run off-thread via libuv's thread pool, so a chunk
+ * being compressed doesn't block the event loop --
+ * with `concurrency=8`, eight uploads truly compress in parallel.
+ */
+export async function encodeChunk(
+  buf: Buffer,
+  encoding: UploadEncoding | undefined
+): Promise<Uint8Array> {
+  if (encoding === "zstd") {
+    // L3 is libzstd's default; passed explicitly for self-documenting
+    // code. L9+ trades ~14% size for 4x compress time and forces the
+    // server's decoder to allocate 15-30 MiB of window state -- not
+    // worth it once decode cost is counted.
+    return await zstdCompressAsync(buf, {
+      params: { [zlibConstants.ZSTD_c_compressionLevel]: 3 },
+    });
+  }
+  if (encoding === "gzip") {
+    // zlib default (L6). Counter-intuitively, lower levels (L1/L5)
+    // DEcompress SLOWER on the server (sparser Huffman codes); L9
+    // costs ~2x the compress CPU for no meaningful size win.
+    return await gzipAsync(buf);
+  }
+  return buf;
+}
+
+/**
+ * Read a single chunk from the staging ZIP, compress it with the server's
+ * preferred codec, and POST it to the chunk-upload endpoint.
+ *
+ * Wire format by codec (driven by {@link pickUploadEncoding}):
+ *  - `zstd`  -> `Content-Encoding: zstd` + `file` multipart field.
+ *               Only works against servers that opted in via
+ *               `Content-Encoding` detection (getsentry/sentry#113760+).
+ *  - `gzip`  -> LEGACY `file_gzip` multipart field, NO `Content-Encoding`
+ *               header. Works with every server that advertises `gzip`,
+ *               including pre-zstd self-hosted deployments.
+ *  - plain   -> `file` multipart field, no `Content-Encoding`.
+ *
+ * NB: never emit `Content-Encoding: gzip` alongside the `file_gzip`
+ * field -- zstd-aware servers reject that combination (400) to avoid
+ * ambiguity.
+ */
+export async function uploadChunk(params: {
+  chunk: ChunkInfo;
+  tmpZipPath: string;
+  encoding: UploadEncoding | undefined;
+  fetch: (url: string, init: RequestInit) => Promise<Response>;
+  url: string;
+}): Promise<void> {
+  const { chunk, tmpZipPath, encoding, fetch: authFetch, url } = params;
+
+  const chunkFh = await open(tmpZipPath, "r");
+  let buf: Buffer;
+  try {
+    buf = Buffer.alloc(chunk.size);
+    await chunkFh.read(buf, 0, chunk.size, chunk.offset);
+  } finally {
+    await chunkFh.close();
+  }
+
+  const payload = await encodeChunk(buf, encoding);
+
+  // gzip uses the legacy `file_gzip` field for backwards compatibility
+  // with pre-zstd servers; zstd and plain use the standard `file` field.
+  const fieldName = encoding === "gzip" ? "file_gzip" : "file";
+  const form = new FormData();
+  form.append(
+    fieldName,
+    new Blob([payload], { type: "application/octet-stream" }),
+    chunk.sha1
+  );
+
+  const init: RequestInit = { method: "POST", body: form };
+  if (encoding === "zstd") {
+    init.headers = { "Content-Encoding": "zstd" };
+  }
+
+  const response = await authFetch(url, init);
+  if (!response.ok) {
+    throw new ApiError(
+      `Chunk upload failed: ${response.status} ${response.statusText}`,
+      response.status,
+      await response.text().catch(() => ""),
+      url
+    );
+  }
+}
+
+/**
+ * Split a ZIP file into chunks and compute SHA-1 checksums.
+ *
+ * Reads the file sequentially — only one chunk buffer is live at a time.
+ *
+ * @param zipPath - Path to the ZIP file
+ * @param chunkSize - Size of each chunk in bytes
+ * @returns Per-chunk metadata and an overall SHA-1 checksum of the entire file
+ */
+export async function hashChunks(
+  zipPath: string,
+  chunkSize: number
+): Promise<{ chunks: ChunkInfo[]; overallChecksum: string }> {
+  const fh = await open(zipPath, "r");
+  try {
+    const fileSize = (await stat(zipPath)).size;
+    const chunks: ChunkInfo[] = [];
+    const overallHasher = createHash("sha1");
+
+    for (let offset = 0; offset < fileSize; offset += chunkSize) {
+      const size = Math.min(chunkSize, fileSize - offset);
+      const buf = Buffer.alloc(size);
+      await fh.read(buf, 0, size, offset);
+      const sha1 = createHash("sha1").update(buf).digest("hex");
+      overallHasher.update(buf);
+      chunks.push({ sha1, offset, size });
+    }
+
+    return { chunks, overallChecksum: overallHasher.digest("hex") };
+  } finally {
+    await fh.close();
+  }
+}
+
+/**
+ * Upload chunks the server reports as missing, in parallel.
+ *
+ * Filters the full chunk list against the set of missing checksums,
+ * then uploads each missing chunk concurrently up to the server's
+ * advertised concurrency limit.
+ *
+ * @param params.chunks - All chunks from {@link hashChunks}
+ * @param params.missingChecksums - SHA-1 checksums the server needs
+ * @param params.tmpZipPath - Path to the ZIP file on disk
+ * @param params.serverOptions - Chunk upload config from server
+ * @param params.encoding - Wire codec (zstd/gzip/undefined)
+ * @param params.regionUrl - Region base URL for authenticated fetch
+ */
+export async function uploadMissingChunks(params: {
+  chunks: ChunkInfo[];
+  missingChecksums: Set<string>;
+  tmpZipPath: string;
+  serverOptions: ChunkServerOptions;
+  encoding: UploadEncoding | undefined;
+  regionUrl: string;
+}): Promise<void> {
+  const {
+    chunks,
+    missingChecksums,
+    tmpZipPath,
+    serverOptions,
+    encoding,
+    regionUrl,
+  } = params;
+  const missingChunks = chunks.filter((c) => missingChecksums.has(c.sha1));
+
+  if (missingChunks.length === 0) {
+    return;
+  }
+
+  const limit = pLimit(serverOptions.concurrency);
+  const { fetch: authFetch } = getSdkConfig(regionUrl);
+
+  await Promise.all(
+    missingChunks.map((chunk) =>
+      limit(() =>
+        uploadChunk({
+          chunk,
+          tmpZipPath,
+          encoding,
+          fetch: authFetch,
+          url: serverOptions.url,
+        })
+      )
+    )
+  );
+}
+
+/**
+ * Poll an assemble endpoint until the server reports completion.
+ *
+ * Re-sends the same assemble body on each poll (the server uses
+ * the checksum to look up existing assembly state). Returns when
+ * the state is `"ok"` or `"created"`. Throws on `"error"` or timeout.
+ *
+ * @param params.regionUrl - Region base URL
+ * @param params.endpoint - The endpoint path to POST to
+ * @param params.body - The request body to send on each poll
+ * @param params.entityName - Human-readable name for error messages
+ * @param params.schema - Zod schema for the response (defaults to {@link AssembleResponseSchema})
+ */
+export async function pollAssembly(params: {
+  regionUrl: string;
+  endpoint: string;
+  body: unknown;
+  entityName: string;
+  schema?: z.ZodType<AssembleResponse>;
+}): Promise<void> {
+  const {
+    regionUrl,
+    endpoint,
+    body,
+    entityName,
+    schema = AssembleResponseSchema,
+  } = params;
+  const deadline = Date.now() + ASSEMBLE_MAX_WAIT_MS;
+
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, ASSEMBLE_POLL_INTERVAL_MS));
+
+    const { data: pollResult } = await apiRequestToRegion<AssembleResponse>(
+      regionUrl,
+      endpoint,
+      {
+        method: "POST",
+        body,
+        schema,
+      }
+    );
+
+    if (pollResult.state === "ok" || pollResult.state === "created") {
+      return;
+    }
+
+    if (pollResult.state === "error") {
+      throw new ApiError(
+        `${entityName} assembly failed`,
+        500,
+        pollResult.detail ?? "Unknown error",
+        endpoint
+      );
+    }
+    // "not_found" or "assembling" — keep polling
+  }
+
+  throw new ApiError(
+    `${entityName} assembly timed out`,
+    408,
+    `Assembly did not complete within ${ASSEMBLE_MAX_WAIT_MS / 1000}s`,
+    endpoint
+  );
+}

--- a/src/lib/api/chunk-upload.ts
+++ b/src/lib/api/chunk-upload.ts
@@ -270,6 +270,35 @@ export async function hashChunks(
 }
 
 /**
+ * Split an in-memory buffer into chunks and compute SHA-1 checksums.
+ *
+ * Same as {@link hashChunks} but operates on a `Buffer` instead of a file,
+ * used by DIF uploads (e.g. ProGuard) where the raw bytes are chunked
+ * directly without wrapping in a ZIP.
+ *
+ * @param content - Raw file content
+ * @param chunkSize - Size of each chunk in bytes
+ * @returns Per-chunk metadata and an overall SHA-1 checksum of the entire buffer
+ */
+export function hashBuffer(
+  content: Buffer,
+  chunkSize: number
+): { chunks: ChunkInfo[]; overallChecksum: string } {
+  const chunks: ChunkInfo[] = [];
+  const overallHasher = createHash("sha1");
+
+  for (let offset = 0; offset < content.length; offset += chunkSize) {
+    const size = Math.min(chunkSize, content.length - offset);
+    const buf = content.subarray(offset, offset + size);
+    const sha1 = createHash("sha1").update(buf).digest("hex");
+    overallHasher.update(buf);
+    chunks.push({ sha1, offset, size });
+  }
+
+  return { chunks, overallChecksum: overallHasher.digest("hex") };
+}
+
+/**
  * Upload chunks the server reports as missing, in parallel.
  *
  * Filters the full chunk list against the set of missing checksums,
@@ -314,6 +343,95 @@ export async function uploadMissingChunks(params: {
         uploadChunk({
           chunk,
           tmpZipPath,
+          encoding,
+          fetch: authFetch,
+          url: serverOptions.url,
+        })
+      )
+    )
+  );
+}
+
+/**
+ * Upload a single chunk from an in-memory buffer, compress it, and POST.
+ *
+ * Same wire format as {@link uploadChunk} but reads from a buffer
+ * instead of a file handle.
+ */
+async function uploadBufferChunk(params: {
+  chunk: ChunkInfo;
+  content: Buffer;
+  encoding: UploadEncoding | undefined;
+  fetch: (url: string, init: RequestInit) => Promise<Response>;
+  url: string;
+}): Promise<void> {
+  const { chunk, content, encoding, fetch: authFetch, url } = params;
+
+  const buf = content.subarray(chunk.offset, chunk.offset + chunk.size);
+  const payload = await encodeChunk(Buffer.from(buf), encoding);
+
+  const fieldName = encoding === "gzip" ? "file_gzip" : "file";
+  const form = new FormData();
+  form.append(
+    fieldName,
+    new Blob([payload], { type: "application/octet-stream" }),
+    chunk.sha1
+  );
+
+  const init: RequestInit = { method: "POST", body: form };
+  if (encoding === "zstd") {
+    init.headers = { "Content-Encoding": "zstd" };
+  }
+
+  const response = await authFetch(url, init);
+  if (!response.ok) {
+    throw new ApiError(
+      `Chunk upload failed: ${response.status} ${response.statusText}`,
+      response.status,
+      await response.text().catch(() => ""),
+      url
+    );
+  }
+}
+
+/**
+ * Upload missing chunks from an in-memory buffer, in parallel.
+ *
+ * Same as {@link uploadMissingChunks} but reads chunk data from a buffer
+ * instead of a file. Used by DIF uploads (e.g. ProGuard) where raw bytes
+ * are chunked directly without wrapping in a ZIP.
+ */
+export async function uploadMissingBufferChunks(params: {
+  chunks: ChunkInfo[];
+  missingChecksums: Set<string>;
+  content: Buffer;
+  serverOptions: ChunkServerOptions;
+  encoding: UploadEncoding | undefined;
+  regionUrl: string;
+}): Promise<void> {
+  const {
+    chunks,
+    missingChecksums,
+    content,
+    serverOptions,
+    encoding,
+    regionUrl,
+  } = params;
+  const missingChunks = chunks.filter((c) => missingChecksums.has(c.sha1));
+
+  if (missingChunks.length === 0) {
+    return;
+  }
+
+  const limit = pLimit(serverOptions.concurrency);
+  const { fetch: authFetch } = getSdkConfig(regionUrl);
+
+  await Promise.all(
+    missingChunks.map((chunk) =>
+      limit(() =>
+        uploadBufferChunk({
+          chunk,
+          content,
           encoding,
           fetch: authFetch,
           url: serverOptions.url,

--- a/src/lib/api/proguard.ts
+++ b/src/lib/api/proguard.ts
@@ -1,34 +1,29 @@
 /**
  * ProGuard/R8 DIF Upload API
  *
- * Builds a ZIP bundle with ProGuard mapping files (named
- * `proguard/<uuid>.txt`) and uploads via the DIF chunk-upload
- * + assemble protocol.
+ * Uploads ProGuard mapping files via the DIF chunk-upload + assemble
+ * protocol. Each mapping file is chunked as raw bytes (no ZIP wrapping)
+ * and assembled individually through the DIF endpoint.
  *
  * Protocol differences from artifact bundles (sourcemaps):
- * - No manifest.json — just the mapping file entries in the ZIP
+ * - Raw bytes are chunked directly (no ZIP, no SYSB header)
  * - Assemble endpoint: `projects/{org}/{project}/files/difs/assemble/`
- *   (not `organizations/{org}/artifactbundle/assemble/`)
- * - The assemble body keys each file by its overall checksum, with
- *   per-file metadata (`name`, `debug_id`, `chunks`)
+ * - The assemble body keys each file by its overall SHA-1 checksum
+ * - Multiple files are sent in a single assemble request
  */
 
-import { unlink } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { z } from "zod";
 import { ApiError } from "../errors.js";
 import { logger } from "../logger.js";
 import { resolveOrgRegion } from "../region.js";
-import { type ZipCompression, ZipWriter } from "../sourcemap/zip.js";
 import {
+  type AssembleResponse,
   AssembleResponseSchema,
   type ChunkInfo,
   getChunkUploadOptions,
-  hashChunks,
+  hashBuffer,
   pickUploadEncoding,
-  pollAssembly,
-  uploadMissingChunks,
+  uploadMissingBufferChunks,
 } from "./chunk-upload.js";
 import { apiRequestToRegion } from "./infrastructure.js";
 
@@ -54,8 +49,6 @@ export type ProguardUploadOptions = {
   project: string;
   /** Mapping files to upload. */
   mappings: ProguardMapping[];
-  /** Skip event reprocessing after upload. */
-  noReprocessing?: boolean;
 };
 
 // ── Schemas ─────────────────────────────────────────────────────────
@@ -68,42 +61,76 @@ const DifAssembleResponseSchema = z.record(z.string(), AssembleResponseSchema);
 
 type DifAssembleResponse = z.infer<typeof DifAssembleResponseSchema>;
 
-// ── API Functions ───────────────────────────────────────────────────
+// ── Internal types ──────────────────────────────────────────────────
+
+/** Per-mapping chunk metadata computed before the assemble request. */
+type ChunkedMapping = {
+  /** Mapping metadata (path, uuid, content). */
+  mapping: ProguardMapping;
+  /** Per-chunk SHA-1 checksums and offsets. */
+  chunks: ChunkInfo[];
+  /** SHA-1 of the entire mapping file. */
+  overallChecksum: string;
+};
+
+/** Result of checking a DIF assemble response. */
+type AssembleCheckResult = {
+  /** True when every entry is `"ok"` or `"created"`. */
+  allDone: boolean;
+  /** SHA-1 checksums the server still needs uploaded. */
+  missingChecksums: Set<string>;
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────
 
 /**
- * Build a ProGuard mapping ZIP at the given path.
+ * Check a DIF assemble response for completion, errors, and missing chunks.
  *
- * Each mapping is stored as `proguard/<uuid>.txt` inside the ZIP.
- * No manifest.json — Sentry's symbolicator identifies the file type
- * from the `proguard/` path prefix and UUID naming convention.
- *
- * @param outputPath - Where to write the ZIP file
- * @param mappings - Mapping files to include
- * @param options.compression - ZIP entry compression method
+ * @throws {ApiError} If any entry reports an `"error"` state.
  */
-export async function buildProguardBundle(
-  outputPath: string,
-  mappings: ProguardMapping[],
-  options: { compression?: ZipCompression }
-): Promise<void> {
-  const zip = await ZipWriter.create(outputPath, {
-    compression: options.compression,
-  });
-  try {
-    for (const mapping of mappings) {
-      await zip.addEntry(`proguard/${mapping.uuid}.txt`, mapping.content);
+function checkAssembleResponse(
+  response: DifAssembleResponse,
+  checksums: string[],
+  endpoint: string
+): AssembleCheckResult {
+  const missingChecksums = new Set<string>();
+  let allDone = true;
+
+  for (const checksum of checksums) {
+    const entry: AssembleResponse | undefined = response[checksum];
+    if (!entry) {
+      log.debug(`No assemble response for checksum ${checksum}`);
+      allDone = false;
+      continue;
     }
-    await zip.finalize();
-  } catch (error) {
-    await zip.close();
-    throw error;
+    if (entry.state === "error") {
+      throw new ApiError(
+        "ProGuard mapping assembly failed",
+        500,
+        entry.detail ?? "Unknown error",
+        endpoint
+      );
+    }
+    if (entry.state === "ok" || entry.state === "created") {
+      continue;
+    }
+    allDone = false;
+    for (const sha1 of entry.missingChunks ?? []) {
+      missingChecksums.add(sha1);
+    }
   }
+
+  return { allDone, missingChecksums };
 }
+
+// ── API Functions ───────────────────────────────────────────────────
 
 /**
  * Upload ProGuard mapping files to Sentry via the DIF chunk-upload protocol.
  *
- * Main orchestrator: build ZIP → chunk → assemble → upload missing → poll.
+ * Each mapping file's raw bytes are chunked directly (no ZIP wrapping).
+ * All mappings are sent in a single assemble request, each keyed by its
+ * overall SHA-1 checksum with per-file metadata (`name`, `chunks`).
  *
  * @param options - Upload configuration (org, project, mappings)
  * @throws {ApiError} If the upload or assembly fails
@@ -115,78 +142,30 @@ export async function uploadProguardMappings(
 
   // Step 1: Get chunk upload configuration
   const serverOptions = await getChunkUploadOptions(org);
-
-  // Pick wire codec — STORED + wire compression saves double-compress
   const encoding = pickUploadEncoding(serverOptions.compression);
-  const zipCompression: ZipCompression = encoding ? "stored" : "deflate";
 
-  // Step 2: Build proguard bundle ZIP to a temp file
-  const tmpZipPath = join(tmpdir(), `sentry-proguard-bundle-${Date.now()}.zip`);
-  try {
-    await buildProguardBundle(tmpZipPath, mappings, {
-      compression: zipCompression,
-    });
-    await uploadProguardBundle({
-      tmpZipPath,
-      org,
-      project,
-      mappings,
-      serverOptions,
-      encoding,
-    });
-  } finally {
-    await unlink(tmpZipPath).catch((error) => {
-      log.debug("Failed to clean up temp ZIP", error);
-    });
-  }
-}
-
-/**
- * Upload an already-built ProGuard bundle ZIP to Sentry.
- *
- * Handles steps 3–6 of the upload protocol: chunk + hash → assemble →
- * upload missing → poll. Uses the DIF assemble endpoint which has a
- * per-checksum keyed request/response format.
- */
-async function uploadProguardBundle(opts: {
-  tmpZipPath: string;
-  org: string;
-  project: string;
-  mappings: ProguardMapping[];
-  serverOptions: import("./chunk-upload.js").ChunkServerOptions;
-  encoding: import("./chunk-upload.js").UploadEncoding | undefined;
-}): Promise<void> {
-  const { tmpZipPath, org, project, mappings, serverOptions, encoding } = opts;
-
-  // Step 3: Split into chunks, hash each chunk + compute overall checksum
-  const { chunks, overallChecksum } = await hashChunks(
-    tmpZipPath,
-    serverOptions.chunkSize
-  );
+  // Step 2: Hash each mapping file into chunks
+  const chunkedMappings: ChunkedMapping[] = mappings.map((mapping) => {
+    const { chunks, overallChecksum } = hashBuffer(
+      mapping.content,
+      serverOptions.chunkSize
+    );
+    return { mapping, chunks, overallChecksum };
+  });
 
   const regionUrl = await resolveOrgRegion(org);
-
-  // Step 4: Request DIF assembly — body is keyed by overall checksum
-  // For proguard, we upload a single ZIP containing all mappings. The
-  // assemble endpoint accepts one entry per DIF. Since the ZIP is one
-  // file, there's exactly one entry keyed by the overall checksum.
-  // Use the first mapping's UUID as the debug_id and name; the ZIP
-  // itself contains all mappings as separate entries.
   const assembleEndpoint = `projects/${org}/${project}/files/difs/assemble/`;
-  const assembleBody: Record<string, unknown> = {};
 
-  // Each mapping gets its own assemble entry keyed by checksum.
-  // For a single-mapping upload this is straightforward; for multi-mapping
-  // uploads the server processes all entries in the single ZIP.
-  assembleBody[overallChecksum] = {
-    name:
-      mappings.length === 1
-        ? `proguard/${mappings[0]?.uuid}.txt`
-        : "proguard-mappings.zip",
-    debug_id: mappings[0]?.uuid,
-    chunks: chunks.map((c: ChunkInfo) => c.sha1),
-  };
+  // Step 3: Build assemble body — one entry per mapping, keyed by checksum
+  const assembleBody: Record<string, { name: string; chunks: string[] }> = {};
+  for (const cm of chunkedMappings) {
+    assembleBody[cm.overallChecksum] = {
+      name: `proguard/${cm.mapping.uuid}.txt`,
+      chunks: cm.chunks.map((c: ChunkInfo) => c.sha1),
+    };
+  }
 
+  // Step 4: Request DIF assembly — server reports which chunks it needs
   const { data: firstAssemble } = await apiRequestToRegion<DifAssembleResponse>(
     regionUrl,
     assembleEndpoint,
@@ -197,68 +176,51 @@ async function uploadProguardBundle(opts: {
     }
   );
 
-  // The DIF response is keyed by checksum — extract our entry
-  const assembleResult = firstAssemble[overallChecksum];
-  if (!assembleResult) {
-    throw new ApiError(
-      "DIF assembly failed: no response for checksum",
-      500,
-      `Checksum ${overallChecksum} not found in response`,
-      assembleEndpoint
-    );
-  }
+  const checksums = chunkedMappings.map((cm) => cm.overallChecksum);
+  const { allDone, missingChecksums } = checkAssembleResponse(
+    firstAssemble,
+    checksums,
+    assembleEndpoint
+  );
 
-  // If already assembled, we're done
-  if (assembleResult.state === "ok" || assembleResult.state === "created") {
+  if (allDone) {
     return;
   }
 
-  // Fail fast on server-side assembly error
-  if (assembleResult.state === "error") {
-    throw new ApiError(
-      "ProGuard mapping assembly failed",
-      500,
-      assembleResult.detail ?? "Unknown error",
-      assembleEndpoint
-    );
+  // Step 5: Upload missing chunks in parallel across all mappings
+  for (const cm of chunkedMappings) {
+    await uploadMissingBufferChunks({
+      chunks: cm.chunks,
+      missingChecksums,
+      content: cm.mapping.content,
+      serverOptions,
+      encoding,
+      regionUrl,
+    });
   }
 
-  // Step 5: Upload missing chunks in parallel
-  await uploadMissingChunks({
-    chunks,
-    missingChecksums: new Set(assembleResult.missingChunks ?? []),
-    tmpZipPath,
-    serverOptions,
-    encoding,
-    regionUrl,
-  });
-
-  // Step 6: Poll assemble endpoint until done
-  // The DIF assemble endpoint uses the per-checksum keyed format, so
-  // we need a custom polling loop that extracts our entry from the response.
+  // Step 6: Poll assemble endpoint until all mappings are done
   await pollDifAssembly({
     regionUrl,
     endpoint: assembleEndpoint,
     body: assembleBody,
-    checksum: overallChecksum,
+    checksums,
   });
 }
 
 /**
- * Poll a DIF assemble endpoint until the server reports completion.
+ * Poll a DIF assemble endpoint until all entries report completion.
  *
- * Unlike the standard {@link pollAssembly}, the DIF endpoint returns
- * a per-checksum keyed response. This extracts and checks the state
- * of a specific checksum entry.
+ * The DIF endpoint returns a per-checksum keyed response. This checks
+ * the state of every checksum entry until all are `"ok"` or `"created"`.
  */
 async function pollDifAssembly(params: {
   regionUrl: string;
   endpoint: string;
   body: unknown;
-  checksum: string;
+  checksums: string[];
 }): Promise<void> {
-  const { regionUrl, endpoint, body, checksum } = params;
-  // Import constants inline to avoid circular — they're just numbers
+  const { regionUrl, endpoint, body, checksums } = params;
   const POLL_INTERVAL_MS = 1000;
   const MAX_WAIT_MS = 300_000;
   const deadline = Date.now() + MAX_WAIT_MS;
@@ -276,25 +238,10 @@ async function pollDifAssembly(params: {
       }
     );
 
-    const entry = pollResult[checksum];
-    if (!entry) {
-      log.debug(`DIF poll: checksum ${checksum} not in response, retrying...`);
-      continue;
-    }
-
-    if (entry.state === "ok" || entry.state === "created") {
+    const { allDone } = checkAssembleResponse(pollResult, checksums, endpoint);
+    if (allDone) {
       return;
     }
-
-    if (entry.state === "error") {
-      throw new ApiError(
-        "ProGuard mapping assembly failed",
-        500,
-        entry.detail ?? "Unknown error",
-        endpoint
-      );
-    }
-    // "not_found" or "assembling" — keep polling
   }
 
   throw new ApiError(

--- a/src/lib/api/proguard.ts
+++ b/src/lib/api/proguard.ts
@@ -1,0 +1,306 @@
+/**
+ * ProGuard/R8 DIF Upload API
+ *
+ * Builds a ZIP bundle with ProGuard mapping files (named
+ * `proguard/<uuid>.txt`) and uploads via the DIF chunk-upload
+ * + assemble protocol.
+ *
+ * Protocol differences from artifact bundles (sourcemaps):
+ * - No manifest.json — just the mapping file entries in the ZIP
+ * - Assemble endpoint: `projects/{org}/{project}/files/difs/assemble/`
+ *   (not `organizations/{org}/artifactbundle/assemble/`)
+ * - The assemble body keys each file by its overall checksum, with
+ *   per-file metadata (`name`, `debug_id`, `chunks`)
+ */
+
+import { unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+import { ApiError } from "../errors.js";
+import { logger } from "../logger.js";
+import { resolveOrgRegion } from "../region.js";
+import { type ZipCompression, ZipWriter } from "../sourcemap/zip.js";
+import {
+  AssembleResponseSchema,
+  type ChunkInfo,
+  getChunkUploadOptions,
+  hashChunks,
+  pickUploadEncoding,
+  pollAssembly,
+  uploadMissingChunks,
+} from "./chunk-upload.js";
+import { apiRequestToRegion } from "./infrastructure.js";
+
+const log = logger.withTag("api.proguard");
+
+// ── Types ───────────────────────────────────────────────────────────
+
+/** A single ProGuard mapping file to upload. */
+export type ProguardMapping = {
+  /** Filesystem path (for display/logging). */
+  path: string;
+  /** The UUID for this mapping (content-derived or user-forced). */
+  uuid: string;
+  /** Pre-read content buffer (avoids double-read when UUID was computed). */
+  content: Buffer;
+};
+
+/** Options for {@link uploadProguardMappings}. */
+export type ProguardUploadOptions = {
+  /** Organization slug. */
+  org: string;
+  /** Project slug. */
+  project: string;
+  /** Mapping files to upload. */
+  mappings: ProguardMapping[];
+  /** Skip event reprocessing after upload. */
+  noReprocessing?: boolean;
+};
+
+// ── Schemas ─────────────────────────────────────────────────────────
+
+/**
+ * DIF assemble response — keyed by overall checksum, each value has
+ * the same shape as the standard assemble response.
+ */
+const DifAssembleResponseSchema = z.record(z.string(), AssembleResponseSchema);
+
+type DifAssembleResponse = z.infer<typeof DifAssembleResponseSchema>;
+
+// ── API Functions ───────────────────────────────────────────────────
+
+/**
+ * Build a ProGuard mapping ZIP at the given path.
+ *
+ * Each mapping is stored as `proguard/<uuid>.txt` inside the ZIP.
+ * No manifest.json — Sentry's symbolicator identifies the file type
+ * from the `proguard/` path prefix and UUID naming convention.
+ *
+ * @param outputPath - Where to write the ZIP file
+ * @param mappings - Mapping files to include
+ * @param options.compression - ZIP entry compression method
+ */
+export async function buildProguardBundle(
+  outputPath: string,
+  mappings: ProguardMapping[],
+  options: { compression?: ZipCompression }
+): Promise<void> {
+  const zip = await ZipWriter.create(outputPath, {
+    compression: options.compression,
+  });
+  try {
+    for (const mapping of mappings) {
+      await zip.addEntry(`proguard/${mapping.uuid}.txt`, mapping.content);
+    }
+    await zip.finalize();
+  } catch (error) {
+    await zip.close();
+    throw error;
+  }
+}
+
+/**
+ * Upload ProGuard mapping files to Sentry via the DIF chunk-upload protocol.
+ *
+ * Main orchestrator: build ZIP → chunk → assemble → upload missing → poll.
+ *
+ * @param options - Upload configuration (org, project, mappings)
+ * @throws {ApiError} If the upload or assembly fails
+ */
+export async function uploadProguardMappings(
+  options: ProguardUploadOptions
+): Promise<void> {
+  const { org, project, mappings } = options;
+
+  // Step 1: Get chunk upload configuration
+  const serverOptions = await getChunkUploadOptions(org);
+
+  // Pick wire codec — STORED + wire compression saves double-compress
+  const encoding = pickUploadEncoding(serverOptions.compression);
+  const zipCompression: ZipCompression = encoding ? "stored" : "deflate";
+
+  // Step 2: Build proguard bundle ZIP to a temp file
+  const tmpZipPath = join(tmpdir(), `sentry-proguard-bundle-${Date.now()}.zip`);
+  try {
+    await buildProguardBundle(tmpZipPath, mappings, {
+      compression: zipCompression,
+    });
+    await uploadProguardBundle({
+      tmpZipPath,
+      org,
+      project,
+      mappings,
+      serverOptions,
+      encoding,
+    });
+  } finally {
+    await unlink(tmpZipPath).catch((error) => {
+      log.debug("Failed to clean up temp ZIP", error);
+    });
+  }
+}
+
+/**
+ * Upload an already-built ProGuard bundle ZIP to Sentry.
+ *
+ * Handles steps 3–6 of the upload protocol: chunk + hash → assemble →
+ * upload missing → poll. Uses the DIF assemble endpoint which has a
+ * per-checksum keyed request/response format.
+ */
+async function uploadProguardBundle(opts: {
+  tmpZipPath: string;
+  org: string;
+  project: string;
+  mappings: ProguardMapping[];
+  serverOptions: import("./chunk-upload.js").ChunkServerOptions;
+  encoding: import("./chunk-upload.js").UploadEncoding | undefined;
+}): Promise<void> {
+  const { tmpZipPath, org, project, mappings, serverOptions, encoding } = opts;
+
+  // Step 3: Split into chunks, hash each chunk + compute overall checksum
+  const { chunks, overallChecksum } = await hashChunks(
+    tmpZipPath,
+    serverOptions.chunkSize
+  );
+
+  const regionUrl = await resolveOrgRegion(org);
+
+  // Step 4: Request DIF assembly — body is keyed by overall checksum
+  // For proguard, we upload a single ZIP containing all mappings. The
+  // assemble endpoint accepts one entry per DIF. Since the ZIP is one
+  // file, there's exactly one entry keyed by the overall checksum.
+  // Use the first mapping's UUID as the debug_id and name; the ZIP
+  // itself contains all mappings as separate entries.
+  const assembleEndpoint = `projects/${org}/${project}/files/difs/assemble/`;
+  const assembleBody: Record<string, unknown> = {};
+
+  // Each mapping gets its own assemble entry keyed by checksum.
+  // For a single-mapping upload this is straightforward; for multi-mapping
+  // uploads the server processes all entries in the single ZIP.
+  assembleBody[overallChecksum] = {
+    name:
+      mappings.length === 1
+        ? `proguard/${mappings[0]?.uuid}.txt`
+        : "proguard-mappings.zip",
+    debug_id: mappings[0]?.uuid,
+    chunks: chunks.map((c: ChunkInfo) => c.sha1),
+  };
+
+  const { data: firstAssemble } = await apiRequestToRegion<DifAssembleResponse>(
+    regionUrl,
+    assembleEndpoint,
+    {
+      method: "POST",
+      body: assembleBody,
+      schema: DifAssembleResponseSchema,
+    }
+  );
+
+  // The DIF response is keyed by checksum — extract our entry
+  const assembleResult = firstAssemble[overallChecksum];
+  if (!assembleResult) {
+    throw new ApiError(
+      "DIF assembly failed: no response for checksum",
+      500,
+      `Checksum ${overallChecksum} not found in response`,
+      assembleEndpoint
+    );
+  }
+
+  // If already assembled, we're done
+  if (assembleResult.state === "ok" || assembleResult.state === "created") {
+    return;
+  }
+
+  // Fail fast on server-side assembly error
+  if (assembleResult.state === "error") {
+    throw new ApiError(
+      "ProGuard mapping assembly failed",
+      500,
+      assembleResult.detail ?? "Unknown error",
+      assembleEndpoint
+    );
+  }
+
+  // Step 5: Upload missing chunks in parallel
+  await uploadMissingChunks({
+    chunks,
+    missingChecksums: new Set(assembleResult.missingChunks ?? []),
+    tmpZipPath,
+    serverOptions,
+    encoding,
+    regionUrl,
+  });
+
+  // Step 6: Poll assemble endpoint until done
+  // The DIF assemble endpoint uses the per-checksum keyed format, so
+  // we need a custom polling loop that extracts our entry from the response.
+  await pollDifAssembly({
+    regionUrl,
+    endpoint: assembleEndpoint,
+    body: assembleBody,
+    checksum: overallChecksum,
+  });
+}
+
+/**
+ * Poll a DIF assemble endpoint until the server reports completion.
+ *
+ * Unlike the standard {@link pollAssembly}, the DIF endpoint returns
+ * a per-checksum keyed response. This extracts and checks the state
+ * of a specific checksum entry.
+ */
+async function pollDifAssembly(params: {
+  regionUrl: string;
+  endpoint: string;
+  body: unknown;
+  checksum: string;
+}): Promise<void> {
+  const { regionUrl, endpoint, body, checksum } = params;
+  // Import constants inline to avoid circular — they're just numbers
+  const POLL_INTERVAL_MS = 1000;
+  const MAX_WAIT_MS = 300_000;
+  const deadline = Date.now() + MAX_WAIT_MS;
+
+  while (Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+
+    const { data: pollResult } = await apiRequestToRegion<DifAssembleResponse>(
+      regionUrl,
+      endpoint,
+      {
+        method: "POST",
+        body,
+        schema: DifAssembleResponseSchema,
+      }
+    );
+
+    const entry = pollResult[checksum];
+    if (!entry) {
+      log.debug(`DIF poll: checksum ${checksum} not in response, retrying...`);
+      continue;
+    }
+
+    if (entry.state === "ok" || entry.state === "created") {
+      return;
+    }
+
+    if (entry.state === "error") {
+      throw new ApiError(
+        "ProGuard mapping assembly failed",
+        500,
+        entry.detail ?? "Unknown error",
+        endpoint
+      );
+    }
+    // "not_found" or "assembling" — keep polling
+  }
+
+  throw new ApiError(
+    "ProGuard mapping assembly timed out",
+    408,
+    `Assembly did not complete within ${MAX_WAIT_MS / 1000}s`,
+    endpoint
+  );
+}

--- a/src/lib/api/proguard.ts
+++ b/src/lib/api/proguard.ts
@@ -17,6 +17,8 @@ import { ApiError } from "../errors.js";
 import { logger } from "../logger.js";
 import { resolveOrgRegion } from "../region.js";
 import {
+  ASSEMBLE_MAX_WAIT_MS,
+  ASSEMBLE_POLL_INTERVAL_MS,
   type AssembleResponse,
   AssembleResponseSchema,
   type ChunkInfo,
@@ -221,12 +223,10 @@ async function pollDifAssembly(params: {
   checksums: string[];
 }): Promise<void> {
   const { regionUrl, endpoint, body, checksums } = params;
-  const POLL_INTERVAL_MS = 1000;
-  const MAX_WAIT_MS = 300_000;
-  const deadline = Date.now() + MAX_WAIT_MS;
+  const deadline = Date.now() + ASSEMBLE_MAX_WAIT_MS;
 
   while (Date.now() < deadline) {
-    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    await new Promise((r) => setTimeout(r, ASSEMBLE_POLL_INTERVAL_MS));
 
     const { data: pollResult } = await apiRequestToRegion<DifAssembleResponse>(
       regionUrl,
@@ -247,7 +247,7 @@ async function pollDifAssembly(params: {
   throw new ApiError(
     "ProGuard mapping assembly timed out",
     408,
-    `Assembly did not complete within ${MAX_WAIT_MS / 1000}s`,
+    `Assembly did not complete within ${ASSEMBLE_MAX_WAIT_MS / 1000}s`,
     endpoint
   );
 }

--- a/src/lib/api/sourcemaps.ts
+++ b/src/lib/api/sourcemaps.ts
@@ -1,77 +1,56 @@
 /**
  * Sourcemap Upload API
  *
- * Implements the Sentry chunk-upload + assemble protocol for
- * artifact bundle uploads. Replaces the `@sentry/cli sourcemaps upload`
- * command with a native TypeScript implementation.
+ * Implements artifact bundle building and upload for sourcemaps.
+ * The underlying chunk-upload protocol (chunking, hashing, codec
+ * selection, chunk upload, assembly polling) lives in
+ * {@link ./chunk-upload.ts} and is shared with other upload flows
+ * (e.g. ProGuard DIF uploads).
  *
  * Protocol overview:
  * 1. GET  chunk-upload options (chunk size, concurrency, compression)
  * 2. Build artifact bundle ZIP (streaming to disk via {@link ZipWriter})
  * 3. Split ZIP into chunks, compute SHA-1 checksums
  * 4. POST assemble request → server reports missing chunks
- * 5. Upload missing chunks in parallel as multipart/form-data. When the
- *    server advertises a codec in `compression`, chunks are compressed
- *    per-request and the codec is announced via `Content-Encoding`. Codec
- *    preference is `zstd` > `gzip` > plain. Newer servers advertise both;
- *    older servers advertise only `gzip`; the `chunk-upload.no-compression`
- *    kill-switch makes the list empty.
+ * 5. Upload missing chunks in parallel as multipart/form-data
  * 6. Poll assemble endpoint until complete
  */
 
-import { createHash } from "node:crypto";
-import { open, readFile, stat, unlink } from "node:fs/promises";
+import { readFile, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { promisify } from "node:util";
-import {
-  gzip as gzipCb,
-  constants as zlibConstants,
-  zstdCompress as zstdCompressCb,
-} from "node:zlib";
-import pLimit from "p-limit";
-import { z } from "zod";
 import { ApiError } from "../errors.js";
-import { logger } from "../logger.js";
 import { resolveOrgRegion } from "../region.js";
-import { getSdkConfig } from "../sentry-client.js";
 import { type ZipCompression, ZipWriter } from "../sourcemap/zip.js";
+import {
+  type AssembleResponse,
+  AssembleResponseSchema,
+  type ChunkInfo,
+  type ChunkServerOptions,
+  getChunkUploadOptions,
+  hashChunks,
+  pickUploadEncoding,
+  pollAssembly,
+  type UploadEncoding,
+  uploadMissingChunks,
+} from "./chunk-upload.js";
 import { apiRequestToRegion } from "./infrastructure.js";
 
-const gzipAsync = promisify(gzipCb);
-const zstdCompressAsync = promisify(zstdCompressCb);
-const log = logger.withTag("api.sourcemaps");
-
-// ── Schemas ─────────────────────────────────────────────────────────
-
-/** Server-provided chunk upload configuration. */
-export const ChunkServerOptionsSchema = z.object({
-  /** Absolute URL to upload chunks to. */
-  url: z.string(),
-  /** Maximum size of a single chunk in bytes. */
-  chunkSize: z.number(),
-  /** Maximum number of chunks per upload request. */
-  chunksPerRequest: z.number(),
-  /** Maximum total request body size in bytes. */
-  maxRequestSize: z.number(),
-  /** Hash algorithm for chunk checksums (always "sha1"). */
-  hashAlgorithm: z.string(),
-  /** Maximum concurrent upload requests. */
-  concurrency: z.number(),
-  /** Supported compression methods (e.g., ["gzip"]). */
-  compression: z.array(z.string()),
-});
-
-export type ChunkServerOptions = z.infer<typeof ChunkServerOptionsSchema>;
-
-/** Response from the artifact bundle assemble endpoint. */
-export const AssembleResponseSchema = z.object({
-  state: z.enum(["not_found", "created", "assembling", "ok", "error"]),
-  missingChunks: z.array(z.string()).optional(),
-  detail: z.string().nullable().optional(),
-});
-
-export type AssembleResponse = z.infer<typeof AssembleResponseSchema>;
+// ── Re-exports for backward compatibility ───────────────────────────
+// These were originally defined in this module. External consumers
+// (commands, tests) may still import them from here.
+// biome-ignore lint/performance/noBarrelFile: backward-compat re-exports, not a barrel
+export {
+  type AssembleResponse,
+  AssembleResponseSchema,
+  type ChunkServerOptions,
+  ChunkServerOptionsSchema,
+  encodeChunk,
+  getChunkUploadOptions,
+  hashChunks,
+  pickUploadEncoding,
+  type UploadEncoding,
+} from "./chunk-upload.js";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -122,24 +101,6 @@ export type UploadOptions = {
   files: ArtifactFile[];
 };
 
-/** Chunk metadata after splitting the ZIP for upload. */
-type ChunkInfo = {
-  /** SHA-1 checksum of this chunk. */
-  sha1: string;
-  /** Byte offset in the ZIP file. */
-  offset: number;
-  /** Byte size of this chunk. */
-  size: number;
-};
-
-// ── Constants ───────────────────────────────────────────────────────
-
-/** Interval between assemble poll requests. */
-const ASSEMBLE_POLL_INTERVAL_MS = 1000;
-
-/** Maximum time to wait for assembly. */
-const ASSEMBLE_MAX_WAIT_MS = 300_000;
-
 // ── Helpers ─────────────────────────────────────────────────────────
 
 /**
@@ -152,152 +113,6 @@ function urlToBundlePath(url: string): string {
 }
 
 // ── API Functions ───────────────────────────────────────────────────
-
-/**
- * Get chunk upload configuration for an organization.
- *
- * @param orgSlug - Organization slug
- * @returns Server-provided upload options (chunk size, concurrency, etc.)
- */
-export async function getChunkUploadOptions(
-  orgSlug: string
-): Promise<ChunkServerOptions> {
-  const regionUrl = await resolveOrgRegion(orgSlug);
-  const { data } = await apiRequestToRegion<ChunkServerOptions>(
-    regionUrl,
-    `organizations/${orgSlug}/chunk-upload/`,
-    { schema: ChunkServerOptionsSchema }
-  );
-  return data;
-}
-
-/**
- * Codecs the CLI knows how to emit, in order of preference.
- *
- * `zstd` is the forward-looking codec: advertised only by servers that
- * implement `Content-Encoding`-based detection. `gzip` is the legacy
- * codec supported by every Sentry server since forever; we still send
- * it under the original `file_gzip` multipart field name so that
- * pre-zstd servers -- which ignore `Content-Encoding` -- keep working.
- */
-const UPLOAD_CODECS = ["zstd", "gzip"] as const;
-export type UploadEncoding = (typeof UPLOAD_CODECS)[number];
-
-/**
- * Select the most efficient upload codec the server advertises, or
- * `undefined` for plain (uncompressed) uploads when the server opts out
- * of compression (e.g. the `chunk-upload.no-compression` kill-switch)
- * or advertises only codecs we don't implement.
- *
- * Exported for testing.
- */
-export function pickUploadEncoding(
-  compression: string[]
-): UploadEncoding | undefined {
-  for (const codec of UPLOAD_CODECS) {
-    if (compression.includes(codec)) {
-      return codec;
-    }
-  }
-  if (compression.length > 0) {
-    log.debug(
-      `server advertised unsupported codecs [${compression.join(", ")}]; falling back to plain upload`
-    );
-  }
-  return;
-}
-
-/**
- * Compress a chunk buffer with the chosen codec. Exported for testing.
- *
- * Both codecs run off-thread via libuv's thread pool, so a chunk
- * being compressed doesn't block the event loop --
- * with `concurrency=8`, eight uploads truly compress in parallel.
- */
-export async function encodeChunk(
-  buf: Buffer,
-  encoding: UploadEncoding | undefined
-): Promise<Uint8Array> {
-  if (encoding === "zstd") {
-    // L3 is libzstd's default; passed explicitly for self-documenting
-    // code. L9+ trades ~14% size for 4x compress time and forces the
-    // server's decoder to allocate 15-30 MiB of window state -- not
-    // worth it once decode cost is counted.
-    return await zstdCompressAsync(buf, {
-      params: { [zlibConstants.ZSTD_c_compressionLevel]: 3 },
-    });
-  }
-  if (encoding === "gzip") {
-    // zlib default (L6). Counter-intuitively, lower levels (L1/L5)
-    // DEcompress SLOWER on the server (sparser Huffman codes); L9
-    // costs ~2x the compress CPU for no meaningful size win.
-    return await gzipAsync(buf);
-  }
-  return buf;
-}
-
-/**
- * Read a single chunk from the staging ZIP, compress it with the server's
- * preferred codec, and POST it to the chunk-upload endpoint.
- *
- * Wire format by codec (driven by {@link pickUploadEncoding}):
- *  - `zstd`  -> `Content-Encoding: zstd` + `file` multipart field.
- *               Only works against servers that opted in via
- *               `Content-Encoding` detection (getsentry/sentry#113760+).
- *  - `gzip`  -> LEGACY `file_gzip` multipart field, NO `Content-Encoding`
- *               header. Works with every server that advertises `gzip`,
- *               including pre-zstd self-hosted deployments.
- *  - plain   -> `file` multipart field, no `Content-Encoding`.
- *
- * NB: never emit `Content-Encoding: gzip` alongside the `file_gzip`
- * field -- zstd-aware servers reject that combination (400) to avoid
- * ambiguity.
- */
-async function uploadChunk(params: {
-  chunk: ChunkInfo;
-  tmpZipPath: string;
-  encoding: UploadEncoding | undefined;
-  fetch: (url: string, init: RequestInit) => Promise<Response>;
-  url: string;
-}): Promise<void> {
-  const { chunk, tmpZipPath, encoding, fetch: authFetch, url } = params;
-
-  const chunkFh = await open(tmpZipPath, "r");
-  let buf: Buffer;
-  try {
-    buf = Buffer.alloc(chunk.size);
-    await chunkFh.read(buf, 0, chunk.size, chunk.offset);
-  } finally {
-    await chunkFh.close();
-  }
-
-  const payload = await encodeChunk(buf, encoding);
-
-  // gzip uses the legacy `file_gzip` field for backwards compatibility
-  // with pre-zstd servers; zstd and plain use the standard `file` field.
-  const fieldName = encoding === "gzip" ? "file_gzip" : "file";
-  const form = new FormData();
-  form.append(
-    fieldName,
-    new Blob([payload], { type: "application/octet-stream" }),
-    chunk.sha1
-  );
-
-  const init: RequestInit = { method: "POST", body: form };
-  if (encoding === "zstd") {
-    init.headers = { "Content-Encoding": "zstd" };
-  }
-
-  const response = await authFetch(url, init);
-  if (!response.ok) {
-    throw new ApiError(
-      `Chunk upload failed: ${response.status} ${response.statusText}`,
-      response.status,
-      await response.text().catch(() => ""),
-      url
-    );
-  }
-}
 
 /**
  * Build an artifact bundle ZIP at the given path.
@@ -379,40 +194,6 @@ export async function buildArtifactBundle(
     // Close handle without finalizing on entry write failure
     await zip.close();
     throw error;
-  }
-}
-
-/**
- * Split a ZIP file into chunks and compute SHA-1 checksums.
- *
- * Reads the file sequentially — only one chunk buffer is live at a time.
- *
- * @param zipPath - Path to the ZIP file
- * @param chunkSize - Size of each chunk in bytes
- * @returns Per-chunk metadata and an overall SHA-1 checksum of the entire file
- */
-export async function hashChunks(
-  zipPath: string,
-  chunkSize: number
-): Promise<{ chunks: ChunkInfo[]; overallChecksum: string }> {
-  const fh = await open(zipPath, "r");
-  try {
-    const fileSize = (await stat(zipPath)).size;
-    const chunks: ChunkInfo[] = [];
-    const overallHasher = createHash("sha1");
-
-    for (let offset = 0; offset < fileSize; offset += chunkSize) {
-      const size = Math.min(chunkSize, fileSize - offset);
-      const buf = Buffer.alloc(size);
-      await fh.read(buf, 0, size, offset);
-      const sha1 = createHash("sha1").update(buf).digest("hex");
-      overallHasher.update(buf);
-      chunks.push({ sha1, offset, size });
-    }
-
-    return { chunks, overallChecksum: overallHasher.digest("hex") };
-  } finally {
-    await fh.close();
   }
 }
 
@@ -529,63 +310,20 @@ async function uploadArtifactBundle(opts: {
   }
 
   // Step 5: Upload missing chunks in parallel
-  const missingSet = new Set(firstAssemble.missingChunks ?? []);
-  const missingChunks = chunks.filter((c) => missingSet.has(c.sha1));
-
-  if (missingChunks.length > 0) {
-    const limit = pLimit(serverOptions.concurrency);
-    // Use the CLI's authenticated fetch for chunk uploads
-    const { fetch: authFetch } = getSdkConfig(regionUrl);
-
-    await Promise.all(
-      missingChunks.map((chunk) =>
-        limit(() =>
-          uploadChunk({
-            chunk,
-            tmpZipPath,
-            encoding,
-            fetch: authFetch,
-            url: serverOptions.url,
-          })
-        )
-      )
-    );
-  }
+  await uploadMissingChunks({
+    chunks,
+    missingChecksums: new Set(firstAssemble.missingChunks ?? []),
+    tmpZipPath,
+    serverOptions,
+    encoding,
+    regionUrl,
+  });
 
   // Step 6: Poll assemble endpoint until done
-  const deadline = Date.now() + ASSEMBLE_MAX_WAIT_MS;
-  while (Date.now() < deadline) {
-    await new Promise((r) => setTimeout(r, ASSEMBLE_POLL_INTERVAL_MS));
-
-    const { data: pollResult } = await apiRequestToRegion<AssembleResponse>(
-      regionUrl,
-      assembleEndpoint,
-      {
-        method: "POST",
-        body: assembleBody,
-        schema: AssembleResponseSchema,
-      }
-    );
-
-    if (pollResult.state === "ok" || pollResult.state === "created") {
-      return;
-    }
-
-    if (pollResult.state === "error") {
-      throw new ApiError(
-        "Artifact bundle assembly failed",
-        500,
-        pollResult.detail ?? "Unknown error",
-        assembleEndpoint
-      );
-    }
-    // "not_found" or "assembling" — keep polling
-  }
-
-  throw new ApiError(
-    "Artifact bundle assembly timed out",
-    408,
-    `Assembly did not complete within ${ASSEMBLE_MAX_WAIT_MS / 1000}s`,
-    assembleEndpoint
-  );
+  await pollAssembly({
+    regionUrl,
+    endpoint: assembleEndpoint,
+    body: assembleBody,
+    entityName: "Artifact bundle",
+  });
 }

--- a/test/commands/proguard/upload.test.ts
+++ b/test/commands/proguard/upload.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for `sentry proguard upload` command.
+ *
+ * Core invariants (UUID computation, round-trips, determinism) are tested
+ * via property-based tests in proguard.property.test.ts. These tests focus
+ * on command-level behavior: flag validation, dry-run mode, error paths,
+ * and API orchestration.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { uploadCommand } from "../../../src/commands/proguard/upload.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as proguardApi from "../../../src/lib/api/proguard.js";
+import { ContextError, ValidationError } from "../../../src/lib/errors.js";
+
+type UploadFuncFlags = {
+  uuid?: string;
+  "no-upload"?: boolean;
+  "require-one"?: boolean;
+  "no-reprocessing"?: boolean;
+};
+
+/** The loader returns a wrapped async function, not a raw generator. */
+type CmdFunc = (
+  this: unknown,
+  flags: UploadFuncFlags,
+  ...paths: string[]
+) => Promise<unknown>;
+
+function makeContext() {
+  return {
+    stdout: { write: vi.fn(() => true) },
+    stderr: { write: vi.fn(() => true) },
+    cwd: "/tmp",
+  };
+}
+
+describe("sentry proguard upload", () => {
+  let dir: string;
+  let func: CmdFunc;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "sentry-proguard-upload-"));
+    savedEnv = {
+      SENTRY_ORG: process.env.SENTRY_ORG,
+      SENTRY_PROJECT: process.env.SENTRY_PROJECT,
+    };
+    process.env.SENTRY_ORG = "test-org";
+    process.env.SENTRY_PROJECT = "test-project";
+    func = (await uploadCommand.loader()) as unknown as CmdFunc;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = v;
+      }
+    }
+  });
+
+  // ── Input validation ─────────────────────────────────────────────
+
+  test("no paths: throws ContextError", async () => {
+    const ctx = makeContext();
+    try {
+      await func.call(ctx, {});
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContextError);
+    }
+  });
+
+  test("no paths with --require-one: throws ValidationError", async () => {
+    const ctx = makeContext();
+    try {
+      await func.call(ctx, { "require-one": true });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as Error).message).toContain("--require-one");
+    }
+  });
+
+  test("--uuid with multiple files: throws ValidationError", async () => {
+    const f1 = join(dir, "mapping1.txt");
+    const f2 = join(dir, "mapping2.txt");
+    writeFileSync(f1, "void\n");
+    writeFileSync(f2, "other\n");
+
+    const ctx = makeContext();
+    try {
+      await func.call(
+        ctx,
+        { uuid: "5db7294d-87fc-5726-a5c0-4a90679657a5" },
+        f1,
+        f2,
+      );
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as Error).message).toContain("--uuid");
+    }
+  });
+
+  test("--uuid with invalid format: throws ValidationError", async () => {
+    const f = join(dir, "mapping.txt");
+    writeFileSync(f, "void\n");
+
+    const ctx = makeContext();
+    try {
+      await func.call(ctx, { uuid: "not-a-uuid" }, f);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as Error).message).toContain("Invalid UUID format");
+    }
+  });
+
+  test("non-existent file: throws ValidationError", async () => {
+    const missing = join(dir, "does-not-exist.txt");
+    const ctx = makeContext();
+    try {
+      await func.call(ctx, {}, missing);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as Error).message).toContain("does not exist");
+    }
+  });
+
+  test("directory path: throws ValidationError", async () => {
+    const ctx = makeContext();
+    try {
+      await func.call(ctx, {}, dir);
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as Error).message).toContain("directory");
+    }
+  });
+
+  // ── --no-upload (dry-run) ────────────────────────────────────────
+
+  test("--no-upload: succeeds without uploading", async () => {
+    const f = join(dir, "mapping.txt");
+    writeFileSync(f, "void\n");
+
+    const ctx = makeContext();
+    await func.call(ctx, { "no-upload": true }, f);
+
+    // stdout.write should have been called with output containing the UUID
+    expect(ctx.stdout.write).toHaveBeenCalled();
+  });
+
+  test("--no-upload: does not require credentials", async () => {
+    delete process.env.SENTRY_ORG;
+    delete process.env.SENTRY_PROJECT;
+
+    const f = join(dir, "mapping.txt");
+    writeFileSync(f, "void\n");
+
+    const ctx = makeContext();
+    // Should succeed without org/project set
+    await expect(
+      func.call(ctx, { "no-upload": true }, f),
+    ).resolves.toBeUndefined();
+  });
+
+  // ── Happy path: upload ───────────────────────────────────────────
+
+  test("single file: calls uploadProguardMappings with correct args", async () => {
+    const f = join(dir, "mapping.txt");
+    writeFileSync(f, "void\n");
+
+    const uploadSpy = vi
+      .spyOn(proguardApi, "uploadProguardMappings")
+      .mockResolvedValue(undefined);
+    try {
+      const ctx = makeContext();
+      await func.call(ctx, {}, f);
+
+      expect(uploadSpy).toHaveBeenCalledTimes(1);
+      const callArgs = uploadSpy.mock.calls[0]?.[0];
+      expect(callArgs?.org).toBe("test-org");
+      expect(callArgs?.project).toBe("test-project");
+      expect(callArgs?.mappings).toHaveLength(1);
+      expect(callArgs?.mappings[0]?.uuid).toBe(
+        "5db7294d-87fc-5726-a5c0-4a90679657a5",
+      );
+      expect(callArgs?.mappings[0]?.content).toBeInstanceOf(Buffer);
+    } finally {
+      uploadSpy.mockRestore();
+    }
+  });
+
+  test("multiple files: uploads all mappings", async () => {
+    const f1 = join(dir, "mapping1.txt");
+    const f2 = join(dir, "mapping2.txt");
+    writeFileSync(f1, "content one\n");
+    writeFileSync(f2, "content two\n");
+
+    const uploadSpy = vi
+      .spyOn(proguardApi, "uploadProguardMappings")
+      .mockResolvedValue(undefined);
+    try {
+      const ctx = makeContext();
+      await func.call(ctx, {}, f1, f2);
+
+      expect(uploadSpy).toHaveBeenCalledTimes(1);
+      const callArgs = uploadSpy.mock.calls[0]?.[0];
+      expect(callArgs?.mappings).toHaveLength(2);
+      // Different content should yield different UUIDs
+      expect(callArgs?.mappings[0]?.uuid).not.toBe(
+        callArgs?.mappings[1]?.uuid,
+      );
+    } finally {
+      uploadSpy.mockRestore();
+    }
+  });
+
+  test("--uuid: forces specific UUID for single file upload", async () => {
+    const f = join(dir, "mapping.txt");
+    writeFileSync(f, "void\n");
+    const forcedUuid = "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeeee";
+
+    const uploadSpy = vi
+      .spyOn(proguardApi, "uploadProguardMappings")
+      .mockResolvedValue(undefined);
+    try {
+      const ctx = makeContext();
+      await func.call(ctx, { uuid: forcedUuid }, f);
+
+      const callArgs = uploadSpy.mock.calls[0]?.[0];
+      expect(callArgs?.mappings[0]?.uuid).toBe(forcedUuid);
+    } finally {
+      uploadSpy.mockRestore();
+    }
+  });
+
+  test("--no-reprocessing: passes flag through to API", async () => {
+    const f = join(dir, "mapping.txt");
+    writeFileSync(f, "void\n");
+
+    const uploadSpy = vi
+      .spyOn(proguardApi, "uploadProguardMappings")
+      .mockResolvedValue(undefined);
+    try {
+      const ctx = makeContext();
+      await func.call(ctx, { "no-reprocessing": true }, f);
+
+      const callArgs = uploadSpy.mock.calls[0]?.[0];
+      expect(callArgs?.noReprocessing).toBe(true);
+    } finally {
+      uploadSpy.mockRestore();
+    }
+  });
+});

--- a/test/commands/proguard/upload.test.ts
+++ b/test/commands/proguard/upload.test.ts
@@ -100,7 +100,7 @@ describe("sentry proguard upload", () => {
         ctx,
         { uuid: "5db7294d-87fc-5726-a5c0-4a90679657a5" },
         f1,
-        f2,
+        f2
       );
       expect.unreachable("should have thrown");
     } catch (err) {
@@ -169,7 +169,7 @@ describe("sentry proguard upload", () => {
     const ctx = makeContext();
     // Should succeed without org/project set
     await expect(
-      func.call(ctx, { "no-upload": true }, f),
+      func.call(ctx, { "no-upload": true }, f)
     ).resolves.toBeUndefined();
   });
 
@@ -192,7 +192,7 @@ describe("sentry proguard upload", () => {
       expect(callArgs?.project).toBe("test-project");
       expect(callArgs?.mappings).toHaveLength(1);
       expect(callArgs?.mappings[0]?.uuid).toBe(
-        "5db7294d-87fc-5726-a5c0-4a90679657a5",
+        "5db7294d-87fc-5726-a5c0-4a90679657a5"
       );
       expect(callArgs?.mappings[0]?.content).toBeInstanceOf(Buffer);
     } finally {
@@ -217,9 +217,7 @@ describe("sentry proguard upload", () => {
       const callArgs = uploadSpy.mock.calls[0]?.[0];
       expect(callArgs?.mappings).toHaveLength(2);
       // Different content should yield different UUIDs
-      expect(callArgs?.mappings[0]?.uuid).not.toBe(
-        callArgs?.mappings[1]?.uuid,
-      );
+      expect(callArgs?.mappings[0]?.uuid).not.toBe(callArgs?.mappings[1]?.uuid);
     } finally {
       uploadSpy.mockRestore();
     }

--- a/test/commands/proguard/upload.test.ts
+++ b/test/commands/proguard/upload.test.ts
@@ -20,7 +20,6 @@ type UploadFuncFlags = {
   uuid?: string;
   "no-upload"?: boolean;
   "require-one"?: boolean;
-  "no-reprocessing"?: boolean;
 };
 
 /** The loader returns a wrapped async function, not a raw generator. */
@@ -237,24 +236,6 @@ describe("sentry proguard upload", () => {
 
       const callArgs = uploadSpy.mock.calls[0]?.[0];
       expect(callArgs?.mappings[0]?.uuid).toBe(forcedUuid);
-    } finally {
-      uploadSpy.mockRestore();
-    }
-  });
-
-  test("--no-reprocessing: passes flag through to API", async () => {
-    const f = join(dir, "mapping.txt");
-    writeFileSync(f, "void\n");
-
-    const uploadSpy = vi
-      .spyOn(proguardApi, "uploadProguardMappings")
-      .mockResolvedValue(undefined);
-    try {
-      const ctx = makeContext();
-      await func.call(ctx, { "no-reprocessing": true }, f);
-
-      const callArgs = uploadSpy.mock.calls[0]?.[0];
-      expect(callArgs?.noReprocessing).toBe(true);
     } finally {
       uploadSpy.mockRestore();
     }

--- a/test/lib/api/proguard.test.ts
+++ b/test/lib/api/proguard.test.ts
@@ -1,0 +1,142 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { buildProguardBundle } from "../../../src/lib/api/proguard.js";
+import type { ProguardMapping } from "../../../src/lib/api/proguard.js";
+
+describe("buildProguardBundle", () => {
+  // ZIP local file header format: at offset 8 (LE u16) is the
+  // compression method (0 = STORED, 8 = DEFLATE). The CLI prefixes
+  // every bundle with an 8-byte SYSB SourceBundle header.
+  const SYSB_HEADER_BYTES = 8;
+  const LOCAL_HEADER_METHOD_OFFSET = SYSB_HEADER_BYTES + 8;
+
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "proguard-bundle-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeMapping(
+    uuid = "5db7294d-87fc-5726-a5c0-4a90679657a5",
+    content = "void\n",
+  ): ProguardMapping {
+    return {
+      path: "/fake/mapping.txt",
+      uuid,
+      content: Buffer.from(content, "utf-8"),
+    };
+  }
+
+  test("starts with SYSB magic header", async () => {
+    const out = join(tmpDir, "bundle.zip");
+    await buildProguardBundle(out, [makeMapping()], {});
+
+    const bytes = await readFile(out);
+    // SYSB magic: 53 59 53 42
+    expect(bytes.toString("ascii", 0, 4)).toBe("SYSB");
+    // Version 2
+    expect(bytes.readUInt32LE(4)).toBe(2);
+  });
+
+  test("stores entry as proguard/<uuid>.txt", async () => {
+    const uuid = "5db7294d-87fc-5726-a5c0-4a90679657a5";
+    const out = join(tmpDir, "bundle.zip");
+    await buildProguardBundle(out, [makeMapping(uuid)], {
+      compression: "stored",
+    });
+
+    const bytes = await readFile(out);
+    // The entry name should appear in the ZIP file data
+    const entryName = `proguard/${uuid}.txt`;
+    expect(bytes.includes(Buffer.from(entryName, "utf-8"))).toBe(true);
+  });
+
+  test("does not include a manifest.json", async () => {
+    const out = join(tmpDir, "bundle.zip");
+    await buildProguardBundle(out, [makeMapping()], {
+      compression: "stored",
+    });
+
+    const bytes = await readFile(out);
+    // There should be no manifest.json entry — only proguard/ entries
+    expect(bytes.includes(Buffer.from("manifest.json", "utf-8"))).toBe(false);
+  });
+
+  test("default compression is DEFLATE", async () => {
+    // Use redundant content so DEFLATE has work to do
+    const mapping = makeMapping(
+      "c038584d-c366-570c-ad1e-034fa0d194d7",
+      "line\n".repeat(500),
+    );
+    const out = join(tmpDir, "bundle-deflate.zip");
+    await buildProguardBundle(out, [mapping], {});
+
+    const bytes = await readFile(out);
+    expect(bytes.readUInt16LE(LOCAL_HEADER_METHOD_OFFSET)).toBe(8);
+  });
+
+  test("compression: 'stored' writes entries uncompressed", async () => {
+    const out = join(tmpDir, "bundle-stored.zip");
+    await buildProguardBundle(out, [makeMapping()], {
+      compression: "stored",
+    });
+
+    const bytes = await readFile(out);
+    expect(bytes.readUInt16LE(LOCAL_HEADER_METHOD_OFFSET)).toBe(0);
+  });
+
+  test("STORED archive contains raw mapping content", async () => {
+    const content = "com.example.MyClass -> a:\n    void method() -> b\n";
+    const out = join(tmpDir, "bundle-raw.zip");
+    await buildProguardBundle(
+      out,
+      [makeMapping("aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeeee", content)],
+      { compression: "stored" },
+    );
+
+    const bytes = await readFile(out);
+    expect(bytes.includes(Buffer.from(content, "utf-8"))).toBe(true);
+  });
+
+  test("handles multiple mappings in a single ZIP", async () => {
+    const uuid1 = "11111111-1111-5111-8111-111111111111";
+    const uuid2 = "22222222-2222-5222-8222-222222222222";
+    const mappings: ProguardMapping[] = [
+      makeMapping(uuid1, "mapping one content"),
+      makeMapping(uuid2, "mapping two content"),
+    ];
+
+    const out = join(tmpDir, "bundle-multi.zip");
+    await buildProguardBundle(out, mappings, { compression: "stored" });
+
+    const bytes = await readFile(out);
+    expect(bytes.includes(Buffer.from(`proguard/${uuid1}.txt`))).toBe(true);
+    expect(bytes.includes(Buffer.from(`proguard/${uuid2}.txt`))).toBe(true);
+    expect(bytes.includes(Buffer.from("mapping one content"))).toBe(true);
+    expect(bytes.includes(Buffer.from("mapping two content"))).toBe(true);
+  });
+
+  test("STORED archive is larger than DEFLATE for redundant input", async () => {
+    const mapping = makeMapping(
+      "c038584d-c366-570c-ad1e-034fa0d194d7",
+      "com.example.MyClass -> a:\n".repeat(500),
+    );
+
+    const deflateOut = join(tmpDir, "bundle-deflate-size.zip");
+    const storedOut = join(tmpDir, "bundle-stored-size.zip");
+    await buildProguardBundle(deflateOut, [mapping], {});
+    await buildProguardBundle(storedOut, [mapping], {
+      compression: "stored",
+    });
+
+    const deflateSize = (await readFile(deflateOut)).length;
+    const storedSize = (await readFile(storedOut)).length;
+    expect(storedSize).toBeGreaterThan(deflateSize * 2);
+  });
+});

--- a/test/lib/api/proguard.test.ts
+++ b/test/lib/api/proguard.test.ts
@@ -2,8 +2,8 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { buildProguardBundle } from "../../../src/lib/api/proguard.js";
 import type { ProguardMapping } from "../../../src/lib/api/proguard.js";
+import { buildProguardBundle } from "../../../src/lib/api/proguard.js";
 
 describe("buildProguardBundle", () => {
   // ZIP local file header format: at offset 8 (LE u16) is the
@@ -24,7 +24,7 @@ describe("buildProguardBundle", () => {
 
   function makeMapping(
     uuid = "5db7294d-87fc-5726-a5c0-4a90679657a5",
-    content = "void\n",
+    content = "void\n"
   ): ProguardMapping {
     return {
       path: "/fake/mapping.txt",
@@ -72,7 +72,7 @@ describe("buildProguardBundle", () => {
     // Use redundant content so DEFLATE has work to do
     const mapping = makeMapping(
       "c038584d-c366-570c-ad1e-034fa0d194d7",
-      "line\n".repeat(500),
+      "line\n".repeat(500)
     );
     const out = join(tmpDir, "bundle-deflate.zip");
     await buildProguardBundle(out, [mapping], {});
@@ -97,7 +97,7 @@ describe("buildProguardBundle", () => {
     await buildProguardBundle(
       out,
       [makeMapping("aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeeee", content)],
-      { compression: "stored" },
+      { compression: "stored" }
     );
 
     const bytes = await readFile(out);
@@ -125,7 +125,7 @@ describe("buildProguardBundle", () => {
   test("STORED archive is larger than DEFLATE for redundant input", async () => {
     const mapping = makeMapping(
       "c038584d-c366-570c-ad1e-034fa0d194d7",
-      "com.example.MyClass -> a:\n".repeat(500),
+      "com.example.MyClass -> a:\n".repeat(500)
     );
 
     const deflateOut = join(tmpDir, "bundle-deflate-size.zip");

--- a/test/lib/api/proguard.test.ts
+++ b/test/lib/api/proguard.test.ts
@@ -1,142 +1,76 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import type { ProguardMapping } from "../../../src/lib/api/proguard.js";
-import { buildProguardBundle } from "../../../src/lib/api/proguard.js";
+/**
+ * Tests for ProGuard upload infrastructure.
+ *
+ * Tests the raw-byte chunking used by the DIF upload protocol.
+ * ProGuard mappings are chunked as raw bytes (no ZIP wrapping).
+ */
 
-describe("buildProguardBundle", () => {
-  // ZIP local file header format: at offset 8 (LE u16) is the
-  // compression method (0 = STORED, 8 = DEFLATE). The CLI prefixes
-  // every bundle with an 8-byte SYSB SourceBundle header.
-  const SYSB_HEADER_BYTES = 8;
-  const LOCAL_HEADER_METHOD_OFFSET = SYSB_HEADER_BYTES + 8;
+import { describe, expect, test } from "vitest";
+import { hashBuffer } from "../../../src/lib/api/chunk-upload.js";
 
-  let tmpDir: string;
+describe("hashBuffer", () => {
+  test("single chunk for small content", () => {
+    const content = Buffer.from("void\n");
+    const { chunks, overallChecksum } = hashBuffer(content, 8192);
 
-  beforeEach(async () => {
-    tmpDir = await mkdtemp(join(tmpdir(), "proguard-bundle-test-"));
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.offset).toBe(0);
+    expect(chunks[0]?.size).toBe(5);
+    expect(chunks[0]?.sha1).toMatch(/^[0-9a-f]{40}$/);
+    expect(overallChecksum).toMatch(/^[0-9a-f]{40}$/);
+    // Single chunk: chunk sha1 === overall checksum
+    expect(chunks[0]?.sha1).toBe(overallChecksum);
   });
 
-  afterEach(async () => {
-    await rm(tmpDir, { recursive: true, force: true });
+  test("splits into multiple chunks when content exceeds chunkSize", () => {
+    const content = Buffer.alloc(100, "a");
+    const { chunks, overallChecksum } = hashBuffer(content, 30);
+
+    // 100 bytes / 30 per chunk = 4 chunks (30 + 30 + 30 + 10)
+    expect(chunks).toHaveLength(4);
+    expect(chunks[0]?.offset).toBe(0);
+    expect(chunks[0]?.size).toBe(30);
+    expect(chunks[1]?.offset).toBe(30);
+    expect(chunks[1]?.size).toBe(30);
+    expect(chunks[2]?.offset).toBe(60);
+    expect(chunks[2]?.size).toBe(30);
+    expect(chunks[3]?.offset).toBe(90);
+    expect(chunks[3]?.size).toBe(10);
+    expect(overallChecksum).toMatch(/^[0-9a-f]{40}$/);
   });
 
-  function makeMapping(
-    uuid = "5db7294d-87fc-5726-a5c0-4a90679657a5",
-    content = "void\n"
-  ): ProguardMapping {
-    return {
-      path: "/fake/mapping.txt",
-      uuid,
-      content: Buffer.from(content, "utf-8"),
-    };
-  }
+  test("overall checksum is deterministic", () => {
+    const content = Buffer.from("com.example.MyClass -> a:\n");
+    const result1 = hashBuffer(content, 8192);
+    const result2 = hashBuffer(content, 8192);
 
-  test("starts with SYSB magic header", async () => {
-    const out = join(tmpDir, "bundle.zip");
-    await buildProguardBundle(out, [makeMapping()], {});
-
-    const bytes = await readFile(out);
-    // SYSB magic: 53 59 53 42
-    expect(bytes.toString("ascii", 0, 4)).toBe("SYSB");
-    // Version 2
-    expect(bytes.readUInt32LE(4)).toBe(2);
+    expect(result1.overallChecksum).toBe(result2.overallChecksum);
+    expect(result1.chunks).toHaveLength(result2.chunks.length);
   });
 
-  test("stores entry as proguard/<uuid>.txt", async () => {
-    const uuid = "5db7294d-87fc-5726-a5c0-4a90679657a5";
-    const out = join(tmpDir, "bundle.zip");
-    await buildProguardBundle(out, [makeMapping(uuid)], {
-      compression: "stored",
-    });
+  test("different content yields different checksums", () => {
+    const content1 = Buffer.from("mapping one\n");
+    const content2 = Buffer.from("mapping two\n");
+    const result1 = hashBuffer(content1, 8192);
+    const result2 = hashBuffer(content2, 8192);
 
-    const bytes = await readFile(out);
-    // The entry name should appear in the ZIP file data
-    const entryName = `proguard/${uuid}.txt`;
-    expect(bytes.includes(Buffer.from(entryName, "utf-8"))).toBe(true);
+    expect(result1.overallChecksum).not.toBe(result2.overallChecksum);
   });
 
-  test("does not include a manifest.json", async () => {
-    const out = join(tmpDir, "bundle.zip");
-    await buildProguardBundle(out, [makeMapping()], {
-      compression: "stored",
-    });
+  test("chunk SHA-1 checksums are valid hex strings", () => {
+    const content = Buffer.alloc(200, "x");
+    const { chunks } = hashBuffer(content, 50);
 
-    const bytes = await readFile(out);
-    // There should be no manifest.json entry — only proguard/ entries
-    expect(bytes.includes(Buffer.from("manifest.json", "utf-8"))).toBe(false);
+    for (const chunk of chunks) {
+      expect(chunk.sha1).toMatch(/^[0-9a-f]{40}$/);
+    }
   });
 
-  test("default compression is DEFLATE", async () => {
-    // Use redundant content so DEFLATE has work to do
-    const mapping = makeMapping(
-      "c038584d-c366-570c-ad1e-034fa0d194d7",
-      "line\n".repeat(500)
-    );
-    const out = join(tmpDir, "bundle-deflate.zip");
-    await buildProguardBundle(out, [mapping], {});
+  test("empty buffer yields no chunks", () => {
+    const content = Buffer.alloc(0);
+    const { chunks, overallChecksum } = hashBuffer(content, 8192);
 
-    const bytes = await readFile(out);
-    expect(bytes.readUInt16LE(LOCAL_HEADER_METHOD_OFFSET)).toBe(8);
-  });
-
-  test("compression: 'stored' writes entries uncompressed", async () => {
-    const out = join(tmpDir, "bundle-stored.zip");
-    await buildProguardBundle(out, [makeMapping()], {
-      compression: "stored",
-    });
-
-    const bytes = await readFile(out);
-    expect(bytes.readUInt16LE(LOCAL_HEADER_METHOD_OFFSET)).toBe(0);
-  });
-
-  test("STORED archive contains raw mapping content", async () => {
-    const content = "com.example.MyClass -> a:\n    void method() -> b\n";
-    const out = join(tmpDir, "bundle-raw.zip");
-    await buildProguardBundle(
-      out,
-      [makeMapping("aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeeee", content)],
-      { compression: "stored" }
-    );
-
-    const bytes = await readFile(out);
-    expect(bytes.includes(Buffer.from(content, "utf-8"))).toBe(true);
-  });
-
-  test("handles multiple mappings in a single ZIP", async () => {
-    const uuid1 = "11111111-1111-5111-8111-111111111111";
-    const uuid2 = "22222222-2222-5222-8222-222222222222";
-    const mappings: ProguardMapping[] = [
-      makeMapping(uuid1, "mapping one content"),
-      makeMapping(uuid2, "mapping two content"),
-    ];
-
-    const out = join(tmpDir, "bundle-multi.zip");
-    await buildProguardBundle(out, mappings, { compression: "stored" });
-
-    const bytes = await readFile(out);
-    expect(bytes.includes(Buffer.from(`proguard/${uuid1}.txt`))).toBe(true);
-    expect(bytes.includes(Buffer.from(`proguard/${uuid2}.txt`))).toBe(true);
-    expect(bytes.includes(Buffer.from("mapping one content"))).toBe(true);
-    expect(bytes.includes(Buffer.from("mapping two content"))).toBe(true);
-  });
-
-  test("STORED archive is larger than DEFLATE for redundant input", async () => {
-    const mapping = makeMapping(
-      "c038584d-c366-570c-ad1e-034fa0d194d7",
-      "com.example.MyClass -> a:\n".repeat(500)
-    );
-
-    const deflateOut = join(tmpDir, "bundle-deflate-size.zip");
-    const storedOut = join(tmpDir, "bundle-stored-size.zip");
-    await buildProguardBundle(deflateOut, [mapping], {});
-    await buildProguardBundle(storedOut, [mapping], {
-      compression: "stored",
-    });
-
-    const deflateSize = (await readFile(deflateOut)).length;
-    const storedSize = (await readFile(storedOut)).length;
-    expect(storedSize).toBeGreaterThan(deflateSize * 2);
+    expect(chunks).toHaveLength(0);
+    expect(overallChecksum).toMatch(/^[0-9a-f]{40}$/);
   });
 });


### PR DESCRIPTION
## Summary

Implements `sentry proguard upload <path>...` to upload Android ProGuard/R8 mapping files via the DIF chunk-upload protocol. Part of the parity effort tracked in #600.

Closes #1053

## Changes

- **Extract shared chunk-upload infrastructure** from `sourcemaps.ts` into new `src/lib/api/chunk-upload.ts` — schemas, types, codec selection, chunking, hashing, chunk upload, and assembly polling are now shared between sourcemap and proguard uploads
- **Add in-memory buffer chunking** (`hashBuffer`, `uploadMissingBufferChunks`) — ProGuard mappings are chunked as raw bytes (no ZIP wrapping), matching the legacy `sentry-cli` DIF protocol
- **Add proguard upload API** (`src/lib/api/proguard.ts`) — each mapping file's raw bytes are independently chunked and assembled via the DIF endpoint (`projects/{org}/{project}/files/difs/assemble/`), with all mappings in a single assemble request keyed by individual checksums
- **Add `sentry proguard upload` command** (`src/commands/proguard/upload.ts`) with flags:
  - `--uuid` — force a specific UUID instead of computing from content (single file only)
  - `--no-upload` — dry-run mode: compute and print UUIDs without uploading (no auth needed)
  - `--require-one` — error if no mapping files provided
- **Refactor `sourcemaps.ts`** to import from shared `chunk-upload.ts` with backward-compatible re-exports
- **Tests**: 7 tests for buffer chunking, 11 tests for command behavior (validation, dry-run, upload orchestration)

## Protocol Notes

The DIF upload protocol differs from artifact bundles (sourcemaps) in three ways:
1. **Raw bytes** are chunked directly — no ZIP wrapping, no SYSB source bundle header
2. **Different endpoint**: `projects/{org}/{project}/files/difs/assemble/` (per-project, not per-org)
3. **Per-checksum keyed** request/response format — each mapping file gets its own entry in the assemble body

This matches the legacy `sentry-cli` (Rust) implementation byte-for-byte.