### PR TITLE
build(deps): pin patched dependency keys to exact versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,9 +83,9 @@
   "packageManager": "pnpm@10.11.0",
   "pnpm": {
     "patchedDependencies": {
-      "@stricli/core": "patches/@stricli%2Fcore@1.2.7.patch",
-      "@sentry/node-core": "patches/@sentry%2Fnode-core@10.50.0.patch",
-      "@sentry/core": "patches/@sentry%2Fcore@10.50.0.patch"
+      "@stricli/core@1.2.7": "patches/@stricli%2Fcore@1.2.7.patch",
+      "@sentry/node-core@10.50.0": "patches/@sentry%2Fnode-core@10.50.0.patch",
+      "@sentry/core@10.50.0": "patches/@sentry%2Fcore@10.50.0.patch"
     },
     "overrides": {
       "esbuild@>=0.17.0 <0.28.1": "0.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,13 +12,13 @@ overrides:
   vite: 8.0.16
 
 patchedDependencies:
-  '@sentry/core':
+  '@sentry/core@10.50.0':
     hash: 2351f28c53bf19ae9eb2f6d741b6cb880bc9c6e60bf7ddd14fde6a0e25bde762
     path: patches/@sentry%2Fcore@10.50.0.patch
-  '@sentry/node-core':
+  '@sentry/node-core@10.50.0':
     hash: 70711b63f77a0c4b4fe10c70350be7126dc05b220ea303cda74090bce733f467
     path: patches/@sentry%2Fnode-core@10.50.0.patch
-  '@stricli/core':
+  '@stricli/core@1.2.7':
     hash: 402d573df36b19c62010d4ff41e49826f69d5c47212b8052ee7b042df34f973f
     path: patches/@stricli%2Fcore@1.2.7.patch
 
@@ -3209,7 +3209,7 @@ snapshots:
 
   '@sentry/core@10.50.0(patch_hash=2351f28c53bf19ae9eb2f6d741b6cb880bc9c6e60bf7ddd14fde6a0e25bde762)': {}
 
-  '@sentry/core@10.60.0(patch_hash=2351f28c53bf19ae9eb2f6d741b6cb880bc9c6e60bf7ddd14fde6a0e25bde762)': {}
+  '@sentry/core@10.60.0': {}
 
   '@sentry/node-core@10.50.0(patch_hash=70711b63f77a0c4b4fe10c70350be7126dc05b220ea303cda74090bce733f467)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
     dependencies:
@@ -3223,10 +3223,10 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@sentry/node-core@10.60.0(patch_hash=70711b63f77a0c4b4fe10c70350be7126dc05b220ea303cda74090bce733f467)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node-core@10.60.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@sentry/conventions': 0.12.0
-      '@sentry/core': 10.60.0(patch_hash=2351f28c53bf19ae9eb2f6d741b6cb880bc9c6e60bf7ddd14fde6a0e25bde762)
+      '@sentry/core': 10.60.0
       '@sentry/opentelemetry': 10.60.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
       import-in-the-middle: 3.2.0
     optionalDependencies:
@@ -3241,8 +3241,8 @@ snapshots:
       '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
-      '@sentry/core': 10.60.0(patch_hash=2351f28c53bf19ae9eb2f6d741b6cb880bc9c6e60bf7ddd14fde6a0e25bde762)
-      '@sentry/node-core': 10.60.0(patch_hash=70711b63f77a0c4b4fe10c70350be7126dc05b220ea303cda74090bce733f467)(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
+      '@sentry/core': 10.60.0
+      '@sentry/node-core': 10.60.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
       '@sentry/opentelemetry': 10.60.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))
       '@sentry/server-utils': 10.60.0
       import-in-the-middle: 3.2.0
@@ -3265,7 +3265,7 @@ snapshots:
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
       '@sentry/conventions': 0.12.0
-      '@sentry/core': 10.60.0(patch_hash=2351f28c53bf19ae9eb2f6d741b6cb880bc9c6e60bf7ddd14fde6a0e25bde762)
+      '@sentry/core': 10.60.0
 
   '@sentry/server-utils@10.60.0':
     dependencies:
@@ -3273,7 +3273,7 @@ snapshots:
       '@apm-js-collab/code-transformer-bundler-plugins': 0.5.0
       '@apm-js-collab/tracing-hooks': 0.10.0
       '@sentry/conventions': 0.12.0
-      '@sentry/core': 10.60.0(patch_hash=2351f28c53bf19ae9eb2f6d741b6cb880bc9c6e60bf7ddd14fde6a0e25bde762)
+      '@sentry/core': 10.60.0
       magic-string: 0.30.21
     transitivePeerDependencies:
       - supports-color
@@ -3326,11 +3326,11 @@ snapshots:
 
   '@stricli/auto-complete@1.2.8':
     dependencies:
-      '@stricli/core': 1.2.8(patch_hash=402d573df36b19c62010d4ff41e49826f69d5c47212b8052ee7b042df34f973f)
+      '@stricli/core': 1.2.8
 
   '@stricli/core@1.2.7(patch_hash=402d573df36b19c62010d4ff41e49826f69d5c47212b8052ee7b042df34f973f)': {}
 
-  '@stricli/core@1.2.8(patch_hash=402d573df36b19c62010d4ff41e49826f69d5c47212b8052ee7b042df34f973f)': {}
+  '@stricli/core@1.2.8': {}
 
   '@trpc/server@11.18.0(typescript@5.9.3)':
     dependencies:

--- a/script/check-patches.ts
+++ b/script/check-patches.ts
@@ -52,7 +52,29 @@ const patches = pkg.pnpm?.patchedDependencies ?? {};
 const warnings: string[] = [];
 const errors: string[] = [];
 
-for (const [name, patchPath] of Object.entries(patches)) {
+/**
+ * Split a patchedDependencies key into its bare package name and optional
+ * version selector. pnpm supports both name-only keys (`@sentry/core`) and
+ * exact-version keys (`@sentry/core@10.50.0`); the latter scopes a patch to a
+ * single version so pnpm never attempts to apply it to mismatched nested copies
+ * (e.g. a transitive `@sentry/core@10.60.0`), which otherwise emits a
+ * "Could not apply patch" warning.
+ *
+ * Scoped names begin with `@`, so only an `@` after index 0 delimits a version.
+ *
+ * @param key - A patchedDependencies key, versioned or not.
+ * @returns The bare package name and the version selector (undefined if absent).
+ */
+function parsePatchKey(key: string): { name: string; version?: string } {
+  const atIndex = key.lastIndexOf("@");
+  if (atIndex > 0) {
+    return { name: key.slice(0, atIndex), version: key.slice(atIndex + 1) };
+  }
+  return { name: key };
+}
+
+for (const [key, patchPath] of Object.entries(patches)) {
+  const { name } = parsePatchKey(key);
   // Extract version from patch path: "patches/@stricli%2Fcore@1.2.5.patch" → "1.2.5"
   // Handles pre-release versions like "1.2.3-beta.1" by matching everything after @M.N.P until .patch
   const versionMatch = patchPath.match(/@(\d+\.\d+\.\d+[^@]*)\.patch$/);


### PR DESCRIPTION
## Problem

Every `pnpm install` prints three "Could not apply patch" warnings:

```
WARN  Could not apply patch .../@sentry%2Fcore@10.50.0.patch to .../@sentry/node/node_modules/@sentry/core
WARN  Could not apply patch .../@stricli%2Fcore@1.2.7.patch to .../@stricli/auto-complete/node_modules/@stricli/core
WARN  Could not apply patch .../@sentry%2Fnode-core@10.50.0.patch to .../@sentry/node/node_modules/@sentry/node-core
```

## Root cause

The `pnpm.patchedDependencies` keys were **name-only** (`@sentry/core`, `@sentry/node-core`, `@stricli/core`). pnpm interprets a name-only key as "apply to every version in the tree," so it tried to apply the version-specific patches to transitive nested copies that resolve to different versions:

- `@spotlightjs/spotlight` (dev tool) → `@sentry/node@10.60.0` → nested `@sentry/core@10.60.0` & `@sentry/node-core@10.60.0`
- `@stricli/auto-complete@1.2.8` → nested `@stricli/core@1.2.8`

The patches only ever apply cleanly to the top-level `10.50.0` / `1.2.7` copies (the ones the CLI actually bundles), so each mismatched nested copy produced a warning — pnpm then silently installs those nested copies unpatched (which is correct; they don't need the patch).

## Fix

- **`package.json`** — pin each patch key to its exact target version (`@sentry/core@10.50.0`, `@sentry/node-core@10.50.0`, `@stricli/core@1.2.7`) so pnpm scopes the patch to the intended version only and never touches the nested copies.
- **`script/check-patches.ts`** — add a `parsePatchKey()` helper (with JSDoc) to split the now-versioned keys into a bare package name, so installed-version resolution and the content assertions keep working.
- **`pnpm-lock.yaml`** — regenerated; nested copies drop their `patch_hash` suffixes while the top-level patched copies retain theirs.

## Verification

- `pnpm install` → zero patch warnings.
- `pnpm run check:patches` → `✓ All patched dependency versions match installed versions`.
- `-H` alias patch still applied (stale marker absent in both ESM & CJS `@stricli/core` bundles); top-level Sentry patches retain their `patch_hash` in the lockfile.