### PR TITLE
fix(error-reporting): stop reporting network fetch failures as crashes (CLI-16W)

### DIFF
--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -64,11 +64,11 @@ export function classifySilenced(error: unknown): SilenceReason | null {
   if (error instanceof OutputError) {
     return "output_error";
   }
-  // Network-level failures (offline, DNS, connection refused/timeout, proxy)
-  // mean the CLI could not reach Sentry at all. There is nothing actionable in
-  // a "user is offline" report, so drop it — same rationale as EPIPE/EBADF OS
-  // noise in `beforeSend`. Covers both the wrapped ApiError(status 0) and a raw
-  // `TypeError: "fetch failed"` that escaped before wrapping (CLI-16W).
+  // A raw `TypeError: "fetch failed"` (CLI-16W) means the CLI could not reach
+  // Sentry at all (offline, DNS, connection refused/timeout). There is nothing
+  // actionable in a "user is offline" report, so drop it — same rationale as
+  // EPIPE/EBADF OS noise in `beforeSend`. Note: TLS cert errors are wrapped as
+  // ApiError(status 0), NOT matched here, so they stay captured/actionable.
   if (isNetworkError(error)) {
     return "network_error";
   }

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -3,11 +3,11 @@
  *
  * Provides two things:
  *
- * 1. **Silencing rules** — `OutputError`, `ContextError` (a required value the
- *    user omitted), expected-state `AuthError`, 401–499 `ApiError`, and 400
- *    `ApiError`s that report an unparseable user search query are not sent to
- *    Sentry as issues. A `cli.error.silenced` metric preserves volume +
- *    user/org context.
+ * 1. **Silencing rules** — `OutputError`, network failures (offline/DNS/proxy),
+ *    `ContextError` (a required value the user omitted), expected-state
+ *    `AuthError`, 401–499 `ApiError`, and 400 `ApiError`s that report an
+ *    unparseable user search query are not sent to Sentry as issues. A
+ *    `cli.error.silenced` metric preserves volume + user/org context.
  *
  * 2. **Grouping tags** — enriches every error event with `cli_error.*` tags
  *    that Sentry's server-side fingerprint rules use for stable grouping.
@@ -27,6 +27,7 @@ import {
   ContextError,
   DeviceFlowError,
   HostScopeError,
+  isNetworkError,
   isSearchQueryParseError,
   OutputError,
   ResolutionError,
@@ -50,7 +51,8 @@ type SilenceReason =
   | "context_missing"
   | "auth_expected"
   | "api_user_error"
-  | "api_query_error";
+  | "api_query_error"
+  | "network_error";
 
 /**
  * Classify whether an error should be silenced.
@@ -61,6 +63,14 @@ type SilenceReason =
 export function classifySilenced(error: unknown): SilenceReason | null {
   if (error instanceof OutputError) {
     return "output_error";
+  }
+  // Network-level failures (offline, DNS, connection refused/timeout, proxy)
+  // mean the CLI could not reach Sentry at all. There is nothing actionable in
+  // a "user is offline" report, so drop it — same rationale as EPIPE/EBADF OS
+  // noise in `beforeSend`. Covers both the wrapped ApiError(status 0) and a raw
+  // `TypeError: "fetch failed"` that escaped before wrapping (CLI-16W).
+  if (isNetworkError(error)) {
+    return "network_error";
   }
   // A ContextError always means the user omitted a required value (no
   // org/project could be resolved, a required ID was not provided, etc.). It is

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -781,23 +781,23 @@ export function isSearchQueryParseError(error: ApiError): boolean {
 }
 
 /**
- * Whether an error is a network-level failure — the CLI could not reach the
- * Sentry API at all (offline, DNS failure, connection refused/timeout, proxy).
+ * Whether an error is a raw network-level fetch failure — the CLI could not
+ * reach the Sentry API at all (offline, DNS failure, connection
+ * refused/timeout). Node's `fetch` (undici) rejects with exactly
+ * `TypeError: "fetch failed"` for every such failure (the real errno is in
+ * `cause`).
  *
- * Two shapes occur:
- * - An {@link ApiError} with `status === 0`, produced when the SDK/raw paths
- *   wrap a fetch rejection (see `throwApiError` / `handleFetchError`).
- * - A raw `TypeError: "fetch failed"` — Node's `fetch` (undici) uses this exact
- *   message for every network-level failure (the real errno is in `cause`).
+ * This reflects the user's environment, not a CLI bug, so it is treated as a
+ * user error (no upgrade nudge) and is not reported to Sentry — the same
+ * rationale as dropping EPIPE/EBADF OS noise in `beforeSend`.
  *
- * These reflect the user's environment, not a CLI bug, so they are treated as
- * user errors (no upgrade nudge) and are not reported to Sentry as issues —
- * the same rationale as dropping EPIPE/EBADF OS noise in `beforeSend`.
+ * NOTE: This deliberately does NOT match `ApiError` with `status === 0`. That
+ * status is shared by genuine connectivity failures AND TLS certificate errors,
+ * and the latter are actionable user-configuration issues (e.g. a missing CA
+ * cert) that must stay visible. Callers that want the "user environment, not a
+ * CLI bug" treatment for `status === 0` check it explicitly.
  */
 export function isNetworkError(error: unknown): boolean {
-  if (error instanceof ApiError) {
-    return error.status === 0;
-  }
   return error instanceof TypeError && error.message === "fetch failed";
 }
 
@@ -810,13 +810,18 @@ export function isNetworkError(error: unknown): boolean {
  * Explicit non-user subclasses must be checked before that fallback.
  */
 export function isUserError(error: unknown): boolean {
-  // Network failures (ApiError status 0 or a raw "fetch failed" TypeError) are
-  // the user's environment, not a CLI bug.
+  // A raw "fetch failed" TypeError is a network-level failure — the user's
+  // environment, not a CLI bug.
   if (isNetworkError(error)) {
     return true;
   }
 
   if (error instanceof ApiError) {
+    // Status 0 = no HTTP response (network failure or TLS cert error) — the
+    // user's environment/config, not a CLI bug.
+    if (error.status === 0) {
+      return true;
+    }
     // 400 usually means the CLI constructed a bad request, so it is treated as
     // a CLI bug — except when the server reports the user's search query was
     // unparseable, which is a user input mistake.

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -781,6 +781,27 @@ export function isSearchQueryParseError(error: ApiError): boolean {
 }
 
 /**
+ * Whether an error is a network-level failure — the CLI could not reach the
+ * Sentry API at all (offline, DNS failure, connection refused/timeout, proxy).
+ *
+ * Two shapes occur:
+ * - An {@link ApiError} with `status === 0`, produced when the SDK/raw paths
+ *   wrap a fetch rejection (see `throwApiError` / `handleFetchError`).
+ * - A raw `TypeError: "fetch failed"` — Node's `fetch` (undici) uses this exact
+ *   message for every network-level failure (the real errno is in `cause`).
+ *
+ * These reflect the user's environment, not a CLI bug, so they are treated as
+ * user errors (no upgrade nudge) and are not reported to Sentry as issues —
+ * the same rationale as dropping EPIPE/EBADF OS noise in `beforeSend`.
+ */
+export function isNetworkError(error: unknown): boolean {
+  if (error instanceof ApiError) {
+    return error.status === 0;
+  }
+  return error instanceof TypeError && error.message === "fetch failed";
+}
+
+/**
  * Classify errors caused by user input, configuration, auth state, or account
  * settings. These errors already tell the user what to fix, so upgrade nudges
  * should use the neutral update banner instead of implying a CLI bug fix.
@@ -789,14 +810,16 @@ export function isSearchQueryParseError(error: ApiError): boolean {
  * Explicit non-user subclasses must be checked before that fallback.
  */
 export function isUserError(error: unknown): boolean {
+  // Network failures (ApiError status 0 or a raw "fetch failed" TypeError) are
+  // the user's environment, not a CLI bug.
+  if (isNetworkError(error)) {
+    return true;
+  }
+
   if (error instanceof ApiError) {
-    // Status 0 = network-level failure (DNS, ECONNREFUSED) — user environment,
-    // not a CLI bug. 400 usually means the CLI constructed a bad request, so it
-    // is treated as a CLI bug — except when the server reports the user's search
-    // query was unparseable, which is a user input mistake.
-    if (error.status === 0) {
-      return true;
-    }
+    // 400 usually means the CLI constructed a bad request, so it is treated as
+    // a CLI bug — except when the server reports the user's search query was
+    // unparseable, which is a user input mistake.
     if (isSearchQueryParseError(error)) {
       return true;
     }

--- a/src/lib/sentry-client.ts
+++ b/src/lib/sentry-client.ts
@@ -25,7 +25,12 @@ import {
 } from "./custom-ca.js";
 import { applyCustomHeaders } from "./custom-headers.js";
 import { getAuthToken, refreshToken } from "./db/auth.js";
-import { ApiError, HostScopeError, TimeoutError } from "./errors.js";
+import {
+  ApiError,
+  HostScopeError,
+  isNetworkError,
+  TimeoutError,
+} from "./errors.js";
 import { logger } from "./logger.js";
 import {
   clearLastCacheHitAge,
@@ -349,6 +354,21 @@ function handleFetchError(
       error: new TimeoutError(
         `Request timed out after ${seconds}s.`,
         "The Sentry API did not respond in time. Try again; if the problem persists, check https://status.sentry.io."
+      ),
+    };
+  }
+  // Network-level failure (DNS, connection refused/timeout, offline, proxy):
+  // Node's fetch rejects with a raw `TypeError: "fetch failed"`. After retries
+  // are exhausted, wrap it in a clear ApiError(status 0) instead of surfacing
+  // the cryptic TypeError (CLI-16W). status 0 marks it as a non-CLI-bug network
+  // error for `isUserError`/`classifySilenced`, mirroring `throwApiError`.
+  if (isNetworkError(error) && isLastAttempt) {
+    return {
+      action: "throw",
+      error: new ApiError(
+        "Network error",
+        0,
+        "Unable to reach the Sentry API. Check your internet connection (or proxy/VPN) and try again."
       ),
     };
   }

--- a/src/lib/sentry-client.ts
+++ b/src/lib/sentry-client.ts
@@ -25,12 +25,7 @@ import {
 } from "./custom-ca.js";
 import { applyCustomHeaders } from "./custom-headers.js";
 import { getAuthToken, refreshToken } from "./db/auth.js";
-import {
-  ApiError,
-  HostScopeError,
-  isNetworkError,
-  TimeoutError,
-} from "./errors.js";
+import { ApiError, HostScopeError, TimeoutError } from "./errors.js";
 import { logger } from "./logger.js";
 import {
   clearLastCacheHitAge,
@@ -354,21 +349,6 @@ function handleFetchError(
       error: new TimeoutError(
         `Request timed out after ${seconds}s.`,
         "The Sentry API did not respond in time. Try again; if the problem persists, check https://status.sentry.io."
-      ),
-    };
-  }
-  // Network-level failure (DNS, connection refused/timeout, offline, proxy):
-  // Node's fetch rejects with a raw `TypeError: "fetch failed"`. After retries
-  // are exhausted, wrap it in a clear ApiError(status 0) instead of surfacing
-  // the cryptic TypeError (CLI-16W). status 0 marks it as a non-CLI-bug network
-  // error for `isUserError`/`classifySilenced`, mirroring `throwApiError`.
-  if (isNetworkError(error) && isLastAttempt) {
-    return {
-      action: "throw",
-      error: new ApiError(
-        "Network error",
-        0,
-        "Unable to reach the Sentry API. Check your internet connection (or proxy/VPN) and try again."
       ),
     };
   }

--- a/test/lib/error-reporting.test.ts
+++ b/test/lib/error-reporting.test.ts
@@ -239,16 +239,18 @@ describe("classifySilenced", () => {
     expect(classifySilenced(new ApiError("bad", 400))).toBeNull();
   });
 
-  test("silences ApiError with status 0 (network failure)", () => {
-    expect(classifySilenced(new ApiError("Network error", 0))).toBe(
-      "network_error"
-    );
-  });
-
   test("silences a raw 'fetch failed' TypeError (network failure)", () => {
     expect(classifySilenced(new TypeError("fetch failed"))).toBe(
       "network_error"
     );
+  });
+
+  test("does NOT silence a TLS cert error wrapped as ApiError(0)", () => {
+    // status 0 is shared by network failures and TLS cert errors; the latter
+    // are actionable (missing CA) and must stay captured.
+    expect(
+      classifySilenced(new ApiError("TLS certificate error", 0))
+    ).toBeNull();
   });
 
   test("does NOT silence an unrelated TypeError", () => {
@@ -623,7 +625,7 @@ describe("reportCliError integration", () => {
   });
 
   test("silences a network error and emits metric", () => {
-    reportCliError(new ApiError("Network error", 0));
+    reportCliError(new TypeError("fetch failed"));
     expect(captureSpy).not.toHaveBeenCalled();
     expect(metricSpy).toHaveBeenCalledWith(
       "cli.error.silenced",

--- a/test/lib/error-reporting.test.ts
+++ b/test/lib/error-reporting.test.ts
@@ -239,6 +239,22 @@ describe("classifySilenced", () => {
     expect(classifySilenced(new ApiError("bad", 400))).toBeNull();
   });
 
+  test("silences ApiError with status 0 (network failure)", () => {
+    expect(classifySilenced(new ApiError("Network error", 0))).toBe(
+      "network_error"
+    );
+  });
+
+  test("silences a raw 'fetch failed' TypeError (network failure)", () => {
+    expect(classifySilenced(new TypeError("fetch failed"))).toBe(
+      "network_error"
+    );
+  });
+
+  test("does NOT silence an unrelated TypeError", () => {
+    expect(classifySilenced(new TypeError("x is not a function"))).toBeNull();
+  });
+
   test("silences ApiError 400 with a search-query parse detail", () => {
     expect(
       classifySilenced(
@@ -602,6 +618,18 @@ describe("reportCliError integration", () => {
       1,
       expect.objectContaining({
         attributes: expect.objectContaining({ reason: "output_error" }),
+      })
+    );
+  });
+
+  test("silences a network error and emits metric", () => {
+    reportCliError(new ApiError("Network error", 0));
+    expect(captureSpy).not.toHaveBeenCalled();
+    expect(metricSpy).toHaveBeenCalledWith(
+      "cli.error.silenced",
+      1,
+      expect.objectContaining({
+        attributes: expect.objectContaining({ reason: "network_error" }),
       })
     );
   });

--- a/test/lib/errors.test.ts
+++ b/test/lib/errors.test.ts
@@ -527,12 +527,16 @@ describe("isUserError", () => {
 });
 
 describe("isNetworkError", () => {
-  test("true for ApiError with status 0", () => {
-    expect(isNetworkError(new ApiError("Network error", 0))).toBe(true);
-  });
-
   test("true for a raw 'fetch failed' TypeError (undici network failure)", () => {
     expect(isNetworkError(new TypeError("fetch failed"))).toBe(true);
+  });
+
+  test("false for ApiError status 0 (shared with TLS cert errors)", () => {
+    // status 0 is also used for TLS cert errors, which must stay actionable.
+    expect(isNetworkError(new ApiError("Network error", 0))).toBe(false);
+    expect(isNetworkError(new ApiError("TLS certificate error", 0))).toBe(
+      false
+    );
   });
 
   test("false for an ApiError with an HTTP status", () => {

--- a/test/lib/errors.test.ts
+++ b/test/lib/errors.test.ts
@@ -11,6 +11,7 @@ import {
   formatError,
   getExitCode,
   HostScopeError,
+  isNetworkError,
   isSearchQueryParseError,
   isUserError,
   OutputError,
@@ -499,6 +500,11 @@ describe("isUserError", () => {
     ["SeerError", new SeerError("not_enabled"), true],
     ["WizardError", new WizardError("wizard failed"), true],
     ["ApiError 0 (network)", new ApiError("network error", 0), true],
+    [
+      "raw fetch failed TypeError (network)",
+      new TypeError("fetch failed"),
+      true,
+    ],
     ["ApiError 400", new ApiError("bad request", 400), false],
     [
       "ApiError 400 (search query parse)",
@@ -517,6 +523,31 @@ describe("isUserError", () => {
     ["null", null, false],
   ])("classifies %s", (_label, errorValue, expected) => {
     expect(isUserError(errorValue)).toBe(expected);
+  });
+});
+
+describe("isNetworkError", () => {
+  test("true for ApiError with status 0", () => {
+    expect(isNetworkError(new ApiError("Network error", 0))).toBe(true);
+  });
+
+  test("true for a raw 'fetch failed' TypeError (undici network failure)", () => {
+    expect(isNetworkError(new TypeError("fetch failed"))).toBe(true);
+  });
+
+  test("false for an ApiError with an HTTP status", () => {
+    expect(isNetworkError(new ApiError("bad", 400))).toBe(false);
+    expect(isNetworkError(new ApiError("server", 500))).toBe(false);
+  });
+
+  test("false for an unrelated TypeError", () => {
+    expect(isNetworkError(new TypeError("x is not a function"))).toBe(false);
+  });
+
+  test("false for non-error values", () => {
+    expect(isNetworkError(new Error("boom"))).toBe(false);
+    expect(isNetworkError("fetch failed")).toBe(false);
+    expect(isNetworkError(null)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

When the CLI cannot reach the Sentry API — offline, DNS failure, connection
refused/timeout — Node's `fetch` (undici) rejects with a raw
`TypeError: "fetch failed"`. This escapes uncaught and is reported to Sentry as
a CLI bug. This is [CLI-16W](https://sentry.sentry.io/issues/7414325252/)
(`TypeError: fetch failed`, culprit `GetAddrInfoReqWrap.onlookupall (node:dns)`)
— **17 users**, ongoing on 0.38.0.

A "user is offline" report is not actionable for the CLI team — the same class
of noise the codebase already drops for EPIPE/EBADF in `beforeSend`.

## Fix

- **`isNetworkError()`** (new, in `errors.ts`) — matches the raw
  `TypeError: "fetch failed"`, undici's unambiguous signature for every
  network-level failure (the real errno is in `cause`).
- **`classifySilenced`** silences network errors (`reason: network_error`);
  volume is preserved via the `cli.error.silenced` metric.
- **`isUserError`** treats a raw network `TypeError` as user-environment (no
  "Upgrading may resolve this" nudge).

### Why not `ApiError(status 0)` (addressing Seer review)

`status 0` is shared by genuine connectivity failures **and TLS certificate
errors**. TLS errors are actionable user-config issues (e.g. a missing CA cert)
and must stay visible, and `isTlsCertError` can't reliably re-detect TLS from
the already-wrapped `ApiError(0)`. So `isNetworkError` deliberately matches
**only** the raw `TypeError` — `ApiError(status 0)`, including TLS, stays
captured/actionable. `isUserError` keeps its explicit `status === 0` check so
those still skip the upgrade nudge.

## Test plan

- `isNetworkError`: raw `fetch failed` TypeError → true; `ApiError(0)` (incl.
  TLS), HTTP statuses, unrelated TypeErrors, non-errors → false.
- `classifySilenced`: `fetch failed` TypeError → `network_error`; TLS
  `ApiError(0)` → **not** silenced (regression test); unrelated TypeError →
  captured.
- `isUserError`: raw `fetch failed` TypeError → true.
- `reportCliError`: network error emits the metric and is not captured.
- `vitest run test/lib/{errors,error-reporting,telemetry,sentry-client}.test.ts`
  → 316 passed; `biome check` clean.

Fixes CLI-16W