### PR TITLE
fix(ci): grant PR risk write permission

### DIFF
--- a/.github/workflows/pr-risk.yml
+++ b/.github/workflows/pr-risk.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   issues: write
 
 concurrency:


### PR DESCRIPTION
## Summary

The PR risk workflow can now score successfully, but the label write still returns `Resource not accessible by integration` on PR labels. This grants `pull-requests: write` in addition to `issues: write` so the action can apply `risk: low`, `risk: medium`, or `risk: high`.

## Test Plan

- Verified #1134 rerun loads `getsentry/pr-risk-action@v0` and scores `medium`.
- Verified label add currently fails with 403 from the Actions token before this permission change.
