### PR TITLE
docs: Enable Starlight agent markdown

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -2,6 +2,7 @@ import starlight from "@astrojs/starlight";
 import sentry from "@sentry/astro";
 import sentryStarlightTheme, {
   monochromeCodeTheme,
+  sentryAgentMarkdown,
 } from "@sentry/starlight-theme";
 import { defineConfig } from "astro/config";
 
@@ -58,7 +59,7 @@ export default defineConfig({
           href: "https://github.com/getsentry/cli",
         },
       ],
-      plugins: [sentryStarlightTheme()],
+      plugins: [sentryStarlightTheme(), sentryAgentMarkdown()],
       components: {
         Header: "./src/components/Header.astro",
         PageTitle: "./src/components/PageTitle.astro",


### PR DESCRIPTION
Enable the Sentry Starlight theme's agent Markdown plugin in the docs Astro config so the site emits the static Markdown routes described by the theme README.

Local validation: `pnpm install --frozen-lockfile` passes in `docs/`. `pnpm build` in `docs/` currently fails during Astro prerendering because the generated bundle imports `nanoid/non-secure` as a default export; I confirmed the same failure with the original plugin list, so it is not introduced by this change.
