### PR TITLE
fix: handle slashes in default branch names for code-mappings

### DIFF
--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -266,8 +266,11 @@ export function inferDefaultBranch(remote: string, cwd?: string): string {
   try {
     const output = git(["symbolic-ref", `refs/remotes/${remote}/HEAD`], cwd);
     // refs/remotes/origin/main → main
-    const parts = output.split("/");
-    return parts.at(-1) ?? "main";
+    // refs/remotes/origin/release/2.0 → release/2.0
+    const prefix = `refs/remotes/${remote}/`;
+    return output.startsWith(prefix)
+      ? output.slice(prefix.length) || "main"
+      : "main";
   } catch {
     return "main";
   }


### PR DESCRIPTION
## Summary

Follow-up to #1087 — fixes a warden bot finding where `inferDefaultBranch()` truncated branch names containing slashes.

## Bug

`inferDefaultBranch()` used `output.split('/').at(-1)` to extract the branch name from a git symbolic-ref output like `refs/remotes/origin/main`. This broke for branches with slashes:

| Ref output | Expected | Got |
|-----------|----------|-----|
| `refs/remotes/origin/main` | `main` | `main` |
| `refs/remotes/origin/release/2.0` | `release/2.0` | `2.0` |

## Fix

Use prefix-based slicing: strip the known `refs/remotes/{remote}/` prefix, preserving the full branch name regardless of slashes.