### PR TITLE
fix(build): ignore NODE_OPTIONS in the SEA binary to keep the V8 code cache valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "consola": "^3.4.2",
     "esbuild": "^0.25.0",
     "fast-check": "^4.5.3",
-    "fossilize": "^0.8.1",
+    "fossilize": "^0.10.1",
     "hono": "^4.12.15",
     "http-cache-semantics": "^4.2.0",
     "ignore": "^7.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,8 +92,8 @@ importers:
         specifier: ^4.5.3
         version: 4.8.0
       fossilize:
-        specifier: ^0.8.1
-        version: 0.8.1
+        specifier: ^0.10.1
+        version: 0.10.1
       hono:
         specifier: ^4.12.15
         version: 4.12.23
@@ -1801,8 +1801,8 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
-  fossilize@0.8.1:
-    resolution: {integrity: sha512-cyjES48pTg6gx9qcdAx7JJ/0PFvLKBeFEZVDMAOf7b6RSDUckla64N+si3Ljxw0nnXOtrE3rCCr0mLevdP+CsQ==}
+  fossilize@0.10.1:
+    resolution: {integrity: sha512-+7rb/72OJmlgwDGnqmtzwcZ3A4sOut/BTu4kzUo2jzsa8k0F401TXFkHSg1y2U/M442BqaYtARgWv508gjdw+g==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4681,7 +4681,7 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  fossilize@0.8.1:
+  fossilize@0.10.1:
     dependencies:
       '@stricli/auto-complete': 1.2.7
       '@stricli/core': 1.2.7(patch_hash=402d573df36b19c62010d4ff41e49826f69d5c47212b8052ee7b042df34f973f)

--- a/script/build.ts
+++ b/script/build.ts
@@ -321,6 +321,12 @@ async function compileAllTargets(
         fossilizeBin,
         "--no-bundle",
         "--hole-punch",
+        // Make the binary ignore NODE_OPTIONS so user V8 flags (e.g.
+        // `NODE_OPTIONS=--max-old-space-size=8192`) don't change V8's
+        // flag-hash and reject the embedded code cache ("Code cache data
+        // rejected"). process.env is untouched, so child processes still
+        // inherit the user's NODE_OPTIONS.
+        "--ignore-node-options",
         "--output-name",
         "sentry",
         "--platforms",


### PR DESCRIPTION
## Problem

The standalone `sentry` binary is a Node SEA with an embedded V8 code cache.
When a user has V8 flags in `NODE_OPTIONS` (e.g.
`NODE_OPTIONS=--max-old-space-size=8192`, common in JS toolchains), those flags
change V8's `FlagList::Hash()` at runtime, so V8 rejects the build-time code
cache and prints `Warning: Code cache data rejected` (then recompiles).

## Fix

- Bump `fossilize` `^0.8.1` → `^0.10.1`.
- Pass `--ignore-node-options` to the fossilize invocation in `script/build.ts`.

fossilize patches the binary to ignore `NODE_OPTIONS` (equivalent to building
Node with `--without-node-options`): it renames the `.rodata` `NODE_OPTIONS`
lookup constant so `getenv()` returns null and no V8 flags are applied. The
runtime flag-hash then matches the build-time default and the embedded code
cache is accepted (kept; not disabled).

`process.env` is untouched, so `process.env.NODE_OPTIONS` stays set and any
child process still inherits the user's flags.

fossilize 0.10.x details: BYK/fossilize#31 (the feature) and BYK/fossilize#33
(NUL-termination selector fix for win-x64 / node 24 — relevant here since
`NODE_VERSION` is `lts` = 24.x).

## Notes

- Only host-platform (linux-x64, built on ubuntu) currently embeds a code
  cache; the patch is applied to all targets and is a no-op effect for
  cross-compiled ones (just renames the constant), so it's safe everywhere.
- Typecheck + Biome lint clean; lockfile change is fossilize-only.