### PR TITLE
fix(init): stop reporting cancelled wizard prompts

### DIFF
--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -467,7 +467,6 @@ async function preamble(
     confirmed = await confirmExperimental(options, ui);
   } catch (err) {
     if (err instanceof WizardCancelledError) {
-      captureException(err);
       setTag("wizard.outcome", "bailed");
       showCancelledFeedback(ui);
       process.exitCode = 0;
@@ -958,7 +957,6 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
       // active step as `in_progress` rather than flipping it to
       // failed; the post-dispose report shows the cancel message
       // instead.
-      captureException(err);
       setTag("wizard.outcome", "bailed");
       showCancelledFeedback(ui);
       process.exitCode = 0;

--- a/test/lib/init/wizard-runner.test.ts
+++ b/test/lib/init/wizard-runner.test.ts
@@ -1,4 +1,6 @@
 import { MastraClient } from "@mastra/client-js";
+// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
+import * as Sentry from "@sentry/node-core/light";
 import {
   afterEach,
   beforeEach,
@@ -435,13 +437,19 @@ describe("runWizard", () => {
     const { ui, calls, respond } = createMockUI({ welcome: true });
     respond.welcome(CANCELLED);
     useMockUI(ui, calls);
+    const captureSpy = vi.spyOn(Sentry, "captureException");
 
-    await forceStdinTty(() => runWizard(makeOptions({ yes: false })));
+    try {
+      await forceStdinTty(() => runWizard(makeOptions({ yes: false })));
 
-    expect(process.exitCode).toBe(0);
-    expect(lastCancelMessage()).toBe("Setup cancelled.");
-    expect(lastFeedbackOutcome()).toBe("cancelled");
-    expect(getWorkflowSpy).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(0);
+      expect(lastCancelMessage()).toBe("Setup cancelled.");
+      expect(lastFeedbackOutcome()).toBe("cancelled");
+      expect(getWorkflowSpy).not.toHaveBeenCalled();
+      expect(captureSpy).not.toHaveBeenCalled();
+    } finally {
+      captureSpy.mockRestore();
+    }
   });
 
   test("falls back to generic continue prompt without rich welcome", async () => {
@@ -659,6 +667,7 @@ describe("runWizard", () => {
   });
 
   test("tears down forwarding and stops the spinner on cancellation", async () => {
+    const captureSpy = vi.spyOn(Sentry, "captureException");
     const payload: ToolPayload = {
       type: "tool",
       operation: "run-commands",
@@ -674,12 +683,17 @@ describe("runWizard", () => {
     };
     executeToolSpy.mockRejectedValue(new WizardCancelledError());
 
-    await runWizard(makeOptions());
+    try {
+      await runWizard(makeOptions());
 
-    expect(process.exitCode).toBe(0);
-    expect(spinnerMock.stop).toHaveBeenCalledWith("Cancelled", 0);
-    expect(lastCancelMessage()).toBe("Setup cancelled.");
-    expect(lastFeedbackOutcome()).toBe("cancelled");
+      expect(process.exitCode).toBe(0);
+      expect(spinnerMock.stop).toHaveBeenCalledWith("Cancelled", 0);
+      expect(lastCancelMessage()).toBe("Setup cancelled.");
+      expect(lastFeedbackOutcome()).toBe("cancelled");
+      expect(captureSpy).not.toHaveBeenCalled();
+    } finally {
+      captureSpy.mockRestore();
+    }
   });
 
   test("tears down forwarding when a WizardError is rethrown from a tool", async () => {


### PR DESCRIPTION
## Summary

Stops treating intentional `sentry init` prompt cancellations as Sentry error issues. The wizard still records `wizard.outcome=bailed`, shows the cancellation feedback, and exits cleanly, but no longer calls `captureException` for `WizardCancelledError`.

Adds regression coverage for both welcome-screen cancellation and mid-step wizard cancellation so this does not come back as telemetry noise.

## Test Plan

- `pnpm exec vitest run test/lib/init/wizard-runner.test.ts --testNamePattern "cancels cleanly from rich welcome screen|tears down forwarding and stops the spinner on cancellation|aborts the MastraClient signal on cancellation"`
- `pnpm exec biome check src/lib/init/wizard-runner.ts test/lib/init/wizard-runner.test.ts`

Sentry issue: CLI-1P9