### PR TITLE
feat(init): record wizard abandonment via the shared telemetry harness

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -18,7 +18,7 @@
  */
 
 import path from "node:path";
-import { setTag } from "@sentry/node-core/light";
+import { flush, setTag } from "@sentry/node-core/light";
 import type { SentryContext } from "../context.js";
 import { findProjectsBySlug } from "../lib/api/projects.js";
 import { looksLikePath, parseOrgProjectArg } from "../lib/arg-parsing.js";
@@ -445,16 +445,25 @@ export const initCommand = buildCommand<
       // The .unref() timer doesn't hold the loop itself, so it's a no-op
       // in the happy path (Linux: handle drains naturally; `--yes`
       // on Darwin: LoggingUI doesn't open /dev/tty, may still drain
-      // naturally). On the Darwin hang path, it force-exits after a
-      // 100ms grace window — imperceptible to the user and enough
-      // for Sentry telemetry + stdio flushes to complete first.
+      // naturally). On the Darwin hang path, the lingering handle keeps
+      // the loop ref'd so `beforeExit` (which owns the normal flush) may
+      // never fire — a bare `process.exit` here would then drop the run's
+      // telemetry entirely, which is exactly how completed runs ended up
+      // with no recorded `wizard.outcome`. So instead of exiting blind,
+      // flush explicitly (bounded) and then exit, with a hard backstop in
+      // case the flush itself hangs. The 100ms lead lets the synchronous
+      // unwind (incl. `reportCliError` on the error path) queue its events
+      // before we flush.
       //
       // Skipped under `bun test` (which sets NODE_ENV=test automatically)
       // because the test runner calls `initCommand.func` directly; an
       // unref'd timer would still fire and terminate the runner mid-suite.
       if (process.platform === "darwin" && process.env.NODE_ENV !== "test") {
         setTimeout(() => {
-          process.exit(process.exitCode ?? 0);
+          const exitCode = process.exitCode ?? 0;
+          // Hard backstop: never let a stuck flush trap the process.
+          setTimeout(() => process.exit(exitCode), 2500).unref();
+          Promise.resolve(flush(2000)).finally(() => process.exit(exitCode));
         }, 100).unref();
       }
     }

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -31,6 +31,7 @@ import {
   TimeoutError,
   UpgradeError,
   ValidationError,
+  WizardAbandonedError,
   WizardError,
 } from "./errors.js";
 
@@ -234,6 +235,13 @@ function deriveErrorKind(error: Error): string | undefined {
   if (error instanceof HostScopeError) {
     return "host_scope";
   }
+  // Must precede the WizardError check — WizardAbandonedError is a subclass
+  // and `instanceof` matches the whole prototype chain. Groups all
+  // abandonment into one issue; the `cause` keeps SIGHUP/SIGTERM/Ctrl+C
+  // distinguishable without fragmenting the group per step.
+  if (error instanceof WizardAbandonedError) {
+    return `wizard_abandoned_${error.cause}`;
+  }
   if (error instanceof WizardError) {
     return "wizard";
   }
@@ -306,6 +314,11 @@ function setCliErrorContext(scope: Sentry.Scope, error: unknown): void {
     scope.setContext("cli_error", {
       reason: error.reason,
       org_slug: error.orgSlug,
+    });
+  } else if (error instanceof WizardAbandonedError) {
+    scope.setContext("cli_error", {
+      cause: error.cause,
+      step: error.step,
     });
   }
 }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -681,6 +681,41 @@ export class WizardError extends CliError {
   }
 }
 
+/** How the wizard was abandoned, used for the exit code and issue tags. */
+export type AbandonCause = "ctrl_c_spinner" | "sigint" | "sighup" | "sigterm";
+
+/** Conventional 128+signal exit codes so shells/CI see a recognizable status. */
+const ABANDON_EXIT_CODES: Record<AbandonCause, number> = {
+  ctrl_c_spinner: 130, // SIGINT
+  sigint: 130,
+  sighup: 129,
+  sigterm: 143,
+};
+
+/**
+ * Thrown when the wizard is abandoned mid-run by a process-terminating
+ * signal (closed terminal → SIGHUP, `kill` → SIGTERM) or a Ctrl+C while a
+ * spinner/tool is running (no prompt to unwind through). Subclass of
+ * {@link WizardError} so it flows through the same `withTelemetry` →
+ * `reportCliError` → `captureException` harness as every other command
+ * failure — abandonment becomes a grouped, searchable Sentry issue rather
+ * than a silent exit. See `error-reporting.ts` for the grouping kind.
+ */
+export class WizardAbandonedError extends WizardError {
+  // `override` because ES2022 `Error` declares `cause`; we narrow it.
+  override readonly cause: AbandonCause;
+  readonly step?: string;
+
+  constructor(cause: AbandonCause, step?: string) {
+    super(`Setup abandoned (${cause})${step ? ` during "${step}"` : ""}.`, {
+      exitCode: ABANDON_EXIT_CODES[cause],
+    });
+    this.name = "WizardAbandonedError";
+    this.cause = cause;
+    this.step = step;
+  }
+}
+
 // Error Utilities
 
 /**

--- a/src/lib/init/ui/ink-ui.ts
+++ b/src/lib/init/ui/ink-ui.ts
@@ -52,7 +52,7 @@ import { ReadStream } from "node:tty";
 
 const _require = createRequire(import.meta.url);
 
-import { setTag } from "@sentry/node-core/light";
+import { flush, setTag } from "@sentry/node-core/light";
 import { CLI_VERSION } from "../../constants.js";
 import { stripAnsi } from "../../formatters/plain-detect.js";
 import { formatFeedbackHint, type InitFeedbackOutcome } from "../feedback.js";
@@ -381,6 +381,15 @@ export class InkUI implements WizardUI {
   private tipIndex = 0;
   private activePromptCancel: (() => void) | undefined;
   private cancelHandler: (() => void) | undefined;
+  /**
+   * Runner-supplied abandonment callback (see {@link WizardUI.setAbandonHandler}).
+   * When set, a Ctrl+C during a spinner routes here so the runner can abort
+   * the in-flight await and unwind through the shared failure harness —
+   * giving us a flushed Sentry issue — instead of a bare `process.exit`.
+   */
+  private abandonHandler:
+    | ((cause: "ctrl_c_spinner" | "sigint") => void)
+    | undefined;
   /**
    * Guard so `tearDown()` runs at most once even when called from
    * multiple paths (Ctrl+C in a spinner, then SIGINT, then
@@ -821,25 +830,41 @@ export class InkUI implements WizardUI {
     }
     if (this.cancelRequested) {
       // Safety valve: teardown already started but hasn't finished
-      // (or something is stuck). Force-exit so the user isn't trapped.
+      // (or something is stuck). The user is insisting — leave promptly,
+      // but flush the outcome first (bounded) so the run isn't lost, with a
+      // hard backstop so an impatient second Ctrl+C still exits.
       setTag("wizard.outcome", "abandoned");
-      process.exit(130);
+      setTimeout(() => process.exit(130), 1200).unref();
+      Promise.resolve(flush(1000)).finally(() => process.exit(130));
+      return;
     }
     this.cancelRequested = true;
+    // Preferred path: hand control back to the runner. It aborts the
+    // in-flight operation and unwinds through `withTelemetry` →
+    // `reportCliError`, so abandonment is captured as a flushed Sentry
+    // issue and our `[Symbol.asyncDispose]` performs the teardown. We do
+    // NOT tear down or exit here — that would race the graceful unwind.
+    if (this.abandonHandler) {
+      this.abandonHandler("ctrl_c_spinner");
+      return;
+    }
+    // Fallback (no runner handler registered — shouldn't happen during a
+    // real run): tear down and exit directly. Telemetry may be dropped
+    // here, which is exactly the gap the abandonHandler path closes.
     this.failureMessage = "Setup cancelled.";
     this.feedback("cancelled");
     this.tearDown();
-    // Mark as abandoned before exit so the Sentry span carries the
-    // outcome even though beforeExit never fires for explicit process.exit().
     setTag("wizard.outcome", "abandoned");
-    // Match the SIGINT convention so shells (and CI) see a
-    // distinguishable exit. The runner's `await using` won't get a
-    // chance to run after this, but tearDown above already did all
-    // the cleanup that path would have performed.
-    // Defer exit by one tick so the event loop can flush the
-    // stdout writes from tearDown (alternate-screen escape +
-    // cancellation report) before the process terminates.
+    // Defer exit by one tick so the event loop can flush the stdout writes
+    // from tearDown (alternate-screen escape + cancellation report) before
+    // the process terminates.
     setImmediate(() => process.exit(130));
+  }
+
+  setAbandonHandler(
+    handler: (cause: "ctrl_c_spinner" | "sigint") => void
+  ): void {
+    this.abandonHandler = handler;
   }
 
   /**

--- a/src/lib/init/ui/logging-ui.ts
+++ b/src/lib/init/ui/logging-ui.ts
@@ -76,10 +76,28 @@ const DEFAULT_OPTIONS: Required<LoggingUIOptions> = {
 export class LoggingUI implements WizardUI {
   private readonly stdout: NodeJS.WritableStream;
   private readonly stderr: NodeJS.WritableStream;
+  private sigintListener: (() => void) | undefined;
 
   constructor(options: LoggingUIOptions = {}) {
     this.stdout = options.stdout ?? DEFAULT_OPTIONS.stdout;
     this.stderr = options.stderr ?? DEFAULT_OPTIONS.stderr;
+  }
+
+  /**
+   * In non-interactive mode there are no prompts to cancel, so Ctrl+C
+   * (SIGINT) is always abandonment. Route it to the runner's handler so it
+   * unwinds through the shared failure harness (flushed Sentry issue)
+   * rather than Node's default terminate-without-telemetry. The runner
+   * additionally owns SIGHUP/SIGTERM.
+   */
+  setAbandonHandler(
+    handler: (cause: "ctrl_c_spinner" | "sigint") => void
+  ): void {
+    if (this.sigintListener) {
+      return;
+    }
+    this.sigintListener = () => handler("sigint");
+    process.on("SIGINT", this.sigintListener);
   }
 
   // ── Lifecycle ─────────────────────────────────────────────────────
@@ -217,8 +235,11 @@ export class LoggingUI implements WizardUI {
   // ── Disposal ──────────────────────────────────────────────────────
 
   [Symbol.asyncDispose](): Promise<void> {
-    // No teardown needed — LoggingUI holds no resources beyond the
-    // injected stream references.
+    // Detach the SIGINT listener so it can't fire after the run ends.
+    if (this.sigintListener) {
+      process.removeListener("SIGINT", this.sigintListener);
+      this.sigintListener = undefined;
+    }
     return Promise.resolve();
   }
 

--- a/src/lib/init/ui/types.ts
+++ b/src/lib/init/ui/types.ts
@@ -247,6 +247,23 @@ export type WizardUI = AsyncDisposable & {
    */
   setIntroMode?(enabled: boolean): void;
 
+  /**
+   * Register the runner's abandonment callback. The runner owns the
+   * `AbortController` and the suspend/resume loop, so when the UI detects
+   * a terminating input that isn't a prompt cancellation — a Ctrl+C while a
+   * spinner/tool is running — it invokes this instead of exiting the
+   * process directly. The runner aborts the in-flight operation and unwinds
+   * through the normal `withTelemetry` failure path, so abandonment is
+   * captured as a Sentry issue and flushed like any other command failure.
+   *
+   * Optional: implementations that can't observe input (or have nothing to
+   * route) leave it undefined. `LoggingUI` uses it to install a SIGINT
+   * handler; `InkUI` routes its spinner-phase Ctrl+C through it.
+   */
+  setAbandonHandler?(
+    handler: (cause: "ctrl_c_spinner" | "sigint") => void
+  ): void;
+
   // ── Logging ───────────────────────────────────────────────────────
 
   log: WizardLog;

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -18,6 +18,7 @@ import { MastraClient } from "@mastra/client-js";
 import {
   addBreadcrumb,
   captureException,
+  flush,
   getTraceData,
   setTag,
 } from "@sentry/node-core/light";
@@ -25,7 +26,14 @@ import { formatBanner } from "../banner.js";
 import { CLI_VERSION } from "../constants.js";
 import { customFetch } from "../custom-ca.js";
 import { detectAgent } from "../detect-agent.js";
-import { ApiError, EXIT, WizardError } from "../errors.js";
+import { reportCliError } from "../error-reporting.js";
+import {
+  type AbandonCause,
+  ApiError,
+  EXIT,
+  WizardAbandonedError,
+  WizardError,
+} from "../errors.js";
 import {
   renderInlineMarkdown,
   stripColorTags,
@@ -83,6 +91,14 @@ type SpinState = { running: boolean };
 const INIT_SERVICE_AUTH_FAILED_LABEL = "Authentication failed";
 
 const APPLY_CODEMODS_STEP = "apply-codemods";
+
+/**
+ * Grace window after an abandonment signal before the watchdog captures +
+ * flushes + force-exits itself. Long enough for the graceful unwind (abort →
+ * catch → throw → dispose → flush) to win in the common case, short enough
+ * that an uninterruptible await can't trap the process.
+ */
+const ABANDON_WATCHDOG_MS = 4000;
 
 type CompactPhaseHistoryEntry = {
   ok: boolean;
@@ -806,6 +822,67 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     },
   };
 
+  // Abandonment bridge. A terminating signal (closed terminal → SIGHUP,
+  // `kill` → SIGTERM) or a Ctrl+C during a spinner has no prompt to unwind
+  // through, so the suspend/resume loop is blocked on an `await`. Rather
+  // than `process.exit()` (which drops telemetry), we abort the in-flight
+  // operation and let the rejected await land in the main catch below,
+  // which throws `WizardAbandonedError`. That flows through the same
+  // `withTelemetry` → `reportCliError` harness as every other command
+  // failure, so abandonment becomes a flushed Sentry issue.
+  let pendingAbandon: { cause: AbandonCause; step?: string } | null = null;
+  // Flipped true on every terminal path (the suspend-loop catch and the
+  // success path). The watchdog checks it so a signal that arrives during the
+  // post-loop phase (handleFinalResult → verifySetup) can't report a spurious
+  // `abandoned` + force-exit on a run that actually completed.
+  let settled = false;
+
+  const requestAbandon = (cause: AbandonCause): void => {
+    if (pendingAbandon) {
+      return; // first signal wins; ignore repeats
+    }
+    const step = activeStepId;
+    pendingAbandon = { cause, step };
+    abortController.abort();
+    // Watchdog: if the graceful unwind can't interrupt the current await
+    // (e.g. an uninterruptible local op) it never reaches the catch below,
+    // so capture + flush + exit ourselves. No-op once the run has settled by
+    // any other path so we don't race the normal exit machinery or override a
+    // completion. Tears the UI down first so the terminal is restored.
+    setTimeout(async () => {
+      if (settled) {
+        return;
+      }
+      const abandoned = new WizardAbandonedError(cause, step);
+      reportCliError(abandoned);
+      try {
+        await ui[Symbol.asyncDispose]();
+      } catch {
+        // Teardown is best-effort — never block the exit on it.
+      }
+      Promise.resolve(flush(2000)).finally(() => {
+        process.exit(abandoned.exitCode);
+      });
+    }, ABANDON_WATCHDOG_MS).unref();
+  };
+
+  // SIGHUP (terminal closed) and SIGTERM (`kill`) are the silent killers the
+  // CLI never handled — install them here where the AbortController lives.
+  // SIGINT stays owned by the UI: at a prompt it must cancel cleanly
+  // (`bailed`), only its no-prompt/spinner case routes to abandonment via
+  // `setAbandonHandler` below.
+  const onSighup = (): void => requestAbandon("sighup");
+  const onSigterm = (): void => requestAbandon("sigterm");
+  process.on("SIGHUP", onSighup);
+  process.on("SIGTERM", onSigterm);
+  using _signalCleanup = {
+    [Symbol.dispose]: (): void => {
+      process.removeListener("SIGHUP", onSighup);
+      process.removeListener("SIGTERM", onSigterm);
+    },
+  };
+  ui.setAbandonHandler?.((cause) => requestAbandon(cause));
+
   const client = new MastraClient({
     baseUrl: MASTRA_API_URL,
     retries: 0,
@@ -968,6 +1045,32 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
       });
     }
   } catch (err) {
+    // We reached a terminal state by a code path (not the watchdog) — disarm
+    // any armed watchdog so it can't double-report or force-exit.
+    settled = true;
+    // Abandonment wins over the error's own type: a terminating signal /
+    // spinner-Ctrl+C aborts the in-flight await, which surfaces here as an
+    // AbortError. Re-throw as WizardAbandonedError so it flows through the
+    // shared `withTelemetry` → `reportCliError` harness — a flushed,
+    // grouped Sentry issue, exactly like any other command failure.
+    // Assertion (not annotation) so the type keys off the union, not the
+    // closure-assigned-only `pendingAbandon` — TS's flow analysis pins it to
+    // its `null` initializer because the only assignment lives in a closure.
+    const abandon = pendingAbandon as {
+      cause: AbandonCause;
+      step?: string;
+    } | null;
+    if (abandon) {
+      if (spinState.running) {
+        spin.stop("Cancelled", 0);
+        spinState.running = false;
+      }
+      // Leave the active step `in_progress` like a clean cancel.
+      setTag("wizard.outcome", "abandoned");
+      setTag("wizard.abandon_cause", abandon.cause);
+      showCancelledFeedback(ui);
+      throw new WizardAbandonedError(abandon.cause, abandon.step);
+    }
     const isAuthFailure = err instanceof ApiError && err.status === 401;
     // A running spinner owns a live interval, so stop it before any early
     // return or rethrow to avoid leaving the event loop artificially busy.
@@ -1023,6 +1126,9 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
 
   await handleFinalResult(result, spin, spinState, ui, directory);
   setTag("wizard.outcome", "completed");
+  // Run completed — disarm any watchdog a late signal (e.g. during
+  // verifySetup) may have armed, so it can't override this with `abandoned`.
+  settled = true;
   if (result.result?.platform) {
     setTag("wizard.platform", String(result.result.platform));
   }


### PR DESCRIPTION
## Summary

When a `sentry init` run is abandoned — the terminal is closed (SIGHUP), the process is killed (SIGTERM), or the user hits Ctrl+C while a spinner is running — the CLI used to exit without recording an outcome or flushing telemetry. Those runs were invisible in the Init Command Health funnel: `started` counted them, but nothing ever showed up as completed/bailed/errored. This routes abandonment through the same `withTelemetry` → `reportCliError` path every other command failure already uses, so it becomes a normal, grouped, flushed Sentry issue.

## Changes

- New `WizardAbandonedError` (subclass of `WizardError`) with a `cause` (`sighup`/`sigterm`/`sigint`/`ctrl_c_spinner`); grouped server-side via a `deriveErrorKind` branch.
- The runner installs `SIGHUP`/`SIGTERM` handlers and exposes a `setAbandonHandler` bridge to the UI (Ink's spinner-Ctrl+C, LoggingUI's SIGINT). On a signal it aborts the in-flight workflow await; the rejected await lands in the existing catch and throws `WizardAbandonedError`, so the shared harness captures + flushes it. Ctrl+C *at a prompt* still bails cleanly as before.
- A short watchdog guarantees exit (and tears the UI down first) if the abort can't interrupt, and disarms once the run settles so it can't override a run that actually completed.
- Made the macOS force-exit safety net flush-aware — it could fire before the fire-and-forget flush finished, which is the likely cause of completed runs showing no `wizard.outcome`.

## Test Plan

- `vitest run` over the touched modules (error-reporting, logging-ui, wizard-runner, factory, telemetry) — green.
- Manual: in a sandbox, `kill -TERM`/`kill -HUP` the process and close the terminal mid-run; confirm a flushed `wizard.outcome:abandoned` span and a `WizardAbandonedError` issue in the `cli` project. Ctrl+C at a prompt still records `bailed`.

Part 1 of 2 — the server-side reaper that terminalizes the matching suspended runs is in getsentry/cli-init-api.