### PR TITLE
feat(build): add `build download` command for preprod artifacts

### DIFF
--- a/docs/src/content/docs/contributing.md
+++ b/docs/src/content/docs/contributing.md
@@ -54,6 +54,7 @@ cli/
 │   ├── commands/       # CLI commands
 │   │   ├── alert/       # create, delete, edit, list, view
 │   │   ├── auth/        # login, logout, refresh, status, token, whoami
+│   │   ├── build/       # download
 │   │   ├── cli/         # defaults, feedback, fix, import, setup, uninstall, upgrade
 │   │   ├── code-mappings/# upload
 │   │   ├── dart-symbol-map/# upload

--- a/docs/src/fragments/commands/build.md
+++ b/docs/src/fragments/commands/build.md
@@ -1,0 +1,25 @@
+
+
+## Examples
+
+```bash
+# Download a build artifact by ID
+sentry build download 1234567890
+
+# Download to a specific path
+sentry build download 1234567890 --output ./app.ipa
+
+# Output the result as JSON
+sentry build download 1234567890 --json
+```
+
+## Important Notes
+
+- `build download` fetches a mobile build artifact (APK or IPA) previously
+  uploaded to Sentry's preprod system for size analysis. **Sentry SaaS only.**
+- The build must be installable. Builds that are still processing — or that have
+  no downloadable artifact — cannot be downloaded.
+- Without `--output`, the artifact is saved as
+  `preprod_artifact_<build-id>.<ext>` in the current directory.
+- The organization is resolved from `--org`, `SENTRY_ORG`, config defaults, or a
+  detected DSN.

--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -376,6 +376,14 @@ Manage Sentry alert rules
 
 → Full flags and examples: `references/alert.md`
 
+### Build
+
+Manage mobile build artifacts
+
+- `sentry build download <build-id>` — Download a build artifact
+
+→ Full flags and examples: `references/build.md`
+
 ### CLI
 
 CLI-related commands

--- a/plugins/sentry-cli/skills/sentry-cli/references/build.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/build.md
@@ -1,0 +1,34 @@
+---
+name: sentry-cli-build
+version: 0.39.0-dev.0
+description: Manage mobile build artifacts
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Build Commands
+
+Manage mobile build artifacts
+
+### `sentry build download <build-id>`
+
+Download a build artifact
+
+**Flags:**
+- `-o, --output <value> - Output path (default: preprod_artifact_<build-id>.<ext> in the current directory)`
+
+**Examples:**
+
+```bash
+# Download a build artifact by ID
+sentry build download 1234567890
+
+# Download to a specific path
+sentry build download 1234567890 --output ./app.ipa
+
+# Output the result as JSON
+sentry build download 1234567890 --json
+```
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import { apiCommand } from "./commands/api.js";
 import { authRoute } from "./commands/auth/index.js";
 import { whoamiCommand } from "./commands/auth/whoami.js";
 import { bashHookCommand } from "./commands/bash-hook.js";
+import { buildRoute } from "./commands/build/index.js";
 import { cliRoute } from "./commands/cli/index.js";
 import { codeMappingsRoute } from "./commands/code-mappings/index.js";
 import { dartSymbolMapRoute } from "./commands/dart-symbol-map/index.js";
@@ -97,6 +98,7 @@ export const routes = buildRouteMap({
     help: helpCommand,
     alert: alertRoute,
     auth: authRoute,
+    build: buildRoute,
     cli: cliRoute,
     "code-mappings": codeMappingsRoute,
     "dart-symbol-map": dartSymbolMapRoute,

--- a/src/commands/build/download.ts
+++ b/src/commands/build/download.ts
@@ -1,0 +1,131 @@
+/**
+ * sentry build download <build-id>
+ *
+ * Download a mobile build artifact (APK/IPA) previously uploaded to Sentry's
+ * preprod system for size analysis. Resolves the build's download URL via the
+ * preprod-artifacts install-details endpoint and streams the binary to disk.
+ *
+ * Org-scoped (no project). Sentry SaaS only.
+ */
+
+import { resolve } from "node:path";
+import type { SentryContext } from "../../context.js";
+import {
+  buildFormatFromUrl,
+  downloadBuildArtifact,
+  getBuildInstallDetails,
+  toBinaryDownloadUrl,
+} from "../../lib/api/preprod-artifacts.js";
+import { buildCommand } from "../../lib/command.js";
+import { ContextError, ResolutionError } from "../../lib/errors.js";
+import { mdKvTable, renderMarkdown } from "../../lib/formatters/markdown.js";
+import { CommandOutput } from "../../lib/formatters/output.js";
+import { resolveOrgRegion } from "../../lib/region.js";
+import { resolveOrg } from "../../lib/resolve-target.js";
+
+const USAGE_HINT = "sentry build download <build-id>";
+
+/** Structured result for `build download`. */
+type BuildDownloadResult = {
+  /** The downloaded build's ID. */
+  buildId: string;
+  /** Organization slug the build belongs to. */
+  org: string;
+  /** Local path the artifact was written to. */
+  output: string;
+  /** The artifact format (`ipa` or `apk`). */
+  format: "ipa" | "apk";
+};
+
+/** Human-readable formatter for the download result. */
+function formatDownloadResult(data: BuildDownloadResult): string {
+  return renderMarkdown(
+    mdKvTable([
+      ["Build ID", data.buildId],
+      ["Format", data.format],
+      ["Saved to", data.output],
+    ])
+  );
+}
+
+export const downloadCommand = buildCommand({
+  docs: {
+    brief: "Download a build artifact",
+    fullDescription:
+      "Download a mobile build artifact (APK or IPA) previously uploaded to " +
+      "Sentry's preprod system for size analysis. The build is resolved by " +
+      "ID within the organization; the artifact is streamed to a local file.\n\n" +
+      "This feature only works with Sentry SaaS.\n\n" +
+      "Usage:\n" +
+      "  sentry build download 1234567890\n" +
+      "  sentry build download 1234567890 --output ./app.ipa",
+  },
+  output: {
+    human: formatDownloadResult,
+  },
+  parameters: {
+    positional: {
+      kind: "tuple",
+      parameters: [
+        {
+          brief: "ID of the build to download",
+          parse: String,
+          placeholder: "build-id",
+        },
+      ],
+    },
+    flags: {
+      output: {
+        kind: "parsed",
+        parse: String,
+        brief:
+          "Output path (default: preprod_artifact_<build-id>.<ext> in the current directory)",
+        optional: true,
+      },
+    },
+    aliases: {
+      o: "output",
+    },
+  },
+  async *func(
+    this: SentryContext,
+    flags: { output?: string },
+    buildId: string
+  ) {
+    const resolved = await resolveOrg({ cwd: this.cwd });
+    if (!resolved) {
+      throw new ContextError("Organization", USAGE_HINT);
+    }
+    const { org } = resolved;
+
+    const details = await getBuildInstallDetails(org, buildId);
+    if (!(details.isInstallable && details.installUrl)) {
+      throw new ResolutionError(
+        `Build ${buildId}`,
+        "is not installable",
+        USAGE_HINT,
+        [
+          "The build may still be processing, or it has no downloadable artifact.",
+        ]
+      );
+    }
+
+    const url = toBinaryDownloadUrl(details.installUrl);
+    const format = buildFormatFromUrl(url);
+    const output = resolve(
+      this.cwd,
+      flags.output ?? `preprod_artifact_${buildId}.${format}`
+    );
+
+    const regionUrl = await resolveOrgRegion(org);
+    await downloadBuildArtifact(regionUrl, url, output);
+
+    yield new CommandOutput<BuildDownloadResult>({
+      buildId,
+      org,
+      output,
+      format,
+    });
+    return { hint: `Downloaded build ${buildId} to ${output}` };
+  },
+});

--- a/src/commands/build/index.ts
+++ b/src/commands/build/index.ts
@@ -1,0 +1,21 @@
+/**
+ * `sentry build` — manage mobile build artifacts for preprod size analysis.
+ *
+ * Currently exposes `download`. Upload (APK/AAB, and iOS XCArchive/IPA) is
+ * ported separately.
+ */
+
+import { buildRouteMap } from "../../lib/route-map.js";
+import { downloadCommand } from "./download.js";
+
+export const buildRoute = buildRouteMap({
+  routes: {
+    download: downloadCommand,
+  },
+  docs: {
+    brief: "Manage mobile build artifacts",
+    fullDescription:
+      "Upload and download mobile build artifacts (APK/AAB/IPA/XCArchive) for " +
+      "Sentry preprod size analysis. Sentry SaaS only.",
+  },
+});

--- a/src/lib/api/preprod-artifacts.ts
+++ b/src/lib/api/preprod-artifacts.ts
@@ -1,0 +1,152 @@
+/**
+ * Preprod artifacts (mobile build) API.
+ *
+ * Backs `sentry build download`: resolves a preprod build's install/download
+ * URL via the preprod-artifacts `install-details` endpoint and streams the
+ * binary (APK/IPA) to disk.
+ *
+ * The install URL is Sentry-hosted (same origin as the org's region). iOS
+ * install URLs point at a `response_format=plist` manifest; rewrite it to
+ * `response_format=ipa` to fetch the actual binary. The auth token is attached
+ * to the download only when the URL matches the region origin — never a
+ * third-party/signed storage URL — to avoid leaking the token.
+ */
+
+import { createWriteStream } from "node:fs";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { z } from "zod";
+import { customFetch } from "../custom-ca.js";
+import { getAuthToken } from "../db/auth.js";
+import { ApiError, ValidationError } from "../errors.js";
+import { logger } from "../logger.js";
+import { resolveOrgRegion } from "../region.js";
+import { apiRequestToRegion } from "./infrastructure.js";
+
+const log = logger.withTag("api.preprod-artifacts");
+
+/** Downloadable mobile build formats. */
+export type BuildFormat = "ipa" | "apk";
+
+/**
+ * Response from `organizations/{org}/preprodartifacts/{id}/install-details/`.
+ */
+export const BuildInstallDetailsSchema = z.object({
+  /** Whether the build has a downloadable/installable artifact. */
+  isInstallable: z.boolean(),
+  /** Absolute URL to download the artifact, or `null` when unavailable. */
+  installUrl: z.string().nullable(),
+});
+
+/** Install/download details for a preprod build artifact. */
+export type BuildInstallDetails = z.infer<typeof BuildInstallDetailsSchema>;
+
+/**
+ * Fetch install/download details for a preprod build artifact.
+ *
+ * @param org - Organization slug.
+ * @param buildId - Preprod artifact (build) ID.
+ * @returns Whether the build is installable and its (absolute) download URL.
+ * @throws {ApiError} On a non-2xx response.
+ */
+export async function getBuildInstallDetails(
+  org: string,
+  buildId: string
+): Promise<BuildInstallDetails> {
+  const regionUrl = await resolveOrgRegion(org);
+  const endpoint = `organizations/${org}/preprodartifacts/${encodeURIComponent(
+    buildId
+  )}/install-details/`;
+  const { data } = await apiRequestToRegion(regionUrl, endpoint, {
+    schema: BuildInstallDetailsSchema,
+  });
+  return data;
+}
+
+/**
+ * Rewrite an iOS install URL that points at a plist manifest so it fetches the
+ * IPA binary directly. Non-plist URLs are returned unchanged.
+ *
+ * @param installUrl - The install URL from {@link getBuildInstallDetails}.
+ */
+export function toBinaryDownloadUrl(installUrl: string): string {
+  return installUrl.replace("response_format=plist", "response_format=ipa");
+}
+
+/**
+ * Infer the artifact file extension from the download URL's `response_format`.
+ *
+ * @param url - The (binary) download URL.
+ * @throws {ValidationError} When the URL carries no recognized `response_format`.
+ */
+export function buildFormatFromUrl(url: string): BuildFormat {
+  if (url.includes("response_format=ipa")) {
+    return "ipa";
+  }
+  if (url.includes("response_format=apk")) {
+    return "apk";
+  }
+  throw new ValidationError(
+    "Unsupported build format in download URL",
+    "installUrl"
+  );
+}
+
+/**
+ * Compare a URL's origin against the region base URL.
+ *
+ * @returns `true` only when both parse and share an origin; `false` otherwise
+ *   (including parse failures, in which case the auth token is withheld).
+ */
+function isRegionOrigin(url: string, regionUrl: string): boolean {
+  try {
+    return new URL(url).origin === new URL(regionUrl).origin;
+  } catch (err) {
+    log.debug(
+      "Could not compare download URL origin; withholding auth token",
+      err
+    );
+    return false;
+  }
+}
+
+/**
+ * Stream a build artifact to a local file.
+ *
+ * The auth token is attached only when `url` shares the region origin, so it is
+ * never sent to a third-party/signed storage URL.
+ *
+ * @param regionUrl - The org's region base URL (origin gate for the token).
+ * @param url - The absolute (binary) download URL.
+ * @param destPath - Local path to write the artifact to.
+ * @throws {ApiError} On a non-2xx response or missing body.
+ */
+export async function downloadBuildArtifact(
+  regionUrl: string,
+  url: string,
+  destPath: string
+): Promise<void> {
+  const headers: Record<string, string> = {};
+  if (isRegionOrigin(url, regionUrl)) {
+    const token = getAuthToken();
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+  }
+
+  const response = await customFetch(url, { headers });
+  if (!(response.ok && response.body)) {
+    throw new ApiError(
+      "Failed to download build artifact",
+      response.status,
+      response.statusText || "Download failed",
+      url
+    );
+  }
+
+  // Stream to disk so large (hundreds-of-MB) artifacts never buffer in memory.
+  await pipeline(
+    Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
+    createWriteStream(destPath)
+  );
+}

--- a/test/commands/build/download.test.ts
+++ b/test/commands/build/download.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for `sentry build download`.
+ *
+ * Drives the command through its wrapper `loader()` and spies on the
+ * preprod-artifacts API + org/region resolution, so the orchestration
+ * (URL rewrite, format inference, default output path, not-installable guard)
+ * is exercised without a network.
+ */
+
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { downloadCommand } from "../../../src/commands/build/download.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as preprod from "../../../src/lib/api/preprod-artifacts.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as region from "../../../src/lib/region.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as resolveTarget from "../../../src/lib/resolve-target.js";
+
+let tmpDir: string;
+
+/** Minimal SentryContext with stdout capture and cwd pinned to the temp dir. */
+function createContext() {
+  const writes: string[] = [];
+  return {
+    context: {
+      stdout: {
+        write: (data: string | Uint8Array) => {
+          writes.push(
+            typeof data === "string" ? data : new TextDecoder().decode(data)
+          );
+          return true;
+        },
+      },
+      stderr: { write: () => true },
+      cwd: tmpDir,
+    },
+    output: () => writes.join(""),
+  };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("build download", () => {
+  let installSpy: ReturnType<typeof vi.spyOn>;
+  let downloadSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "build-download-"));
+    vi.spyOn(resolveTarget, "resolveOrg").mockResolvedValue({ org: "test-org" });
+    vi.spyOn(region, "resolveOrgRegion").mockResolvedValue(
+      "https://us.sentry.io"
+    );
+    installSpy = vi.spyOn(preprod, "getBuildInstallDetails");
+    downloadSpy = vi
+      .spyOn(preprod, "downloadBuildArtifact")
+      .mockImplementation(async (_region, _url, dest) => {
+        await writeFile(dest, "FAKE-BINARY");
+      });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("downloads an ipa to the default path (rewriting plist → ipa)", async () => {
+    installSpy.mockResolvedValue({
+      isInstallable: true,
+      installUrl: "https://us.sentry.io/dl/?response_format=plist",
+    });
+    const { context, output } = createContext();
+    const func = await downloadCommand.loader();
+
+    await func.call(context, { output: undefined }, "build-1");
+
+    expect(installSpy).toHaveBeenCalledWith("test-org", "build-1");
+    // The plist manifest URL is rewritten to fetch the ipa binary.
+    expect(downloadSpy.mock.calls.at(-1)?.[1]).toContain("response_format=ipa");
+    const dest = join(tmpDir, "preprod_artifact_build-1.ipa");
+    expect(await exists(dest)).toBe(true);
+    expect(await readFile(dest, "utf8")).toBe("FAKE-BINARY");
+    expect(output()).toContain("build-1");
+    expect(output()).toContain("ipa");
+  });
+
+  test("writes to a custom --output path", async () => {
+    installSpy.mockResolvedValue({
+      isInstallable: true,
+      installUrl: "https://us.sentry.io/dl/?response_format=apk",
+    });
+    const outPath = join(tmpDir, "custom.apk");
+    const { context } = createContext();
+    const func = await downloadCommand.loader();
+
+    await func.call(context, { output: outPath }, "b2");
+
+    expect(await exists(outPath)).toBe(true);
+    expect(await exists(join(tmpDir, "preprod_artifact_b2.apk"))).toBe(false);
+  });
+
+  test("rejects a non-installable build without downloading", async () => {
+    installSpy.mockResolvedValue({ isInstallable: false, installUrl: null });
+    const { context } = createContext();
+    const func = await downloadCommand.loader();
+
+    await expect(
+      func.call(context, { output: undefined }, "b3")
+    ).rejects.toThrow(/not installable/i);
+    expect(downloadSpy).not.toHaveBeenCalled();
+  });
+});

--- a/test/lib/api/preprod-artifacts.test.ts
+++ b/test/lib/api/preprod-artifacts.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for the preprod-artifacts (mobile build) API.
+ *
+ * Pure URL helpers are tested directly. `getBuildInstallDetails` mocks the
+ * region request layer; `downloadBuildArtifact` mocks `customFetch` and the
+ * auth-token getter so the streaming write and — critically — the
+ * same-origin-only auth attachment can be verified without a network.
+ */
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ApiError, ValidationError } from "../../../src/lib/errors.js";
+
+const { customFetchMock, apiRequestToRegionMock, getAuthTokenMock } =
+  vi.hoisted(() => ({
+    customFetchMock: vi.fn(),
+    apiRequestToRegionMock: vi.fn(),
+    getAuthTokenMock: vi.fn<() => string | undefined>(() => "secret-token"),
+  }));
+
+vi.mock("../../../src/lib/region.js", () => ({
+  resolveOrgRegion: vi.fn(async () => "https://us.sentry.io"),
+}));
+vi.mock("../../../src/lib/api/infrastructure.js", () => ({
+  apiRequestToRegion: apiRequestToRegionMock,
+}));
+vi.mock("../../../src/lib/custom-ca.js", () => ({
+  customFetch: customFetchMock,
+}));
+vi.mock("../../../src/lib/db/auth.js", () => ({
+  getAuthToken: getAuthTokenMock,
+}));
+
+import {
+  buildFormatFromUrl,
+  downloadBuildArtifact,
+  getBuildInstallDetails,
+  toBinaryDownloadUrl,
+} from "../../../src/lib/api/preprod-artifacts.js";
+
+describe("toBinaryDownloadUrl", () => {
+  test("rewrites a plist manifest URL to fetch the ipa binary", () => {
+    expect(
+      toBinaryDownloadUrl("https://us.sentry.io/dl/?response_format=plist")
+    ).toBe("https://us.sentry.io/dl/?response_format=ipa");
+  });
+
+  test("leaves non-plist URLs unchanged", () => {
+    expect(
+      toBinaryDownloadUrl("https://us.sentry.io/dl/?response_format=apk")
+    ).toBe("https://us.sentry.io/dl/?response_format=apk");
+  });
+});
+
+describe("buildFormatFromUrl", () => {
+  test("detects ipa", () => {
+    expect(buildFormatFromUrl("https://x/?response_format=ipa")).toBe("ipa");
+  });
+  test("detects apk", () => {
+    expect(buildFormatFromUrl("https://x/?response_format=apk")).toBe("apk");
+  });
+  test("throws on an unrecognized format", () => {
+    expect(() => buildFormatFromUrl("https://x/?response_format=zip")).toThrow(
+      ValidationError
+    );
+  });
+});
+
+describe("getBuildInstallDetails", () => {
+  beforeEach(() => {
+    apiRequestToRegionMock.mockReset();
+  });
+
+  test("hits the install-details endpoint and returns parsed data", async () => {
+    apiRequestToRegionMock.mockResolvedValue({
+      data: { isInstallable: true, installUrl: "https://u/" },
+      headers: new Headers(),
+    });
+
+    const result = await getBuildInstallDetails("my-org", "build 1");
+
+    expect(result).toEqual({ isInstallable: true, installUrl: "https://u/" });
+    const lastCall = apiRequestToRegionMock.mock.calls.at(-1);
+    expect(lastCall?.[0]).toBe("https://us.sentry.io");
+    // Build id is URL-encoded into the path.
+    expect(lastCall?.[1]).toBe(
+      "organizations/my-org/preprodartifacts/build%201/install-details/"
+    );
+    expect(lastCall?.[2]?.schema).toBeDefined();
+  });
+});
+
+describe("downloadBuildArtifact", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "preprod-dl-"));
+    customFetchMock.mockReset();
+    getAuthTokenMock.mockReturnValue("secret-token");
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("streams the body to disk and attaches auth for a same-origin URL", async () => {
+    customFetchMock.mockResolvedValue(
+      new Response("FAKE-BINARY", { status: 200 })
+    );
+    const dest = join(tmpDir, "out.ipa");
+
+    await downloadBuildArtifact(
+      "https://us.sentry.io",
+      "https://us.sentry.io/dl/?response_format=ipa",
+      dest
+    );
+
+    expect(await readFile(dest, "utf8")).toBe("FAKE-BINARY");
+    const init = customFetchMock.mock.calls.at(-1)?.[1] as {
+      headers: Record<string, string>;
+    };
+    expect(init.headers.Authorization).toBe("Bearer secret-token");
+  });
+
+  test("does NOT attach the auth token to a cross-origin (signed) URL", async () => {
+    customFetchMock.mockResolvedValue(new Response("X", { status: 200 }));
+
+    await downloadBuildArtifact(
+      "https://us.sentry.io",
+      "https://cdn.example.com/blob?response_format=ipa",
+      join(tmpDir, "o2.ipa")
+    );
+
+    const init = customFetchMock.mock.calls.at(-1)?.[1] as {
+      headers: Record<string, string>;
+    };
+    expect(init.headers.Authorization).toBeUndefined();
+  });
+
+  test("omits auth when no token is available", async () => {
+    getAuthTokenMock.mockReturnValue(undefined);
+    customFetchMock.mockResolvedValue(new Response("X", { status: 200 }));
+
+    await downloadBuildArtifact(
+      "https://us.sentry.io",
+      "https://us.sentry.io/dl/?response_format=ipa",
+      join(tmpDir, "o3.ipa")
+    );
+
+    const init = customFetchMock.mock.calls.at(-1)?.[1] as {
+      headers: Record<string, string>;
+    };
+    expect(init.headers.Authorization).toBeUndefined();
+  });
+
+  test("throws ApiError on a non-2xx response", async () => {
+    customFetchMock.mockResolvedValue(
+      new Response("nope", { status: 404, statusText: "Not Found" })
+    );
+
+    await expect(
+      downloadBuildArtifact(
+        "https://us.sentry.io",
+        "https://us.sentry.io/dl/?response_format=ipa",
+        join(tmpDir, "o4.ipa")
+      )
+    ).rejects.toThrow(ApiError);
+  });
+});


### PR DESCRIPTION
First PR of the **build/Emerge** workstream (porting `sentry-cli build`/`snapshots` from the legacy Rust CLI). Establishes the new `build` command group + a `preprod-artifacts` API module, starting with the lowest-risk, self-contained subcommand.

## `build download <build-id>`
Downloads a mobile build artifact (APK/IPA) previously uploaded to Sentry's preprod system for size analysis.

- Resolves the download URL via the org-scoped `organizations/{org}/preprodartifacts/{id}/install-details/` endpoint.
- Rewrites an iOS `response_format=plist` manifest URL to `response_format=ipa` to fetch the actual binary; infers the format (`ipa`/`apk`).
- Streams the artifact to `preprod_artifact_<build-id>.<ext>` (or `--output`/`-o`). Large artifacts stream to disk — never buffered in memory.
- Org-scoped (no project); resolved from `--org`/`SENTRY_ORG`/config/DSN. **Sentry SaaS only.**

### Security note
The download attaches the auth token **only when the URL shares the org region's origin**, so it is never leaked to a third-party/signed storage URL (mirrors the CLI's existing signed-download handling). Covered by tests.

## Files
- `src/lib/api/preprod-artifacts.ts` — `getBuildInstallDetails`, `toBinaryDownloadUrl`, `buildFormatFromUrl`, `downloadBuildArtifact` (origin-gated auth + streaming).
- `src/commands/build/{index,download}.ts` — new `build` route group + `download` command.
- `src/app.ts` — register the `build` route.
- `docs/src/fragments/commands/build.md` + regenerated skill/contributing docs.
- Tests: 13 (pure URL helpers, `getBuildInstallDetails` endpoint shape, streaming download, **auth-origin gating** same/cross-origin/no-token, non-2xx → `ApiError`, and command orchestration incl. not-installable guard).

## Follow-ups (tracked, not in this PR)
`build upload` (Android APK/AAB via chunk-upload), git/VCS metadata, `snapshots download`/`diff`. `snapshots upload` is an objectstore command (deferred to the objectstore session); iOS `.car` asset parsing is native-macOS-only and intentionally skipped.

`typecheck`, `lint`, `check:deps`, `check:fragments` all pass.