### PR TITLE
fix(init): make discovery artifact-aware

### DIFF
--- a/src/lib/init/tools/list-dir.ts
+++ b/src/lib/init/tools/list-dir.ts
@@ -1,12 +1,73 @@
 import fs from "node:fs";
 import path from "node:path";
-import { NODE_MODULES_DIRNAME } from "../../constants.js";
-import { normalizePath } from "../../scan/index.js";
+import { DEFAULT_SKIP_DIRS, normalizePath } from "../../scan/index.js";
 import type { DirEntry, ListDirPayload, ToolResult } from "../types.js";
 import { safePath } from "./shared.js";
 import type { InitToolDefinition } from "./types.js";
 
 const NATIVE_SEP = path.sep;
+const DEFAULT_MAX_DEPTH = 5;
+const DEFAULT_MAX_ENTRIES = 500;
+const INIT_SKIP_DIRS = new Set([
+  ...DEFAULT_SKIP_DIRS,
+  "out",
+  "tmp",
+  "temp",
+  "bin",
+  "obj",
+  ".pytest_cache",
+  ".mypy_cache",
+  ".ruff_cache",
+  ".pnpm-store",
+  "bower_components",
+  "Pods",
+]);
+const PRIORITY_FILE_NAMES = new Set([
+  "package.json",
+  "tsconfig.json",
+  "pyproject.toml",
+  "requirements.txt",
+  "requirements-dev.txt",
+  "setup.py",
+  "setup.cfg",
+  "Pipfile",
+  "Gemfile",
+  "go.mod",
+  "build.gradle",
+  "build.gradle.kts",
+  "settings.gradle",
+  "settings.gradle.kts",
+  "pom.xml",
+  "Cargo.toml",
+  "pubspec.yaml",
+  "mix.exs",
+  "composer.json",
+  "Podfile",
+  "CMakeLists.txt",
+  "angular.json",
+  "app.json",
+  "wrangler.toml",
+  "wrangler.jsonc",
+  "serverless.yml",
+  "serverless.ts",
+  "bunfig.toml",
+  "manage.py",
+  "app.py",
+  "main.py",
+  "artisan",
+  "symfony.lock",
+  "wp-config.php",
+  "appsettings.json",
+  "Program.cs",
+  "Startup.cs",
+  "main.go",
+  "instrumentation.ts",
+  "instrumentation.js",
+]);
+const PRIORITY_FILE_PATTERNS = [
+  /^(?:app|vite|next|nuxt|astro|svelte|remix|webpack|metro)\.config\.(?:js|mjs|cjs|ts|mts|cts)$/u,
+  /^sentry\.(?:client|server|edge)\.config\.(?:js|mjs|cjs|ts|mts|cts)$/u,
+];
 
 /**
  * List files and directories within the workflow sandbox.
@@ -17,8 +78,8 @@ const NATIVE_SEP = path.sep;
 export async function listDir(payload: ListDirPayload): Promise<ToolResult> {
   const { cwd, params } = payload;
   const targetPath = safePath(cwd, params.path);
-  const maxDepth = params.maxDepth ?? 3;
-  const maxEntries = params.maxEntries ?? 500;
+  const maxDepth = params.maxDepth ?? DEFAULT_MAX_DEPTH;
+  const maxEntries = params.maxEntries ?? DEFAULT_MAX_ENTRIES;
   const recursive = params.recursive ?? false;
   const state: WalkState = {
     cwd,
@@ -30,10 +91,21 @@ export async function listDir(payload: ListDirPayload): Promise<ToolResult> {
     maxDepth,
     maxEntries,
     recursive,
+    skippedDirectories: new Set(),
+    truncated: false,
   };
 
-  await walkDirectory(targetPath, 0, state);
-  return { ok: true, data: { entries: state.entries } };
+  await walkDirectoryBreadthFirst(targetPath, state);
+  return {
+    ok: true,
+    data: {
+      entries: state.entries,
+      truncated: state.truncated,
+      skippedDirectories: [...state.skippedDirectories],
+      maxDepth,
+      maxEntries,
+    },
+  };
 }
 
 type WalkState = {
@@ -43,6 +115,14 @@ type WalkState = {
   maxDepth: number;
   maxEntries: number;
   recursive: boolean;
+  skippedDirectories: Set<string>;
+  truncated: boolean;
+};
+
+type WalkCandidate = {
+  abs: string;
+  dirent: fs.Dirent;
+  entry: DirEntry;
 };
 
 async function readDirEntries(dir: string): Promise<fs.Dirent[]> {
@@ -53,13 +133,12 @@ async function readDirEntries(dir: string): Promise<fs.Dirent[]> {
   }
 }
 
-function shouldRecurseInto(entry: fs.Dirent, state: WalkState): boolean {
+function shouldSkipDirectory(entry: fs.Dirent, state: WalkState): boolean {
   return (
     state.recursive &&
     entry.isDirectory() &&
     !entry.isSymbolicLink() &&
-    !entry.name.startsWith(".") &&
-    entry.name !== NODE_MODULES_DIRNAME
+    (entry.name.startsWith(".") || INIT_SKIP_DIRS.has(entry.name))
   );
 }
 
@@ -74,7 +153,8 @@ function shouldRecurseInto(entry: fs.Dirent, state: WalkState): boolean {
 function toDirEntry(
   state: WalkState,
   dir: string,
-  entry: fs.Dirent
+  entry: fs.Dirent,
+  depth: number
 ): DirEntry | undefined {
   const abs = dir + NATIVE_SEP + entry.name;
   const relNative = abs.slice(state.cwdPrefixLen);
@@ -91,30 +171,165 @@ function toDirEntry(
     name: entry.name,
     path: normalizePath(relNative),
     type: entry.isDirectory() ? "directory" : "file",
+    depth,
   };
 }
 
-async function walkDirectory(
-  dir: string,
-  depth: number,
-  state: WalkState
-): Promise<void> {
-  if (depth > state.maxDepth || state.entries.length >= state.maxEntries) {
-    return;
-  }
+function isPriorityFile(filePath: string): boolean {
+  const name = filePath.split("/").at(-1) ?? filePath;
+  return (
+    PRIORITY_FILE_NAMES.has(name) ||
+    PRIORITY_FILE_PATTERNS.some((pattern) => pattern.test(name))
+  );
+}
 
-  for (const entry of await readDirEntries(dir)) {
-    if (state.entries.length >= state.maxEntries) {
-      return;
+function entrySortRank(candidate: WalkCandidate): number {
+  const { entry } = candidate;
+  if (entry.type === "file" && isPriorityFile(entry.path)) {
+    return 0;
+  }
+  if (entry.type === "directory" && !entry.skipped) {
+    return 1;
+  }
+  if (entry.type === "file") {
+    return 2;
+  }
+  return 3;
+}
+
+function sortCandidates(candidates: WalkCandidate[]): WalkCandidate[] {
+  return candidates.sort((a, b) => {
+    const aRank = entrySortRank(a);
+    const bRank = entrySortRank(b);
+    if (aRank !== bRank) {
+      return aRank - bRank;
     }
-    const nextEntry = toDirEntry(state, dir, entry);
-    if (!nextEntry) {
+    return a.entry.path.localeCompare(b.entry.path);
+  });
+}
+
+async function readCandidates(
+  dir: string,
+  childDepth: number,
+  state: WalkState
+): Promise<WalkCandidate[]> {
+  const candidates: WalkCandidate[] = [];
+  for (const dirent of await readDirEntries(dir)) {
+    const entry = toDirEntry(state, dir, dirent, childDepth);
+    if (!entry) {
       continue;
     }
-    state.entries.push(nextEntry);
-    if (shouldRecurseInto(entry, state)) {
-      await walkDirectory(dir + NATIVE_SEP + entry.name, depth + 1, state);
+    if (shouldSkipDirectory(dirent, state)) {
+      entry.skipped = true;
+      state.skippedDirectories.add(entry.path);
     }
+    candidates.push({
+      abs: dir + NATIVE_SEP + dirent.name,
+      dirent,
+      entry,
+    });
+  }
+  return sortCandidates(candidates);
+}
+
+function stopAtEntryLimit(state: WalkState): boolean {
+  if (state.entries.length < state.maxEntries) {
+    return false;
+  }
+  state.truncated = true;
+  return true;
+}
+
+function appendCandidateEntries(
+  candidates: WalkCandidate[],
+  state: WalkState
+): boolean {
+  let index = 0;
+  for (const candidate of candidates) {
+    if (stopAtEntryLimit(state)) {
+      return false;
+    }
+    state.entries.push(candidate.entry);
+    if (
+      state.entries.length >= state.maxEntries &&
+      index < candidates.length - 1
+    ) {
+      state.truncated = true;
+      return false;
+    }
+    index += 1;
+  }
+  return true;
+}
+
+function shouldQueueDirectory(
+  candidate: WalkCandidate,
+  state: WalkState
+): boolean {
+  if (
+    candidate.entry.type !== "directory" ||
+    candidate.entry.skipped ||
+    candidate.dirent.isSymbolicLink()
+  ) {
+    return false;
+  }
+  if (candidate.entry.depth && candidate.entry.depth > state.maxDepth) {
+    state.truncated = true;
+    return false;
+  }
+  return true;
+}
+
+function enqueueSubdirectories(
+  candidates: WalkCandidate[],
+  queue: Array<{ dir: string; depth: number }>,
+  currentDepth: number,
+  state: WalkState
+): void {
+  for (const candidate of candidates) {
+    if (!shouldQueueDirectory(candidate, state)) {
+      continue;
+    }
+    queue.push({
+      dir: candidate.abs,
+      depth: candidate.entry.depth ?? currentDepth + 1,
+    });
+  }
+}
+
+async function walkDirectoryBreadthFirst(
+  targetPath: string,
+  state: WalkState
+): Promise<void> {
+  const queue: Array<{ dir: string; depth: number }> = [
+    { dir: targetPath, depth: 0 },
+  ];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) {
+      break;
+    }
+    if (current.depth > state.maxDepth) {
+      state.truncated = true;
+      continue;
+    }
+
+    const candidates = await readCandidates(
+      current.dir,
+      current.depth + 1,
+      state
+    );
+
+    if (!appendCandidateEntries(candidates, state)) {
+      return;
+    }
+
+    if (!state.recursive) {
+      continue;
+    }
+
+    enqueueSubdirectories(candidates, queue, current.depth, state);
   }
 }
 

--- a/src/lib/init/types.ts
+++ b/src/lib/init/types.ts
@@ -2,6 +2,16 @@ export type DirEntry = {
   name: string;
   path: string;
   type: "file" | "directory";
+  depth?: number;
+  skipped?: true;
+};
+
+export type DirListingResult = {
+  entries: DirEntry[];
+  truncated: boolean;
+  skippedDirectories: string[];
+  maxDepth: number;
+  maxEntries: number;
 };
 
 export type ExistingProjectData = {

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -839,11 +839,12 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
   let run: Awaited<ReturnType<typeof workflow.createRun>>;
   let result: WorkflowRunResult;
   try {
-    const [dirListing, existingSentry] = await Promise.all([
+    const [dirListingResult, existingSentry] = await Promise.all([
       precomputeDirListing(directory),
       precomputeSentryDetection(directory).catch(() => null),
     ]);
-    const fileCache = await preReadCommonFiles(directory, dirListing);
+    const { entries: dirListing, ...dirListingMeta } = dirListingResult;
+    const fileCache = await preReadCommonFiles(directory);
     ui.setIntroMode?.(false);
     spin.message("Connecting to wizard...");
     run = await withInitServiceAuthClassification(
@@ -870,6 +871,7 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
               },
               initialState: {
                 dirListing,
+                dirListingMeta,
                 fileCache,
                 existingSentry: existingSentry?.data,
                 knownPlatform: context.existingProject?.platform,

--- a/src/lib/init/workflow-inputs.ts
+++ b/src/lib/init/workflow-inputs.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs";
-import path from "node:path";
 import { MAX_FILE_BYTES } from "./constants.js";
 import { detectSentry } from "./tools/detect-sentry.js";
 import { listDir } from "./tools/list-dir.js";
-import type { DirEntry } from "./types.js";
+import { safePath } from "./tools/shared.js";
+import type { DirListingResult } from "./types.js";
 
 /**
  * Common config files that multiple init steps frequently inspect.
@@ -34,6 +34,10 @@ const COMMON_CONFIG_FILES = [
   "next.config.js",
   "next.config.mjs",
   "next.config.ts",
+  "app.config.js",
+  "app.config.mjs",
+  "app.config.cjs",
+  "app.config.ts",
   "nuxt.config.ts",
   "nuxt.config.js",
   "angular.json",
@@ -80,46 +84,51 @@ const COMMON_CONFIG_FILES = [
 ] as const;
 
 const MAX_PREREAD_TOTAL_BYTES = 512 * 1024;
+const INIT_DISCOVERY_MAX_DEPTH = 5;
+const INIT_DISCOVERY_MAX_ENTRIES = 500;
 
 /**
  * Pre-compute the initial directory listing before the first workflow call.
  */
 export async function precomputeDirListing(
   directory: string
-): Promise<DirEntry[]> {
+): Promise<DirListingResult> {
   const result = await listDir({
     type: "tool",
     operation: "list-dir",
     cwd: directory,
-    params: { path: ".", recursive: true, maxDepth: 3, maxEntries: 500 },
+    params: {
+      path: ".",
+      recursive: true,
+      maxDepth: INIT_DISCOVERY_MAX_DEPTH,
+      maxEntries: INIT_DISCOVERY_MAX_ENTRIES,
+    },
   });
-  return (result.data as { entries?: DirEntry[] } | undefined)?.entries ?? [];
+  return {
+    entries: [],
+    truncated: false,
+    skippedDirectories: [],
+    maxDepth: INIT_DISCOVERY_MAX_DEPTH,
+    maxEntries: INIT_DISCOVERY_MAX_ENTRIES,
+    ...((result.data as Partial<DirListingResult> | undefined) ?? {}),
+  };
 }
 
 /**
  * Pre-read common config files to avoid repeated suspend/resume round-trips.
  */
 export async function preReadCommonFiles(
-  directory: string,
-  dirListing: DirEntry[]
+  directory: string
 ): Promise<Record<string, string | null>> {
-  // `listDir` emits POSIX-normalized paths regardless of host OS,
-  // so `COMMON_CONFIG_FILES` (POSIX) membership checks don't need
-  // any per-path separator translation.
-  const listingPaths = new Set(dirListing.map((entry) => entry.path));
-  const toRead = COMMON_CONFIG_FILES.filter((filePath) =>
-    listingPaths.has(filePath)
-  );
-
   const cache: Record<string, string | null> = {};
   let totalBytes = 0;
 
-  for (const filePath of toRead) {
+  for (const filePath of COMMON_CONFIG_FILES) {
     if (totalBytes >= MAX_PREREAD_TOTAL_BYTES) {
       break;
     }
     try {
-      const absPath = path.join(directory, filePath);
+      const absPath = safePath(directory, filePath);
       const stat = await fs.promises.stat(absPath);
       // Guard against FIFOs / sockets / devices — `fs.readFile` on a
       // FIFO blocks indefinitely waiting for a writer. `stat` follows
@@ -136,7 +145,10 @@ export async function preReadCommonFiles(
         cache[filePath] = content;
         totalBytes += content.length;
       }
-    } catch {
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
       cache[filePath] = null;
     }
   }

--- a/test/lib/init/tools/filesystem-tools.test.ts
+++ b/test/lib/init/tools/filesystem-tools.test.ts
@@ -72,7 +72,10 @@ describe("filesystem tools", () => {
 
     expect(result.ok).toBe(true);
     expect(entries.map((entry) => entry.path)).toContain("src/app.ts");
-    expect(precomputed.map((entry) => entry.path)).toContain("src/app.ts");
+    expect(precomputed.entries.map((entry) => entry.path)).toContain(
+      "src/app.ts"
+    );
+    expect(precomputed.maxDepth).toBe(5);
   });
 
   test("reads files and checks existence in batches", async () => {

--- a/test/lib/init/tools/list-dir.test.ts
+++ b/test/lib/init/tools/list-dir.test.ts
@@ -27,10 +27,26 @@ function makePayload(
 }
 
 function entriesOf(result: Awaited<ReturnType<typeof listDir>>): DirEntry[] {
+  return dataOf(result).entries;
+}
+
+function dataOf(result: Awaited<ReturnType<typeof listDir>>): {
+  entries: DirEntry[];
+  maxDepth: number;
+  maxEntries: number;
+  skippedDirectories: string[];
+  truncated: boolean;
+} {
   if (!result.ok) {
     throw new Error(`expected listDir to succeed, got: ${result.error}`);
   }
-  return (result.data as { entries: DirEntry[] }).entries;
+  return result.data as {
+    entries: DirEntry[];
+    maxDepth: number;
+    maxEntries: number;
+    skippedDirectories: string[];
+    truncated: boolean;
+  };
 }
 
 describe("listDir", () => {
@@ -73,6 +89,26 @@ describe("listDir", () => {
     );
     const paths = entries.map((e) => e.path).sort();
     expect(paths).toEqual(["src", "top.ts"]);
+  });
+
+  test("recursive listing is breadth-first and keeps root files before nested files", async () => {
+    mkdirSync(join(testDir, "src", "deep"), { recursive: true });
+    writeFileSync(join(testDir, "src", "deep", "nested.ts"), "");
+    writeFileSync(join(testDir, "z.ts"), "");
+    writeFileSync(join(testDir, "package.json"), "{}");
+
+    const entries = entriesOf(
+      await listDir(makePayload(testDir, { path: ".", recursive: true }))
+    );
+    const paths = entries.map((e) => e.path);
+
+    expect(paths.indexOf("package.json")).toBeLessThan(paths.indexOf("src"));
+    expect(paths.indexOf("src")).toBeLessThan(
+      paths.indexOf("src/deep/nested.ts")
+    );
+    expect(paths.indexOf("z.ts")).toBeLessThan(
+      paths.indexOf("src/deep/nested.ts")
+    );
   });
 
   test("recursive mode descends into subdirectories up to maxDepth", async () => {
@@ -138,15 +174,105 @@ describe("listDir", () => {
     expect(paths).not.toContain("node_modules/pkg");
   });
 
+  test("surfaces artifact directories but does not recurse into them", async () => {
+    const artifactDirs = [
+      "dist",
+      "build",
+      ".next",
+      "target",
+      "out",
+      "bin",
+      "obj",
+      ".pytest_cache",
+    ];
+    for (const dir of artifactDirs) {
+      mkdirSync(join(testDir, dir, "nested"), { recursive: true });
+      writeFileSync(join(testDir, dir, "nested", "generated.js"), "");
+    }
+
+    const data = dataOf(
+      await listDir(makePayload(testDir, { path: ".", recursive: true }))
+    );
+    const paths = data.entries.map((e) => e.path);
+
+    for (const dir of artifactDirs) {
+      const entry = data.entries.find((e) => e.path === dir);
+      expect(entry).toMatchObject({
+        path: dir,
+        type: "directory",
+        skipped: true,
+      });
+      expect(paths).not.toContain(`${dir}/nested`);
+      expect(paths).not.toContain(`${dir}/nested/generated.js`);
+      expect(data.skippedDirectories).toContain(dir);
+    }
+  });
+
+  test("keeps source/config files when dist contains hundreds of generated assets", async () => {
+    writeFileSync(join(testDir, "package.json"), "{}");
+    writeFileSync(join(testDir, "app.config.ts"), "export default {};\n");
+    writeFileSync(join(testDir, "vite.config.ts"), "export default {};\n");
+    mkdirSync(join(testDir, "app", "routes"), { recursive: true });
+    writeFileSync(join(testDir, "app", "router.tsx"), "export {};\n");
+    writeFileSync(join(testDir, "app", "routes", "__root.tsx"), "export {};\n");
+    mkdirSync(join(testDir, "dist", "client", "assets"), { recursive: true });
+    for (let i = 0; i < 300; i += 1) {
+      writeFileSync(
+        join(testDir, "dist", "client", "assets", `chunk-${i}.js`),
+        ""
+      );
+    }
+
+    const data = dataOf(
+      await listDir(
+        makePayload(testDir, {
+          path: ".",
+          recursive: true,
+          maxDepth: 5,
+          maxEntries: 50,
+        })
+      )
+    );
+    const paths = data.entries.map((e) => e.path);
+
+    expect(paths).toContain("package.json");
+    expect(paths).toContain("app.config.ts");
+    expect(paths).toContain("vite.config.ts");
+    expect(paths).toContain("app/router.tsx");
+    expect(paths).toContain("app/routes/__root.tsx");
+    expect(paths).toContain("dist");
+    expect(paths).not.toContain("dist/client");
+    expect(paths.some((p) => p.startsWith("dist/client/assets/"))).toBe(false);
+    expect(data.entries.find((e) => e.path === "dist")?.skipped).toBe(true);
+    expect(data.skippedDirectories).toContain("dist");
+    expect(data.truncated).toBe(false);
+  });
+
   test("applies maxEntries as a hard cap", async () => {
     for (let i = 0; i < 20; i += 1) {
       writeFileSync(join(testDir, `f${i.toString().padStart(2, "0")}.ts`), "");
     }
 
-    const entries = entriesOf(
+    const data = dataOf(
       await listDir(makePayload(testDir, { path: ".", maxEntries: 5 }))
     );
+    const entries = data.entries;
     expect(entries).toHaveLength(5);
+    expect(data.maxEntries).toBe(5);
+    expect(data.truncated).toBe(true);
+  });
+
+  test("does not mark truncated when entry count exactly equals maxEntries", async () => {
+    for (let i = 0; i < 5; i += 1) {
+      writeFileSync(join(testDir, `f${i}.ts`), "");
+    }
+
+    const data = dataOf(
+      await listDir(makePayload(testDir, { path: ".", maxEntries: 5 }))
+    );
+
+    expect(data.entries).toHaveLength(5);
+    expect(data.truncated).toBe(false);
   });
 
   test("throws on sandbox escape via `..`", async () => {

--- a/test/lib/init/wizard-runner.test.ts
+++ b/test/lib/init/wizard-runner.test.ts
@@ -208,7 +208,13 @@ beforeEach(() => {
   });
   precomputeDirListingSpy = vi
     .spyOn(workflowInputs, "precomputeDirListing")
-    .mockResolvedValue([]);
+    .mockResolvedValue({
+      entries: [],
+      truncated: false,
+      skippedDirectories: [],
+      maxDepth: 5,
+      maxEntries: 500,
+    });
   preReadCommonFilesSpy = vi
     .spyOn(workflowInputs, "preReadCommonFiles")
     .mockResolvedValue({});
@@ -812,7 +818,13 @@ describe("runWizard", () => {
     const fileCache = { "package.json": '{"name":"app"}' };
     const detectedSentry = { status: "none" as const, signals: [] };
 
-    precomputeDirListingSpy.mockResolvedValue(dirListing);
+    precomputeDirListingSpy.mockResolvedValue({
+      entries: dirListing,
+      truncated: false,
+      skippedDirectories: [],
+      maxDepth: 5,
+      maxEntries: 500,
+    });
     preReadCommonFilesSpy.mockResolvedValue(fileCache);
     precomputeSentryDetectionSpy.mockResolvedValue({
       ok: true,
@@ -838,6 +850,12 @@ describe("runWizard", () => {
     expect(args.inputData).not.toHaveProperty("fileCache");
     expect(args.inputData).not.toHaveProperty("existingSentry");
     expect(args.initialState?.dirListing).toEqual(dirListing);
+    expect(args.initialState?.dirListingMeta).toEqual({
+      truncated: false,
+      skippedDirectories: [],
+      maxDepth: 5,
+      maxEntries: 500,
+    });
     expect(args.initialState?.fileCache).toEqual(fileCache);
     expect(args.initialState?.existingSentry).toEqual(detectedSentry);
   });

--- a/test/lib/safe-read.test.ts
+++ b/test/lib/safe-read.test.ts
@@ -6,13 +6,12 @@
  */
 
 import { execSync } from "node:child_process";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { applyPatchset } from "../../src/lib/init/tools/apply-patchset.js";
 import { readFiles } from "../../src/lib/init/tools/read-files.js";
-import type { DirEntry } from "../../src/lib/init/types.js";
 import { preReadCommonFiles } from "../../src/lib/init/workflow-inputs.js";
 import { safeReadFile } from "../../src/lib/safe-read.js";
 import {
@@ -264,12 +263,35 @@ describe("workflow-inputs preReadCommonFiles FIFO safety", () => {
     // a FIFO. Without the `stat.isFile()` guard the read would hang.
     createFifo(join(dir, "tsconfig.json"));
 
-    const listing: DirEntry[] = [
-      { name: "package.json", path: "package.json", type: "file" },
-      { name: "tsconfig.json", path: "tsconfig.json", type: "file" },
-    ];
-    const cache = await preReadCommonFiles(dir, listing);
+    const cache = await preReadCommonFiles(dir);
     expect(cache["package.json"]).toBe('{"name":"x"}');
     expect(cache["tsconfig.json"]).toBeNull();
+  });
+
+  test("reads common config files even when they are absent from dirListing", async () => {
+    writeFileSync(join(dir, "package.json"), '{"name":"x"}');
+    writeFileSync(join(dir, "app.config.ts"), "export default {};\n");
+
+    const cache = await preReadCommonFiles(dir);
+
+    expect(cache["package.json"]).toBe('{"name":"x"}');
+    expect(cache["app.config.ts"]).toBe("export default {};\n");
+  });
+
+  test("does not read common config symlinks outside the project", async () => {
+    const outsideDir = join(
+      tmpdir(),
+      `preread-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    mkdirSync(outsideDir, { recursive: true });
+    writeFileSync(join(outsideDir, "package.json"), '{"secret":true}');
+    symlinkSync(join(outsideDir, "package.json"), join(dir, "package.json"));
+
+    try {
+      const cache = await preReadCommonFiles(dir);
+      expect(cache["package.json"]).toBeNull();
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Stabilizes `sentry init` project discovery so generated artifact folders like `dist` do not crowd out source and config files before planning. The CLI `list-dir` traversal is now root-first, skips known artifact directories while surfacing them, and carries listing metadata through initial workflow state.

Paired server PR: getsentry/cli-init-api#173

## Changes

- make `list-dir` breadth-first/root-first with artifact directory skips and explicit metadata
- pre-read common root config files directly while keeping sandbox and FIFO safeguards
- request depth 5 for init discovery and pass truncation/skipped metadata to the workflow

## Test Plan

- `pnpm exec vitest run test/lib/init/tools/list-dir.test.ts test/lib/init/tools/filesystem-tools.test.ts test/lib/safe-read.test.ts test/lib/init/wizard-runner.test.ts`
- `pnpm run generate:schema && pnpm run typecheck`
- `pnpm exec biome check --linter-enabled=false src/lib/init/workflow-inputs.ts src/lib/init/wizard-runner.ts src/lib/init/types.ts src/lib/init/tools/list-dir.ts test/lib/init/tools/list-dir.test.ts test/lib/init/tools/filesystem-tools.test.ts test/lib/safe-read.test.ts test/lib/init/wizard-runner.test.ts`
