### PR TITLE
fix(init): mirror onboarding project creation

### DIFF
--- a/src/lib/init/preflight.ts
+++ b/src/lib/init/preflight.ts
@@ -1,12 +1,17 @@
 import type { SentryTeam } from "../../types/index.js";
-import { listOrganizations } from "../api-client.js";
+import {
+  getOrganization,
+  listOrganizations,
+  listTeams,
+} from "../api-client.js";
 import { getAuthToken } from "../db/auth.js";
 import { ApiError, WizardError } from "../errors.js";
-import { resolveOrCreateTeam } from "../resolve-team.js";
+import { buildOrgNotFoundError, resolveOrCreateTeam } from "../resolve-team.js";
 import { slugify } from "../utils.js";
 import { WizardCancelledError } from "./clack-utils.js";
 import { tryGetExistingProjectData } from "./existing-project.js";
 import { resolveOrgPrefetched } from "./org-prefetch.js";
+import { formatMemberProjectCreationDisabledError } from "./project-creation-errors.js";
 import type {
   ExistingProjectData,
   ResolvedInitContext,
@@ -310,37 +315,22 @@ async function resolveTeam(
   initial: WizardOptions,
   ui: WizardUI
 ): Promise<string | undefined> {
+  if (!initial.team) {
+    return await resolveImplicitTeam(org, initial, ui);
+  }
+
   try {
     const result = await resolveOrCreateTeam(org, {
       team: initial.team,
       usageHint: "sentry init",
       dryRun: initial.dryRun,
       deferAutoCreateOnEmptyOrg: true,
-      onAmbiguous: initial.yes
-        ? (candidates) => Promise.resolve((candidates[0] as SentryTeam).slug)
-        : async (candidates) => {
-            const selected = await ui.select<string>({
-              message: "Which team should own this project?",
-              options: candidates.map((team) => ({
-                value: team.slug,
-                label: team.slug,
-                ...(team.name !== team.slug ? { hint: team.name } : {}),
-              })),
-            });
-            if (isCancelled(selected)) {
-              throw new WizardCancelledError();
-            }
-            return selected;
-          },
     });
     return result.source === "deferred" ? undefined : result.slug;
   } catch (error) {
     if (error instanceof WizardCancelledError) {
       throw error;
     }
-    // 403 from listTeams: member lacks team:read. Return undefined (same as the
-    // "deferred" path) so the wizard continues to the project creation tool,
-    // where resolveProjectCreation has the createProjectWithAutoTeam fallback.
     if (error instanceof ApiError && error.status === 403) {
       return;
     }
@@ -348,6 +338,86 @@ async function resolveTeam(
       ? error
       : new WizardError(error instanceof Error ? error.message : String(error));
   }
+}
+
+function canCreateProjectInTeam(team: SentryTeam): boolean {
+  return Array.isArray(team.access) && team.access.includes("team:admin");
+}
+
+function hasOrgWriteAccess(access: unknown): boolean {
+  return Array.isArray(access) && access.includes("org:write");
+}
+
+async function assertOrgScopedCreationCanProceed(org: string): Promise<void> {
+  let organization: Awaited<ReturnType<typeof getOrganization>>;
+  try {
+    organization = await getOrganization(org);
+  } catch {
+    // If org details cannot be fetched, let the actual create endpoint surface
+    // the precise API error during the project-creation step.
+    return;
+  }
+
+  if (
+    organization.allowMemberProjectCreation === false &&
+    !hasOrgWriteAccess(organization.access)
+  ) {
+    throw new WizardError(formatMemberProjectCreationDisabledError(org));
+  }
+}
+
+async function listTeamsForImplicitInit(
+  org: string
+): Promise<SentryTeam[] | undefined> {
+  try {
+    return await listTeams(org);
+  } catch (error) {
+    // 403 from listTeams means the user cannot inspect team access. Continue
+    // without a team so init mirrors onboarding's org-scoped auto-team path.
+    if (error instanceof ApiError && error.status === 403) {
+      await assertOrgScopedCreationCanProceed(org);
+      return;
+    }
+    if (error instanceof ApiError && error.status === 404) {
+      return await buildOrgNotFoundError(org, "sentry init");
+    }
+    throw error instanceof WizardError
+      ? error
+      : new WizardError(error instanceof Error ? error.message : String(error));
+  }
+}
+
+async function resolveImplicitTeam(
+  org: string,
+  initial: WizardOptions,
+  ui: WizardUI
+): Promise<string | undefined> {
+  const teams = await listTeamsForImplicitInit(org);
+  if (!teams) {
+    return;
+  }
+
+  const candidateTeams = teams.filter(canCreateProjectInTeam);
+  if (candidateTeams.length === 0) {
+    await assertOrgScopedCreationCanProceed(org);
+    return;
+  }
+  if (candidateTeams.length === 1 || initial.yes) {
+    return (candidateTeams[0] as SentryTeam).slug;
+  }
+
+  const selected = await ui.select<string>({
+    message: "Which team should own this project?",
+    options: candidateTeams.map((team) => ({
+      value: team.slug,
+      label: team.slug,
+      ...(team.name !== team.slug ? { hint: team.name } : {}),
+    })),
+  });
+  if (isCancelled(selected)) {
+    throw new WizardCancelledError();
+  }
+  return selected;
 }
 
 /**

--- a/src/lib/init/project-creation-errors.ts
+++ b/src/lib/init/project-creation-errors.ts
@@ -1,0 +1,8 @@
+export function formatMemberProjectCreationDisabledError(org: string): string {
+  return (
+    `Project creation is disabled for members in "${org}".\n` +
+    "Ask an org owner to either enable project creation for members\n" +
+    "or create the project for you. Once the project exists, run:\n" +
+    `  sentry init ${org}/<project-slug>`
+  );
+}

--- a/src/lib/init/tools/create-sentry-project.ts
+++ b/src/lib/init/tools/create-sentry-project.ts
@@ -2,9 +2,9 @@
  * Sentry project creation tool for the init wizard.
  *
  * Implements the `create-sentry-project` and `ensure-sentry-project` wizard
- * operations. Uses the team-scoped endpoint when the caller has team access,
- * falling back to POST /organizations/{org}/projects/ for org members who
- * lack team:write.
+ * operations. Uses the team-scoped endpoint for explicit or Team Admin teams;
+ * otherwise uses POST /organizations/{org}/projects/, the onboarding endpoint
+ * that auto-creates a personal team for eligible members.
  */
 
 import { captureException } from "@sentry/node-core/light";
@@ -17,6 +17,7 @@ import { ApiError } from "../../errors.js";
 import { resolveOrCreateTeam } from "../../resolve-team.js";
 import { slugify } from "../../utils.js";
 import { tryGetExistingProjectData } from "../existing-project.js";
+import { formatMemberProjectCreationDisabledError } from "../project-creation-errors.js";
 import type {
   CreateSentryProjectPayload,
   EnsureSentryProjectPayload,
@@ -32,20 +33,36 @@ type ProjectData = {
   url: string;
 };
 
+type ProjectCreationResponse = {
+  project: {
+    id: string;
+    slug: string;
+  };
+  dsn?: string | null;
+  url: string;
+};
+
+function toProjectData(response: ProjectCreationResponse): ProjectData {
+  return {
+    projectSlug: response.project.slug,
+    projectId: response.project.id,
+    dsn: response.dsn ?? "",
+    url: response.url,
+  };
+}
+
 /**
- * Resolve project creation using the team-based flow, falling back to the
- * org-scoped endpoint on 403 (member lacks team creation permission).
+ * Resolve project creation using the frontend onboarding policy.
  *
  * @param opts.org - Organization slug
  * @param opts.name - Project display name
  * @param opts.platform - Platform identifier (null/undefined → omitted from request)
  * @param opts.team - Pre-resolved team slug (explicit or auto-selected by preflight).
- *   When undefined the team is resolved fresh via resolveOrCreateTeam.
+ *   When undefined, use the org-scoped onboarding endpoint directly.
  * @param opts.suppressFallback - When true, a 403 from the team-scoped flow is
  *   surfaced directly rather than triggering the org-scoped fallback. Set only
  *   when the team was explicitly named via `--team` — a 403 there is meaningful
  *   user feedback, not a permission gap.
- * @param opts.slugHint - Slug used for auto-creating a team when org has none
  * @returns Resolved project identifiers and DSN
  */
 async function resolveProjectCreation(opts: {
@@ -54,9 +71,8 @@ async function resolveProjectCreation(opts: {
   platform: string | null | undefined;
   team: string | undefined;
   suppressFallback: boolean;
-  slugHint: string;
 }): Promise<ProjectData> {
-  const { org, name, team, suppressFallback, slugHint } = opts;
+  const { org, name, team, suppressFallback } = opts;
   // Coerce null → undefined: CreateProjectBody.platform is string | undefined.
   const platform = opts.platform ?? undefined;
 
@@ -90,26 +106,23 @@ async function resolveProjectCreation(opts: {
     }
   };
 
-  try {
-    const teamSlug = team
-      ? team
-      : (
-          await resolveOrCreateTeam(org, {
-            autoCreateSlug: slugHint,
-            usageHint: "sentry init",
-          })
-        ).slug;
+  if (!team) {
     return await withPlatformFallback(async (p) => {
-      const result = await createProjectWithDsn(org, teamSlug, {
+      const result = await createProjectWithAutoTeam(org, {
         name,
         platform: p,
       });
-      return {
-        projectSlug: result.project.slug,
-        projectId: result.project.id,
-        dsn: result.dsn ?? "",
-        url: result.url,
-      };
+      return toProjectData(result);
+    });
+  }
+
+  try {
+    return await withPlatformFallback(async (p) => {
+      const result = await createProjectWithDsn(org, team, {
+        name,
+        platform: p,
+      });
+      return toProjectData(result);
     });
   } catch (innerError) {
     // Fall back to org-scoped endpoint on 403, unless the fallback is suppressed
@@ -134,22 +147,16 @@ async function resolveProjectCreation(opts: {
         name,
         platform: p,
       });
-      return {
-        projectSlug: result.project.slug,
-        projectId: result.project.id,
-        url: result.url,
-        dsn: result.dsn ?? "",
-      };
+      return toProjectData(result);
     });
   }
 }
 
 /**
- * Validate team access for a dry-run, mirroring preflight.ts:resolveTeam.
+ * Validate explicit team access for a dry-run, mirroring preflight.ts:resolveTeam.
  *
- * Calls resolveOrCreateTeam with dryRun=true and deferAutoCreateOnEmptyOrg=true
- * so no real teams are created. A 403 is swallowed — the real run falls back
- * to the org-scoped endpoint.
+ * When `team` is undefined, preflight intentionally chose the org-scoped
+ * onboarding endpoint, so there is no local team path to validate.
  *
  * @throws Non-403 errors from resolveOrCreateTeam (org not found, network, etc.)
  */
@@ -158,6 +165,10 @@ async function validateTeamForDryRun(
   team: string | undefined,
   autoCreateSlug: string
 ): Promise<void> {
+  if (!team) {
+    return;
+  }
+
   try {
     await resolveOrCreateTeam(org, {
       team,
@@ -175,8 +186,8 @@ async function validateTeamForDryRun(
 
 /**
  * Create a new Sentry project using the org that preflight already resolved.
- * Team creation is deferred here for empty-org init flows so the final project
- * slug can be reused as the team slug.
+ * When preflight does not resolve a Team Admin team, creation uses the same
+ * org-scoped auto-team endpoint as Sentry onboarding.
  *
  * New Sentry orgs have member project creation disabled by default
  * (Organization.flags.disable_member_project_creation = true). When the org
@@ -235,16 +246,15 @@ export async function createSentryProject(
       };
     }
 
-    // Try the normal team-based flow. If the user is an org member who can't
-    // create or see teams (403), fall back to POST /organizations/{org}/projects/
-    // which requires only project:read scope and auto-creates a personal team.
+    // Use the Team Admin path when preflight found one; otherwise use the
+    // org-scoped onboarding path, which auto-creates a personal team for
+    // eligible members.
     const projectData = await resolveProjectCreation({
       org: context.org,
       name,
       platform: payload.params.platform,
       team: context.team,
       suppressFallback: Boolean(context.isExplicitTeam),
-      slugHint: slug,
     });
 
     return {
@@ -267,11 +277,7 @@ export async function createSentryProject(
     ) {
       return {
         ok: false,
-        error:
-          `Project creation is disabled for members in "${context.org}".\n` +
-          "Ask an org owner to either enable project creation for members\n" +
-          "or create the project for you. Once the project exists, run:\n" +
-          `  sentry init ${context.org}/<project-slug>`,
+        error: formatMemberProjectCreationDisabledError(context.org),
       };
     }
     // 409: project already exists (from either the team-scoped or org-scoped

--- a/test/lib/init/preflight.test.ts
+++ b/test/lib/init/preflight.test.ts
@@ -115,6 +115,8 @@ function feedbackOutcomes(calls: MockCall[]): string[] {
 
 let resolveOrgPrefetchedSpy: ReturnType<typeof spyOn>;
 let listOrganizationsSpy: ReturnType<typeof spyOn>;
+let listTeamsSpy: ReturnType<typeof spyOn>;
+let getOrganizationSpy: ReturnType<typeof spyOn>;
 let getProjectSpy: ReturnType<typeof spyOn>;
 let tryGetPrimaryDsnSpy: ReturnType<typeof spyOn>;
 let getAuthTokenSpy: ReturnType<typeof spyOn>;
@@ -129,6 +131,24 @@ beforeEach(() => {
   listOrganizationsSpy = vi
     .spyOn(apiClient, "listOrganizations")
     .mockResolvedValue([{ id: "1", slug: "acme", name: "Acme" }]);
+  listTeamsSpy = vi.spyOn(apiClient, "listTeams").mockResolvedValue([
+    {
+      id: "1",
+      slug: "platform",
+      name: "Platform",
+      access: ["team:admin"],
+      isMember: true,
+    } as any,
+  ]);
+  getOrganizationSpy = vi
+    .spyOn(apiClient, "getOrganization")
+    .mockResolvedValue({
+      id: "1",
+      slug: "acme",
+      name: "Acme",
+      access: ["project:read"],
+      allowMemberProjectCreation: true,
+    } as any);
   getProjectSpy = vi.spyOn(apiClient, "getProject").mockResolvedValue({
     id: "42",
     slug: "my-app",
@@ -157,6 +177,8 @@ beforeEach(() => {
 afterEach(() => {
   resolveOrgPrefetchedSpy.mockRestore();
   listOrganizationsSpy.mockRestore();
+  listTeamsSpy.mockRestore();
+  getOrganizationSpy.mockRestore();
   getProjectSpy.mockRestore();
   tryGetPrimaryDsnSpy.mockRestore();
   getAuthTokenSpy.mockRestore();
@@ -302,20 +324,23 @@ describe("resolveInitContext", () => {
     expect(context?.existingProject).toBeUndefined();
   });
 
-  test("defers empty-org team creation until project creation", async () => {
-    resolveOrCreateTeamSpy.mockResolvedValue({ source: "deferred" } as any);
+  test("uses org-scoped creation when no Team Admin team is available", async () => {
+    listTeamsSpy.mockResolvedValueOnce([
+      {
+        id: "1",
+        slug: "frontend",
+        name: "Frontend",
+        access: ["team:read"],
+        isMember: true,
+      } as any,
+    ]);
 
     const { ui } = createMockUI();
     const context = await resolveInitContext(makeOptions(), ui);
 
     expect(context?.team).toBeUndefined();
-    expect(resolveOrCreateTeamSpy).toHaveBeenCalledWith(
-      "acme",
-      expect.objectContaining({
-        team: undefined,
-        deferAutoCreateOnEmptyOrg: true,
-      })
-    );
+    expect(getOrganizationSpy).toHaveBeenCalledWith("acme");
+    expect(resolveOrCreateTeamSpy).not.toHaveBeenCalled();
   });
 
   test("clears the project when the user chooses to create new", async () => {
@@ -353,18 +378,76 @@ describe("resolveInitContext", () => {
     );
   });
 
-  test("uses the ambiguity callback when team selection requires it", async () => {
+  test("selects a Team Admin team over non-admin member teams", async () => {
+    listTeamsSpy.mockResolvedValueOnce([
+      {
+        id: "1",
+        slug: "frontend",
+        name: "Frontend",
+        access: ["team:read"],
+        isMember: true,
+      } as any,
+      {
+        id: "2",
+        slug: "platform",
+        name: "Platform",
+        access: ["team:admin"],
+        isMember: true,
+      } as any,
+    ]);
+
+    const { ui } = createMockUI();
+    const context = await resolveInitContext(makeOptions(), ui);
+
+    expect(context?.team).toBe("platform");
+    expect(resolveOrCreateTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("prompts when multiple Team Admin teams are available", async () => {
     const { ui, respond } = createMockUI();
     respond.select("mobile");
-    resolveOrCreateTeamSpy.mockImplementation(async (_org, options) => {
-      const slug = await options.onAmbiguous?.([
-        { slug: "mobile", name: "Mobile", isMember: true },
-        { slug: "platform", name: "Platform", isMember: true },
-      ] as any);
-      return { slug, source: "auto-selected" };
-    });
+    listTeamsSpy.mockResolvedValueOnce([
+      {
+        id: "1",
+        slug: "mobile",
+        name: "Mobile",
+        access: ["team:admin"],
+        isMember: true,
+      } as any,
+      {
+        id: "2",
+        slug: "platform",
+        name: "Platform",
+        access: ["team:admin"],
+        isMember: true,
+      } as any,
+    ]);
 
     const context = await resolveInitContext(makeOptions({ yes: false }), ui);
+
+    expect(context?.team).toBe("mobile");
+  });
+
+  test("selects the first Team Admin team in --yes mode", async () => {
+    listTeamsSpy.mockResolvedValueOnce([
+      {
+        id: "1",
+        slug: "mobile",
+        name: "Mobile",
+        access: ["team:admin"],
+        isMember: true,
+      } as any,
+      {
+        id: "2",
+        slug: "platform",
+        name: "Platform",
+        access: ["team:admin"],
+        isMember: true,
+      } as any,
+    ]);
+
+    const { ui } = createMockUI();
+    const context = await resolveInitContext(makeOptions({ yes: true }), ui);
 
     expect(context?.team).toBe("mobile");
   });
@@ -462,7 +545,7 @@ describe("resolveInitContext", () => {
   });
 
   test("swallows 403 from listTeams and resolves context with team:undefined", async () => {
-    resolveOrCreateTeamSpy.mockRejectedValueOnce(
+    listTeamsSpy.mockRejectedValueOnce(
       new ApiError("Forbidden", 403, "No team:read access")
     );
 
@@ -471,6 +554,88 @@ describe("resolveInitContext", () => {
 
     // 403 is swallowed so the wizard can proceed to the org-scoped fallback
     expect(context).not.toBeNull();
+    expect(context?.team).toBeUndefined();
+    expect(getOrganizationSpy).toHaveBeenCalledWith("acme");
+    expect(resolveOrCreateTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("preserves rich org-not-found guidance when implicit team lookup returns 404", async () => {
+    resolveOrgPrefetchedSpy.mockResolvedValueOnce({ org: "missing-org" });
+    listOrganizationsSpy.mockResolvedValueOnce([
+      { id: "1", slug: "acme", name: "Acme" },
+      { id: "2", slug: "beta", name: "Beta" },
+    ]);
+    listTeamsSpy.mockRejectedValueOnce(
+      new ApiError("Not found", 404, "Organization not found")
+    );
+
+    const { ui, calls } = createMockUI();
+    await expect(resolveInitContext(makeOptions(), ui)).rejects.toThrow(
+      "Organization 'missing-org'"
+    );
+
+    const errorCall = calls.find(
+      (c): c is Extract<MockCall, { kind: "log.error" }> =>
+        c.kind === "log.error"
+    );
+    expect(errorCall?.message).toContain("Your organizations:");
+    expect(errorCall?.message).toContain("acme");
+    expect(errorCall?.message).toContain("beta");
+  });
+
+  test("fails early when listTeams is forbidden and member project creation is disabled", async () => {
+    listTeamsSpy.mockRejectedValueOnce(
+      new ApiError("Forbidden", 403, "No team:read access")
+    );
+    getOrganizationSpy.mockResolvedValueOnce({
+      id: "1",
+      slug: "acme",
+      name: "Acme",
+      access: ["project:read"],
+      allowMemberProjectCreation: false,
+    } as any);
+
+    const { ui } = createMockUI();
+    await expect(resolveInitContext(makeOptions(), ui)).rejects.toThrow(
+      "Project creation is disabled for members"
+    );
+  });
+
+  test("fails early when member project creation is disabled and no Team Admin team exists", async () => {
+    listTeamsSpy.mockResolvedValueOnce([]);
+    getOrganizationSpy.mockResolvedValueOnce({
+      id: "1",
+      slug: "acme",
+      name: "Acme",
+      access: ["project:read"],
+      allowMemberProjectCreation: false,
+    } as any);
+
+    const { ui, calls } = createMockUI();
+    await expect(resolveInitContext(makeOptions(), ui)).rejects.toThrow(
+      "Project creation is disabled for members"
+    );
+
+    const errorCall = calls.find(
+      (c): c is Extract<MockCall, { kind: "log.error" }> =>
+        c.kind === "log.error"
+    );
+    expect(errorCall?.message).toContain("sentry init acme/<project-slug>");
+  });
+
+  test("allows org-scoped creation when member creation is disabled but token has org:write", async () => {
+    listTeamsSpy.mockResolvedValueOnce([]);
+    getOrganizationSpy.mockResolvedValueOnce({
+      id: "1",
+      slug: "acme",
+      name: "Acme",
+      access: ["org:write"],
+      allowMemberProjectCreation: false,
+    } as any);
+
+    const { ui } = createMockUI();
+    const context = await resolveInitContext(makeOptions(), ui);
+
     expect(context?.team).toBeUndefined();
   });
 });

--- a/test/lib/init/tools/create-sentry-project.test.ts
+++ b/test/lib/init/tools/create-sentry-project.test.ts
@@ -251,7 +251,7 @@ describe("createSentryProject", () => {
     expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
   });
 
-  test("resolves the team at project creation time when preflight deferred it", async () => {
+  test("uses org-scoped auto-team creation when preflight did not resolve a team", async () => {
     getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
 
     const result = await createSentryProject(makePayload(), {
@@ -262,26 +262,17 @@ describe("createSentryProject", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(resolveOrCreateTeamSpy).toHaveBeenCalledWith(
-      "acme",
-      expect.objectContaining({
-        autoCreateSlug: "my-app",
-        usageHint: "sentry init",
-      })
-    );
-    expect(createProjectWithDsnSpy).toHaveBeenCalledWith(
-      "acme",
-      "generated-team",
-      expect.objectContaining({
-        name: "my-app",
-        platform: "javascript-react",
-      })
-    );
+    expect(resolveOrCreateTeamSpy).not.toHaveBeenCalled();
+    expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
+    expect(createProjectWithAutoTeamSpy).toHaveBeenCalledWith("acme", {
+      name: "my-app",
+      platform: "javascript-react",
+    });
   });
 
   test("returns clear error with sentry-init guidance when org disables member creation", async () => {
     getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
-    createProjectWithDsnSpy.mockRejectedValueOnce(
+    createProjectWithAutoTeamSpy.mockRejectedValueOnce(
       new ApiError(
         "Failed to create project: 403 Forbidden",
         403,
@@ -324,7 +315,7 @@ describe("createSentryProject", () => {
     const result = await createSentryProject(makePayload(), {
       dryRun: false,
       org: "acme",
-      team: undefined,
+      team: "platform",
       project: undefined,
     });
 
@@ -353,7 +344,7 @@ describe("createSentryProject", () => {
     expect(createProjectWithAutoTeamSpy).not.toHaveBeenCalled();
   });
 
-  test("does not fall back on policy 403 — avoids wasted round-trip to org-scoped endpoint", async () => {
+  test("does not fall back on team-scoped policy 403", async () => {
     getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
     createProjectWithDsnSpy.mockRejectedValueOnce(
       new ApiError(
@@ -366,7 +357,7 @@ describe("createSentryProject", () => {
     const result = await createSentryProject(makePayload(), {
       dryRun: false,
       org: "acme",
-      team: undefined,
+      team: "platform",
       project: undefined,
     });
 
@@ -380,9 +371,6 @@ describe("createSentryProject", () => {
       new ApiError("Conflict", 409, "Slug already in use")
     );
     getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
-    createProjectWithDsnSpy.mockRejectedValueOnce(
-      new ApiError("Forbidden", 403, "No project:write access")
-    );
 
     const result = await createSentryProject(makePayload(), {
       dryRun: false,
@@ -393,12 +381,11 @@ describe("createSentryProject", () => {
 
     expect(result.ok).toBe(false);
     expect(result.error).toContain("already exists");
-    createProjectWithAutoTeamSpy.mockRestore();
   });
 
   // ── dry-run ──────────────────────────────────────────────────────────────
 
-  test("uses the final project slug for deferred team resolution in dry-run mode", async () => {
+  test("does not resolve a team for org-scoped dry-run mode", async () => {
     getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
 
     const result = await createSentryProject(makePayload(), {
@@ -409,14 +396,7 @@ describe("createSentryProject", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(resolveOrCreateTeamSpy).toHaveBeenCalledWith(
-      "acme",
-      expect.objectContaining({
-        autoCreateSlug: "my-app",
-        usageHint: "sentry init",
-        dryRun: true,
-      })
-    );
+    expect(resolveOrCreateTeamSpy).not.toHaveBeenCalled();
     expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Mirrors Sentry frontend onboarding project creation in `sentry init`: explicit `--team` stays strict, implicit creation chooses Team Admin teams, and no Team Admin team uses the org-scoped auto-team endpoint.
- Stops treating arbitrary member teams as good implicit defaults, so init does not pick a team-scoped endpoint the user cannot use.
- Adds clearer guidance when member project creation is disabled and covers the preflight/tool routing with focused tests.

## Test plan
- [x] `pnpm exec biome check --no-errors-on-unmatched src/lib/init/preflight.ts src/lib/init/tools/create-sentry-project.ts src/lib/init/project-creation-errors.ts test/lib/init/preflight.test.ts test/lib/init/tools/create-sentry-project.test.ts`
- [x] `pnpm vitest run test/lib/init/preflight.test.ts test/lib/init/tools/create-sentry-project.test.ts`
- [x] `pnpm run generate:schema`
- [x] `pnpm run typecheck`
- [x] `git diff --check`