### PR TITLE
fix(cli): make `sentry cli --version` print the version

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -160,7 +160,7 @@ export async function runCli(cliArgs: string[]): Promise<void> {
   const { isatty } = await import("node:tty");
   const { ExitCode, run } = await import("@stricli/core");
   const { app } = await import("./app.js");
-  const { hoistGlobalFlags } = await import("./lib/argv-hoist.js");
+  const { preprocessArgv } = await import("./lib/argv-hoist.js");
   const { buildContext } = await import("./context.js");
   const { AuthError, OutputError, formatError, getExitCode } = await import(
     "./lib/errors.js"
@@ -184,12 +184,15 @@ export async function runCli(cliArgs: string[]): Promise<void> {
     shouldSuppressNotification,
   } = await import("./lib/version-check.js");
 
-  // Move global flags (--verbose, -v, --log-level, --json, --fields) from any
-  // position to the end of argv, where Stricli's leaf-command parser can
-  // find them. This allows `sentry --verbose issue list` to work.
+  // Preprocess argv before dispatch (see preprocessArgv):
+  //  - `--version` after a route group/subcommand (e.g. `sentry cli --version`)
+  //    is normalized to a top-level `--version`; Stricli only handles it at the
+  //    application proxy. `-v` is left alone — it's the --verbose alias.
+  //  - global flags (--verbose, -v, --log-level, --json, --fields) are hoisted
+  //    to the tail so `sentry --verbose issue list` works.
   // The original cliArgs are kept for post-run checks (e.g., help recovery)
   // that rely on the original token positions.
-  const hoistedArgs = hoistGlobalFlags(cliArgs);
+  const hoistedArgs = preprocessArgv(cliArgs);
 
   // ---------------------------------------------------------------------------
   // Error-recovery middleware

--- a/src/lib/argv-hoist.ts
+++ b/src/lib/argv-hoist.ts
@@ -149,6 +149,37 @@ function consumeFlag(
 }
 
 /**
+ * Detect a top-level `--version` request anywhere in the command path.
+ *
+ * Stricli only handles `--version` at the application proxy, so it works for
+ * `sentry --version` but not for `sentry cli --version` (the route map treats
+ * `--version` as an unknown subcommand) or `sentry <group> <sub> --version`.
+ * Callers use this to normalize such invocations to a plain `--version` so the
+ * app-level handler prints the version consistently.
+ *
+ * Only the long `--version` form is recognized: `-v` is the reserved short
+ * alias for `--verbose` (see {@link GLOBAL_FLAGS}). Tokens after a `--` escape
+ * separator are ignored so `sentry monitor run <slug> -- tool --version`
+ * forwards `--version` to the wrapped command instead of printing the CLI
+ * version. The `--version=value` form is not matched (no command defines a
+ * `--version` value flag).
+ *
+ * @param argv - Raw CLI arguments (e.g., `process.argv.slice(2)`)
+ * @returns true if a bare `--version` token appears before any `--` separator
+ */
+export function isVersionRequest(argv: readonly string[]): boolean {
+  for (const token of argv) {
+    if (token === "--") {
+      return false;
+    }
+    if (token === "--version") {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Move global flags from any position in argv to the end.
  *
  * Tokens after `--` are never touched. The relative order of both
@@ -186,4 +217,27 @@ export function hoistGlobalFlags(argv: readonly string[]): string[] {
   }
 
   return [...remaining, ...hoisted, ...positionalTail];
+}
+
+/**
+ * Preprocess raw CLI argv before Stricli dispatch.
+ *
+ * Composes the two argv transforms applied on every invocation:
+ * 1. A top-level `--version` (see {@link isVersionRequest}) is normalized to a
+ *    plain `["--version"]` so the application-level version handler prints it
+ *    regardless of how deep in the route tree it appeared.
+ * 2. Otherwise, global flags are hoisted to the tail (see
+ *    {@link hoistGlobalFlags}).
+ *
+ * Kept as a single entry point so callers apply one transform and stay under
+ * the cognitive-complexity budget.
+ *
+ * @param argv - Raw CLI arguments (e.g., `process.argv.slice(2)`)
+ * @returns The argv to hand to Stricli's `run`
+ */
+export function preprocessArgv(argv: readonly string[]): string[] {
+  if (isVersionRequest(argv)) {
+    return ["--version"];
+  }
+  return hoistGlobalFlags(argv);
 }

--- a/src/lib/argv-hoist.ts
+++ b/src/lib/argv-hoist.ts
@@ -164,6 +164,12 @@ function consumeFlag(
  * version. The `--version=value` form is not matched (no command defines a
  * `--version` value flag).
  *
+ * This is a naive token scan, so a bare `--version` token always wins — even
+ * when it would otherwise be the value of a preceding value flag (e.g. the
+ * contrived `sentry issue list -q --version`). Use the `=` form
+ * (`-q=--version`) to pass the literal string instead. No command defines a
+ * `--version` flag, so there is no real collision.
+ *
  * @param argv - Raw CLI arguments (e.g., `process.argv.slice(2)`)
  * @returns true if a bare `--version` token appears before any `--` separator
  */

--- a/test/lib/argv-hoist.test.ts
+++ b/test/lib/argv-hoist.test.ts
@@ -7,7 +7,11 @@
  */
 
 import { describe, expect, test } from "vitest";
-import { hoistGlobalFlags } from "../../src/lib/argv-hoist.js";
+import {
+  hoistGlobalFlags,
+  isVersionRequest,
+  preprocessArgv,
+} from "../../src/lib/argv-hoist.js";
 
 describe("hoistGlobalFlags", () => {
   // -------------------------------------------------------------------------
@@ -338,5 +342,63 @@ describe("hoistGlobalFlags", () => {
       "date",
       "--verbose",
     ]);
+  });
+});
+
+describe("isVersionRequest", () => {
+  test("true for top-level --version", () => {
+    expect(isVersionRequest(["--version"])).toBe(true);
+  });
+
+  test("true for --version after a route group (sentry cli --version)", () => {
+    expect(isVersionRequest(["cli", "--version"])).toBe(true);
+  });
+
+  test("true for --version after a nested subcommand", () => {
+    expect(isVersionRequest(["issue", "list", "--version"])).toBe(true);
+  });
+
+  test("false when --version is absent", () => {
+    expect(isVersionRequest(["cli", "upgrade"])).toBe(false);
+    expect(isVersionRequest([])).toBe(false);
+  });
+
+  test("does not match the -v short alias (reserved for --verbose)", () => {
+    expect(isVersionRequest(["cli", "-v"])).toBe(false);
+  });
+
+  test("ignores --version after the -- escape (passed to wrapped command)", () => {
+    // `sentry monitor run <slug> -- mytool --version` must forward --version
+    // to the wrapped command, not print the Sentry CLI version.
+    expect(
+      isVersionRequest(["monitor", "run", "job", "--", "mytool", "--version"])
+    ).toBe(false);
+  });
+
+  test("does not match --version=foo (not a bare version flag)", () => {
+    expect(isVersionRequest(["cli", "--version=1.2.3"])).toBe(false);
+  });
+});
+
+describe("preprocessArgv", () => {
+  test("normalizes a route-scoped --version to a plain --version", () => {
+    expect(preprocessArgv(["cli", "--version"])).toEqual(["--version"]);
+    expect(preprocessArgv(["issue", "list", "--version"])).toEqual([
+      "--version",
+    ]);
+  });
+
+  test("hoists global flags when no --version is present", () => {
+    expect(preprocessArgv(["--verbose", "issue", "list"])).toEqual([
+      "issue",
+      "list",
+      "--verbose",
+    ]);
+  });
+
+  test("leaves a wrapped-command --version (after --) to hoisting, not version", () => {
+    expect(
+      preprocessArgv(["monitor", "run", "job", "--", "tool", "--version"])
+    ).toEqual(["monitor", "run", "job", "--", "tool", "--version"]);
   });
 });


### PR DESCRIPTION
## Problem

Reported by sergical in #discuss-cli: `sentry cli --version` errors with
`No command registered for \`--version\``, even though `sentry --version` works.

Stricli only handles `--version` at the **application proxy**, so it never reaches
route maps. The behavior was inconsistent across the tree:

| Command | Before |
|---|---|
| `sentry --version` | `0.0.0-dev` ✅ |
| `sentry cli --version` | `No command registered for \`--version\`` ❌ |
| `sentry issue --version` | `No flag registered for --version` ❌ |

## Fix

`preprocessArgv()` (in `argv-hoist.ts`) now normalizes a top-level `--version` token —
appearing after any route group/subcommand, before any `--` escape — to a plain
`["--version"]`, so the app-level version handler prints it. After the fix, `sentry
cli --version`, `sentry issue --version`, and `sentry issue list --version` all print
the version, consistent with `sentry --version`.

Notes:
- **`-v` is intentionally left alone** — it's the reserved short alias for `--verbose`
  (`GLOBAL_FLAGS`). Only the long `--version` form is normalized. (BYK's guidance in the
  thread was specifically about `sentry cli --version`.)
- Tokens after a `--` escape are ignored, so `sentry monitor run <slug> -- tool --version`
  still forwards `--version` to the wrapped command.
- `--version=value` is not matched (no command defines a `--version` value flag).
- Extracted `preprocessArgv` (version-normalize + existing global-flag hoist) so `runCli`
  stays under the cognitive-complexity budget.

**Out of scope:** aliasing `sentry upgrade` → CLI upgrade. Per BYK in-thread, `sentry
upgrade` is reserved for SDK upgrade flows and must not be remapped.

## Tests

Unit tests added for `isVersionRequest` and `preprocessArgv` (route-scoped `--version`,
nested subcommand, `-v` non-match, post-`--` escape, `--version=foo` non-match). Verified
in dev: `sentry cli --version` → `0.0.0-dev`; `sentry cli -v` unchanged. typecheck + lint clean.