### PR TITLE
feat(init): speak the Vercel Workflows protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@biomejs/biome": "2.3.8",
     "@clack/prompts": "0.11.0",
     "@hono/node-server": "^2.0.6",
-    "@mastra/client-js": "^1.26.0",
     "@sentry/api": "^0.180.0",
     "@sentry/core": "10.50.0",
     "@sentry/node-core": "10.50.0",

--- a/plugins/sentry-cli/skills/sentry-cli/references/dashboard.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/dashboard.md
@@ -42,7 +42,7 @@ View a dashboard
 - `-w, --web - Open in browser`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-r, --refresh <value> - Auto-refresh interval in seconds (default: 60, min: 10)`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01"`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01"`
 
 **Examples:**
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/event.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/event.md
@@ -37,7 +37,7 @@ List events for an issue
 - `-n, --limit <value> - Number of events (1-1000) - (default: "25")`
 - `-q, --query <value> - Search query (Sentry search syntax)`
 - `--full - Include full event body (stacktraces)`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/explore.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/explore.md
@@ -24,7 +24,7 @@ Query aggregate event data (Explore)
 - `-s, --sort <value> - Sort field (prefix with - for desc, e.g., "-count()")`
 - `-e, --environment <value>... - Replay environment filter for --dataset replays (repeatable, comma-separated)`
 - `-n, --limit <value> - Number of rows (1-1000) - (default: "25")`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "24h")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "24h")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/issue.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/issue.md
@@ -19,7 +19,7 @@ List issues in a project
 - `-q, --query <value> - Search query (Sentry syntax, implicit AND, no OR operator)`
 - `-n, --limit <value> - Maximum number of issues to list - (default: "25")`
 - `-s, --sort <value> - Sort by: recommended, date, new, freq, user (default: recommended on sentry.io, else date)`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "90d")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "90d")`
 - `-c, --cursor <value> - Pagination cursor (use "next" for next page, "prev" for previous)`
 - `--compact - Single-line rows for compact output (auto-detects if omitted)`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
@@ -92,7 +92,7 @@ List events for a specific issue
 - `-n, --limit <value> - Number of events (1-1000) - (default: "25")`
 - `-q, --query <value> - Search query (Sentry search syntax)`
 - `--full - Include full event body (stacktraces)`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/log.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/log.md
@@ -19,7 +19,7 @@ List logs from a project
 - `-n, --limit <value> - Number of log entries (1-1000) - (default: "100")`
 - `-q, --query <value> - Filter query (e.g., "level:error", "project:backend", "project:[a,b]")`
 - `-f, --follow <value> - Stream logs (optionally specify poll interval in seconds)`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01"`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01"`
 - `-s, --sort <value> - Sort order: "newest" (default) or "oldest" - (default: "newest")`
 - `--fresh - Bypass cache, re-detect projects, and fetch fresh data`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/replay.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/replay.md
@@ -20,7 +20,7 @@ List recent Session Replays
 - `-q, --query <value> - Search query (Sentry replay search syntax)`
 - `-e, --environment <value>... - Filter by environment (repeatable, comma-separated)`
 - `-s, --sort <value> - Sort by: date, oldest, duration, errors, activity, or a raw replay sort field - (default: "date")`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/span.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/span.md
@@ -19,7 +19,7 @@ List spans in a project or trace
 - `-n, --limit <value> - Number of spans (<=1000) - (default: "25")`
 - `-q, --query <value> - Filter spans (e.g., "op:db", "project:backend", "project:[cli,api]")`
 - `-s, --sort <value> - Sort order: date, duration - (default: "date")`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/trace.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/trace.md
@@ -19,7 +19,7 @@ List recent traces in a project
 - `-n, --limit <value> - Number of traces (1-1000) - (default: "25")`
 - `-q, --query <value> - Search query (Sentry search syntax)`
 - `-s, --sort <value> - Sort by: date, duration - (default: "date")`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 
@@ -91,7 +91,7 @@ View logs associated with a trace
 
 **Flags:**
 - `-w, --web - Open trace in browser`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "14d")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "14d")`
 - `-n, --limit <value> - Number of log entries (<=1000) - (default: "100")`
 - `-q, --query <value> - Filter query (e.g., "level:error", "project:backend", "project:[a,b]")`
 - `-s, --sort <value> - Sort order: "newest" (default) or "oldest" - (default: "newest")`

--- a/src/lib/init/readiness.ts
+++ b/src/lib/init/readiness.ts
@@ -66,16 +66,22 @@ async function checkAuth(): Promise<boolean> {
 }
 
 async function checkMastraApi(): Promise<boolean> {
+  const log = logger.withTag("readiness");
+  const url = `${MASTRA_API_URL}/health`;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), HEALTH_CHECK_TIMEOUT_MS);
   try {
-    const resp = await customFetch(`${MASTRA_API_URL}/health`, {
+    log.debug(`health check GET ${url}`);
+    const resp = await customFetch(url, {
       signal: controller.signal,
       method: "GET",
     });
+    if (!resp.ok) {
+      log.debug(`health check returned ${resp.status} for ${url}`);
+    }
     return resp.ok;
   } catch (error) {
-    logger.withTag("readiness").debug("Mastra API health check failed", error);
+    log.debug(`health check failed for ${url}`, error);
     return false;
   } finally {
     clearTimeout(timer);

--- a/src/lib/init/types.ts
+++ b/src/lib/init/types.ts
@@ -277,4 +277,11 @@ export type WorkflowRunResult = {
   suspendPayload?: unknown;
   result?: WizardOutput;
   error?: string;
+  /**
+   * Internal: the suspend-point sequence number from the server, carried on the
+   * result so recovery paths can sync the run's `seqRef` after `runById` fetches
+   * state through a separate `seqRef`. Without this, `resumeAsync` would build a
+   * stale token after recovery.
+   */
+  _seq?: number;
 };

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -601,7 +601,7 @@ const RUN_STATE_RECOVERY_MAX_WAIT_MS = 120_000;
 const RUN_STATE_RECOVERY_TIMEOUT_MS = 10_000;
 
 type ResumeRetryArgs = {
-  run: Pick<WorkflowRun, "resumeAsync" | "runId">;
+  run: Pick<WorkflowRun, "resumeAsync" | "runId" | "updateSeq">;
   workflow: Pick<WorkflowHandle, "runById">;
   stepId: string;
   payload: SuspendPayload;
@@ -723,6 +723,19 @@ async function tryRecoverCurrentRunState(
   return null;
 }
 
+/**
+ * After `workflow.runById()` recovers the current run state, sync the seq
+ * counter back into the run so the next `resumeAsync` builds the correct token.
+ */
+function syncSeqFromRecovery(
+  run: Pick<WorkflowRun, "updateSeq">,
+  recovered: WorkflowRunResult
+): void {
+  if (typeof recovered._seq === "number") {
+    run.updateSeq(recovered._seq);
+  }
+}
+
 async function resumeWithRecovery(
   args: ResumeRetryArgs
 ): Promise<WorkflowRunResult> {
@@ -758,6 +771,7 @@ async function resumeWithRecovery(
         payload
       );
       if (recovered) {
+        syncSeqFromRecovery(run, recovered);
         addBreadcrumb({
           category: "wizard",
           message: `stale-step recovery succeeded for ${stepId}`,
@@ -796,6 +810,7 @@ async function resumeWithRecovery(
     );
     ui.clearOverlay?.();
     if (recovered) {
+      syncSeqFromRecovery(run, recovered);
       addBreadcrumb({
         category: "wizard",
         message: `resume state recovery succeeded for ${stepId}`,

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -1,7 +1,7 @@
 /**
  * Wizard Runner
  *
- * Main suspend/resume loop that drives the remote Mastra workflow.
+ * Main suspend/resume loop that drives the remote wizard workflow.
  * Each iteration: check status → if suspended, perform tool or
  * interactive prompt → resume with result → repeat.
  *
@@ -14,7 +14,6 @@
 import { randomBytes } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 
-import { MastraClient } from "@mastra/client-js";
 import {
   addBreadcrumb,
   captureException,
@@ -60,7 +59,6 @@ import {
 import { handleInteractive } from "./interactive.js";
 import { resolveInitContext } from "./preflight.js";
 import { checkReadiness } from "./readiness.js";
-
 import { describeTool, executeTool } from "./tools/registry.js";
 import type {
   ResolvedInitContext,
@@ -74,6 +72,11 @@ import { getUIAsync } from "./ui/factory.js";
 import { LoggingUIPromptError } from "./ui/logging-ui.js";
 import type { SpinnerHandle, WelcomeOptions, WizardUI } from "./ui/types.js";
 import { verifySetup } from "./verify-setup.js";
+import {
+  createWorkflowClient,
+  type WorkflowHandle,
+  type WorkflowRun,
+} from "./workflow-client.js";
 import {
   precomputeDirListing,
   precomputeSentryDetection,
@@ -598,13 +601,8 @@ const RUN_STATE_RECOVERY_MAX_WAIT_MS = 120_000;
 const RUN_STATE_RECOVERY_TIMEOUT_MS = 10_000;
 
 type ResumeRetryArgs = {
-  run: {
-    resumeAsync: (args: Record<string, unknown>) => Promise<unknown>;
-    readonly runId: string;
-  };
-  workflow: {
-    runById: (runId: string, opts?: { fields?: string[] }) => Promise<unknown>;
-  };
+  run: Pick<WorkflowRun, "resumeAsync" | "runId">;
+  workflow: Pick<WorkflowHandle, "runById">;
   stepId: string;
   payload: SuspendPayload;
   resumeData: Record<string, unknown>;
@@ -615,10 +613,9 @@ type ResumeRetryArgs = {
 };
 
 /**
- * Detect Mastra's "not suspended" conflict — means the server already
- * processed this step (our previous request succeeded but the response was
- * dropped before we received it). The MastraClientError message embeds the
- * server body, e.g.:
+ * Detect a "not suspended" conflict — means the server already processed this
+ * step (our previous request succeeded but the response was dropped before we
+ * received it). The client error message embeds the server body, e.g.:
  *   "HTTP error! status: 500 - {"error":"This workflow step 'X' was not suspended..."}"
  * or:
  *   "HTTP error! status: 500 - {"error":"This workflow run was not suspended"}"
@@ -873,7 +870,7 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
   assertHostedInitServiceAcceptsTokenHost();
   const token = context.authToken;
 
-  // AbortController bound to the MastraClient lifecycle. Aborting on
+  // AbortController bound to the workflow-client lifecycle. Aborting on
   // teardown (success OR failure, via `using` below) cancels any in-flight
   // fetches — releasing keep-alive sockets so the event loop drains and
   // `sentry init` returns to the shell promptly. Without this, a stuck or
@@ -887,16 +884,14 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     },
   };
 
-  const client = new MastraClient({
+  const client = createWorkflowClient({
     baseUrl: MASTRA_API_URL,
-    retries: 0,
     headers: token ? { Authorization: `Bearer ${token}` } : {},
     abortSignal: abortController.signal,
-    fetch: ((url, init) => {
+    fetch: ((url: string, init?: RequestInit) => {
       const traceData = getTraceData();
-      // Preserve `init.signal` via the spread — MastraClient may pass its
-      // own per-request signal, and the client-level `abortSignal` is
-      // forwarded through the same channel.
+      // Preserve `init.signal` via the spread — the client-level `abortSignal`
+      // is forwarded through the same channel.
       return customFetch(url, {
         ...init,
         headers: {
@@ -907,7 +902,7 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
           ...(traceData.baggage && { baggage: traceData.baggage }),
         },
       });
-    }) as typeof fetch,
+    }) as (url: string, init?: RequestInit) => Promise<Response>,
   });
   const workflow = client.getWorkflow(WORKFLOW_ID);
 

--- a/src/lib/init/workflow-client.ts
+++ b/src/lib/init/workflow-client.ts
@@ -120,6 +120,58 @@ function toWorkflowRunResult(
   return { status: "suspended", suspended: [] };
 }
 
+const MAX_ERROR_DETAIL_LEN = 500;
+const HTML_BODY_RE = /<html|<!doctype/i;
+const ERROR_LINE_RE = /\b[A-Z]\w*Error\b[^<\n]*/;
+const WHITESPACE_RE = /\s+/g;
+
+/**
+ * Reduce an error response body to a short, human-useful message.
+ *
+ * The server may return JSON (`{ "error": "..." }`), a plain string, or — when a
+ * dev server crashes — a large HTML error page (e.g. Bun's fallback overlay). We
+ * never surface the raw HTML/markup, so extract the meaningful bit and cap the
+ * length.
+ */
+function extractErrorDetail(body: string): string {
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return "(empty response)";
+  }
+
+  // JSON error envelope from our own API.
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed) as { error?: unknown };
+      if (typeof parsed.error === "string" && parsed.error) {
+        return truncate(parsed.error);
+      }
+    } catch {
+      // fall through
+    }
+  }
+
+  // HTML error page (e.g. a crashed dev server) — pull the first meaningful
+  // "<Something>Error: message" line out of the markup instead of dumping it.
+  if (HTML_BODY_RE.test(trimmed)) {
+    const match = trimmed.match(ERROR_LINE_RE);
+    return truncate(
+      match
+        ? match[0]
+        : "server returned an HTML error page (is the dev server crashing?)"
+    );
+  }
+
+  return truncate(trimmed);
+}
+
+function truncate(s: string): string {
+  const oneLine = s.replace(WHITESPACE_RE, " ").trim();
+  return oneLine.length > MAX_ERROR_DETAIL_LEN
+    ? `${oneLine.slice(0, MAX_ERROR_DETAIL_LEN)}…`
+    : oneLine;
+}
+
 /** One-line description of a run state for debug logs. */
 function describeRunState(state: RunStatePayload): string {
   const parts = [`status=${state.status}`];
@@ -155,9 +207,10 @@ export function createWorkflowClient(options: WorkflowClientOptions): {
       signal: abortSignal,
     });
     if (!res.ok) {
-      const errorBody = await res.text();
-      log.debug(`POST ${path} failed: ${res.status}`, errorBody);
-      throw new Error(`HTTP error! status: ${res.status} - ${errorBody}`);
+      const rawBody = await res.text();
+      const detail = extractErrorDetail(rawBody);
+      log.debug(`POST ${path} failed: ${res.status}`, detail);
+      throw new Error(`HTTP error! status: ${res.status} - ${detail}`);
     }
     log.debug(`POST ${path} -> ${res.status}`);
     return (await res.json()) as Record<string, unknown>;
@@ -171,9 +224,9 @@ export function createWorkflowClient(options: WorkflowClientOptions): {
       signal: abortSignal,
     });
     if (!res.ok) {
-      const errorBody = await res.text();
-      log.debug(`GET /api/run failed: ${res.status}`, errorBody);
-      throw new Error(`HTTP error! status: ${res.status} - ${errorBody}`);
+      const detail = extractErrorDetail(await res.text());
+      log.debug(`GET /api/run failed: ${res.status}`, detail);
+      throw new Error(`HTTP error! status: ${res.status} - ${detail}`);
     }
     const state = (await res.json()) as RunStatePayload;
     log.debug(`GET /api/run -> ${describeRunState(state)}`);

--- a/src/lib/init/workflow-client.ts
+++ b/src/lib/init/workflow-client.ts
@@ -21,10 +21,14 @@
  * (runId, seq) plus the Bearer auth is what authorizes the resume.
  */
 
+import { logger } from "../logger.js";
 import type { SuspendPayload, WorkflowRunResult } from "./types.js";
 
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 300_000;
+
+/** Scoped diagnostic logger. Surfaced with `--verbose` / `--log-level=debug`. */
+const log = logger.withTag("wizard-client");
 
 type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
 
@@ -116,10 +120,26 @@ function toWorkflowRunResult(
   return { status: "suspended", suspended: [] };
 }
 
+/** One-line description of a run state for debug logs. */
+function describeRunState(state: RunStatePayload): string {
+  const parts = [`status=${state.status}`];
+  if (state.seq !== undefined) {
+    parts.push(`seq=${state.seq}`);
+  }
+  if (state.request?.type === "tool") {
+    parts.push(`op=${state.request.operation}`);
+  } else if (state.request?.type === "interactive") {
+    parts.push(`kind=${state.request.kind}`);
+  }
+  return parts.join(" ");
+}
+
 export function createWorkflowClient(options: WorkflowClientOptions): {
   getWorkflow(id: string): WorkflowHandle;
 } {
   const { baseUrl, headers = {}, fetch, abortSignal } = options;
+
+  log.debug(`workflow client targeting ${baseUrl}`);
 
   const jsonHeaders = { "content-type": "application/json", ...headers };
 
@@ -127,6 +147,7 @@ export function createWorkflowClient(options: WorkflowClientOptions): {
     path: string,
     body: unknown
   ): Promise<Record<string, unknown>> {
+    log.debug(`POST ${baseUrl}${path}`);
     const res = await fetch(`${baseUrl}${path}`, {
       method: "POST",
       headers: jsonHeaders,
@@ -134,24 +155,29 @@ export function createWorkflowClient(options: WorkflowClientOptions): {
       signal: abortSignal,
     });
     if (!res.ok) {
-      throw new Error(
-        `HTTP error! status: ${res.status} - ${await res.text()}`
-      );
+      const errorBody = await res.text();
+      log.debug(`POST ${path} failed: ${res.status}`, errorBody);
+      throw new Error(`HTTP error! status: ${res.status} - ${errorBody}`);
     }
+    log.debug(`POST ${path} -> ${res.status}`);
     return (await res.json()) as Record<string, unknown>;
   }
 
   async function getRunState(runId: string): Promise<RunStatePayload> {
-    const res = await fetch(
-      `${baseUrl}/api/run?runId=${encodeURIComponent(runId)}`,
-      { method: "GET", headers, signal: abortSignal }
-    );
+    const url = `${baseUrl}/api/run?runId=${encodeURIComponent(runId)}`;
+    const res = await fetch(url, {
+      method: "GET",
+      headers,
+      signal: abortSignal,
+    });
     if (!res.ok) {
-      throw new Error(
-        `HTTP error! status: ${res.status} - ${await res.text()}`
-      );
+      const errorBody = await res.text();
+      log.debug(`GET /api/run failed: ${res.status}`, errorBody);
+      throw new Error(`HTTP error! status: ${res.status} - ${errorBody}`);
     }
-    return (await res.json()) as RunStatePayload;
+    const state = (await res.json()) as RunStatePayload;
+    log.debug(`GET /api/run -> ${describeRunState(state)}`);
+    return state;
   }
 
   /**
@@ -163,13 +189,20 @@ export function createWorkflowClient(options: WorkflowClientOptions): {
     seqRef: { current: number }
   ): Promise<WorkflowRunResult> {
     const deadline = Date.now() + POLL_TIMEOUT_MS;
+    let polls = 0;
     for (;;) {
       const state = await getRunState(runId);
       if (state.status !== "running") {
+        log.debug(
+          `run ${runId} settled as "${state.status}" after ${polls} poll(s)`
+        );
         return toWorkflowRunResult(state, seqRef);
       }
+      polls += 1;
       if (Date.now() > deadline) {
-        throw new Error("Workflow polling timed out");
+        throw new Error(
+          `Workflow polling timed out after ${polls} poll(s) (run ${runId})`
+        );
       }
       await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     }
@@ -192,10 +225,12 @@ export function createWorkflowClient(options: WorkflowClientOptions): {
           ...(initialState ?? {}),
         });
         runId = String(started.runId);
+        log.debug(`workflow started, run ${runId}`);
         return pollUntilSettled(runId, seqRef);
       },
       async resumeAsync({ resumeData }) {
         const token = `wizard:${runId}:${seqRef.current}`;
+        log.debug(`resuming run ${runId} with token ${token}`);
         await post("/api/resume", { token, result: resumeData });
         return pollUntilSettled(runId, seqRef);
       },

--- a/src/lib/init/workflow-client.ts
+++ b/src/lib/init/workflow-client.ts
@@ -52,6 +52,13 @@ export type WorkflowRun = {
     resumeData: Record<string, unknown>;
     tracingOptions?: Record<string, unknown>;
   }): Promise<WorkflowRunResult>;
+  /**
+   * Sync the run's internal suspend-point sequence counter from a recovered
+   * result. Called after `workflow.runById()` fetches state through its own
+   * isolated `seqRef` — without this, the next `resumeAsync` would build a
+   * stale token targeting the wrong hook.
+   */
+  updateSeq(seq: number): void;
 };
 
 export type WorkflowHandle = {
@@ -102,6 +109,7 @@ function toWorkflowRunResult(
       suspended: [[stepId]],
       suspendPayload: state.request,
       steps: { [stepId]: { suspendPayload: state.request } },
+      _seq: seqRef.current,
     };
   }
   // "running" — represented as suspended-less; the caller keeps polling.
@@ -190,6 +198,9 @@ export function createWorkflowClient(options: WorkflowClientOptions): {
         const token = `wizard:${runId}:${seqRef.current}`;
         await post("/api/resume", { token, result: resumeData });
         return pollUntilSettled(runId, seqRef);
+      },
+      updateSeq(seq: number) {
+        seqRef.current = seq;
       },
     };
     return run;

--- a/src/lib/init/workflow-client.ts
+++ b/src/lib/init/workflow-client.ts
@@ -1,0 +1,211 @@
+/**
+ * Workflow client shim.
+ *
+ * The init server migrated from the Mastra workflow engine to Vercel Workflows,
+ * which exposes a different HTTP protocol:
+ *   - POST /api/wizard          -> { runId }
+ *   - GET  /api/run?runId=...    -> run status + the pending tool/interactive request
+ *   - POST /api/resume           -> { token, result }
+ *
+ * The wizard runner was written against the Mastra client
+ * (`client.getWorkflow(id).createRun()` / `run.startAsync()` /
+ * `run.resumeAsync()` / `workflow.runById()` returning a `WorkflowRunResult`).
+ * Rather than rewrite that ~1300-line loop, this shim presents the same surface
+ * while speaking the new protocol underneath, mapping the server's
+ * `{ status, seq, request }` shape onto `WorkflowRunResult`.
+ *
+ * Suspend token: the server addresses each suspend point with a deterministic
+ * hook token `wizard:<runId>:<seq>`. We reconstruct it from the runId returned
+ * by /api/wizard and the `seq` reported by /api/run, so `resumeAsync` can target
+ * the exact hook. The token is never received from the server — knowing
+ * (runId, seq) plus the Bearer auth is what authorizes the resume.
+ */
+
+import type { SuspendPayload, WorkflowRunResult } from "./types.js";
+
+const POLL_INTERVAL_MS = 1000;
+const POLL_TIMEOUT_MS = 300_000;
+
+type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
+
+type RunStatePayload = {
+  status: "running" | "suspended" | "success" | "failed";
+  seq?: number;
+  request?: SuspendPayload;
+  result?: WorkflowRunResult["result"];
+  error?: string;
+};
+
+export type WorkflowRun = {
+  /**
+   * The run id. Empty until `startAsync` returns, because the new server assigns
+   * it when the run starts (unlike Mastra, which minted it at createRun time).
+   */
+  readonly runId: string;
+  startAsync(args: {
+    inputData: Record<string, unknown>;
+    initialState?: Record<string, unknown>;
+    tracingOptions?: Record<string, unknown>;
+  }): Promise<WorkflowRunResult>;
+  resumeAsync(args: {
+    step: string;
+    resumeData: Record<string, unknown>;
+    tracingOptions?: Record<string, unknown>;
+  }): Promise<WorkflowRunResult>;
+};
+
+export type WorkflowHandle = {
+  createRun(): Promise<WorkflowRun>;
+  runById(
+    runId: string,
+    opts?: { fields?: string[] }
+  ): Promise<WorkflowRunResult>;
+};
+
+export type WorkflowClientOptions = {
+  baseUrl: string;
+  headers?: Record<string, string>;
+  fetch: FetchLike;
+  abortSignal?: AbortSignal;
+};
+
+/**
+ * Synthesize a step id from a request so the runner's UI/labels and recovery
+ * logic keep working. Tool requests map to their operation; interactive
+ * requests to their kind.
+ */
+function stepIdForRequest(request: SuspendPayload): string {
+  if (request.type === "tool") {
+    return request.operation;
+  }
+  return `interactive-${request.kind}`;
+}
+
+/** Map the server's run-state payload onto the Mastra `WorkflowRunResult` shape. */
+function toWorkflowRunResult(
+  state: RunStatePayload,
+  seqRef: { current: number }
+): WorkflowRunResult {
+  if (state.status === "success") {
+    return { status: "success", result: state.result };
+  }
+  if (state.status === "failed") {
+    return { status: "failed", error: state.error };
+  }
+  if (state.status === "suspended" && state.request) {
+    if (typeof state.seq === "number") {
+      seqRef.current = state.seq;
+    }
+    const stepId = stepIdForRequest(state.request);
+    return {
+      status: "suspended",
+      suspended: [[stepId]],
+      suspendPayload: state.request,
+      steps: { [stepId]: { suspendPayload: state.request } },
+    };
+  }
+  // "running" — represented as suspended-less; the caller keeps polling.
+  return { status: "suspended", suspended: [] };
+}
+
+export function createWorkflowClient(options: WorkflowClientOptions): {
+  getWorkflow(id: string): WorkflowHandle;
+} {
+  const { baseUrl, headers = {}, fetch, abortSignal } = options;
+
+  const jsonHeaders = { "content-type": "application/json", ...headers };
+
+  async function post(
+    path: string,
+    body: unknown
+  ): Promise<Record<string, unknown>> {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method: "POST",
+      headers: jsonHeaders,
+      body: JSON.stringify(body),
+      signal: abortSignal,
+    });
+    if (!res.ok) {
+      throw new Error(
+        `HTTP error! status: ${res.status} - ${await res.text()}`
+      );
+    }
+    return (await res.json()) as Record<string, unknown>;
+  }
+
+  async function getRunState(runId: string): Promise<RunStatePayload> {
+    const res = await fetch(
+      `${baseUrl}/api/run?runId=${encodeURIComponent(runId)}`,
+      { method: "GET", headers, signal: abortSignal }
+    );
+    if (!res.ok) {
+      throw new Error(
+        `HTTP error! status: ${res.status} - ${await res.text()}`
+      );
+    }
+    return (await res.json()) as RunStatePayload;
+  }
+
+  /**
+   * Poll /api/run until the run leaves the transient "running" state, i.e. it is
+   * suspended on a request, has succeeded, or has failed.
+   */
+  async function pollUntilSettled(
+    runId: string,
+    seqRef: { current: number }
+  ): Promise<WorkflowRunResult> {
+    const deadline = Date.now() + POLL_TIMEOUT_MS;
+    for (;;) {
+      const state = await getRunState(runId);
+      if (state.status !== "running") {
+        return toWorkflowRunResult(state, seqRef);
+      }
+      if (Date.now() > deadline) {
+        throw new Error("Workflow polling timed out");
+      }
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+  }
+
+  function makeRun(): WorkflowRun {
+    const seqRef = { current: -1 };
+    // The server assigns the run id when the run starts. `createRun()` cannot
+    // pre-mint it (unlike Mastra), so it is captured in `startAsync`.
+    let runId = "";
+    const run: WorkflowRun = {
+      get runId() {
+        return runId;
+      },
+      async startAsync({ inputData, initialState }) {
+        // The new server takes a flat input; fold initialState (dirListing,
+        // fileCache, existingSentry, knownPlatform) alongside it.
+        const started = await post("/api/wizard", {
+          ...inputData,
+          ...(initialState ?? {}),
+        });
+        runId = String(started.runId);
+        return pollUntilSettled(runId, seqRef);
+      },
+      async resumeAsync({ resumeData }) {
+        const token = `wizard:${runId}:${seqRef.current}`;
+        await post("/api/resume", { token, result: resumeData });
+        return pollUntilSettled(runId, seqRef);
+      },
+    };
+    return run;
+  }
+
+  return {
+    getWorkflow(_id: string): WorkflowHandle {
+      return {
+        createRun() {
+          return Promise.resolve(makeRun());
+        },
+        runById(runId) {
+          const seqRef = { current: -1 };
+          return pollUntilSettled(runId, seqRef);
+        },
+      };
+    },
+  };
+}

--- a/test/lib/init/wizard-runner.test.ts
+++ b/test/lib/init/wizard-runner.test.ts
@@ -1,4 +1,3 @@
-import { MastraClient } from "@mastra/client-js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as Sentry from "@sentry/node-core/light";
 import {
@@ -49,6 +48,8 @@ import {
   type WizardUI,
 } from "../../../src/lib/init/ui/types.js";
 import { runWizard } from "../../../src/lib/init/wizard-runner.js";
+// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
+import * as workflowClient from "../../../src/lib/init/workflow-client.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as workflowInputs from "../../../src/lib/init/workflow-inputs.js";
 import { createMockUI, type MockCall } from "./ui/mock-ui.js";
@@ -245,18 +246,14 @@ beforeEach(() => {
   };
   capturedClientOptions = [];
   getWorkflowSpy = vi
-    .spyOn(MastraClient.prototype, "getWorkflow")
-    .mockImplementation(function (this: MastraClient) {
-      // `this` is the MastraClient instance. `BaseResource.options` holds the
-      // full ClientOptions passed to the constructor — including abortSignal.
+    .spyOn(workflowClient, "createWorkflowClient")
+    .mockImplementation((options) => {
+      // Capture the options passed to the client — including abortSignal — for
+      // the lifecycle suite.
       capturedClientOptions.push(
-        (
-          this as unknown as {
-            options: { abortSignal?: AbortSignal; retries?: number };
-          }
-        ).options
+        options as { abortSignal?: AbortSignal; retries?: number }
       );
-      return workflow as any;
+      return { getWorkflow: () => workflow } as any;
     });
 });
 
@@ -894,11 +891,10 @@ describe("runWizard", () => {
 });
 
 describe("runWizard — MastraClient lifecycle", () => {
-  test("aborts the MastraClient signal after a successful run", async () => {
+  test("aborts the workflow-client signal after a successful run", async () => {
     await runWizard(makeOptions());
 
     expect(capturedClientOptions).toHaveLength(1);
-    expect(capturedClientOptions[0]?.retries).toBe(0);
     const signal = capturedClientOptions[0]?.abortSignal;
     expect(signal).toBeInstanceOf(AbortSignal);
     // Using the non-null assertion safely — we asserted toBeInstanceOf above.
@@ -961,21 +957,19 @@ describe("runWizard — MastraClient lifecycle", () => {
     // at construction, it would be aborted here too. This proves the
     // `using _mastraCleanup` disposable does NOT fire until teardown.
     let abortedAtConstruction: boolean | undefined;
-    getWorkflowSpy.mockImplementation(function (this: MastraClient) {
-      const opts = (
-        this as unknown as {
-          options: { abortSignal?: AbortSignal; retries?: number };
-        }
-      ).options;
+    getWorkflowSpy.mockImplementation((options) => {
+      const opts = options as { abortSignal?: AbortSignal; retries?: number };
       capturedClientOptions.push(opts);
       abortedAtConstruction = opts.abortSignal?.aborted;
       return {
-        createRun: vi.fn(() =>
-          Promise.resolve({
-            startAsync: startAsyncMock,
-            resumeAsync: vi.fn(() => Promise.resolve({ status: "success" })),
-          })
-        ),
+        getWorkflow: () => ({
+          createRun: vi.fn(() =>
+            Promise.resolve({
+              startAsync: startAsyncMock,
+              resumeAsync: vi.fn(() => Promise.resolve({ status: "success" })),
+            })
+          ),
+        }),
       } as any;
     });
 
@@ -1028,24 +1022,22 @@ describe("runWizard — resumeWithRetry stale-step recovery", () => {
     ) => Promise<WorkflowRunResult>
   ) {
     let runByIdRef: ReturnType<typeof mock>;
-    getWorkflowSpy.mockImplementation(function (this: MastraClient) {
+    getWorkflowSpy.mockImplementation((options) => {
       capturedClientOptions.push(
-        (
-          this as unknown as {
-            options: { abortSignal?: AbortSignal; retries?: number };
-          }
-        ).options
+        options as { abortSignal?: AbortSignal; retries?: number }
       );
       runByIdRef = runByIdMock;
       return {
-        createRun: vi.fn(() =>
-          Promise.resolve({
-            runId: "test-run-id",
-            startAsync: startAsyncMock,
-            resumeAsync: vi.fn(resumeAsyncImpl),
-          })
-        ),
-        runById: runByIdRef,
+        getWorkflow: () => ({
+          createRun: vi.fn(() =>
+            Promise.resolve({
+              runId: "test-run-id",
+              startAsync: startAsyncMock,
+              resumeAsync: vi.fn(resumeAsyncImpl),
+            })
+          ),
+          runById: runByIdRef,
+        }),
       } as any;
     });
   }
@@ -1407,17 +1399,15 @@ describe("runWizard — additional coverage", () => {
   test("classifies createRun 401 before starting the workflow", async () => {
     await useSaaSOAuthAuth();
     const createRunMock = vi.fn(() => Promise.reject(initService401Error()));
-    getWorkflowSpy.mockImplementation(function (this: MastraClient) {
+    getWorkflowSpy.mockImplementation((options) => {
       capturedClientOptions.push(
-        (
-          this as unknown as {
-            options: { abortSignal?: AbortSignal; retries?: number };
-          }
-        ).options
+        options as { abortSignal?: AbortSignal; retries?: number }
       );
       return {
-        createRun: createRunMock,
-        runById: runByIdMock,
+        getWorkflow: () => ({
+          createRun: createRunMock,
+          runById: runByIdMock,
+        }),
       } as any;
     });
 
@@ -1674,23 +1664,21 @@ describe("runWizard — progress rotation for long-running steps", () => {
       resolveResume = resolve;
     });
     const resumeAsyncMock = vi.fn(() => resumePromise);
-    getWorkflowSpy.mockImplementation(function (this: MastraClient) {
+    getWorkflowSpy.mockImplementation((options) => {
       capturedClientOptions.push(
-        (
-          this as unknown as {
-            options: { abortSignal?: AbortSignal; retries?: number };
-          }
-        ).options
+        options as { abortSignal?: AbortSignal; retries?: number }
       );
       return {
-        createRun: vi.fn(() =>
-          Promise.resolve({
-            runId: "test-run-id",
-            startAsync: startAsyncMock,
-            resumeAsync: resumeAsyncMock,
-          })
-        ),
-        runById: runByIdMock,
+        getWorkflow: () => ({
+          createRun: vi.fn(() =>
+            Promise.resolve({
+              runId: "test-run-id",
+              startAsync: startAsyncMock,
+              resumeAsync: resumeAsyncMock,
+            })
+          ),
+          runById: runByIdMock,
+        }),
       } as any;
     });
 
@@ -1749,23 +1737,21 @@ describe("runWizard — progress rotation for long-running steps", () => {
       resolveResume = resolve;
     });
     const resumeAsyncMock = vi.fn(() => resumePromise);
-    getWorkflowSpy.mockImplementation(function (this: MastraClient) {
+    getWorkflowSpy.mockImplementation((options) => {
       capturedClientOptions.push(
-        (
-          this as unknown as {
-            options: { abortSignal?: AbortSignal; retries?: number };
-          }
-        ).options
+        options as { abortSignal?: AbortSignal; retries?: number }
       );
       return {
-        createRun: vi.fn(() =>
-          Promise.resolve({
-            runId: "test-run-id",
-            startAsync: startAsyncMock,
-            resumeAsync: resumeAsyncMock,
-          })
-        ),
-        runById: runByIdMock,
+        getWorkflow: () => ({
+          createRun: vi.fn(() =>
+            Promise.resolve({
+              runId: "test-run-id",
+              startAsync: startAsyncMock,
+              resumeAsync: resumeAsyncMock,
+            })
+          ),
+          runById: runByIdMock,
+        }),
       } as any;
     });
 
@@ -1806,23 +1792,21 @@ describe("runWizard — progress rotation for long-running steps", () => {
       resolveResume = resolve;
     });
     const resumeAsyncMock = vi.fn(() => resumePromise);
-    getWorkflowSpy.mockImplementation(function (this: MastraClient) {
+    getWorkflowSpy.mockImplementation((options) => {
       capturedClientOptions.push(
-        (
-          this as unknown as {
-            options: { abortSignal?: AbortSignal; retries?: number };
-          }
-        ).options
+        options as { abortSignal?: AbortSignal; retries?: number }
       );
       return {
-        createRun: vi.fn(() =>
-          Promise.resolve({
-            runId: "test-run-id",
-            startAsync: startAsyncMock,
-            resumeAsync: resumeAsyncMock,
-          })
-        ),
-        runById: runByIdMock,
+        getWorkflow: () => ({
+          createRun: vi.fn(() =>
+            Promise.resolve({
+              runId: "test-run-id",
+              startAsync: startAsyncMock,
+              resumeAsync: resumeAsyncMock,
+            })
+          ),
+          runById: runByIdMock,
+        }),
       } as any;
     });
 


### PR DESCRIPTION
Updates the init CLI to talk to the migrated init server, which moved from the Mastra workflow engine to **Vercel Workflows**. That migration (getsentry/cli-init-api#183) replaced the Mastra client contract (`/api/workflows/sentry-wizard/{create-run,start-async,resume-async}`) with a new one: `POST /api/wizard`, `GET /api/run`, `POST /api/resume`. Pointing the CLI at the new server currently 404s because those endpoints don't match.

## Changes
- Add `src/lib/init/workflow-client.ts` — a shim presenting the same `createRun/startAsync/resumeAsync/runById` surface the wizard runner already uses, while speaking the new protocol underneath. It maps the server's `{ status, seq, request }` into the existing `WorkflowRunResult` shape and polls `GET /api/run` between suspends.
- Resume targets the deterministic hook token `wizard:<runId>:<seq>`, reconstructed from the runId (returned by `/api/wizard`) and the `seq` reported by `/api/run` — the token is never received from the server, so no capability leaks.
- Replace `MastraClient` in `wizard-runner.ts` with the shim; drop the now-unused `@mastra/client-js` dependency.
- Update `wizard-runner.test.ts` to mock `createWorkflowClient` instead of `MastraClient.prototype.getWorkflow`.

## Testing
`vitest run test/lib/init` — 418 passing. Typecheck + biome clean on changed files.

## Notes / follow-ups
- `DEFAULT_MASTRA_API_URL` still points at the old Cloudflare worker; it should be updated to the new Vercel URL once the server is deployed. Local testing works today via `MASTRA_API_URL=http://localhost:4111`.
- Server-side counterpart: getsentry/cli-init-api#183.

<!--
## Context
The runner is a ~1300-line suspend/resume loop. Rather than rewrite it, the shim keeps that loop intact and only swaps the transport. Server delivers each pending tool/interactive request on the run's stream via getWritable(); the CLI reads it through GET /api/run. Only discover-context is fully ported server-side so far; remaining steps follow the same pattern.
-->