### PR TITLE
fix(init): handle setup service auth failures

### DIFF
--- a/src/lib/api/infrastructure.ts
+++ b/src/lib/api/infrastructure.ts
@@ -101,7 +101,7 @@ function enrich403Detail(rawDetail: string | undefined): string {
  *
  * @see https://github.com/getsentry/sentry/blob/934f1473f198a62f9268d7140b80cd9ca1e59bb9/src/sentry/api/authentication.py#L536-L539
  */
-function enrich401Detail(rawDetail: string | undefined): string {
+export function enrich401Detail(rawDetail: string | undefined): string {
   const lines: string[] = [];
   if (rawDetail) {
     lines.push(rawDetail, "");

--- a/src/lib/init/constants.ts
+++ b/src/lib/init/constants.ts
@@ -1,6 +1,8 @@
-export const MASTRA_API_URL =
-  process.env.MASTRA_API_URL ??
+export const DEFAULT_MASTRA_API_URL =
   "https://sentry-init-agent.getsentry.workers.dev";
+
+export const MASTRA_API_URL =
+  process.env.MASTRA_API_URL ?? DEFAULT_MASTRA_API_URL;
 
 export const WORKFLOW_ID = "sentry-wizard";
 

--- a/src/lib/init/init-service-auth.ts
+++ b/src/lib/init/init-service-auth.ts
@@ -1,0 +1,58 @@
+import { enrich401Detail } from "../api/infrastructure.js";
+import { ApiError, HostScopeError } from "../errors.js";
+import { isSaaSTrustOrigin, normalizeOrigin } from "../sentry-urls.js";
+import { getActiveTokenHost } from "../token-host.js";
+import {
+  DEFAULT_MASTRA_API_URL,
+  MASTRA_API_URL,
+  WORKFLOW_ID,
+} from "./constants.js";
+
+const INIT_SERVICE_REJECTED_TOKEN_MESSAGE =
+  "Sentry Init setup service rejected your authentication token.";
+const WORKFLOW_ENDPOINT = `/api/workflows/${WORKFLOW_ID}`;
+export const WORKFLOW_CREATE_RUN_ENDPOINT = `${WORKFLOW_ENDPOINT}/create-run`;
+export const WORKFLOW_RESUME_ASYNC_ENDPOINT = `${WORKFLOW_ENDPOINT}/resume-async`;
+export const WORKFLOW_START_ASYNC_ENDPOINT = `${WORKFLOW_ENDPOINT}/start-async`;
+const MASTRA_HTTP_401_RE = /HTTP error!\s*status:\s*401\b/i;
+
+function classifyInitServiceAuthFailure(
+  err: unknown,
+  endpoint: string
+): ApiError | null {
+  if (!(err instanceof Error && MASTRA_HTTP_401_RE.test(err.message))) {
+    return null;
+  }
+
+  return new ApiError(
+    INIT_SERVICE_REJECTED_TOKEN_MESSAGE,
+    401,
+    enrich401Detail("Unauthorized: invalid token"),
+    endpoint
+  );
+}
+
+export async function withInitServiceAuthClassification<T>(
+  operation: () => Promise<T>,
+  endpoint: string
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (err) {
+    throw classifyInitServiceAuthFailure(err, endpoint) ?? err;
+  }
+}
+
+export function assertHostedInitServiceAcceptsTokenHost(): void {
+  const tokenHost = getActiveTokenHost();
+  const usesHostedInitService =
+    normalizeOrigin(MASTRA_API_URL) === normalizeOrigin(DEFAULT_MASTRA_API_URL);
+
+  if (tokenHost && usesHostedInitService && !isSaaSTrustOrigin(tokenHost)) {
+    throw new HostScopeError(
+      "Hosted Sentry Init setup service",
+      "https://sentry.io",
+      tokenHost
+    );
+  }
+}

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -25,7 +25,7 @@ import { formatBanner } from "../banner.js";
 import { CLI_VERSION } from "../constants.js";
 import { customFetch } from "../custom-ca.js";
 import { detectAgent } from "../detect-agent.js";
-import { EXIT, WizardError } from "../errors.js";
+import { ApiError, EXIT, WizardError } from "../errors.js";
 import {
   renderInlineMarkdown,
   stripColorTags,
@@ -48,6 +48,13 @@ import {
 } from "./constants.js";
 import { formatError, formatResult } from "./formatters.js";
 import { checkGitStatus } from "./git.js";
+import {
+  assertHostedInitServiceAcceptsTokenHost,
+  WORKFLOW_CREATE_RUN_ENDPOINT,
+  WORKFLOW_RESUME_ASYNC_ENDPOINT,
+  WORKFLOW_START_ASYNC_ENDPOINT,
+  withInitServiceAuthClassification,
+} from "./init-service-auth.js";
 import { handleInteractive } from "./interactive.js";
 import { resolveInitContext } from "./preflight.js";
 import { checkReadiness } from "./readiness.js";
@@ -72,6 +79,8 @@ import {
 } from "./workflow-inputs.js";
 
 type SpinState = { running: boolean };
+
+const INIT_SERVICE_AUTH_FAILED_LABEL = "Authentication failed";
 
 const APPLY_CODEMODS_STEP = "apply-codemods";
 
@@ -654,7 +663,10 @@ async function resumeWithRecovery(
   } = args;
   try {
     const raw = await withTimeout(
-      run.resumeAsync({ step: stepId, resumeData, tracingOptions }),
+      withInitServiceAuthClassification(
+        () => run.resumeAsync({ step: stepId, resumeData, tracingOptions }),
+        WORKFLOW_RESUME_ASYNC_ENDPOINT
+      ),
       API_TIMEOUT_MS,
       "Workflow resume"
     );
@@ -777,6 +789,7 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     },
   };
 
+  assertHostedInitServiceAcceptsTokenHost();
   const token = context.authToken;
 
   // AbortController bound to the MastraClient lifecycle. Aborting on
@@ -833,7 +846,10 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     const fileCache = await preReadCommonFiles(directory, dirListing);
     ui.setIntroMode?.(false);
     spin.message("Connecting to wizard...");
-    run = await workflow.createRun();
+    run = await withInitServiceAuthClassification(
+      () => workflow.createRun(),
+      WORKFLOW_CREATE_RUN_ENDPOINT
+    );
     // Large shared context (dirListing, fileCache, existingSentry)
     // travels via Mastra's workflow `initialState` instead of `inputData`.
     // Keeping it on state means the server stores it exactly once per run
@@ -843,26 +859,36 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     // error. See getsentry/cli-init-api#98.
     result = assertWorkflowResult(
       await withTimeout(
-        run.startAsync({
-          inputData: {
-            directory,
-            yes,
-            dryRun,
-            features,
-          },
-          initialState: {
-            dirListing,
-            fileCache,
-            existingSentry: existingSentry?.data,
-            knownPlatform: context.existingProject?.platform,
-          },
-          tracingOptions,
-        }),
+        withInitServiceAuthClassification(
+          () =>
+            run.startAsync({
+              inputData: {
+                directory,
+                yes,
+                dryRun,
+                features,
+              },
+              initialState: {
+                dirListing,
+                fileCache,
+                existingSentry: existingSentry?.data,
+                knownPlatform: context.existingProject?.platform,
+              },
+              tracingOptions,
+            }),
+          WORKFLOW_START_ASYNC_ENDPOINT
+        ),
         API_TIMEOUT_MS,
         "Workflow start"
       )
     );
   } catch (err) {
+    if (err instanceof ApiError && err.status === 401) {
+      spin.stop(INIT_SERVICE_AUTH_FAILED_LABEL, 1);
+      spinState.running = false;
+      showFailedFeedback(ui, INIT_SERVICE_AUTH_FAILED_LABEL);
+      throw err;
+    }
     spin.stop("Connection failed", 1);
     spinState.running = false;
     ui.log.error(errorMessage(err));
@@ -942,13 +968,18 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
       });
     }
   } catch (err) {
+    const isAuthFailure = err instanceof ApiError && err.status === 401;
     // A running spinner owns a live interval, so stop it before any early
     // return or rethrow to avoid leaving the event loop artificially busy.
     if (spinState.running) {
-      const [label, code] =
-        err instanceof WizardCancelledError
-          ? (["Cancelled", 0] as const)
-          : (["Error", 1] as const);
+      let label = "Error";
+      let code: 0 | 1 = 1;
+      if (err instanceof WizardCancelledError) {
+        label = "Cancelled";
+        code = 0;
+      } else if (isAuthFailure) {
+        label = INIT_SERVICE_AUTH_FAILED_LABEL;
+      }
       spin.stop(label, code);
       spinState.running = false;
     }
@@ -964,6 +995,11 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     }
     if (activeStepId) {
       ui.setStep?.(activeStepId, "failed");
+    }
+    if (isAuthFailure) {
+      showFailedFeedback(ui, INIT_SERVICE_AUTH_FAILED_LABEL);
+      setTag("wizard.outcome", "errored");
+      throw err;
     }
     if (err instanceof WizardError) {
       showFailedFeedback(ui);

--- a/test/lib/init/wizard-runner.test.ts
+++ b/test/lib/init/wizard-runner.test.ts
@@ -12,9 +12,16 @@ import {
 } from "vitest";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as banner from "../../../src/lib/banner.js";
+import { clearAuth, setAuthToken } from "../../../src/lib/db/auth.js";
 import { ENV_VAR_AGENTS } from "../../../src/lib/detect-agent.js";
 import { setEnv } from "../../../src/lib/env.js";
-import { EXIT, WizardError } from "../../../src/lib/errors.js";
+import { classifySilenced } from "../../../src/lib/error-reporting.js";
+import {
+  ApiError,
+  EXIT,
+  HostScopeError,
+  WizardError,
+} from "../../../src/lib/errors.js";
 import { WizardCancelledError } from "../../../src/lib/init/clack-utils.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as fmt from "../../../src/lib/init/formatters.js";
@@ -311,6 +318,51 @@ function lastWarn(): string | undefined {
     }
   }
   return;
+}
+
+function lastError(): string | undefined {
+  for (let i = mockUICalls.length - 1; i >= 0; i--) {
+    const call = mockUICalls[i];
+    if (call?.kind === "log.error") {
+      return call.message;
+    }
+  }
+  return;
+}
+
+function initService401Error(): Error {
+  return new Error(
+    'HTTP error! status: 401 - {"error":"Unauthorized: invalid token"}'
+  );
+}
+
+async function useSaaSOAuthAuth(authToken = "oauth-token"): Promise<void> {
+  await clearAuth();
+  const env = { ...process.env };
+  delete env.SENTRY_AUTH_TOKEN;
+  delete env.SENTRY_TOKEN;
+  delete env.SENTRY_FORCE_ENV_TOKEN;
+  setEnv(env);
+  setAuthToken(authToken, 3600, "refresh-token", {
+    host: "https://sentry.io",
+  });
+  resolveInitContextSpy.mockResolvedValue(makeContext({ authToken }));
+}
+
+function initServiceApiErrorShape(endpoint: string) {
+  return {
+    name: "ApiError",
+    status: 401,
+    endpoint,
+  };
+}
+
+function hasExpectedInitServiceAuthPolicy(err: unknown): boolean {
+  return (
+    err instanceof ApiError &&
+    err.status === 401 &&
+    classifySilenced(err) === "api_user_error"
+  );
 }
 
 describe("runWizard", () => {
@@ -1172,6 +1224,39 @@ describe("runWizard — resumeWithRetry stale-step recovery", () => {
     expect(runByIdMock).not.toHaveBeenCalled();
   });
 
+  test("classifies resumeAsync 401 instead of recovering as a transport failure", async () => {
+    await useSaaSOAuthAuth();
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["tool-step"]],
+      steps: { "tool-step": { suspendPayload: toolPayload } },
+    };
+
+    let resumeCount = 0;
+    makeStaleStepRun(() => {
+      resumeCount += 1;
+      return Promise.reject(initService401Error());
+    });
+
+    try {
+      const err = await runWizard(makeOptions()).catch((error) => error);
+
+      expect(err).toMatchObject(
+        initServiceApiErrorShape("/api/workflows/sentry-wizard/resume-async")
+      );
+      expect(hasExpectedInitServiceAuthPolicy(err)).toBe(true);
+      expect(err).not.toBeInstanceOf(WizardError);
+      expect(resumeCount).toBe(1);
+      expect(runByIdMock).not.toHaveBeenCalled();
+      expect(spinnerMock.stop).toHaveBeenCalledWith("Authentication failed", 1);
+      expect(err.format()).toContain("sentry auth login");
+      expect(lastError()).toBeUndefined();
+      expect(lastCancelMessage()).toBe("Authentication failed");
+    } finally {
+      await clearAuth();
+    }
+  });
+
   test("observes run state after a resume timeout without replaying resumeAsync", async () => {
     vi.useFakeTimers();
     mockStartResult = {
@@ -1294,6 +1379,120 @@ describe("runWizard — additional coverage", () => {
 
     expect(spinnerMock.stop).toHaveBeenCalledWith("Connection failed", 1);
     expect(lastCancelMessage()).toBe("Setup failed");
+  });
+
+  test("classifies init service 401 as expected OAuth auth state", async () => {
+    await useSaaSOAuthAuth();
+    startAsyncMock.mockRejectedValue(initService401Error());
+    const captureSpy = vi.spyOn(Sentry, "captureException");
+
+    try {
+      const err = await runWizard(makeOptions()).catch((error) => error);
+
+      expect(err).toMatchObject(
+        initServiceApiErrorShape("/api/workflows/sentry-wizard/start-async")
+      );
+      expect(hasExpectedInitServiceAuthPolicy(err)).toBe(true);
+      expect(err.format()).toContain("sentry auth login");
+      expect(spinnerMock.stop).toHaveBeenCalledWith("Authentication failed", 1);
+      expect(lastError()).toBeUndefined();
+      expect(lastCancelMessage()).toBe("Authentication failed");
+      expect(captureSpy).not.toHaveBeenCalled();
+    } finally {
+      captureSpy.mockRestore();
+      await clearAuth();
+    }
+  });
+
+  test("classifies createRun 401 before starting the workflow", async () => {
+    await useSaaSOAuthAuth();
+    const createRunMock = vi.fn(() => Promise.reject(initService401Error()));
+    getWorkflowSpy.mockImplementation(function (this: MastraClient) {
+      capturedClientOptions.push(
+        (
+          this as unknown as {
+            options: { abortSignal?: AbortSignal; retries?: number };
+          }
+        ).options
+      );
+      return {
+        createRun: createRunMock,
+        runById: runByIdMock,
+      } as any;
+    });
+
+    try {
+      const err = await runWizard(makeOptions()).catch((error) => error);
+
+      expect(err).toMatchObject(
+        initServiceApiErrorShape("/api/workflows/sentry-wizard/create-run")
+      );
+      expect(hasExpectedInitServiceAuthPolicy(err)).toBe(true);
+      expect(createRunMock).toHaveBeenCalledTimes(1);
+      expect(startAsyncMock).not.toHaveBeenCalled();
+      expect(err.format()).toContain("sentry auth login");
+      expect(spinnerMock.stop).toHaveBeenCalledWith("Authentication failed", 1);
+      expect(lastError()).toBeUndefined();
+      expect(lastCancelMessage()).toBe("Authentication failed");
+    } finally {
+      await clearAuth();
+    }
+  });
+
+  test("classifies init service 401 with env-token guidance", async () => {
+    await clearAuth();
+    const env = {
+      ...process.env,
+      SENTRY_AUTH_TOKEN: "env-token",
+      SENTRY_FORCE_ENV_TOKEN: "1",
+    };
+    delete env.SENTRY_TOKEN;
+    setEnv(env);
+    resolveInitContextSpy.mockResolvedValue(
+      makeContext({ authToken: "env-token" })
+    );
+    startAsyncMock.mockRejectedValue(initService401Error());
+
+    try {
+      const err = await runWizard(makeOptions()).catch((error) => error);
+
+      expect(err).toMatchObject(
+        initServiceApiErrorShape("/api/workflows/sentry-wizard/start-async")
+      );
+      expect(hasExpectedInitServiceAuthPolicy(err)).toBe(true);
+      expect(err.format()).toContain("SENTRY_AUTH_TOKEN");
+      expect(err.format()).toContain("not recognized or has been revoked");
+      expect(err.format()).toContain("auth-tokens");
+      expect(lastError()).toBeUndefined();
+    } finally {
+      setEnv(process.env);
+      await clearAuth();
+    }
+  });
+
+  test("blocks self-hosted tokens before constructing hosted init workflow", async () => {
+    await clearAuth();
+    setAuthToken("self-hosted-token", 3600, "refresh-token", {
+      host: "https://sentry.internal.example.com",
+    });
+    resolveInitContextSpy.mockResolvedValue(
+      makeContext({ authToken: "self-hosted-token" })
+    );
+
+    try {
+      const err = await runWizard(makeOptions()).catch((error) => error);
+
+      expect(err).toBeInstanceOf(HostScopeError);
+      expect(getWorkflowSpy).not.toHaveBeenCalled();
+      expect(startAsyncMock).not.toHaveBeenCalled();
+      expect(capturedClientOptions).toHaveLength(0);
+      expect(err.format()).toContain("sentry.internal.example.com");
+      expect(err.format()).toContain(
+        "sentry auth login --url https://sentry.io"
+      );
+    } finally {
+      await clearAuth();
+    }
   });
 
   test("throws when the workflow response has an unrecognised status", async () => {


### PR DESCRIPTION
## Summary

Treat hosted init setup-service 401 responses as expected auth/API state instead of generic wizard failures. The Mastra SDK wrapper is adapted into the same `ApiError(401)` path other commands use, so users get existing OAuth/env-token guidance and telemetry silencing stays consistent.

The hosted init path also refuses self-hosted credentials before constructing the Mastra client, avoiding forwarding tokens the hosted service cannot validate. The same auth classification now covers create, start, and resume workflow calls.

Related: CLI-17A

## Test Plan

- `pnpm exec biome check src/lib/api/infrastructure.ts src/lib/init/constants.ts src/lib/init/init-service-auth.ts src/lib/init/wizard-runner.ts test/lib/init/wizard-runner.test.ts`
- `pnpm exec vitest run test/lib/init/wizard-runner.test.ts test/lib/error-reporting.test.ts` — 128 passed
- `pnpm exec tsc --noEmit --pretty false`
