### PR TITLE
fix(debug-files): accurate upload count and preserve --require-all hint

### DIFF
--- a/src/commands/debug-files/upload.ts
+++ b/src/commands/debug-files/upload.ts
@@ -450,6 +450,12 @@ async function* doUpload(
 ) {
   const results = await uploadDebugFiles(params);
 
+  // Files the server (or the local size gate) rejected come back as
+  // error/not_found results; they must not be counted as uploaded.
+  const failures = results.filter(
+    (r) => r.state === "error" || r.state === "not_found"
+  );
+
   yield new CommandOutput<DebugFilesUploadResult>({
     org: params.org,
     project: params.project,
@@ -460,7 +466,7 @@ async function* doUpload(
       state: r.state,
       detail: r.detail,
     })),
-    filesUploaded: results.length,
+    filesUploaded: results.length - failures.length,
   });
 
   // Scan-time oversized files were dropped before the queue was built, so they
@@ -471,9 +477,13 @@ async function* doUpload(
       ? ` ${params.oversizedCount} file(s) were skipped for exceeding the maximum file size (${params.maxFileSize} bytes).`
       : "";
 
-  const failures = results.filter(
-    (r) => r.state === "error" || r.state === "not_found"
-  );
+  // Appended to whichever hint returns first so `--require-all` feedback is
+  // never lost behind an upload failure or a size-drop (all already exit 1).
+  const requireAllNote =
+    params.requireAll && params.missingRequestedIds.length > 0
+      ? ` Missing requested debug id(s): ${params.missingRequestedIds.join(", ")}.`
+      : "";
+
   if (failures.length > 0) {
     setExitCode(1);
     const details = failures
@@ -483,14 +493,14 @@ async function* doUpload(
       )
       .join("; ");
     return {
-      hint: `${failures.length === 1 ? "1 file" : `${failures.length} files`} had failures: ${details}.${scanOversize}`,
+      hint: `${failures.length === 1 ? "1 file" : `${failures.length} files`} had failures: ${details}.${scanOversize}${requireAllNote}`,
     };
   }
 
   if (params.oversizedCount > 0) {
     setExitCode(1);
     return {
-      hint: `Uploaded ${results.length} debug file(s) to ${params.org}/${params.project}, but ${params.oversizedCount} file(s) were skipped for exceeding the maximum file size (${params.maxFileSize} bytes).`,
+      hint: `Uploaded ${results.length} debug file(s) to ${params.org}/${params.project}, but ${params.oversizedCount} file(s) were skipped for exceeding the maximum file size (${params.maxFileSize} bytes).${requireAllNote}`,
     };
   }
 

--- a/test/commands/debug-files/upload.test.ts
+++ b/test/commands/debug-files/upload.test.ts
@@ -461,6 +461,65 @@ describe("sentry debug-files upload", () => {
     expect(exitCode).toBe(1);
   });
 
+  test("filesUploaded excludes failed/dropped results", async () => {
+    process.env.SENTRY_ORG = "test-org";
+    process.env.SENTRY_PROJECT = "test-project";
+    await writeBreakpad();
+
+    vi.spyOn(debugFilesApi, "uploadDebugFiles").mockResolvedValue([
+      {
+        name: "ok.sym",
+        debugId: KNOWN_DEBUG_ID,
+        checksum: "a".repeat(40),
+        state: "ok",
+        detail: null,
+      },
+      {
+        name: "toobig.sym",
+        debugId: "22222222-2222-2222-2222-222222222222",
+        checksum: "",
+        state: "error",
+        detail: "Exceeds server maximum file size",
+      },
+    ]);
+
+    const { output } = await runUpload([tempDir, "--json"]);
+    const parsed = JSON.parse(output);
+    // Both results are listed, but only the non-failed one counts as uploaded.
+    expect(parsed.files).toHaveLength(2);
+    expect(parsed.filesUploaded).toBe(1);
+  });
+
+  test("--require-all note is preserved alongside an upload failure", async () => {
+    process.env.SENTRY_ORG = "test-org";
+    process.env.SENTRY_PROJECT = "test-project";
+    await writeBreakpad();
+
+    vi.spyOn(debugFilesApi, "uploadDebugFiles").mockResolvedValue([
+      {
+        name: "example.sym",
+        debugId: KNOWN_DEBUG_ID,
+        checksum: "a".repeat(40),
+        state: "error",
+        detail: "could not process",
+      },
+    ]);
+
+    const { exitCode, output } = await runUpload([
+      tempDir,
+      "--id",
+      KNOWN_DEBUG_ID,
+      "--id",
+      "11111111-1111-1111-1111-111111111111",
+      "--require-all",
+    ]);
+    expect(exitCode).toBe(1);
+    // The failure hint must still surface the missing required id — the
+    // --require-all feedback must not be swallowed by the earlier failure exit.
+    expect(output).toContain("had failures");
+    expect(output).toContain("11111111-1111-1111-1111-111111111111");
+  });
+
   test("--require-all on a real upload fails when an --id is missing", async () => {
     process.env.SENTRY_ORG = "test-org";
     process.env.SENTRY_PROJECT = "test-project";


### PR DESCRIPTION
Follow-up to #1146, addressing two bot findings on that PR.

## 1. `filesUploaded` over-counted (Bugbot/Seer, Low)
#1146 surfaces size-dropped files as `error` results so a partial drop exits non-zero. But `doUpload` reported `filesUploaded: results.length`, which then included those `error`/`not_found` entries — over-reporting the number of files actually uploaded in the JSON output.

Fixed: compute `failures` before the summary and report `results.length - failures.length`.

## 2. `--require-all` hint dropped after a failure (Bugbot, Medium)
When an upload failure or a size-drop returned first, `doUpload` returned before the `--require-all` branch, so the "missing requested debug id(s)" note was omitted from the hint. The exit code was still correctly non-zero, but the actionable feedback was lost.

Fixed: build a `requireAllNote` once and append it to whichever hint returns (failure / size-drop), so the missing-id feedback is never swallowed.

## Tests
- `filesUploaded excludes failed/dropped results` — mixed ok/error results ⇒ `filesUploaded` counts only the ok one.
- `--require-all note is preserved alongside an upload failure` — failure + missing required id ⇒ hint contains both "had failures" and the missing id.

`typecheck`, `lint`, and the debug-files upload suite (36 tests) all pass.