### PR TITLE
fix(ci): allow PR risk labels

### DIFF
--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  issues: write
 
 concurrency:
   group: pr-risk-${{ github.event.pull_request.number }}
@@ -26,6 +27,7 @@ jobs:
           pr-number: ${{ github.event.pull_request.number }}
           result-path: risk-pr-result.json
           skip-reviews: "true"
+          apply-label: "true"
 
       - name: Upload risk result
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Lets the PR risk workflow apply the `risk: low`, `risk: medium`, or `risk: high` label returned by `getsentry/pr-risk-action@v0`.

The shared action now creates/removes the risk labels, but the caller workflow needs `issues: write` because PR labels use GitHub's Issues API.

## Test Plan

- `PYTHONPATH=src python3 -m unittest discover -s tests` in `getsentry/pr-risk-action`
- Verified the previous `getsentry/cli#1134` run only had read permissions, which explains why no label could be applied.
