### PR TITLE
fix(debug-files): exit non-zero when files are dropped for size

### DIFF
--- a/src/commands/debug-files/upload.ts
+++ b/src/commands/debug-files/upload.ts
@@ -426,7 +426,11 @@ function* doNothingToUpload(
 
 /**
  * Perform the upload, yield the result, and return a hint. Non-terminal states
- * (error, not_found) set the exit code and return a descriptive hint.
+ * (error, not_found) set the exit code and return a descriptive hint. Files
+ * skipped for exceeding the maximum file size — at scan time (`oversizedCount`)
+ * or at upload time (returned as `error` results by `uploadDebugFiles`) — also
+ * set a non-zero exit, so a partial size-drop is never reported as a clean
+ * success (consistent with the all-dropped path in `doNothingToUpload`).
  * Also honors `--require-all` against the requested `--id` values.
  */
 async function* doUpload(
@@ -439,6 +443,8 @@ async function* doUpload(
     maxWaitMs: number;
     missingRequestedIds: string[];
     requireAll: boolean;
+    oversizedCount: number;
+    maxFileSize: number;
     serverOptions?: ChunkServerOptions;
   }
 ) {
@@ -457,6 +463,14 @@ async function* doUpload(
     filesUploaded: results.length,
   });
 
+  // Scan-time oversized files were dropped before the queue was built, so they
+  // never appear in `results`. Note them on any failure hint and treat them as
+  // a failure in their own right below.
+  const scanOversize =
+    params.oversizedCount > 0
+      ? ` ${params.oversizedCount} file(s) were skipped for exceeding the maximum file size (${params.maxFileSize} bytes).`
+      : "";
+
   const failures = results.filter(
     (r) => r.state === "error" || r.state === "not_found"
   );
@@ -469,7 +483,14 @@ async function* doUpload(
       )
       .join("; ");
     return {
-      hint: `${failures.length === 1 ? "1 file" : `${failures.length} files`} had failures: ${details}`,
+      hint: `${failures.length === 1 ? "1 file" : `${failures.length} files`} had failures: ${details}.${scanOversize}`,
+    };
+  }
+
+  if (params.oversizedCount > 0) {
+    setExitCode(1);
+    return {
+      hint: `Uploaded ${results.length} debug file(s) to ${params.org}/${params.project}, but ${params.oversizedCount} file(s) were skipped for exceeding the maximum file size (${params.maxFileSize} bytes).`,
     };
   }
 
@@ -713,6 +734,8 @@ export const uploadCommand = buildCommand({
       maxWaitMs,
       missingRequestedIds: missingIds,
       requireAll,
+      oversizedCount,
+      maxFileSize,
     });
   },
 });

--- a/src/lib/api/debug-files.ts
+++ b/src/lib/api/debug-files.ts
@@ -300,30 +300,61 @@ function buildResults(
 // ── API Functions ───────────────────────────────────────────────────
 
 /**
- * Drop files larger than the server-advertised per-file cap.
+ * Split files into those within the server-advertised per-file cap and those
+ * over it.
  *
  * @param difs - Files queued for upload.
  * @param maxFileSize - Server's per-file byte cap; `0` disables the gate.
- * @returns The subset within the cap. Oversized files are logged at `warn`.
+ * @returns `{ accepted, dropped }`. Oversized files are logged at `warn` and
+ *   returned in `dropped` so the caller can report them as failures rather
+ *   than silently discarding them.
  */
 function filterBySize(
   difs: DebugFileUpload[],
   maxFileSize: number
-): DebugFileUpload[] {
+): { accepted: DebugFileUpload[]; dropped: DebugFileUpload[] } {
   if (maxFileSize <= 0) {
-    return difs;
+    return { accepted: difs, dropped: [] };
   }
   const accepted: DebugFileUpload[] = [];
+  const dropped: DebugFileUpload[] = [];
   for (const dif of difs) {
     if (dif.content.length > maxFileSize) {
       log.warn(
         `Skipping ${dif.name}: size ${dif.content.length} exceeds server maximum file size ${maxFileSize}`
       );
+      dropped.push(dif);
       continue;
     }
     accepted.push(dif);
   }
-  return accepted;
+  return { accepted, dropped };
+}
+
+/**
+ * Build failed result entries for files dropped by the size gate.
+ *
+ * Oversized files are never chunked or assembled, so the server never returns a
+ * state for them. They are reported as `error` results — not silently skipped —
+ * so the command surfaces a non-zero exit and lists them. A partial size-drop
+ * (some files accepted, some over the cap) must not look like a clean success,
+ * mirroring the all-dropped case which throws.
+ *
+ * @param dropped - Files that exceeded `maxFileSize`.
+ * @param maxFileSize - The effective per-file cap, for the detail message.
+ * @returns One `error` result per dropped file (empty `checksum`, never hashed).
+ */
+function buildOversizeResults(
+  dropped: DebugFileUpload[],
+  maxFileSize: number
+): DebugFileUploadResult[] {
+  return dropped.map((dif) => ({
+    name: dif.name,
+    debugId: dif.debugId,
+    checksum: "",
+    state: "error" as const,
+    detail: `Exceeds server maximum file size of ${maxFileSize} bytes (was ${dif.content.length} bytes)`,
+  }));
 }
 
 /**
@@ -355,8 +386,10 @@ function clampMaxWait(requestedMs: number, serverMaxWaitSec: number): number {
  * The server re-parses each uploaded file and indexes every contained object
  * slice itself; `debugId` is advisory.
  *
- * Files larger than the server-advertised `maxFileSize` are dropped with a
- * warning, and the caller's `maxWaitMs` is clamped to the server's `maxWait`.
+ * Files larger than the server-advertised `maxFileSize` are not uploaded and
+ * are returned as `error` results (so a partial drop yields a non-zero exit
+ * rather than a misleading success); the caller's `maxWaitMs` is clamped to the
+ * server's `maxWait`.
  *
  * @param options - Upload configuration (org, project, files, wait mode).
  * @returns Per-file terminal/last-observed assembly state.
@@ -384,7 +417,7 @@ export async function uploadDebugFiles(
     serverOptions.maxFileSize && serverOptions.maxFileSize > 0
       ? serverOptions.maxFileSize
       : DEFAULT_MAX_DIF_SIZE;
-  const accepted = filterBySize(difs, effectiveMaxFileSize);
+  const { accepted, dropped } = filterBySize(difs, effectiveMaxFileSize);
 
   // `difs` is non-empty (checked above), so an empty `accepted` means every
   // file was dropped by the size gate. Fail loudly instead of silently
@@ -456,7 +489,12 @@ export async function uploadDebugFiles(
     });
   }
 
-  return buildResults(chunked, response);
+  // Append oversized files (dropped before assembly) as failed results so a
+  // partial size-drop produces a non-zero exit instead of a silent success.
+  return [
+    ...buildResults(chunked, response),
+    ...buildOversizeResults(dropped, effectiveMaxFileSize),
+  ];
 }
 
 /** Default maximum wait for server-side DIF processing (`--wait`). */

--- a/test/commands/debug-files/upload.test.ts
+++ b/test/commands/debug-files/upload.test.ts
@@ -377,6 +377,52 @@ describe("sentry debug-files upload", () => {
     expect(exitCode).not.toBe(0);
   });
 
+  test("a partial size-drop still uploads the rest but exits non-zero", async () => {
+    process.env.SENTRY_ORG = "test-org";
+    process.env.SENTRY_PROJECT = "test-project";
+    // One in-cap file and one valid-header file well over the cap.
+    await writeBreakpad("small.sym");
+    const bigBody = `${[
+      "MODULE Linux x86_64 1A23B5DA412AFBF7C8662048F3294F3D0 big",
+      "INFO CODE_ID DAA5130F2A41F7FBC8662048F3294F3D439CA7FF",
+    ].join("\n")}\n${Array.from(
+      { length: 500 },
+      (_, i) => `PUBLIC ${i.toString(16)} 0 sym_${i}`
+    ).join("\n")}`;
+    await writeFile(join(tempDir, "big.sym"), bigBody);
+
+    // Cap between the two sizes: the small file passes the scan gate, the big
+    // one is dropped (counted in oversizedCount) before it is ever read fully.
+    vi.spyOn(chunkUpload, "getChunkUploadOptions").mockResolvedValue({
+      url: "https://us.sentry.io/api/0/chunk-upload/",
+      chunkSize: 8192,
+      chunksPerRequest: 64,
+      maxRequestSize: 1_048_576,
+      maxFileSize: 1000,
+      hashAlgorithm: "sha1",
+      concurrency: 8,
+      compression: ["gzip"],
+    } as Awaited<ReturnType<typeof chunkUpload.getChunkUploadOptions>>);
+
+    const spy = vi.spyOn(debugFilesApi, "uploadDebugFiles").mockResolvedValue([
+      {
+        name: "small.sym",
+        debugId: KNOWN_DEBUG_ID,
+        checksum: "a".repeat(40),
+        state: "ok",
+        detail: null,
+      },
+    ]);
+
+    const { exitCode } = await runUpload([tempDir]);
+    // The in-cap file is still uploaded...
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0]?.[0]?.difs).toHaveLength(1);
+    // ...but the dropped oversized file makes the command fail loudly rather
+    // than reporting a clean success.
+    expect(exitCode).toBe(1);
+  });
+
   test("wait mode surfaces processing errors with a non-zero exit", async () => {
     process.env.SENTRY_ORG = "test-org";
     process.env.SENTRY_PROJECT = "test-project";

--- a/test/lib/api/debug-files.test.ts
+++ b/test/lib/api/debug-files.test.ts
@@ -373,7 +373,7 @@ describe("uploadDebugFiles", () => {
     expect(passedMissing.size).toBeGreaterThan(0);
   });
 
-  test("drops files larger than the server maxFileSize before assembling", async () => {
+  test("does not assemble oversized files but reports them as failures", async () => {
     setServerOptions({ maxFileSize: 5 });
     apiRequestToRegionMock.mockImplementationOnce(
       async (_url: string, _endpoint: string, init: { body: object }) => {
@@ -397,11 +397,19 @@ describe("uploadDebugFiles", () => {
       maxWaitMs: 1000,
     });
 
+    // Only the in-cap file is actually assembled.
     const body = lastAssembleBody();
     const names = Object.values(body).map((e) => e.name);
     expect(names).toEqual(["small.so"]);
-    expect(results).toHaveLength(1);
-    expect(results[0]?.name).toBe("small.so");
+
+    // But the oversized file is surfaced as an `error` result so a partial
+    // drop yields a non-zero exit instead of a silent success.
+    expect(results).toHaveLength(2);
+    const small = results.find((r) => r.name === "small.so");
+    const big = results.find((r) => r.name === "big.so");
+    expect(small?.state).toBe("ok");
+    expect(big?.state).toBe("error");
+    expect(big?.detail).toMatch(/maximum file size/);
   });
 
   test("throws when every file exceeds the server maxFileSize", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #1140, addressing Warden finding **9LL-87A** (a comment we missed before merge).

A **partial** size-drop during `debug-files upload` silently exited `0` and printed "Uploaded N debug file(s)". The *all-dropped* cases already fail loudly — `filterBySize` throws `ValidationError`, and the scan-time all-dropped path exits via `doNothingToUpload(... oversizedCount > 0 → exit 1)` — but a partial drop did not honor that same "oversized ⇒ non-zero exit" contract. Oversized files left no result entry, so `doUpload` never counted them as failures.

Two disjoint drop sites both had the gap:

1. **Upload-time (`filterBySize`)** — most relevant for in-memory `--include-sources` source bundles, which bypass the scan-time size gate and can only be caught here. `uploadDebugFiles` now returns these as `error` results so the existing `doUpload` failure path sets exit 1 and lists them.
2. **Scan-time (`prepareDifs` → `oversizedCount`)** — regular oversized files are dropped before the upload queue is built. `doUpload` now receives `oversizedCount`/`maxFileSize` and exits non-zero on a partial drop, matching `doNothingToUpload`.

Accepted (in-cap) files are still uploaded; only the exit code and hint change so a partial drop is no longer mistaken for a clean success.

## Warden findings on #1140

- **9LL-87A** (partial size-drop silently exits 0) — **fixed here.**
- **ANP-RKY** (size gate applied after full file read) — **already fixed** by #1141: `prepareFileDif` now gates on `peeked.size` (from `fd.stat()`) *before* `readFile`, so oversized files are never buffered.

## Tests

- `test/lib/api/debug-files.test.ts`: the partial-drop test now asserts the oversized file is **not** assembled but **is** returned as an `error` result.
- `test/commands/debug-files/upload.test.ts`: new test — a partial scan-time size-drop still uploads the in-cap file but exits `1`.

`pnpm run typecheck`, `biome check`, and both affected test files (40 tests) pass.