### PR TITLE
feat(build): add `build upload` for Android APK/AAB

### DIFF
--- a/docs/src/content/docs/contributing.md
+++ b/docs/src/content/docs/contributing.md
@@ -54,7 +54,7 @@ cli/
 │   ├── commands/       # CLI commands
 │   │   ├── alert/       # create, delete, edit, list, view
 │   │   ├── auth/        # login, logout, refresh, status, token, whoami
-│   │   ├── build/       # download
+│   │   ├── build/       # download, upload
 │   │   ├── cli/         # defaults, feedback, fix, import, setup, uninstall, upgrade
 │   │   ├── code-mappings/# upload
 │   │   ├── dart-symbol-map/# upload

--- a/docs/src/fragments/commands/build.md
+++ b/docs/src/fragments/commands/build.md
@@ -3,6 +3,15 @@
 ## Examples
 
 ```bash
+# Upload an Android build (APK or AAB) for size analysis
+sentry build upload ./app-release.apk
+
+# Upload with a build configuration and release notes
+sentry build upload ./app.aab --build-configuration Release --release-notes "Nightly"
+
+# Tag a build with install groups (repeatable)
+sentry build upload ./app.aab --install-group qa --install-group beta
+
 # Download a build artifact by ID
 sentry build download 1234567890
 
@@ -15,6 +24,10 @@ sentry build download 1234567890 --json
 
 ## Important Notes
 
+- `build upload` supports **Android APK and AAB**. iOS XCArchive/IPA upload is
+  not yet supported. **Sentry SaaS only.**
+- Multiple paths may be uploaded at once; the command exits non-zero if any
+  build fails to upload.
 - `build download` fetches a mobile build artifact (APK or IPA) previously
   uploaded to Sentry's preprod system for size analysis. **Sentry SaaS only.**
 - The build must be installable. Builds that are still processing — or that have

--- a/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -380,6 +380,7 @@ Manage Sentry alert rules
 
 Manage mobile build artifacts
 
+- `sentry build upload <path...>` — Upload builds to a project
 - `sentry build download <build-id>` — Download a build artifact
 
 → Full flags and examples: `references/build.md`

--- a/plugins/sentry-cli/skills/sentry-cli/references/build.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/build.md
@@ -11,6 +11,15 @@ requires:
 
 Manage mobile build artifacts
 
+### `sentry build upload <path...>`
+
+Upload builds to a project
+
+**Flags:**
+- `--build-configuration <value> - Build configuration for the upload (defaults to the current version)`
+- `--release-notes <value> - Release notes for the build`
+- `--install-group <value>... - Install group(s) for this build (repeatable); builds sharing a group show updates for each other`
+
 ### `sentry build download <build-id>`
 
 Download a build artifact
@@ -21,6 +30,15 @@ Download a build artifact
 **Examples:**
 
 ```bash
+# Upload an Android build (APK or AAB) for size analysis
+sentry build upload ./app-release.apk
+
+# Upload with a build configuration and release notes
+sentry build upload ./app.aab --build-configuration Release --release-notes "Nightly"
+
+# Tag a build with install groups (repeatable)
+sentry build upload ./app.aab --install-group qa --install-group beta
+
 # Download a build artifact by ID
 sentry build download 1234567890
 

--- a/src/commands/build/index.ts
+++ b/src/commands/build/index.ts
@@ -1,15 +1,17 @@
 /**
  * `sentry build` — manage mobile build artifacts for preprod size analysis.
  *
- * Currently exposes `download`. Upload (APK/AAB, and iOS XCArchive/IPA) is
- * ported separately.
+ * Exposes `upload` (Android APK/AAB) and `download`. iOS XCArchive/IPA upload
+ * is ported separately.
  */
 
 import { buildRouteMap } from "../../lib/route-map.js";
 import { downloadCommand } from "./download.js";
+import { uploadCommand } from "./upload.js";
 
 export const buildRoute = buildRouteMap({
   routes: {
+    upload: uploadCommand,
     download: downloadCommand,
   },
   docs: {

--- a/src/commands/build/upload.ts
+++ b/src/commands/build/upload.ts
@@ -1,0 +1,224 @@
+/**
+ * sentry build upload <paths...>
+ *
+ * Upload mobile builds to Sentry for preprod size analysis. Each build is
+ * normalized into a deterministic wrapper ZIP and uploaded via the
+ * chunk-upload + preprod-artifacts assemble protocol.
+ *
+ * This PR supports Android APK/AAB. iOS XCArchive/IPA is ported separately;
+ * git/VCS metadata collection is added in a follow-up. Sentry SaaS only.
+ */
+
+import { readFile, stat } from "node:fs/promises";
+import type { SentryContext } from "../../context.js";
+import {
+  type BuildUploadMetadata,
+  uploadBuild,
+} from "../../lib/api/preprod-artifacts.js";
+import {
+  detectBuildFormat,
+  normalizeBuildFile,
+  parsePluginFromPipeline,
+} from "../../lib/build/index.js";
+import { buildCommand } from "../../lib/command.js";
+import { ContextError, ValidationError } from "../../lib/errors.js";
+import {
+  colorTag,
+  mdKvTable,
+  renderMarkdown,
+} from "../../lib/formatters/markdown.js";
+import { CommandOutput } from "../../lib/formatters/output.js";
+import { logger } from "../../lib/logger.js";
+import { resolveOrgAndProject } from "../../lib/resolve-target.js";
+
+const log = logger.withTag("build.upload");
+
+const USAGE_HINT = "sentry build upload <path>";
+
+/** Flags accepted by `build upload`. */
+type UploadFlags = {
+  "build-configuration"?: string;
+  "release-notes"?: string;
+  "install-group"?: string[];
+};
+
+/** Result for a single uploaded path. */
+type BuildUploadEntry = {
+  /** The build file path. */
+  path: string;
+  /** The assembled artifact URL, or `null` if this path failed. */
+  artifactUrl: string | null;
+  /** Failure reason, or `null` on success. */
+  error: string | null;
+};
+
+/** Structured result for `build upload`. */
+type BuildUploadResult = {
+  /** Per-path outcomes. */
+  builds: BuildUploadEntry[];
+  /** Number of builds successfully uploaded. */
+  uploadedCount: number;
+};
+
+/** Human-readable formatter for the upload result. */
+function formatUploadResult(data: BuildUploadResult): string {
+  const rows = data.builds.map((entry): [string, string] => [
+    entry.path,
+    entry.error
+      ? colorTag("error", entry.error)
+      : (entry.artifactUrl ?? colorTag("muted", "uploaded")),
+  ]);
+  const header =
+    data.uploadedCount === data.builds.length
+      ? `Uploaded ${data.uploadedCount} build(s)`
+      : `Uploaded ${data.uploadedCount} of ${data.builds.length} build(s)`;
+  return renderMarkdown(`${header}\n\n${mdKvTable(rows)}`);
+}
+
+/**
+ * Normalize and upload a single build path.
+ *
+ * @throws {ValidationError} When the path is unreadable or an unsupported format.
+ */
+async function uploadOne(
+  ctx: SentryContext,
+  path: string,
+  org: string,
+  project: string,
+  metadata: BuildUploadMetadata
+): Promise<string> {
+  let info: Awaited<ReturnType<typeof stat>>;
+  try {
+    info = await stat(path);
+  } catch (err) {
+    log.debug(`Failed to stat build path ${path}`, err);
+    throw new ValidationError(`Path does not exist: ${path}`, "path");
+  }
+
+  // XCArchive is a directory; iOS support is ported separately.
+  if (info.isDirectory()) {
+    throw new ValidationError(
+      `iOS XCArchive upload is not yet supported: ${path}`,
+      "path"
+    );
+  }
+
+  const content = await readFile(path);
+  const format = detectBuildFormat(content);
+
+  if (format === "ipa" || format === "xcarchive") {
+    throw new ValidationError(
+      `iOS ${format.toUpperCase()} upload is not yet supported: ${path}`,
+      "path"
+    );
+  }
+  if (format !== "apk" && format !== "aab") {
+    throw new ValidationError(
+      `Unsupported build format (expected APK or AAB): ${path}`,
+      "path"
+    );
+  }
+
+  const plugin = parsePluginFromPipeline(ctx.env.SENTRY_PIPELINE);
+  const normalized = normalizeBuildFile(path, content, plugin);
+  return await uploadBuild({ org, project, content: normalized, metadata });
+}
+
+export const uploadCommand = buildCommand({
+  docs: {
+    brief: "Upload builds to a project",
+    fullDescription:
+      "Upload mobile builds to Sentry for preprod size analysis. Each build " +
+      "is wrapped in a deterministic ZIP and uploaded via the chunk-upload + " +
+      "assemble protocol.\n\n" +
+      "Supported formats: Android APK and AAB. (iOS XCArchive/IPA is not yet " +
+      "supported.) This feature only works with Sentry SaaS.\n\n" +
+      "Usage:\n" +
+      "  sentry build upload ./app-release.apk\n" +
+      "  sentry build upload ./app.aab --build-configuration Release\n" +
+      "  sentry build upload ./app.aab --install-group qa --install-group beta",
+  },
+  output: {
+    human: formatUploadResult,
+  },
+  parameters: {
+    positional: {
+      kind: "array",
+      parameter: {
+        brief: "Path(s) to the build(s) to upload (APK or AAB)",
+        parse: String,
+        placeholder: "path",
+      },
+    },
+    flags: {
+      "build-configuration": {
+        kind: "parsed",
+        parse: String,
+        brief:
+          "Build configuration for the upload (defaults to the current version)",
+        optional: true,
+      },
+      "release-notes": {
+        kind: "parsed",
+        parse: String,
+        brief: "Release notes for the build",
+        optional: true,
+      },
+      "install-group": {
+        kind: "parsed",
+        parse: String,
+        brief:
+          "Install group(s) for this build (repeatable); builds sharing a group show updates for each other",
+        variadic: true,
+      },
+    },
+  },
+  async *func(this: SentryContext, flags: UploadFlags, ...paths: string[]) {
+    if (paths.length === 0) {
+      throw new ValidationError("At least one build path is required", "path");
+    }
+
+    const resolved = await resolveOrgAndProject({
+      cwd: this.cwd,
+      usageHint: USAGE_HINT,
+    });
+    if (!resolved) {
+      throw new ContextError("Organization and project", USAGE_HINT);
+    }
+    const { org, project } = resolved;
+
+    const metadata: BuildUploadMetadata = {
+      buildConfiguration: flags["build-configuration"],
+      releaseNotes: flags["release-notes"],
+      installGroups: flags["install-group"],
+    };
+
+    const builds: BuildUploadEntry[] = [];
+    for (const path of paths) {
+      try {
+        const artifactUrl = await uploadOne(this, path, org, project, metadata);
+        builds.push({ path, artifactUrl, error: null });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.debug(`Failed to upload build ${path}`, err);
+        builds.push({ path, artifactUrl: null, error: message });
+      }
+    }
+
+    const uploadedCount = builds.filter((b) => b.error === null).length;
+    yield new CommandOutput<BuildUploadResult>({ builds, uploadedCount });
+
+    if (uploadedCount === 0) {
+      // Every build failed — surface a non-zero exit like the legacy CLI.
+      this.process.exitCode = 1;
+      return { hint: "No builds were uploaded. See the errors above." };
+    }
+    if (uploadedCount < builds.length) {
+      this.process.exitCode = 1;
+      return {
+        hint: `Uploaded ${uploadedCount} of ${builds.length} build(s); some failed.`,
+      };
+    }
+    return { hint: "View your builds in Sentry to see the size analysis." };
+  },
+});

--- a/src/commands/build/upload.ts
+++ b/src/commands/build/upload.ts
@@ -103,6 +103,10 @@ async function uploadOne(
     );
   }
 
+  // NOTE: the build is read fully into memory (and normalized into a second
+  // buffer). Fine for typical mobile builds, but files above Node's ~2 GiB
+  // Buffer cap will throw. A follow-up can stream normalization to a temp file
+  // and use the file-based chunk path; the legacy CLI memory-maps instead.
   const content = await readFile(path);
   const format = detectBuildFormat(content);
 
@@ -169,6 +173,7 @@ export const uploadCommand = buildCommand({
         parse: String,
         brief:
           "Install group(s) for this build (repeatable); builds sharing a group show updates for each other",
+        optional: true,
         variadic: true,
       },
     },
@@ -208,8 +213,10 @@ export const uploadCommand = buildCommand({
     const uploadedCount = builds.filter((b) => b.error === null).length;
     yield new CommandOutput<BuildUploadResult>({ builds, uploadedCount });
 
+    // Deliberate deviation from the legacy CLI, which only exits non-zero when
+    // *every* build fails: we fail loud on *any* failure so CI/agents never
+    // mistake a partial upload for a clean success.
     if (uploadedCount === 0) {
-      // Every build failed — surface a non-zero exit like the legacy CLI.
       this.process.exitCode = 1;
       return { hint: "No builds were uploaded. See the errors above." };
     }

--- a/src/lib/api/preprod-artifacts.ts
+++ b/src/lib/api/preprod-artifacts.ts
@@ -21,6 +21,16 @@ import { getAuthToken } from "../db/auth.js";
 import { ApiError, ValidationError } from "../errors.js";
 import { logger } from "../logger.js";
 import { resolveOrgRegion } from "../region.js";
+import {
+  ASSEMBLE_MAX_WAIT_MS,
+  ASSEMBLE_POLL_INTERVAL_MS,
+  AssembleResponseSchema,
+  type ChunkServerOptions,
+  getChunkUploadOptions,
+  hashBuffer,
+  pickUploadEncoding,
+  uploadMissingBufferChunks,
+} from "./chunk-upload.js";
 import { apiRequestToRegion } from "./infrastructure.js";
 
 const log = logger.withTag("api.preprod-artifacts");
@@ -148,5 +158,140 @@ export async function downloadBuildArtifact(
   await pipeline(
     Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]),
     createWriteStream(destPath)
+  );
+}
+
+/** Optional metadata sent with a build assemble request. */
+export type BuildUploadMetadata = {
+  /** Build configuration name (e.g. `Release`). */
+  buildConfiguration?: string;
+  /** Release notes for the build. */
+  releaseNotes?: string;
+  /** Install group(s) this build belongs to. */
+  installGroups?: string[];
+};
+
+/** Options for {@link uploadBuild}. */
+export type BuildUploadOptions = {
+  /** Organization slug. */
+  org: string;
+  /** Project slug. */
+  project: string;
+  /** Normalized wrapper-ZIP bytes to upload. */
+  content: Buffer;
+  /** Optional build metadata folded into the assemble body. */
+  metadata: BuildUploadMetadata;
+  /** Pre-fetched chunk upload options (fetched if omitted). */
+  serverOptions?: ChunkServerOptions;
+};
+
+/**
+ * Build assemble response — the shared assemble shape plus `artifactUrl`, which
+ * is populated once the build has been fully assembled.
+ */
+const BuildAssembleResponseSchema = AssembleResponseSchema.extend({
+  artifactUrl: z.string().nullable().optional(),
+});
+
+/** Construct the single-object assemble request body for a build. */
+function buildAssembleBody(
+  checksum: string,
+  chunkShas: string[],
+  metadata: BuildUploadMetadata
+): Record<string, unknown> {
+  const body: Record<string, unknown> = { checksum, chunks: chunkShas };
+  if (metadata.buildConfiguration) {
+    body.build_configuration = metadata.buildConfiguration;
+  }
+  if (metadata.releaseNotes) {
+    body.release_notes = metadata.releaseNotes;
+  }
+  if (metadata.installGroups?.length) {
+    body.install_groups = metadata.installGroups;
+  }
+  return body;
+}
+
+/**
+ * Upload a normalized build via the chunk-upload + preprod-artifacts assemble
+ * protocol, polling until the server finishes assembling.
+ *
+ * Unlike DIF uploads there is no no-wait mode: assembly always runs to
+ * completion (or {@link ASSEMBLE_MAX_WAIT_MS}) because the artifact URL is only
+ * known once the build is assembled.
+ *
+ * @param options - Upload configuration.
+ * @returns The assembled artifact's URL.
+ * @throws {ApiError} On an assembly error or timeout.
+ */
+export async function uploadBuild(
+  options: BuildUploadOptions
+): Promise<string> {
+  const { org, project, content, metadata } = options;
+  const serverOptions =
+    options.serverOptions ?? (await getChunkUploadOptions(org));
+  const encoding = pickUploadEncoding(serverOptions.compression);
+  const { chunks, overallChecksum } = hashBuffer(
+    content,
+    serverOptions.chunkSize
+  );
+  const regionUrl = await resolveOrgRegion(org);
+  const endpoint = `projects/${org}/${project}/files/preprodartifacts/assemble/`;
+
+  const body = buildAssembleBody(
+    overallChecksum,
+    chunks.map((chunk) => chunk.sha1),
+    metadata
+  );
+
+  const deadline = Date.now() + ASSEMBLE_MAX_WAIT_MS;
+  while (Date.now() < deadline) {
+    const { data } = await apiRequestToRegion(regionUrl, endpoint, {
+      method: "POST",
+      body,
+      schema: BuildAssembleResponseSchema,
+    });
+
+    if (data.state === "error") {
+      throw new ApiError(
+        "Build assembly failed",
+        500,
+        data.detail ?? "Unknown error",
+        endpoint
+      );
+    }
+    if (data.artifactUrl) {
+      return data.artifactUrl;
+    }
+
+    const missing = new Set(data.missingChunks ?? []);
+    if (missing.size > 0) {
+      await uploadMissingBufferChunks({
+        chunks,
+        missingChecksums: missing,
+        content,
+        serverOptions,
+        encoding,
+        regionUrl,
+      });
+    } else if (data.state === "ok") {
+      throw new ApiError(
+        "Build assembled but no artifact URL was returned",
+        500,
+        data.detail ?? "",
+        endpoint
+      );
+    }
+
+    // Always pace between assemble POSTs (matches the legacy poll loop and
+    // avoids a busy loop should the server keep reporting the same chunks).
+    await new Promise((r) => setTimeout(r, ASSEMBLE_POLL_INTERVAL_MS));
+  }
+
+  throw new ApiError(
+    "Build assembly timed out",
+    408,
+    `Assembly did not complete within ${ASSEMBLE_MAX_WAIT_MS / 1000}s`,
+    endpoint
   );
 }

--- a/src/lib/api/preprod-artifacts.ts
+++ b/src/lib/api/preprod-artifacts.ts
@@ -263,6 +263,16 @@ export async function uploadBuild(
     if (data.artifactUrl) {
       return data.artifactUrl;
     }
+    // A finished ("ok") state without an artifact URL is terminal — fail fast
+    // rather than polling to the deadline (matches the legacy loop).
+    if (data.state === "ok") {
+      throw new ApiError(
+        "Build assembled but no artifact URL was returned",
+        500,
+        data.detail ?? "",
+        endpoint
+      );
+    }
 
     const missing = new Set(data.missingChunks ?? []);
     if (missing.size > 0) {
@@ -274,13 +284,6 @@ export async function uploadBuild(
         encoding,
         regionUrl,
       });
-    } else if (data.state === "ok") {
-      throw new ApiError(
-        "Build assembled but no artifact URL was returned",
-        500,
-        data.detail ?? "",
-        endpoint
-      );
     }
 
     // Always pace between assemble POSTs (matches the legacy poll loop and

--- a/src/lib/build/index.ts
+++ b/src/lib/build/index.ts
@@ -1,0 +1,170 @@
+/**
+ * Mobile build normalization for `sentry build upload`.
+ *
+ * Detects the build format from ZIP entry names and wraps the build into a
+ * deterministic ZIP (STORE compression, fixed mtime) alongside a metadata
+ * file, ready for chunk upload + assembly.
+ *
+ * Determinism matters: a byte-identical wrapper for an identical build lets the
+ * server dedup already-uploaded chunks across re-uploads. We use STORE (level 0)
+ * because APK/AAB/IPA are themselves already-compressed ZIPs — re-compressing
+ * the wrapper would cost CPU for ~no size win — and a fixed modification time so
+ * the output does not vary run to run.
+ *
+ * Only Android APK/AAB is handled here; iOS XCArchive/IPA is ported separately.
+ */
+
+import { basename } from "node:path";
+import { strToU8, unzipSync, zipSync } from "fflate";
+import { CLI_VERSION } from "../constants.js";
+import { logger } from "../logger.js";
+
+const log = logger.withTag("build.normalize");
+
+/** A recognized mobile build format. */
+export type BuildFormat = "apk" | "aab" | "ipa" | "xcarchive";
+
+/** ZIP local-file-header magic bytes (`PK\x03\x04`). */
+const ZIP_MAGIC = [0x50, 0x4b, 0x03, 0x04];
+
+/**
+ * Fixed modification time for normalized ZIP entries. A constant timestamp
+ * (the ZIP epoch, 1980-01-01) keeps the wrapper byte-deterministic so identical
+ * builds produce identical chunks.
+ */
+const FIXED_MTIME = new Date("1980-01-01T00:00:00Z");
+
+/** Name of the metadata file embedded in every normalized build ZIP. */
+const METADATA_FILENAME = ".sentry-cli-metadata.txt";
+
+/** Whether the bytes start with the ZIP local-file-header magic. */
+function hasZipMagic(bytes: Uint8Array): boolean {
+  return ZIP_MAGIC.every((byte, i) => bytes[i] === byte);
+}
+
+/**
+ * List a ZIP's entry names without decompressing any entry.
+ *
+ * The fflate filter is invoked for every entry; returning `false` skips
+ * decompression, so this only parses the central directory.
+ */
+function listZipEntryNames(content: Uint8Array): string[] {
+  const names: string[] = [];
+  unzipSync(content, {
+    filter: (file) => {
+      names.push(file.name);
+      return false;
+    },
+  });
+  return names;
+}
+
+/**
+ * Detect the mobile build format from a file's bytes.
+ *
+ * APK/AAB/IPA are recognized by their ZIP entry names. Returns `null` for
+ * anything unrecognized. (XCArchive is a directory, not a file, and is detected
+ * by the caller.)
+ *
+ * @param content - The raw build file bytes.
+ */
+export function detectBuildFormat(content: Uint8Array): BuildFormat | null {
+  if (!hasZipMagic(content)) {
+    return null;
+  }
+
+  let names: string[];
+  try {
+    names = listZipEntryNames(content);
+  } catch (err) {
+    log.debug("Failed to read ZIP entries while detecting build format", err);
+    return null;
+  }
+
+  const entries = new Set(names);
+  // AAB is more specific than APK (an AAB also nests an AndroidManifest under
+  // base/), so check it first.
+  if (
+    entries.has("BundleConfig.pb") &&
+    entries.has("base/manifest/AndroidManifest.xml")
+  ) {
+    return "aab";
+  }
+  if (entries.has("AndroidManifest.xml")) {
+    return "apk";
+  }
+  // IPA: a Payload/<name>.app/Info.plist entry (recognized so the caller can
+  // emit an "iOS not yet supported" message rather than "unrecognized").
+  if (names.some((name) => /^Payload\/[^/]+\.app\/Info\.plist$/.test(name))) {
+    return "ipa";
+  }
+  return null;
+}
+
+/** A Sentry build plugin parsed from `SENTRY_PIPELINE`. */
+export type PipelinePlugin = { name: string; version: string };
+
+/**
+ * Parse a recognized Sentry plugin from a `SENTRY_PIPELINE` value.
+ *
+ * Format: `"<name>/<version>"` (e.g. `"sentry-gradle-plugin/4.12.0"`). Only the
+ * gradle and fastlane plugins are recognized; anything else yields `null`.
+ *
+ * @param pipeline - The `SENTRY_PIPELINE` value, if set.
+ */
+export function parsePluginFromPipeline(
+  pipeline: string | undefined
+): PipelinePlugin | null {
+  if (!pipeline) {
+    return null;
+  }
+  const slash = pipeline.indexOf("/");
+  if (slash <= 0) {
+    return null;
+  }
+  const name = pipeline.slice(0, slash);
+  const version = pipeline.slice(slash + 1);
+  if (
+    version &&
+    (name === "sentry-gradle-plugin" || name === "sentry-fastlane-plugin")
+  ) {
+    return { name, version };
+  }
+  return null;
+}
+
+/** Build the `.sentry-cli-metadata.txt` contents. */
+function buildMetadataFile(plugin: PipelinePlugin | null): string {
+  const version =
+    process.env.SENTRY_CLI_INTEGRATION_TEST_VERSION_OVERRIDE ?? CLI_VERSION;
+  let out = `sentry-cli-version: ${version}\n`;
+  if (plugin) {
+    out += `${plugin.name}: ${plugin.version}\n`;
+  }
+  return out;
+}
+
+/**
+ * Wrap a build file into a deterministic normalized ZIP for upload.
+ *
+ * The ZIP stores the build under its basename plus `.sentry-cli-metadata.txt`,
+ * using STORE (no compression) and a fixed mtime so identical inputs produce
+ * identical bytes.
+ *
+ * @param filePath - Path to the build file (its basename becomes the ZIP entry).
+ * @param content - The raw build file bytes.
+ * @param plugin - Optional plugin identity for the metadata file.
+ * @returns The normalized ZIP bytes.
+ */
+export function normalizeBuildFile(
+  filePath: string,
+  content: Uint8Array,
+  plugin: PipelinePlugin | null
+): Buffer {
+  const entryOptions = { level: 0 as const, mtime: FIXED_MTIME };
+  const zipped = zipSync({
+    [basename(filePath)]: [content, entryOptions],
+    [METADATA_FILENAME]: [strToU8(buildMetadataFile(plugin)), entryOptions],
+  });
+  return Buffer.from(zipped);
+}

--- a/src/lib/build/index.ts
+++ b/src/lib/build/index.ts
@@ -11,6 +11,12 @@
  * the wrapper would cost CPU for ~no size win — and a fixed modification time so
  * the output does not vary run to run.
  *
+ * Note: the legacy Rust CLI compresses the wrapper with Zstd. STORE is chosen
+ * here deliberately (simpler, no method-93 ZIP writer needed, avoids
+ * double-compression). The tradeoff is that wrapper bytes differ from the Rust
+ * CLI's, so chunks are not deduplicated across the two CLIs — only within this
+ * one, which is what matters for repeated uploads from the same tool.
+ *
  * Only Android APK/AAB is handled here; iOS XCArchive/IPA is ported separately.
  */
 

--- a/test/commands/build/upload.test.ts
+++ b/test/commands/build/upload.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for `sentry build upload`.
+ *
+ * Drives the command through its wrapper `loader()`. Real detection +
+ * normalization run against in-memory ZIP fixtures (a "fake APK" is a ZIP with
+ * an AndroidManifest.xml entry); the API `uploadBuild` and org/project
+ * resolution are spied so no network is touched.
+ */
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { strToU8, zipSync } from "fflate";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { uploadCommand } from "../../../src/commands/build/upload.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as preprod from "../../../src/lib/api/preprod-artifacts.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as resolveTarget from "../../../src/lib/resolve-target.js";
+
+let tmpDir: string;
+
+function createContext() {
+  const writes: string[] = [];
+  return {
+    context: {
+      stdout: {
+        write: (data: string | Uint8Array) => {
+          writes.push(
+            typeof data === "string" ? data : new TextDecoder().decode(data)
+          );
+          return true;
+        },
+      },
+      stderr: { write: () => true },
+      cwd: tmpDir,
+      env: {} as NodeJS.ProcessEnv,
+      process: { ...process, exitCode: undefined } as typeof process,
+    },
+    output: () => writes.join(""),
+    get exitCode() {
+      return this.context.process.exitCode;
+    },
+  };
+}
+
+/** Write a fake APK (a ZIP with a root AndroidManifest.xml) to the temp dir. */
+async function writeApk(name = "app-release.apk"): Promise<string> {
+  const path = join(tmpDir, name);
+  await writeFile(path, zipSync({ "AndroidManifest.xml": strToU8("xml") }));
+  return path;
+}
+
+describe("build upload", () => {
+  let uploadSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "build-upload-"));
+    vi.spyOn(resolveTarget, "resolveOrgAndProject").mockResolvedValue({
+      org: "test-org",
+      project: "test-project",
+    });
+    uploadSpy = vi
+      .spyOn(preprod, "uploadBuild")
+      .mockResolvedValue("https://sentry.io/artifact/1");
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test("uploads an APK and reports the artifact URL", async () => {
+    const apk = await writeApk();
+    const harness = createContext();
+    const func = await uploadCommand.loader();
+
+    await func.call(harness.context, {}, apk);
+
+    expect(uploadSpy).toHaveBeenCalledTimes(1);
+    const opts = uploadSpy.mock.calls[0]?.[0] as { org: string; project: string };
+    expect(opts.org).toBe("test-org");
+    expect(opts.project).toBe("test-project");
+    expect(harness.output()).toContain("https://sentry.io/artifact/1");
+    expect(harness.exitCode).toBeUndefined();
+  });
+
+  test("passes build metadata flags through to the API", async () => {
+    const apk = await writeApk();
+    const harness = createContext();
+    const func = await uploadCommand.loader();
+
+    await func.call(
+      harness.context,
+      {
+        "build-configuration": "Release",
+        "install-group": ["qa", "beta"],
+      },
+      apk
+    );
+
+    const meta = uploadSpy.mock.calls[0]?.[0] as {
+      metadata: { buildConfiguration?: string; installGroups?: string[] };
+    };
+    expect(meta.metadata.buildConfiguration).toBe("Release");
+    expect(meta.metadata.installGroups).toEqual(["qa", "beta"]);
+  });
+
+  test("rejects an unsupported file with a non-zero exit", async () => {
+    const bad = join(tmpDir, "notes.txt");
+    await writeFile(bad, "not a build");
+    const harness = createContext();
+    const func = await uploadCommand.loader();
+
+    await func.call(harness.context, {}, bad);
+
+    expect(uploadSpy).not.toHaveBeenCalled();
+    expect(harness.exitCode).toBe(1);
+    expect(harness.output()).toContain("Unsupported build format");
+  });
+
+  test("rejects a directory (iOS XCArchive) with a non-zero exit", async () => {
+    const dir = join(tmpDir, "MyApp.xcarchive");
+    await mkdir(dir);
+    const harness = createContext();
+    const func = await uploadCommand.loader();
+
+    await func.call(harness.context, {}, dir);
+
+    expect(uploadSpy).not.toHaveBeenCalled();
+    expect(harness.exitCode).toBe(1);
+    expect(harness.output()).toContain("XCArchive");
+  });
+
+  test("uploads the good build but exits non-zero when another fails", async () => {
+    const apk = await writeApk("good.apk");
+    const bad = join(tmpDir, "bad.txt");
+    await writeFile(bad, "nope");
+    const harness = createContext();
+    const func = await uploadCommand.loader();
+
+    await func.call(harness.context, {}, apk, bad);
+
+    expect(uploadSpy).toHaveBeenCalledTimes(1);
+    expect(harness.exitCode).toBe(1);
+  });
+});

--- a/test/commands/build/upload.test.ts
+++ b/test/commands/build/upload.test.ts
@@ -7,17 +7,23 @@
  * resolution are spied so no network is touched.
  */
 
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { mkdir } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { run } from "@stricli/core";
 import { strToU8, zipSync } from "fflate";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { app } from "../../../src/app.js";
 import { uploadCommand } from "../../../src/commands/build/upload.js";
+import type { SentryContext } from "../../../src/context.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as preprod from "../../../src/lib/api/preprod-artifacts.js";
+import { setAuthToken } from "../../../src/lib/db/auth.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
 import * as resolveTarget from "../../../src/lib/resolve-target.js";
+import { useTestConfigDir } from "../../helpers.js";
+
+useTestConfigDir("build-upload-cmd-");
 
 let tmpDir: string;
 
@@ -52,11 +58,40 @@ async function writeApk(name = "app-release.apk"): Promise<string> {
   return path;
 }
 
+/**
+ * Run the command through the real Stricli parser + router (unlike the
+ * `loader()` tests, this exercises flag arity). Returns captured stderr +
+ * exit code.
+ */
+async function runViaApp(
+  args: string[]
+): Promise<{ stderr: string; exitCode: number | undefined }> {
+  let stderr = "";
+  const context: SentryContext = {
+    process: { ...process, exitCode: undefined } as typeof process,
+    env: {} as NodeJS.ProcessEnv,
+    cwd: tmpDir,
+    homeDir: tmpDir,
+    configDir: tmpDir,
+    stdout: { write: () => true },
+    stderr: {
+      write: (data: string | Uint8Array) => {
+        stderr += typeof data === "string" ? data : new TextDecoder().decode(data);
+        return true;
+      },
+    },
+    stdin: process.stdin,
+  };
+  await run(app, ["build", "upload", ...args], context);
+  return { stderr, exitCode: context.process.exitCode };
+}
+
 describe("build upload", () => {
   let uploadSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(join(tmpdir(), "build-upload-"));
+    setAuthToken("test-token", 3600);
     vi.spyOn(resolveTarget, "resolveOrgAndProject").mockResolvedValue({
       org: "test-org",
       project: "test-project",
@@ -144,5 +179,20 @@ describe("build upload", () => {
 
     expect(uploadSpy).toHaveBeenCalledTimes(1);
     expect(harness.exitCode).toBe(1);
+  });
+
+  // Regression guard: --install-group must be OPTIONAL. Declared variadic
+  // without `optional: true`, Stricli treats it as required and the common
+  // `build upload <path>` invocation fails at parse time. This drives the real
+  // parser (the loader() tests above bypass it), so it catches flag arity.
+  test("accepts a build with no --install-group (flag is optional)", async () => {
+    const apk = await writeApk();
+
+    const { stderr, exitCode } = await runViaApp([apk]);
+
+    // Parsing succeeded and dispatched to the command (which uploaded).
+    expect(uploadSpy).toHaveBeenCalledTimes(1);
+    expect(exitCode ?? 0).toBe(0);
+    expect(stderr).not.toMatch(/install-group/i);
   });
 });

--- a/test/lib/api/preprod-artifacts.test.ts
+++ b/test/lib/api/preprod-artifacts.test.ts
@@ -264,6 +264,26 @@ describe("uploadBuild", () => {
     }
   });
 
+  test("omits optional metadata fields when unset", async () => {
+    apiRequestToRegionMock.mockResolvedValue({
+      data: { state: "ok", artifactUrl: "https://sentry.io/artifact/3" },
+      headers: new Headers(),
+    });
+
+    await uploadBuild({
+      org: "my-org",
+      project: "my-project",
+      content,
+      metadata: {},
+    });
+
+    const body = apiRequestToRegionMock.mock.calls.at(-1)?.[2]?.body as Record<
+      string,
+      unknown
+    >;
+    expect(Object.keys(body).sort()).toEqual(["checksum", "chunks"]);
+  });
+
   test("throws ApiError when assembly reports an error", async () => {
     apiRequestToRegionMock.mockResolvedValue({
       data: { state: "error", detail: "bad build" },
@@ -278,5 +298,21 @@ describe("uploadBuild", () => {
         metadata: {},
       })
     ).rejects.toThrow(ApiError);
+  });
+
+  test("fails fast when finished (ok) without an artifact URL", async () => {
+    apiRequestToRegionMock.mockResolvedValue({
+      data: { state: "ok" },
+      headers: new Headers(),
+    });
+
+    await expect(
+      uploadBuild({
+        org: "my-org",
+        project: "my-project",
+        content,
+        metadata: {},
+      })
+    ).rejects.toThrow(/no artifact URL/i);
   });
 });

--- a/test/lib/api/preprod-artifacts.test.ts
+++ b/test/lib/api/preprod-artifacts.test.ts
@@ -13,12 +13,17 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ApiError, ValidationError } from "../../../src/lib/errors.js";
 
-const { customFetchMock, apiRequestToRegionMock, getAuthTokenMock } =
-  vi.hoisted(() => ({
-    customFetchMock: vi.fn(),
-    apiRequestToRegionMock: vi.fn(),
-    getAuthTokenMock: vi.fn<() => string | undefined>(() => "secret-token"),
-  }));
+const {
+  customFetchMock,
+  apiRequestToRegionMock,
+  getAuthTokenMock,
+  uploadMissingBufferChunksMock,
+} = vi.hoisted(() => ({
+  customFetchMock: vi.fn(),
+  apiRequestToRegionMock: vi.fn(),
+  getAuthTokenMock: vi.fn<() => string | undefined>(() => "secret-token"),
+  uploadMissingBufferChunksMock: vi.fn(() => Promise.resolve()),
+}));
 
 vi.mock("../../../src/lib/region.js", () => ({
   resolveOrgRegion: vi.fn(async () => "https://us.sentry.io"),
@@ -32,12 +37,32 @@ vi.mock("../../../src/lib/custom-ca.js", () => ({
 vi.mock("../../../src/lib/db/auth.js", () => ({
   getAuthToken: getAuthTokenMock,
 }));
+vi.mock("../../../src/lib/api/chunk-upload.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../../../src/lib/api/chunk-upload.js")
+    >();
+  return {
+    ...actual,
+    getChunkUploadOptions: vi.fn(async () => ({
+      url: "https://us.sentry.io/api/0/chunk-upload/",
+      chunkSize: 8192,
+      chunksPerRequest: 64,
+      maxRequestSize: 1_048_576,
+      hashAlgorithm: "sha1",
+      concurrency: 8,
+      compression: ["gzip"],
+    })),
+    uploadMissingBufferChunks: uploadMissingBufferChunksMock,
+  };
+});
 
 import {
   buildFormatFromUrl,
   downloadBuildArtifact,
   getBuildInstallDetails,
   toBinaryDownloadUrl,
+  uploadBuild,
 } from "../../../src/lib/api/preprod-artifacts.js";
 
 describe("toBinaryDownloadUrl", () => {
@@ -166,6 +191,92 @@ describe("downloadBuildArtifact", () => {
         "https://us.sentry.io/dl/?response_format=ipa",
         join(tmpDir, "o4.ipa")
       )
+    ).rejects.toThrow(ApiError);
+  });
+});
+
+describe("uploadBuild", () => {
+  const content = Buffer.from("normalized-build-zip-bytes");
+
+  beforeEach(() => {
+    apiRequestToRegionMock.mockReset();
+    uploadMissingBufferChunksMock.mockClear();
+  });
+
+  test("returns the artifactUrl and folds metadata into the assemble body", async () => {
+    apiRequestToRegionMock.mockResolvedValue({
+      data: { state: "ok", artifactUrl: "https://sentry.io/artifact/1" },
+      headers: new Headers(),
+    });
+
+    const url = await uploadBuild({
+      org: "my-org",
+      project: "my-project",
+      content,
+      metadata: {
+        buildConfiguration: "Release",
+        releaseNotes: "notes",
+        installGroups: ["qa", "beta"],
+      },
+    });
+
+    expect(url).toBe("https://sentry.io/artifact/1");
+    const call = apiRequestToRegionMock.mock.calls.at(-1);
+    expect(call?.[1]).toBe(
+      "projects/my-org/my-project/files/preprodartifacts/assemble/"
+    );
+    const body = call?.[2]?.body as Record<string, unknown>;
+    expect(body.checksum).toEqual(expect.any(String));
+    expect(Array.isArray(body.chunks)).toBe(true);
+    expect(body.build_configuration).toBe("Release");
+    expect(body.release_notes).toBe("notes");
+    expect(body.install_groups).toEqual(["qa", "beta"]);
+    // No missing chunks on the first (and only) response.
+    expect(uploadMissingBufferChunksMock).not.toHaveBeenCalled();
+  });
+
+  test("uploads missing chunks then returns the artifactUrl", async () => {
+    vi.useFakeTimers();
+    try {
+      apiRequestToRegionMock
+        .mockResolvedValueOnce({
+          data: { state: "created", missingChunks: ["deadbeef"] },
+          headers: new Headers(),
+        })
+        .mockResolvedValueOnce({
+          data: { state: "ok", artifactUrl: "https://sentry.io/artifact/2" },
+          headers: new Headers(),
+        });
+
+      const promise = uploadBuild({
+        org: "my-org",
+        project: "my-project",
+        content,
+        metadata: {},
+      });
+      // Advance past the inter-poll sleep so the second assemble POST runs.
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expect(promise).resolves.toBe("https://sentry.io/artifact/2");
+      expect(uploadMissingBufferChunksMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("throws ApiError when assembly reports an error", async () => {
+    apiRequestToRegionMock.mockResolvedValue({
+      data: { state: "error", detail: "bad build" },
+      headers: new Headers(),
+    });
+
+    await expect(
+      uploadBuild({
+        org: "my-org",
+        project: "my-project",
+        content,
+        metadata: {},
+      })
     ).rejects.toThrow(ApiError);
   });
 });

--- a/test/lib/build/index.test.ts
+++ b/test/lib/build/index.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for mobile build detection + normalization.
+ *
+ * Fixtures are built in-memory with fflate (no committed binaries): a "fake
+ * APK/AAB" is just a ZIP carrying the marker entry names the detector keys on.
+ */
+
+import { strToU8, unzipSync, zipSync } from "fflate";
+import { describe, expect, test } from "vitest";
+import {
+  detectBuildFormat,
+  normalizeBuildFile,
+  parsePluginFromPipeline,
+} from "../../../src/lib/build/index.js";
+
+function fakeApk(): Uint8Array {
+  return zipSync({ "AndroidManifest.xml": strToU8("binary-xml") });
+}
+
+function fakeAab(): Uint8Array {
+  return zipSync({
+    "BundleConfig.pb": strToU8("cfg"),
+    "base/manifest/AndroidManifest.xml": strToU8("xml"),
+  });
+}
+
+function fakeIpa(): Uint8Array {
+  return zipSync({ "Payload/MyApp.app/Info.plist": strToU8("plist") });
+}
+
+describe("detectBuildFormat", () => {
+  test("detects an APK by its root AndroidManifest.xml", () => {
+    expect(detectBuildFormat(fakeApk())).toBe("apk");
+  });
+
+  test("detects an AAB by BundleConfig.pb + base manifest", () => {
+    expect(detectBuildFormat(fakeAab())).toBe("aab");
+  });
+
+  test("detects an IPA by its Payload/*.app/Info.plist", () => {
+    expect(detectBuildFormat(fakeIpa())).toBe("ipa");
+  });
+
+  test("returns null for a ZIP without build markers", () => {
+    expect(detectBuildFormat(zipSync({ "readme.txt": strToU8("hi") }))).toBe(
+      null
+    );
+  });
+
+  test("returns null for non-ZIP bytes", () => {
+    expect(detectBuildFormat(strToU8("not a zip"))).toBe(null);
+  });
+});
+
+describe("parsePluginFromPipeline", () => {
+  test("parses the gradle plugin", () => {
+    expect(parsePluginFromPipeline("sentry-gradle-plugin/4.12.0")).toEqual({
+      name: "sentry-gradle-plugin",
+      version: "4.12.0",
+    });
+  });
+
+  test("parses the fastlane plugin", () => {
+    expect(parsePluginFromPipeline("sentry-fastlane-plugin/1.2.3")).toEqual({
+      name: "sentry-fastlane-plugin",
+      version: "1.2.3",
+    });
+  });
+
+  test("ignores unrecognized plugins", () => {
+    expect(parsePluginFromPipeline("some-other-tool/9.9.9")).toBe(null);
+  });
+
+  test("returns null for malformed or empty input", () => {
+    expect(parsePluginFromPipeline(undefined)).toBe(null);
+    expect(parsePluginFromPipeline("")).toBe(null);
+    expect(parsePluginFromPipeline("no-slash")).toBe(null);
+    expect(parsePluginFromPipeline("sentry-gradle-plugin/")).toBe(null);
+  });
+});
+
+describe("normalizeBuildFile", () => {
+  test("wraps the build under its basename plus a metadata file", () => {
+    const apk = fakeApk();
+    const zip = normalizeBuildFile("/some/dir/app-release.apk", apk, null);
+
+    const entries = unzipSync(zip);
+    expect(Object.keys(entries).sort()).toEqual([
+      ".sentry-cli-metadata.txt",
+      "app-release.apk",
+    ]);
+    // The build bytes are stored verbatim.
+    expect(entries["app-release.apk"]).toEqual(apk);
+    const metadata = new TextDecoder().decode(entries[".sentry-cli-metadata.txt"]);
+    expect(metadata).toContain("sentry-cli-version:");
+  });
+
+  test("records a recognized plugin in the metadata file", () => {
+    const zip = normalizeBuildFile("/x/app.aab", fakeAab(), {
+      name: "sentry-gradle-plugin",
+      version: "4.12.0",
+    });
+    const metadata = new TextDecoder().decode(
+      unzipSync(zip)[".sentry-cli-metadata.txt"]
+    );
+    expect(metadata).toContain("sentry-gradle-plugin: 4.12.0");
+  });
+
+  test("is deterministic (identical input → identical bytes)", () => {
+    const apk = fakeApk();
+    const a = normalizeBuildFile("/x/app.apk", apk, null);
+    const b = normalizeBuildFile("/x/app.apk", apk, null);
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+  });
+});


### PR DESCRIPTION
Second PR of the **build/Emerge** workstream (after `build download` #1170). Adds the flagship `build upload` for Android.

## `build upload <paths...>`
Uploads mobile builds to Sentry for preprod size analysis.

- **Format detection** (`src/lib/build/`): APK (root `AndroidManifest.xml`) and AAB (`BundleConfig.pb` + `base/manifest/AndroidManifest.xml`) via ZIP entry names — no decompression. IPA is detected only to emit a clear "iOS not yet supported" message.
- **Normalization**: wraps each build into a deterministic ZIP (build under its basename + `.sentry-cli-metadata.txt`) using **STORE + fixed mtime** via `fflate`. Deterministic bytes let the server dedup chunks across re-uploads.
- **Upload** (`uploadBuild` in `preprod-artifacts.ts`): chunk-upload (reusing `chunk-upload.ts`) + the single-object `projects/{org}/{project}/files/preprodartifacts/assemble/` endpoint, polling until the server returns `artifactUrl` (5-min cap, 1s poll).
- Multiple paths with per-file success/error aggregation; **exits non-zero if any build fails**. `--build-configuration`, `--release-notes`, repeatable `--install-group` fold into the assemble body.
- Org+project resolved from context/flags/env. **Sentry SaaS only.**

### Why not zstd-in-zip (matching the legacy CLI)?
Node's built-in zstd is raw-stream only; Zstd *inside* a ZIP needs a writer emitting method-93 entries, which the JS ZIP libs don't do. It also buys nothing here: the wrapper's method is transparent to the server (it just unzips), the inner APK/AAB is already compressed (so STORE avoids pointless double-compression), and dedup determinism comes from the fixed mtime, not the method. Transport already compresses chunks over the wire.

## Tests (33 across 3 files)
- `build/index.test.ts` — APK/AAB/IPA detection, plugin parsing, normalization determinism + contents.
- `preprod-artifacts.test.ts` — `uploadBuild` assemble-body shape, missing-chunk→upload→artifactUrl (fake timers), error → `ApiError`.
- `build/upload.test.ts` — APK upload, metadata pass-through, unsupported-file + directory rejection, partial-failure exit code.

## Follow-ups (not in this PR)
git/VCS metadata + CI auto-detect; iOS XCArchive/IPA upload (`.car` asset parsing is native-macOS-only and skipped); `snapshots` (`download`/`diff` now, `upload` in the objectstore session).

`typecheck`, `lint`, `check:deps`, `check:fragments` all pass.