### PR TITLE
fix: resolve silent error swallowing and unsafe type coercion

### DIFF
--- a/src/commands/issue/utils.ts
+++ b/src/commands/issue/utils.ts
@@ -252,8 +252,8 @@ async function resolveProjectSearch(
   let dsnTarget: Awaited<ReturnType<typeof resolveFromDsn>> | undefined;
   try {
     dsnTarget = await resolveFromDsn(cwd);
-  } catch {
-    // DSN resolution failed — fall through to full search
+  } catch (error) {
+    log.debug("DSN resolution failed, falling through to full search", error);
   }
   if (
     dsnTarget &&

--- a/src/commands/issue/view.ts
+++ b/src/commands/issue/view.ts
@@ -23,6 +23,7 @@ import {
   FRESH_ALIASES,
   FRESH_FLAG,
 } from "../../lib/list-command.js";
+import { logger } from "../../lib/logger.js";
 import {
   collectReplayIds,
   getReplayIdFromEvent,
@@ -31,6 +32,8 @@ import { getSpanTreeLines } from "../../lib/span-tree.js";
 import type { SentryEvent, SentryIssue } from "../../types/index.js";
 import { IssueViewOutputSchema } from "../../types/index.js";
 import { issueIdPositional, resolveIssue } from "./utils.js";
+
+const log = logger.withTag("issue.view");
 
 type ViewFlags = {
   readonly json: boolean;
@@ -53,8 +56,8 @@ async function tryGetLatestEvent(
 ): Promise<SentryEvent | undefined> {
   try {
     return await getLatestEvent(orgSlug, issueId);
-  } catch {
-    // Non-blocking: event fetch failures shouldn't prevent issue display
+  } catch (error) {
+    log.debug("Failed to fetch latest event for issue", error);
     return;
   }
 }
@@ -69,7 +72,8 @@ async function tryListReplayIdsForIssue(
 ): Promise<string[]> {
   try {
     return await listReplayIdsForIssue(orgSlug, issueId);
-  } catch {
+  } catch (error) {
+    log.debug("Failed to fetch replay IDs for issue", error);
     return [];
   }
 }

--- a/src/commands/log/view.ts
+++ b/src/commands/log/view.ts
@@ -543,7 +543,8 @@ export const viewCommand = buildCommand({
               entry["sentry.item_id"],
               entry.trace
             );
-          } catch {
+          } catch (error) {
+            cmdLog.debug("Failed to fetch log item detail", error);
             return;
           }
         });

--- a/src/commands/release/list.ts
+++ b/src/commands/release/list.ts
@@ -31,6 +31,7 @@ import {
   LIST_BASE_ALIASES,
   LIST_TARGET_POSITIONAL,
 } from "../../lib/list-command.js";
+import { logger } from "../../lib/logger.js";
 import {
   dispatchOrgScopedList,
   type HandlerContext,
@@ -46,6 +47,8 @@ import {
 import { buildReleaseUrl } from "../../lib/sentry-urls.js";
 import type { SentryRelease } from "../../types/index.js";
 import { fmtCrashFree } from "./view.js";
+
+const log = logger.withTag("release.list");
 
 export const PAGINATION_KEY = "release-list";
 
@@ -353,8 +356,9 @@ async function resolveProjectIds(
     const info = await getProject(org, project);
     const id = toNumericId(info.id);
     return id ? [id] : undefined;
-  } catch {
-    return;
+  } catch (error) {
+    log.debug(`Failed to resolve project ID for ${org}/${project}`, error);
+    return [];
   }
 }
 
@@ -586,8 +590,8 @@ async function resolveDefaultEnvironment(
         return [candidate];
       }
     }
-  } catch {
-    // Environment listing failed — don't filter
+  } catch (error) {
+    log.debug(`Failed to list environments for ${org}/${project}`, error);
   }
   return;
 }

--- a/src/commands/release/list.ts
+++ b/src/commands/release/list.ts
@@ -346,16 +346,27 @@ function deduplicateTargets(targets: ResolvedTarget[]): ResolvedTarget[] {
   return result.sort((a, b) => targetPriority(a) - targetPriority(b));
 }
 
-/** Resolve a project slug to a numeric ID array for the API query param. */
+/**
+ * Resolve a project slug to a numeric ID array for the API query param.
+ * Returns a non-empty array on success, or an empty array when the project
+ * cannot be resolved (error or unexpected ID shape). The caller must
+ * short-circuit on an empty result to avoid unscoped org-wide queries.
+ */
 async function resolveProjectIds(
   org: string,
   project: string
-): Promise<number[] | undefined> {
+): Promise<number[]> {
   try {
     const { getProject } = await import("../../lib/api-client.js");
     const info = await getProject(org, project);
     const id = toNumericId(info.id);
-    return id ? [id] : undefined;
+    if (!id) {
+      log.debug(
+        `Project ${org}/${project} returned non-numeric ID: ${info.id}`
+      );
+      return [];
+    }
+    return [id];
   } catch (error) {
     log.debug(`Failed to resolve project ID for ${org}/${project}`, error);
     return [];
@@ -365,6 +376,8 @@ async function resolveProjectIds(
 /**
  * Fetch releases for a single target, scoped by project ID.
  * Tags each release with orgSlug and targetProject for labeling.
+ * Returns an empty array when project ID resolution fails to avoid
+ * returning unscoped org-wide releases mislabeled as the target project.
  */
 async function fetchReleasesForTarget(
   t: ResolvedTarget,
@@ -374,6 +387,9 @@ async function fetchReleasesForTarget(
   const ids = t.projectId
     ? [t.projectId]
     : await resolveProjectIds(t.org, t.project);
+  if (ids.length === 0) {
+    return [];
+  }
   const { data } = await listReleasesPaginated(t.org, {
     perPage,
     health: true,

--- a/src/commands/trace/view.ts
+++ b/src/commands/trace/view.ts
@@ -39,7 +39,7 @@ import {
   FRESH_FLAG,
 } from "../../lib/list-command.js";
 import { logger } from "../../lib/logger.js";
-import { resolveOrg } from "../../lib/resolve-target.js";
+import { resolveOrg, toNumericId } from "../../lib/resolve-target.js";
 import { buildTraceUrl } from "../../lib/sentry-urls.js";
 import { setOrgProjectContext } from "../../lib/telemetry.js";
 import {
@@ -550,7 +550,7 @@ export const viewCommand = buildCommand({
     let numericProjectId: number | undefined;
     if (projectFilter) {
       const projectData = await getProject(org, projectFilter);
-      numericProjectId = Number(projectData.id);
+      numericProjectId = toNumericId(projectData.id);
     }
 
     // The trace API requires a timestamp to help locate the trace data.

--- a/src/lib/api/releases.ts
+++ b/src/lib/api/releases.ts
@@ -118,9 +118,9 @@ export async function listReleasesForProject(
 ): Promise<SentryRelease[]> {
   // Resolve slug → numeric ID (the API requires numeric project IDs)
   const info = await getProject(orgSlug, projectSlug);
-  const numericId = Number(info.id);
-  const projectIds =
-    Number.isFinite(numericId) && numericId > 0 ? [numericId] : undefined;
+  const n = Number(info.id);
+  const numericId = Number.isInteger(n) && n > 0 ? n : undefined;
+  const projectIds = numericId ? [numericId] : undefined;
   const { data } = await listReleasesPaginated(orgSlug, {
     ...options,
     project: projectIds,

--- a/src/lib/api/releases.ts
+++ b/src/lib/api/releases.ts
@@ -119,11 +119,14 @@ export async function listReleasesForProject(
   // Resolve slug → numeric ID (the API requires numeric project IDs)
   const info = await getProject(orgSlug, projectSlug);
   const n = Number(info.id);
-  const numericId = Number.isInteger(n) && n > 0 ? n : undefined;
-  const projectIds = numericId ? [numericId] : undefined;
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new ValidationError(
+      `Project "${projectSlug}" has an invalid numeric ID: ${info.id}`
+    );
+  }
   const { data } = await listReleasesPaginated(orgSlug, {
     ...options,
-    project: projectIds,
+    project: [n],
     perPage: options.perPage ?? 100,
   });
   return data;

--- a/src/lib/span-tree.ts
+++ b/src/lib/span-tree.ts
@@ -7,6 +7,9 @@
 import type { SentryEvent, TraceSpan } from "../types/index.js";
 import { getDetailedTrace } from "./api-client.js";
 import { formatSimpleSpanTree, muted } from "./formatters/index.js";
+import { logger } from "./logger.js";
+
+const log = logger.withTag("span-tree");
 
 /**
  * Truncate a span tree to a maximum depth.
@@ -95,7 +98,8 @@ export async function getSpanTreeLines(
         ? spans
         : truncateSpanTree(spans, maxDepth);
     return { lines, spans: truncatedSpans, traceId, success: true };
-  } catch {
+  } catch (error) {
+    log.debug("Failed to fetch span tree", error);
     return {
       lines: [muted("\nUnable to fetch span tree for this event.")],
       spans: null,


### PR DESCRIPTION
## Summary

Supersedes #1079 (Cursor BugBot). That PR had one real bug fix and five logging-only changes that didn't fix the bugs they described. This PR addresses all issues properly.

---

### Fix 1: `fix(release)` — Prevent misleading fallback in release list

**Files:** `src/commands/release/list.ts`

**Root Cause:** `resolveProjectIds()` returned `undefined` on error. The caller passed `project: undefined` to the API, which returned **all releases in the entire org**. Each release was then stamped with `targetProject: t.project` — the user's requested project name. Users saw org-wide releases mislabeled as belonging to their project.

**Fix:** Return `[]` (empty array) on both error and invalid-ID paths. The caller `fetchReleasesForTarget()` short-circuits on empty `ids` and returns `[]` — no results rather than wrong results. Return type tightened from `Promise<number[] | undefined>` to `Promise<number[]>` to enforce this at the type level.

---

### Fix 2: `fix(trace)` — Use `toNumericId()` for project ID validation

**Files:** `src/commands/trace/view.ts`, `src/lib/api/releases.ts`

**Root Cause:** `Number(projectData.id)` returns `NaN` for undefined/non-numeric values. Critically, `NaN ?? -1` evaluates to `NaN` (not `-1`), because `NaN` is not nullish. This could silently pass `NaN` to the trace API as `projectId`, disabling project filtering unpredictably.

**Fix:**
- `trace/view.ts`: Replaced `Number()` with `toNumericId()` which returns `undefined` for invalid inputs, correctly triggering the `?? -1` fallback.
- `releases.ts`: `listReleasesForProject()` now throws `ValidationError` when the project ID is non-numeric, rather than silently widening to an org-wide query. This is the correct behavior for a direct API function where the caller explicitly requested a specific project. (Cannot import `toNumericId` from `resolve-target.ts` due to circular dependency through `api-client.js`.)

---

### Fix 3: `chore` — Add `log.debug()` to silent catch blocks

**Files:** `src/commands/issue/view.ts`, `src/commands/issue/utils.ts`, `src/commands/log/view.ts`, `src/lib/span-tree.ts`

Added `log.debug()` to 6 silent catch blocks per AGENTS.md catch-block rules. Uses module-level `logger.withTag()` per the dominant codebase convention (~35 instances), not function-scoped duplicates.

---

### Differences from #1079

| Issue | #1079 (BugBot) | This PR |
|-------|---------------|---------|
| `release/list.ts` data corruption | Only added `log.debug()` — bug still produces wrong output | Returns `[]` on error + short-circuits caller — no results beats wrong results |
| `releases.ts` `Number()` | Not addressed | Throws `ValidationError` for non-numeric project IDs instead of silently widening query |
| Logger pattern | Function-scoped duplicates (`logger.withTag()` inside each function) | Module-level `const log` per codebase convention |
| Circular dependency | Would have been introduced by importing `toNumericId` into `releases.ts` | Avoided by inlining the validation |