### PR TITLE
feat(init): launch browser login when unauthenticated in a TTY

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -393,6 +393,32 @@ export const initCommand = buildCommand<
       throw err;
     }
 
+    // 3b. Launch the browser login flow when unauthenticated in an
+    //     interactive terminal, matching the auto-login every other command
+    //     gets from `autoAuthMiddleware`. The wizard can't lean on that
+    //     middleware: `runWizard`'s `finally` arms a macOS force-exit timer
+    //     (step 7) that would kill an `AuthError`-triggered login mid-poll,
+    //     and the Ink UI owns the terminal once it mounts. Running login here
+    //     — before `resolveTarget`'s API calls, before the timer is armed, and
+    //     before any UI — avoids both. Skipped for `--yes`/`--dry-run`/non-TTY,
+    //     which fail fast in `checkReadiness` with an actionable message.
+    if (!(isNonInteractiveContext(this) || flags.yes || flags["dry-run"])) {
+      const { getAuthToken } = await import("../lib/db/auth.js");
+      if (!getAuthToken()) {
+        const { runInteractiveLogin } = await import(
+          "../lib/interactive-login.js"
+        );
+        const loginSucceeded = await runInteractiveLogin();
+        if (!loginSucceeded) {
+          setTag("wizard.outcome", "auth_cancelled");
+          // `runInteractiveLogin` already reported the failure; exit 1 to match
+          // `auth login` and `autoAuthMiddleware` rather than a misleading 0.
+          process.exitCode = 1;
+          return;
+        }
+      }
+    }
+
     // 4. Resolve target → org + project
     //    Validation of user-provided slugs happens inside resolveTarget.
     //    For bare slugs, if no existing project is found, the slug becomes

--- a/src/lib/init/readiness.ts
+++ b/src/lib/init/readiness.ts
@@ -44,7 +44,19 @@ export async function checkReadiness(ui: WizardUI): Promise<void> {
   if (!authOk) {
     spin.stop("Prerequisites failed", 1);
     ui.log.error("No authentication token found.");
-    ui.log.info("Run `sentry auth login` to authenticate, then try again.");
+    ui.log.info(
+      "Run `sentry init` from an interactive terminal to sign in automatically,"
+    );
+    ui.log.info(
+      "or export SENTRY_AUTH_TOKEN in your shell for non-interactive use:"
+    );
+    ui.log.info("  export SENTRY_AUTH_TOKEN=<token>");
+    ui.log.info(
+      "The CLI reads SENTRY_AUTH_TOKEN from your shell environment, not from a project .env file."
+    );
+    ui.log.info(
+      "Create a token at https://sentry.io/settings/account/api/auth-tokens/"
+    );
     ui.cancel("Setup failed");
     ui.feedback("failed");
     throw new WizardError("Not authenticated");

--- a/test/commands/init.test.ts
+++ b/test/commands/init.test.ts
@@ -11,12 +11,16 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { initCommand } from "../../src/commands/init.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as projectsApi from "../../src/lib/api/projects.js";
+// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
+import * as authDb from "../../src/lib/db/auth.js";
 import { ContextError, ValidationError } from "../../src/lib/errors.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as prefetchNs from "../../src/lib/init/org-prefetch.js";
 import { resetPrefetch } from "../../src/lib/init/org-prefetch.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as wizardRunner from "../../src/lib/init/wizard-runner.js";
+// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
+import * as interactiveLogin from "../../src/lib/interactive-login.js";
 
 /** Minimal org shape for mock returns */
 const MOCK_ORG = { id: "1", slug: "resolved-org", name: "Resolved Org" };
@@ -30,6 +34,8 @@ let capturedArgs: Record<string, unknown> | undefined;
 let runWizardSpy: ReturnType<typeof spyOn>;
 let findProjectsSpy: ReturnType<typeof spyOn>;
 let warmSpy: ReturnType<typeof spyOn>;
+let getAuthTokenSpy: ReturnType<typeof spyOn>;
+let loginSpy: ReturnType<typeof spyOn>;
 
 const func = (await initCommand.loader()) as unknown as (
   this: {
@@ -79,12 +85,22 @@ beforeEach(() => {
     // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op mock
     () => {}
   );
+  // Default: authenticated, so the interactive auth gate is a no-op and no
+  // real DB/network access happens. Tests that exercise the gate override this.
+  getAuthTokenSpy = vi
+    .spyOn(authDb, "getAuthToken")
+    .mockImplementation(() => "tok_default");
+  loginSpy = vi
+    .spyOn(interactiveLogin, "runInteractiveLogin")
+    .mockImplementation(() => Promise.resolve(true));
 });
 
 afterEach(() => {
   runWizardSpy.mockRestore();
   findProjectsSpy.mockRestore();
   warmSpy.mockRestore();
+  getAuthTokenSpy.mockRestore();
+  loginSpy.mockRestore();
   resetPrefetch();
 });
 
@@ -263,6 +279,59 @@ describe("init command func", () => {
       const ctx = makeContext("/projects/app", { stdinTTY: false });
       await func.call(ctx, { yes: false, "dry-run": true });
       expect(capturedArgs?.dryRun).toBe(true);
+      expect(runWizardSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Interactive auth gate ─────────────────────────────────────────────
+
+  describe("interactive auth gate", () => {
+    const INTERACTIVE_FLAGS = { yes: false, "dry-run": false } as const;
+
+    test("unauthenticated interactive run launches login then proceeds", async () => {
+      getAuthTokenSpy.mockReturnValue(undefined);
+      const ctx = makeContext("/projects/app");
+      await func.call(ctx, INTERACTIVE_FLAGS);
+      expect(loginSpy).toHaveBeenCalledTimes(1);
+      expect(runWizardSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("bails with exit 1 without running the wizard when login is cancelled", async () => {
+      getAuthTokenSpy.mockReturnValue(undefined);
+      loginSpy.mockImplementation(() => Promise.resolve(false));
+      const prevExitCode = process.exitCode;
+      const ctx = makeContext("/projects/app");
+      try {
+        await func.call(ctx, INTERACTIVE_FLAGS);
+        expect(loginSpy).toHaveBeenCalledTimes(1);
+        expect(runWizardSpy).not.toHaveBeenCalled();
+        expect(process.exitCode).toBe(1);
+      } finally {
+        process.exitCode = prevExitCode;
+      }
+    });
+
+    test("skips login when already authenticated", async () => {
+      getAuthTokenSpy.mockImplementation(() => "tok_present");
+      const ctx = makeContext("/projects/app");
+      await func.call(ctx, INTERACTIVE_FLAGS);
+      expect(loginSpy).not.toHaveBeenCalled();
+      expect(runWizardSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("skips login under --yes even when unauthenticated", async () => {
+      getAuthTokenSpy.mockReturnValue(undefined);
+      const ctx = makeContext("/projects/app");
+      await func.call(ctx, { ...DEFAULT_FLAGS, features: ["errors"] });
+      expect(loginSpy).not.toHaveBeenCalled();
+      expect(runWizardSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("skips login in non-TTY context", async () => {
+      getAuthTokenSpy.mockReturnValue(undefined);
+      const ctx = makeContext("/projects/app", { stdinTTY: false });
+      await func.call(ctx, { ...DEFAULT_FLAGS, features: ["errors"] });
+      expect(loginSpy).not.toHaveBeenCalled();
       expect(runWizardSpy).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
## Summary

Running `sentry init` while logged out currently fails fast with "No authentication token found. Run `sentry auth login`". Every other command already auto-launches the browser device-flow login in an interactive terminal (via `autoAuthMiddleware`); this brings `sentry init` to parity by reusing the same `runInteractiveLogin` flow — no new login code.

## Changes

In `src/commands/init.ts`, before any wizard UI/timer setup: if the run is interactive (not `--yes` / `--dry-run` / non-TTY) and there's no auth token, call `runInteractiveLogin()`. On success the wizard proceeds; on cancel it exits 1 (matching `auth login`).

Why here rather than `autoAuthMiddleware`: the wizard's `finally` arms a macOS force-exit timer and the Ink UI takes over the terminal once mounted — either would interfere with an `AuthError`-triggered login mid-poll. Running it early in `init.ts` (before `resolveTarget`'s API calls, before the timer, before any UI) avoids both.

For genuinely non-interactive runs (`--yes`, piped, CI), `checkReadiness` now prints a clearer message — how to export `SENTRY_AUTH_TOKEN` and where to create a token.

## Test Plan

- `test/commands/init.test.ts` — new "interactive auth gate" cases: unauthenticated interactive run launches login then proceeds; cancelled login bails with exit 1 and never runs the wizard; authenticated run skips login.
- `biome check` clean; `vitest run test/commands/init.test.ts` → 48 passed.