### PR TITLE
fix(debug-files): map targeted object for --il2cpp-mapping + free WASM handles

### DIFF
--- a/src/commands/debug-files/upload.ts
+++ b/src/commands/debug-files/upload.ts
@@ -201,7 +201,8 @@ function appendIl2cppMapping(difs: DebugFileUpload[], file: PreparedDif): void {
   try {
     result = createIl2cppLineMapping(
       new Uint8Array(file.content),
-      readSourceFile
+      readSourceFile,
+      file.debugId
     );
   } catch (err) {
     log.debug(`Could not compute IL2CPP line mapping for ${file.path}`, err);
@@ -212,7 +213,9 @@ function appendIl2cppMapping(difs: DebugFileUpload[], file: PreparedDif): void {
   }
   difs.push({
     name: `${basename(file.path)}.il2cpp`,
-    debugId: file.debugId ?? result.debugId,
+    // Use the mapped object's own debug id so the DIF's id always matches its
+    // contents (createIl2cppLineMapping maps the object with file.debugId).
+    debugId: result.debugId,
     content: Buffer.from(result.mapping),
   });
 }

--- a/src/lib/dif/index.ts
+++ b/src/lib/dif/index.ts
@@ -134,7 +134,9 @@ function ensureInitialized(): void {
  */
 export function parseDebugFile(data: Uint8Array): DifArchiveInfo {
   ensureInitialized();
-  const archive = new Archive(data);
+  // `using` frees the WASM handle when this returns; the mapped result holds
+  // only plain values, so the archive is safe to release here.
+  using archive = new Archive(data);
   return {
     fileFormat: archive.fileFormat,
     objects: archive.objects().map((o) => ({
@@ -195,9 +197,9 @@ export function extractEmbeddedPpdb(
   data: Uint8Array
 ): EmbeddedPpdbResult | null {
   ensureInitialized();
-  const archive = new Archive(data);
+  using archive = new Archive(data);
   for (const object of archive.objects()) {
-    const pe = object.asPe();
+    using pe = object.asPe();
     if (!pe) {
       continue;
     }
@@ -279,7 +281,7 @@ export function createSourceBundle(
   options?: { collectIl2cppSources?: boolean }
 ): SourceBundleResult {
   ensureInitialized();
-  const archive = new Archive(data);
+  using archive = new Archive(data);
   const objects = archive.objects();
   const objectCount = objects.length;
   const object = selectBundledObject(objects);
@@ -350,7 +352,7 @@ export function createIl2cppLineMapping(
   targetDebugId?: string
 ): Il2cppMappingResult | null {
   ensureInitialized();
-  const archive = new Archive(data);
+  using archive = new Archive(data);
   const objects = archive.objects();
   // Map the caller's targeted object so the mapping content always corresponds
   // to the debug id the DIF advertises; without this a fat archive plus `--id`
@@ -432,7 +434,7 @@ export type DifSourcesInfo = {
  */
 export function listSources(data: Uint8Array): DifSourcesInfo {
   ensureInitialized();
-  const archive = new Archive(data);
+  using archive = new Archive(data);
   const objects = archive.objects().map((object) => {
     const files: DifSourceFile[] = [];
     let enumerationError: string | null = null;

--- a/src/lib/dif/index.ts
+++ b/src/lib/dif/index.ts
@@ -327,25 +327,38 @@ export type Il2cppMappingResult = {
  * parsed into a C++→C# mapping serialized as a JSON document — the format Sentry
  * consumes for IL2CPP symbolication — which can be uploaded as a separate DIF.
  *
- * The mapping is computed for the single object chosen by
+ * The mapping is computed for the object identified by `targetDebugId` when
+ * given (so the returned debug id always matches the object the mapping
+ * describes), otherwise for the single object chosen by
  * {@link selectBundledObject}, matching {@link createSourceBundle}. Nothing is
  * read from disk by this function itself; `readSource` performs all I/O.
  *
  * @param data - The full contents of the debug information file.
  * @param readSource - Supplies C++ source content for a referenced path, or
  *   `null` to skip. Invoked synchronously (e.g. `readFileSync`).
- * @returns The serialized mapping bytes plus the object's debug id, or `null`
- *   when the archive has no objects or the object references no IL2CPP
+ * @param targetDebugId - Debug id of the specific object to map (typically the
+ *   filter-matched primary). When omitted or not found, falls back to
+ *   {@link selectBundledObject}.
+ * @returns The serialized mapping bytes plus the mapped object's debug id, or
+ *   `null` when the archive has no objects or the object references no IL2CPP
  *   `source_info` markers (an empty mapping).
  * @throws If the buffer cannot be parsed, or if `readSource` throws.
  */
 export function createIl2cppLineMapping(
   data: Uint8Array,
-  readSource: (path: string) => Uint8Array | null
+  readSource: (path: string) => Uint8Array | null,
+  targetDebugId?: string
 ): Il2cppMappingResult | null {
   ensureInitialized();
   const archive = new Archive(data);
-  const object = selectBundledObject(archive.objects());
+  const objects = archive.objects();
+  // Map the caller's targeted object so the mapping content always corresponds
+  // to the debug id the DIF advertises; without this a fat archive plus `--id`
+  // could stamp one slice's id onto another slice's line mappings.
+  const object =
+    (targetDebugId
+      ? objects.find((candidate) => candidate.debugId === targetDebugId)
+      : undefined) ?? selectBundledObject(objects);
   if (!object) {
     return null;
   }

--- a/test/lib/dif/il2cpp.test.ts
+++ b/test/lib/dif/il2cpp.test.ts
@@ -53,6 +53,26 @@ describe("createIl2cppLineMapping", () => {
     expect(doc[CPP_PATH]?.[CS_PATH]).toBeDefined();
   });
 
+  test("returns the mapped object's own debug id when targeting by id", () => {
+    // The returned debug id must always describe the object the mapping came
+    // from, so the uploaded DIF can be stamped with a matching id.
+    const result = createIl2cppLineMapping(
+      bytes(BREAKPAD_WITH_CPP),
+      () => bytes(CPP_WITH_SOURCE_INFO),
+      KNOWN_DEBUG_ID
+    );
+    expect(result?.debugId).toBe(KNOWN_DEBUG_ID);
+  });
+
+  test("falls back to the primary object when targetDebugId is not found", () => {
+    const result = createIl2cppLineMapping(
+      bytes(BREAKPAD_WITH_CPP),
+      () => bytes(CPP_WITH_SOURCE_INFO),
+      "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    );
+    expect(result?.debugId).toBe(KNOWN_DEBUG_ID);
+  });
+
   test("returns null when no referenced source is available", () => {
     expect(
       createIl2cppLineMapping(bytes(BREAKPAD_WITH_CPP), () => null)


### PR DESCRIPTION
Post-merge follow-ups for the `debug-files` DIF work (#1163, #1165).

## 1. `fix`: map the targeted object for `--il2cpp-mapping`

Addresses a Cursor Bugbot finding on #1165 ("IL2CPP mapping wrong object", Medium).

For a fat archive, `createIl2cppLineMapping` mapped the first debug-info object (`selectBundledObject` over **all** objects), while the uploaded `.il2cpp` DIF was stamped with `file.debugId` (the **filter-matched primary**). With `--id` targeting a non-primary slice, the DIF could advertise one debug id while containing another object's line mappings.

- `createIl2cppLineMapping` now takes a `targetDebugId` and maps that specific object (falling back to `selectBundledObject` when omitted/not found).
- `appendIl2cppMapping` passes `file.debugId` and stamps the DIF with the **mapped object's own** id — so the id always matches the contents.

Tests: added cases asserting the returned id tracks the targeted object and the fallback path.

## 2. `perf`: free WASM archive handles after use

Addresses review finding M-1. The DIF helpers (`parseDebugFile`, `extractEmbeddedPpdb`, `createSourceBundle`, `createIl2cppLineMapping`, `listSources`) created `Archive`/`PeFile` WASM handles that were never released, so a scan accumulated them (and their backing byte views) in WASM linear memory until process exit.

- Declared each with `using` so the handle is freed on return.
- Each helper returns only plain values or copied byte buffers, so releasing the archive is safe. Verified empirically that disposing the archive independently of the objects derived from it does **not** double-free (symbolic's self-cell objects own their data), including after forcing GC.

## Verification
`typecheck`, `lint`, `check:deps`, `check:fragments`, and the full debug-files/dif/scan suite (360 tests) all pass. No behavior change for the common single-object case.