### PR TITLE
fix(auth): add alerts:read and alerts:write to default OAuth scopes

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -70,6 +70,7 @@ When creating your Sentry OAuth application:
   - `event:read`, `event:write`
   - `member:read`
   - `team:read`, `team:write`
+  - `alerts:read`, `alerts:write`
 <!-- GENERATED:END oauth-scopes -->
 
 ## Environment Variables

--- a/docs/src/content/docs/self-hosted.md
+++ b/docs/src/content/docs/self-hosted.md
@@ -56,7 +56,7 @@ If your instance is on an older version or you prefer not to create an OAuth app
 1. Go to **Settings → Developer Settings → Personal Tokens** in your Sentry instance (or visit `https://sentry.example.com/settings/account/api/auth-tokens/new-token/`)
 2. Create a new token with the following scopes:
 <!-- GENERATED:START oauth-scopes -->
-`project:read`, `project:write`, `project:admin`, `org:read`, `event:read`, `event:write`, `member:read`, `team:read`, `team:write`
+`project:read`, `project:write`, `project:admin`, `org:read`, `event:read`, `event:write`, `member:read`, `team:read`, `team:write`, `alerts:read`, `alerts:write`
 <!-- GENERATED:END oauth-scopes -->
 3. Pass it to the CLI:
 

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -88,6 +88,8 @@ export const OAUTH_SCOPES: readonly string[] = [
   "member:read",
   "team:read",
   "team:write",
+  "alerts:read",
+  "alerts:write",
 ];
 
 /** Space-joined scope string for OAuth requests (full default set). */


### PR DESCRIPTION
## What

Add `alerts:read` and `alerts:write` to the default OAuth scope set requested during `sentry auth login`.

## Why

`sentry alert metrics create` was returning _"You may not have access to this resource"_ (403) even after a successful `sentry auth login`. Dashboard creation worked fine, so something was inconsistent.

Root cause: the metric alert `POST /organizations/{org}/alert-rules/` endpoint has **two** permission layers:

1. **Scope map check** — allows `org:read`, which the CLI already requests. This passes. ✓
2. **Secondary `check_can_create_alert()`** in `src/sentry/incidents/endpoints/bases.py` — requires one of `alerts:write`, `org:write`, or `org:admin` (or team-admin project access). This fails. ✗

Dashboard creation only has the scope map check (accepts `org:read`), so it worked. Alert creation silently had a harder gate that the CLI's scope set never satisfied.

The fix is adding `alerts:write` (and its paired read scope) to `OAUTH_SCOPES` in `src/lib/oauth.ts`.

## Impact

**Existing users** will need to re-authenticate to pick up the new scopes:

```bash
sentry auth logout
sentry auth login
```

The generated doc sections in `DEVELOPMENT.md` and `docs/src/content/docs/self-hosted.md` are updated to match (these are normally regenerated by `pnpm run generate:docs-sections`).

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC010884QHLG%3A1782261875.924969%22)