### PR TITLE
docs(debug-files): drop planned --symbol-maps (BCSymbolMap) support

### DIFF
--- a/docs/src/fragments/commands/debug-files.md
+++ b/docs/src/fragments/commands/debug-files.md
@@ -76,8 +76,10 @@ sentry debug-files upload ./build --no-upload
   server-side processing and exit non-zero if any file fails. `--require-all`
   fails if a requested `--id` was not found. The server-advertised maximum file
   size and maximum processing wait are honored automatically (oversized files
-  are skipped with a warning). `--symbol-maps` (BCSymbolMap resolution) is not
-  yet supported.
+  are skipped with a warning). BCSymbolMap resolution (the legacy
+  `--symbol-maps` flag) is intentionally unsupported — it only applies to Apple
+  Bitcode, which Apple has deprecated and the App Store no longer accepts. Use
+  the legacy Rust `sentry-cli` if you still need it.
 - Managed .NET PE assemblies that embed a Portable PDB have it extracted and
   uploaded automatically as a separate `<name>.pdb` debug file (no flag needed).
 - `--il2cpp-mapping` computes Unity IL2CPP C++→C# line mappings from each file's

--- a/src/commands/debug-files/upload.ts
+++ b/src/commands/debug-files/upload.ts
@@ -13,9 +13,11 @@
  * place (disable with `--no-zips`); `--derived-data` additionally scans Xcode's
  * DerivedData folder on macOS. Managed PE assemblies that embed a Portable PDB
  * have it extracted and uploaded automatically as a separate DIF, and
- * `--il2cpp-mapping` uploads Unity IL2CPP line mappings. `--symbol-maps`
- * (BCSymbolMap resolution) is deferred to a follow-up PR (see the command's
- * full description).
+ * `--il2cpp-mapping` uploads Unity IL2CPP line mappings. BCSymbolMap
+ * resolution (legacy `--symbol-maps`) is intentionally not supported: it only
+ * applies to Apple Bitcode, which Apple has deprecated and the App Store no
+ * longer accepts. Projects that still need it can use the legacy Rust
+ * `sentry-cli`.
  */
 
 import { createHash } from "node:crypto";
@@ -553,7 +555,9 @@ export const uploadCommand = buildCommand({
       "  sentry debug-files upload ./build --il2cpp-mapping --include-sources\n" +
       "  sentry debug-files upload --derived-data --no-upload\n" +
       "  sentry debug-files upload ./build --no-zips --no-upload\n\n" +
-      "Not yet supported (planned): --symbol-maps (BCSymbolMap resolution).",
+      "BCSymbolMap resolution (legacy --symbol-maps) is not supported: it " +
+      "only applies to Apple Bitcode, which Apple has deprecated. Use the " +
+      "legacy Rust sentry-cli if you still need it.",
   },
   output: {
     human: formatUploadResult,


### PR DESCRIPTION
Closes out the `--symbol-maps` (BCSymbolMap resolution) question for the `debug-files upload` port.

**Decision (CLI team, Daniel Szoke):** don't port it. BCSymbolMaps only apply to Apple **Bitcode**, which Apple has deprecated and the App Store no longer accepts. Anyone who still needs it can continue using the legacy Rust `sentry-cli`.

This was the last outstanding item in the `debug-files upload` port; everything else (core upload, size limits + `--derived-data`, ZIP scanning, embedded Portable PDB, `--il2cpp-mapping`) has shipped.

## Changes
Purely documentation/wording — no behavior change:
- `upload.ts` module JSDoc + `fullDescription`: replace the "not yet supported (planned)" note with a clear statement that BCSymbolMap resolution is intentionally unsupported, pointing to the legacy CLI.
- `docs/src/fragments/commands/debug-files.md`: same wording update.

`typecheck`, `lint`, and `check:fragments` pass; skill/docs generators produce no further diff.