### PR TITLE
ci: pin Node to exact patched versions via central env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,17 @@ env:
   # don't fully support it, causing SIGABRT in Node.js processes.
   # See: https://github.com/actions/runner-images/issues/13602
   UV_USE_IO_URING: "0"
+  # CI Node.js versions, pinned to exact patches and used as the single source
+  # of truth for every actions/setup-node step (referenced as
+  # ${{ env.NODE_VERSION_xx }}). Node 24.17.0 / 22.23.0 (CVE-2026-48931's
+  # http.Agent fix) added a `data` listener on idle agent sockets that makes
+  # keep-alive fetch reuse throw false ERR_STREAM_PREMATURE_CLOSE
+  # ("Premature close" — hit by the skill-eval planner talking to external
+  # APIs). Fixed in 24.18.0 / 22.23.1 (nodejs/node#64004). A floating major
+  # ("24"/"22") silently reuses the runner's pre-cached buggy patch, so pin the
+  # exact patched versions here and bump them in one place.
+  NODE_VERSION_22: "22.23.1"
+  NODE_VERSION_24: "24.18.0"
 
 jobs:
   changes:
@@ -128,7 +139,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: ${{ env.NODE_VERSION_22 }}
       - uses: actions/cache@v5
         id: cache
         with:
@@ -183,7 +194,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: ${{ env.NODE_VERSION_22 }}
       - uses: actions/cache@v5
         id: cache
         with:
@@ -214,7 +225,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: ${{ env.NODE_VERSION_24 }}
       - uses: actions/cache@v5
         id: cache
         with:
@@ -249,7 +260,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: ${{ env.NODE_VERSION_22 }}
       - uses: actions/cache@v5
         id: cache
         with:
@@ -710,13 +721,10 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          # Pin exact patch: Node 24.17.0 (and 22.23.0) shipped CVE-2026-48931's
-          # http.Agent fix, which added a `data` listener on idle sockets that
-          # makes keep-alive fetch reuse throw false ERR_STREAM_PREMATURE_CLOSE.
-          # This surfaces as "Premature close" in the skill-eval planner's HTTP
-          # calls. Fixed in 24.18.0 (nodejs/node#64004). A floating "24" silently
-          # reuses the runner's pre-cached buggy 24.17.0, so pin the exact patch.
-          node-version: "24.18.0"
+          # Pinned to a patched 24 — the skill-eval planner makes keep-alive
+          # HTTPS calls and would hit the ERR_STREAM_PREMATURE_CLOSE regression
+          # on a floating "24". See NODE_VERSION_24 in the top-level env block.
+          node-version: ${{ env.NODE_VERSION_24 }}
       - uses: actions/cache@v5
         id: cache
         with:
@@ -755,7 +763,10 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node }}
+          # Matrix entries stay bare majors ("22"/"24") for the job name and the
+          # `matrix.node == '22'` artifact guard below; map each to its exact
+          # patched version from the central env block here.
+          node-version: ${{ matrix.node == '24' && env.NODE_VERSION_24 || env.NODE_VERSION_22 }}
       - uses: actions/cache@v5
         id: cache
         with:
@@ -818,7 +829,7 @@ jobs:
       # build doesn't rely on whatever ships on the runner image.
       - uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: ${{ env.NODE_VERSION_24 }}
       - uses: actions/cache@v5
         id: cache
         with:

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -27,6 +27,13 @@ concurrency:
   group: docs-preview-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Pin Node to an exact patched version (single source of truth). A floating
+  # "24" can reuse the runner's pre-cached 24.17.0, which carries the
+  # ERR_STREAM_PREMATURE_CLOSE regression on keep-alive fetch reuse
+  # (nodejs/node#64004, fixed in 24.18.0).
+  NODE_VERSION_24: "24.18.0"
+
 jobs:
   preview:
     runs-on: ubuntu-latest
@@ -35,11 +42,12 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
-      # Astro 6 requires Node >= 22.12. Pin an explicit version so the docs
-      # build doesn't rely on whatever ships on the runner image.
+      # Astro 6 requires Node >= 22.12. Pin an exact patched version (see
+      # NODE_VERSION_24) so the docs build doesn't rely on the runner image's
+      # default.
       - uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: ${{ env.NODE_VERSION_24 }}
 
       - uses: actions/cache@v5
         id: cache

--- a/.github/workflows/eval-skill-fork.yml
+++ b/.github/workflows/eval-skill-fork.yml
@@ -9,6 +9,15 @@ permissions:
   statuses: write
   pull-requests: write
 
+env:
+  # Pin Node to the exact patched release rather than floating on the runner's
+  # pre-cached major. Node 24.17.0 (CVE-2026-48931's http.Agent fix) added a
+  # `data` listener on idle agent sockets that makes keep-alive fetch reuse
+  # throw a false ERR_STREAM_PREMATURE_CLOSE — exactly the failure the
+  # skill-eval planner hits talking to external APIs. Fixed in 24.18.0
+  # (nodejs/node#64004). Keep in sync with NODE_VERSION_24 in ci.yml.
+  NODE_VERSION_24: "24.18.0"
+
 jobs:
   remove-labels-on-sync:
     name: Reset eval labels
@@ -37,6 +46,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION_24 }}
 
       - uses: actions/cache@v5
         id: cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  # Pin Node to an exact patched version (single source of truth). A floating
+  # "22" can reuse the runner's pre-cached 22.23.0, which carries the
+  # ERR_STREAM_PREMATURE_CLOSE regression on keep-alive fetch reuse
+  # (nodejs/node#64004, fixed in 22.23.1).
+  NODE_VERSION_22: "22.23.1"
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -33,7 +40,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: ${{ env.NODE_VERSION_22 }}
     - name: Prepare release
       uses: getsentry/craft@v2
       env:

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -13,6 +13,14 @@ permissions:
   contents: read
   issues: write
 
+env:
+  # Pin Node to an exact patched version (single source of truth). A floating
+  # "22" can reuse the runner's pre-cached 22.23.0, which carries the
+  # ERR_STREAM_PREMATURE_CLOSE regression on keep-alive fetch reuse
+  # (nodejs/node#64004, fixed in 22.23.1). This job installs from and uploads
+  # over HTTPS.
+  NODE_VERSION_22: "22.23.1"
+
 jobs:
   finalize:
     name: Finalize Sentry Release
@@ -34,12 +42,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      # The sentry npm package requires Node.js >= 22.12 — pin an explicit
-      # version so this job doesn't depend on the runner image's default.
+      # The sentry npm package requires Node.js >= 22.12 — pin an exact patched
+      # version (see NODE_VERSION_22) so this job doesn't depend on the runner
+      # image's default.
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION_22 }}
 
       - name: Install CLI
         run: npm install -g "sentry@${VERSION}"


### PR DESCRIPTION
## Summary

Follow-up to d7175e2, which pinned **only** the skill-eval E2E job to `24.18.0`. Every other `actions/setup-node` step still floated a bare major (`"22"`/`"24"`) and would silently reuse the runner's pre-cached **buggy** patch (24.17.0 / 22.23.0).

Those patches shipped CVE-2026-48931's `http.Agent` fix, which added a `data` listener on idle agent sockets that makes keep-alive fetch reuse throw false `ERR_STREAM_PREMATURE_CLOSE` ("Premature close"). It's fixed in **24.18.0** and **22.23.1** ([nodejs/node#64004](https://github.com/nodejs/node/pull/64004) — *http: avoid stream listeners on idle agent sockets*).

## What changed

Centralized the Node version into **per-workflow `env` vars** (`NODE_VERSION_22` / `NODE_VERSION_24`) as a single source of truth, and pinned the exact patched releases everywhere:

| Workflow | Jobs touched | Version |
|----------|-------------|---------|
| `ci.yml` | all `"22"`/`"24"` `setup-node` steps (incl. `build-binary`, `build-docs`, `test-e2e`) + `build-npm` matrix | 22.23.1 / 24.18.0 |
| `release.yml` | release (publishes over HTTPS) | 22.23.1 |
| `sentry-release.yml` | finalize (installs + uploads over HTTPS) | 22.23.1 |
| `docs-preview.yml` | docs build | 24.18.0 |
| `eval-skill-fork.yml` | fork skill-eval job — **added** the missing `setup-node` step | 24.18.0 |

The `build-npm` matrix keeps bare-major labels (`["22", "24"]`) for the job name and the `matrix.node == '22'` artifact guard, mapping each label to its exact env-pinned version in the step.

**`build-binary` is included** in the `ci.yml` repin (its `setup-node` went from `"22"` → `${{ env.NODE_VERSION_22 }}`). It runs the binary build via `pnpm tsx script/build.ts` (esbuild + fossilize — pure Node, no Bun), so the pinned Node from `setup-node` is what drives it. *(An earlier revision of this description incorrectly said `build-binary` was unaffected and used Bun — that was wrong on both counts.)*

The **fork** skill-eval workflow (`eval-skill-fork.yml`) had set up pnpm but never ran `setup-node` at all, so `pnpm install`, `generate:docs`, and `eval:skill` ran on the runner's floating Node — the exact unpinned path this PR exists to close, and the one most likely to hit the `ERR_STREAM_PREMATURE_CLOSE` regression (the skill-eval planner talks to external APIs over keep-alive fetch). Added a workflow-level `NODE_VERSION_24` and a pinned `setup-node` step mirroring the non-fork job.

## Validation

- `actionlint` passes with **zero new findings** vs `main` (pre-existing shellcheck style infos unchanged), including the updated `eval-skill-fork.yml`.
- All five workflows parse as valid YAML.