### PR TITLE
feat(build): collect git/VCS metadata for build upload

### DIFF
--- a/docs/src/fragments/commands/build.md
+++ b/docs/src/fragments/commands/build.md
@@ -12,6 +12,9 @@ sentry build upload ./app.aab --build-configuration Release --release-notes "Nig
 # Tag a build with install groups (repeatable)
 sentry build upload ./app.aab --install-group qa --install-group beta
 
+# Attach explicit git metadata (otherwise auto-collected in CI)
+sentry build upload ./app.aab --head-sha "$GIT_SHA" --pr-number 42 --base-ref main
+
 # Download a build artifact by ID
 sentry build download 1234567890
 
@@ -28,6 +31,11 @@ sentry build download 1234567890 --json
   not yet supported. **Sentry SaaS only.**
 - Multiple paths may be uploaded at once; the command exits non-zero if any
   build fails to upload.
+- Git metadata (commit, branch, PR number, repo) is **auto-collected in CI**
+  (GitHub Actions env vars + the local git repo). Use `--no-git-metadata` to
+  disable it, `--force-git-metadata` to collect outside CI, or the explicit
+  `--head-sha` / `--base-sha` / `--head-ref` / `--base-ref` / `--pr-number` /
+  `--vcs-provider` / `--head-repo-name` / `--base-repo-name` flags to override.
 - `build download` fetches a mobile build artifact (APK or IPA) previously
   uploaded to Sentry's preprod system for size analysis. **Sentry SaaS only.**
 - The build must be installable. Builds that are still processing — or that have

--- a/plugins/sentry-cli/skills/sentry-cli/references/build.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/build.md
@@ -28,7 +28,7 @@ Upload builds to a project
 - `--base-ref <value> - Base branch/reference (defaults to the merge-base tracking ref)`
 - `--pr-number <value> - Pull request number (auto-detected in pull_request GitHub Actions runs)`
 - `--force-git-metadata - Force collecting git metadata even outside CI (conflicts with --no-git-metadata)`
-- `--no-git-metadata - Disable collecting/sending git metadata`
+- `--no-git-metadata - Disable automatic git metadata collection`
 
 ### `sentry build download <build-id>`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/build.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/build.md
@@ -19,6 +19,16 @@ Upload builds to a project
 - `--build-configuration <value> - Build configuration for the upload (defaults to the current version)`
 - `--release-notes <value> - Release notes for the build`
 - `--install-group <value>... - Install group(s) for this build (repeatable); builds sharing a group show updates for each other`
+- `--head-sha <value> - VCS commit SHA (defaults to the current commit)`
+- `--base-sha <value> - VCS base commit SHA (defaults to the merge-base with the base ref)`
+- `--vcs-provider <value> - VCS provider (defaults to the current remote's provider)`
+- `--head-repo-name <value> - Head repository name, e.g. owner/repo (defaults to the current)`
+- `--base-repo-name <value> - Base repository name, e.g. owner/repo (for forks)`
+- `--head-ref <value> - Head branch/reference (defaults to the current branch)`
+- `--base-ref <value> - Base branch/reference (defaults to the merge-base tracking ref)`
+- `--pr-number <value> - Pull request number (auto-detected in pull_request GitHub Actions runs)`
+- `--force-git-metadata - Force collecting git metadata even outside CI (conflicts with --no-git-metadata)`
+- `--no-git-metadata - Disable collecting/sending git metadata`
 
 ### `sentry build download <build-id>`
 
@@ -38,6 +48,9 @@ sentry build upload ./app.aab --build-configuration Release --release-notes "Nig
 
 # Tag a build with install groups (repeatable)
 sentry build upload ./app.aab --install-group qa --install-group beta
+
+# Attach explicit git metadata (otherwise auto-collected in CI)
+sentry build upload ./app.aab --head-sha "$GIT_SHA" --pr-number 42 --base-ref main
 
 # Download a build artifact by ID
 sentry build download 1234567890

--- a/src/commands/build/upload.ts
+++ b/src/commands/build/upload.ts
@@ -20,6 +20,12 @@ import {
   normalizeBuildFile,
   parsePluginFromPipeline,
 } from "../../lib/build/index.js";
+import {
+  collectVcsMetadata,
+  isCi,
+  type VcsFlags,
+  vcsInfoToBody,
+} from "../../lib/build/vcs.js";
 import { buildCommand } from "../../lib/command.js";
 import { ContextError, ValidationError } from "../../lib/errors.js";
 import {
@@ -40,7 +46,7 @@ type UploadFlags = {
   "build-configuration"?: string;
   "release-notes"?: string;
   "install-group"?: string[];
-};
+} & VcsFlags;
 
 /** Result for a single uploaded path. */
 type BuildUploadEntry = {
@@ -176,6 +182,67 @@ export const uploadCommand = buildCommand({
         optional: true,
         variadic: true,
       },
+      "head-sha": {
+        kind: "parsed",
+        parse: String,
+        brief: "VCS commit SHA (defaults to the current commit)",
+        optional: true,
+      },
+      "base-sha": {
+        kind: "parsed",
+        parse: String,
+        brief:
+          "VCS base commit SHA (defaults to the merge-base with the base ref)",
+        optional: true,
+      },
+      "vcs-provider": {
+        kind: "parsed",
+        parse: String,
+        brief: "VCS provider (defaults to the current remote's provider)",
+        optional: true,
+      },
+      "head-repo-name": {
+        kind: "parsed",
+        parse: String,
+        brief: "Head repository name, e.g. owner/repo (defaults to the current)",
+        optional: true,
+      },
+      "base-repo-name": {
+        kind: "parsed",
+        parse: String,
+        brief: "Base repository name, e.g. owner/repo (for forks)",
+        optional: true,
+      },
+      "head-ref": {
+        kind: "parsed",
+        parse: String,
+        brief: "Head branch/reference (defaults to the current branch)",
+        optional: true,
+      },
+      "base-ref": {
+        kind: "parsed",
+        parse: String,
+        brief: "Base branch/reference (defaults to the merge-base tracking ref)",
+        optional: true,
+      },
+      "pr-number": {
+        kind: "parsed",
+        parse: Number,
+        brief:
+          "Pull request number (auto-detected in pull_request GitHub Actions runs)",
+        optional: true,
+      },
+      "force-git-metadata": {
+        kind: "boolean",
+        brief:
+          "Force collecting git metadata even outside CI (conflicts with --no-git-metadata)",
+        optional: true,
+      },
+      "no-git-metadata": {
+        kind: "boolean",
+        brief: "Disable collecting/sending git metadata",
+        optional: true,
+      },
     },
   },
   async *func(this: SentryContext, flags: UploadFlags, ...paths: string[]) {
@@ -192,10 +259,22 @@ export const uploadCommand = buildCommand({
     }
     const { org, project } = resolved;
 
+    // Collect git metadata automatically in CI (unless disabled), or when forced.
+    const shouldCollectVcs =
+      Boolean(flags["force-git-metadata"]) ||
+      (!flags["no-git-metadata"] && isCi(this.env));
+    const vcs = collectVcsMetadata(
+      flags,
+      this.cwd,
+      this.env,
+      shouldCollectVcs
+    );
+
     const metadata: BuildUploadMetadata = {
       buildConfiguration: flags["build-configuration"],
       releaseNotes: flags["release-notes"],
       installGroups: flags["install-group"],
+      vcs: vcsInfoToBody(vcs),
     };
 
     const builds: BuildUploadEntry[] = [];

--- a/src/commands/build/upload.ts
+++ b/src/commands/build/upload.ts
@@ -41,6 +41,15 @@ const log = logger.withTag("build.upload");
 
 const USAGE_HINT = "sentry build upload <path>";
 
+/** Parse `--pr-number` as a non-negative integer. */
+function parsePrNumber(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error("PR number must be a non-negative integer");
+  }
+  return parsed;
+}
+
 /** Flags accepted by `build upload`. */
 type UploadFlags = {
   "build-configuration"?: string;
@@ -227,7 +236,7 @@ export const uploadCommand = buildCommand({
       },
       "pr-number": {
         kind: "parsed",
-        parse: Number,
+        parse: parsePrNumber,
         brief:
           "Pull request number (auto-detected in pull_request GitHub Actions runs)",
         optional: true,
@@ -240,7 +249,7 @@ export const uploadCommand = buildCommand({
       },
       "no-git-metadata": {
         kind: "boolean",
-        brief: "Disable collecting/sending git metadata",
+        brief: "Disable automatic git metadata collection",
         optional: true,
       },
     },
@@ -259,6 +268,12 @@ export const uploadCommand = buildCommand({
     }
     const { org, project } = resolved;
 
+    if (flags["force-git-metadata"] && flags["no-git-metadata"]) {
+      throw new ValidationError(
+        "--force-git-metadata and --no-git-metadata cannot be used together",
+        "force-git-metadata"
+      );
+    }
     // Collect git metadata automatically in CI (unless disabled), or when forced.
     const shouldCollectVcs =
       Boolean(flags["force-git-metadata"]) ||

--- a/src/lib/api/preprod-artifacts.ts
+++ b/src/lib/api/preprod-artifacts.ts
@@ -169,6 +169,11 @@ export type BuildUploadMetadata = {
   releaseNotes?: string;
   /** Install group(s) this build belongs to. */
   installGroups?: string[];
+  /**
+   * Pre-flattened VCS fields (snake_case, e.g. `head_sha`, `provider`) merged
+   * into the assemble body. Built via `vcsInfoToBody` in the build/vcs module.
+   */
+  vcs?: Record<string, unknown>;
 };
 
 /** Options for {@link uploadBuild}. */
@@ -209,6 +214,8 @@ function buildAssembleBody(
   if (metadata.installGroups?.length) {
     body.install_groups = metadata.installGroups;
   }
+  // VCS fields are flattened into the assemble body (server flattens `VcsInfo`).
+  Object.assign(body, metadata.vcs ?? {});
   return body;
 }
 

--- a/src/lib/build/vcs.ts
+++ b/src/lib/build/vcs.ts
@@ -11,10 +11,13 @@
  * (empty values omitted), matching the server's flattened `VcsInfo` shape.
  */
 
+import { readFileSync } from "node:fs";
+import { ValidationError } from "../errors.js";
 import {
   getCurrentBranch,
   getHeadCommit,
   getMergeBase,
+  getRemoteDefaultBranch,
   getRemoteUrl,
   getRepositoryName,
 } from "../git.js";
@@ -82,10 +85,64 @@ export function isCi(env: NodeJS.ProcessEnv = process.env): boolean {
   return CI_ENV_VARS.some((name) => env[name] !== undefined && env[name] !== "");
 }
 
-/** Normalize a SHA flag: empty/whitespace → undefined, else lowercased. */
+/** A 40-character lowercase hex SHA-1. */
+const SHA1_RE = /^[0-9a-f]{40}$/;
+
+/**
+ * Normalize an already-trusted SHA (from git/event payload): lowercase and
+ * accept only a valid 40-char hex SHA-1, else undefined.
+ */
 function normalizeSha(sha: string | undefined): string | undefined {
-  const trimmed = sha?.trim();
-  return trimmed ? trimmed.toLowerCase() : undefined;
+  const trimmed = sha?.trim().toLowerCase();
+  return trimmed && SHA1_RE.test(trimmed) ? trimmed : undefined;
+}
+
+/**
+ * Validate a user-supplied `--head-sha`/`--base-sha` value. An empty string is
+ * an explicit "clear" (returns undefined, suppressing auto-inference at the
+ * call site); a non-empty value must be a 40-char hex SHA-1.
+ *
+ * @throws {ValidationError} When a non-empty value is not a valid SHA-1.
+ */
+function validateShaFlag(value: string, flagName: string): string | undefined {
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (!SHA1_RE.test(trimmed)) {
+    throw new ValidationError(
+      `Invalid --${flagName}: expected a 40-character hex SHA-1`,
+      flagName
+    );
+  }
+  return trimmed;
+}
+
+/**
+ * Read the PR head/base SHA from the GitHub Actions event payload.
+ *
+ * On `pull_request` runs `actions/checkout` checks out the ephemeral merge
+ * commit, so `git rev-parse HEAD` is NOT the PR head — the event payload's
+ * `pull_request.{head,base}.sha` is authoritative (matches the legacy CLI).
+ */
+function readGithubEventSha(
+  kind: "head" | "base",
+  env: NodeJS.ProcessEnv
+): string | undefined {
+  const eventPath = env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    return undefined;
+  }
+  try {
+    const payload = JSON.parse(readFileSync(eventPath, "utf8")) as {
+      pull_request?: { head?: { sha?: unknown }; base?: { sha?: unknown } };
+    };
+    const sha = payload.pull_request?.[kind]?.sha;
+    return typeof sha === "string" ? normalizeSha(sha) : undefined;
+  } catch (err) {
+    log.debug(`Could not read ${kind} SHA from GITHUB_EVENT_PATH`, err);
+    return undefined;
+  }
 }
 
 /** Extract a provider name (e.g. `github`) from a git remote URL's host. */
@@ -95,13 +152,17 @@ function providerFromRemoteUrl(url: string): string | undefined {
     host = new URL(url).hostname;
   } catch {
     // SCP-style (git@host:owner/repo) — pull the host between "@" and ":".
-    const match = url.match(/@([^:/]+)[:/]/);
-    host = match?.[1];
+    host = url.match(/@([^:/]+)[:/]/)?.[1];
   }
   if (!host) {
     return undefined;
   }
-  // Drop the TLD: github.com → github, gitlab.example.com → gitlab (best effort).
+  host = host.replace(/\.$/, "").toLowerCase();
+  if (host.endsWith(".ghe.com")) {
+    return "github_enterprise";
+  }
+  // Best effort for the general case: drop the TLD (github.com → github);
+  // self-hosted hosts yield their second-level label (e.g. git.acme.com → acme).
   const labels = host.split(".");
   return labels.length >= 2 ? labels.at(-2) : host;
 }
@@ -135,58 +196,64 @@ function githubPrNumber(env: NodeJS.ProcessEnv): number | undefined {
   return Number.isNaN(parsed) ? undefined : parsed;
 }
 
-/** Resolve the head SHA (flag → git HEAD). */
-function resolveHeadSha(
-  flags: VcsFlags,
-  cwd: string,
-  auto: boolean
-): string | undefined {
-  const fromFlag = normalizeSha(flags["head-sha"]);
-  if (fromFlag) {
-    return fromFlag;
-  }
-  if (!auto) {
-    return undefined;
-  }
+/** Read git HEAD, swallowing "not a repo" into undefined. */
+function tryGitHeadSha(cwd: string): string | undefined {
   try {
-    return getHeadCommit(cwd).toLowerCase();
+    return normalizeSha(getHeadCommit(cwd));
   } catch (err) {
     log.debug("Could not determine HEAD commit", err);
     return undefined;
   }
 }
 
-/** Resolve the head repo name (flag → GitHub env → git remote). */
-function resolveHeadRepoName(
+/**
+ * Resolve the head SHA: explicit flag (present, even if empty) → GitHub event
+ * payload → git HEAD. A present-but-empty flag suppresses auto-inference.
+ */
+function resolveHeadSha(
   flags: VcsFlags,
+  cwd: string,
   env: NodeJS.ProcessEnv,
-  cwd: string,
   auto: boolean
 ): string | undefined {
-  return (
-    flags["head-repo-name"] ||
-    (auto ? env.GITHUB_REPOSITORY || getRepositoryName(cwd) : undefined)
-  );
-}
-
-/** Resolve the base SHA (flag → merge-base with base ref). */
-function resolveBaseSha(
-  flags: VcsFlags,
-  baseRef: string | undefined,
-  cwd: string,
-  auto: boolean
-): string | undefined {
-  const fromFlag = normalizeSha(flags["base-sha"]);
-  if (fromFlag) {
-    return fromFlag;
+  if (flags["head-sha"] !== undefined) {
+    return validateShaFlag(flags["head-sha"], "head-sha");
   }
-  if (!(auto && baseRef)) {
+  if (!auto) {
     return undefined;
   }
-  // Best effort: try the remote-tracking ref first, then the bare name.
-  const sha =
-    getMergeBase(`origin/${baseRef}`, cwd) ?? getMergeBase(baseRef, cwd);
-  return sha?.toLowerCase();
+  return readGithubEventSha("head", env) ?? tryGitHeadSha(cwd);
+}
+
+/** Resolve the head repo name (flag → git remote), matching the legacy CLI. */
+function resolveHeadRepoName(
+  flags: VcsFlags,
+  cwd: string,
+  auto: boolean
+): string | undefined {
+  return flags["head-repo-name"] || (auto ? getRepositoryName(cwd) : undefined);
+}
+
+/**
+ * Resolve the base SHA: explicit flag (present, even if empty) → GitHub event
+ * payload → merge-base of HEAD with the remote's default branch.
+ */
+function resolveBaseSha(
+  flags: VcsFlags,
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  auto: boolean
+): string | undefined {
+  if (flags["base-sha"] !== undefined) {
+    return validateShaFlag(flags["base-sha"], "base-sha");
+  }
+  if (!auto) {
+    return undefined;
+  }
+  return (
+    readGithubEventSha("base", env) ??
+    normalizeSha(getMergeBase("refs/remotes/origin/HEAD", cwd))
+  );
 }
 
 /**
@@ -205,11 +272,11 @@ export function collectVcsMetadata(
 ): VcsInfo {
   const remoteUrl = autoCollect ? getRemoteUrl(cwd) : undefined;
 
-  const headSha = resolveHeadSha(flags, cwd, autoCollect);
+  const headSha = resolveHeadSha(flags, cwd, env, autoCollect);
   const vcsProvider =
     flags["vcs-provider"] ||
     (autoCollect && remoteUrl ? providerFromRemoteUrl(remoteUrl) : undefined);
-  const headRepoName = resolveHeadRepoName(flags, env, cwd, autoCollect);
+  const headRepoName = resolveHeadRepoName(flags, cwd, autoCollect);
   const headRef =
     flags["head-ref"] ||
     (autoCollect ? githubHeadRef(env) || getCurrentBranch(cwd) : undefined);
@@ -218,8 +285,11 @@ export function collectVcsMetadata(
   const baseRefFromUser = flags["base-ref"] !== undefined;
   const baseShaFromUser = flags["base-sha"] !== undefined;
   let baseRef =
-    flags["base-ref"] || (autoCollect ? githubBaseRef(env) : undefined);
-  let baseSha = resolveBaseSha(flags, baseRef, cwd, autoCollect);
+    flags["base-ref"] ||
+    (autoCollect
+      ? githubBaseRef(env) || getRemoteDefaultBranch(cwd)
+      : undefined);
+  let baseSha = resolveBaseSha(flags, cwd, env, autoCollect);
 
   // If base == head and both were auto-inferred, the PR comparison is
   // meaningless — drop base_sha/base_ref but keep head_sha (matches legacy).

--- a/src/lib/build/vcs.ts
+++ b/src/lib/build/vcs.ts
@@ -82,7 +82,17 @@ const CI_ENV_VARS = [
  * @param env - Environment variables (defaults to `process.env`).
  */
 export function isCi(env: NodeJS.ProcessEnv = process.env): boolean {
-  return CI_ENV_VARS.some((name) => env[name] !== undefined && env[name] !== "");
+  return CI_ENV_VARS.some((name) => {
+    const value = env[name];
+    // Treat explicit opt-out values ("", "false", "0") as not-in-CI so a local
+    // `CI=false` does not silently enable git-metadata collection.
+    return (
+      value !== undefined &&
+      value !== "" &&
+      value !== "false" &&
+      value !== "0"
+    );
+  });
 }
 
 /** A 40-character lowercase hex SHA-1. */
@@ -236,10 +246,15 @@ function resolveHeadRepoName(
 
 /**
  * Resolve the base SHA: explicit flag (present, even if empty) → GitHub event
- * payload → merge-base of HEAD with the remote's default branch.
+ * payload → merge-base of HEAD with the base ref (when known) or the remote's
+ * default branch.
+ *
+ * @param baseRef - The resolved base ref (from flag/env/default); when set, the
+ *   merge-base is computed against it so a user-supplied `--base-ref` is honored.
  */
 function resolveBaseSha(
   flags: VcsFlags,
+  baseRef: string | undefined,
   cwd: string,
   env: NodeJS.ProcessEnv,
   auto: boolean
@@ -250,10 +265,16 @@ function resolveBaseSha(
   if (!auto) {
     return undefined;
   }
-  return (
-    readGithubEventSha("base", env) ??
-    normalizeSha(getMergeBase("refs/remotes/origin/HEAD", cwd))
-  );
+  const fromEvent = readGithubEventSha("base", env);
+  if (fromEvent) {
+    return fromEvent;
+  }
+  // Prefer the known base ref (try the remote-tracking ref first, then the bare
+  // name); fall back to the remote's default branch head.
+  const mergeBase = baseRef
+    ? (getMergeBase(`origin/${baseRef}`, cwd) ?? getMergeBase(baseRef, cwd))
+    : getMergeBase("refs/remotes/origin/HEAD", cwd);
+  return normalizeSha(mergeBase);
 }
 
 /**
@@ -289,7 +310,7 @@ export function collectVcsMetadata(
     (autoCollect
       ? githubBaseRef(env) || getRemoteDefaultBranch(cwd)
       : undefined);
-  let baseSha = resolveBaseSha(flags, cwd, env, autoCollect);
+  let baseSha = resolveBaseSha(flags, baseRef, cwd, env, autoCollect);
 
   // If base == head and both were auto-inferred, the PR comparison is
   // meaningless — drop base_sha/base_ref but keep head_sha (matches legacy).

--- a/src/lib/build/vcs.ts
+++ b/src/lib/build/vcs.ts
@@ -1,0 +1,283 @@
+/**
+ * VCS (git) metadata collection for `build upload` (and, later, `snapshots`).
+ *
+ * Mirrors the legacy `collect_git_metadata`: explicit flags always win; when
+ * auto-collection is enabled (CI, unless `--no-git-metadata`), values are
+ * inferred from GitHub Actions env vars and the local git repository.
+ *
+ * The collected {@link VcsInfo} is flattened (via {@link vcsInfoToBody}) into
+ * the build assemble request as top-level `head_sha`, `base_sha`, `provider`,
+ * `head_repo_name`, `base_repo_name`, `head_ref`, `base_ref`, `pr_number`
+ * (empty values omitted), matching the server's flattened `VcsInfo` shape.
+ */
+
+import {
+  getCurrentBranch,
+  getHeadCommit,
+  getMergeBase,
+  getRemoteUrl,
+  getRepositoryName,
+} from "../git.js";
+import { logger } from "../logger.js";
+
+const log = logger.withTag("build.vcs");
+
+/** Structured VCS metadata for a build upload. */
+export type VcsInfo = {
+  /** HEAD commit SHA. */
+  headSha?: string;
+  /** Base commit SHA (merge-base with the target branch). */
+  baseSha?: string;
+  /** VCS provider name (e.g. `github`, `gitlab`). */
+  vcsProvider?: string;
+  /** Head repository name (`owner/repo`). */
+  headRepoName?: string;
+  /** Base repository name (`owner/repo`), for forks. */
+  baseRepoName?: string;
+  /** Head branch/reference. */
+  headRef?: string;
+  /** Base branch/reference. */
+  baseRef?: string;
+  /** Pull request number. */
+  prNumber?: number;
+};
+
+/** Git-metadata flags accepted by build/snapshot upload commands. */
+export type VcsFlags = {
+  "head-sha"?: string;
+  "base-sha"?: string;
+  "vcs-provider"?: string;
+  "head-repo-name"?: string;
+  "base-repo-name"?: string;
+  "head-ref"?: string;
+  "base-ref"?: string;
+  "pr-number"?: number;
+  "force-git-metadata"?: boolean;
+  "no-git-metadata"?: boolean;
+};
+
+/** Environment variables commonly set by CI providers. */
+const CI_ENV_VARS = [
+  "CI",
+  "JENKINS_URL",
+  "HUDSON_URL",
+  "TEAMCITY_VERSION",
+  "CIRCLE_BUILD_URL",
+  "bamboo_resultsUrl",
+  "GITHUB_ACTIONS",
+  "GITLAB_CI",
+  "TRAVIS_JOB_ID",
+  "BITRISE_BUILD_URL",
+  "GO_SERVER_URL",
+  "TF_BUILD",
+  "BUILDKITE",
+];
+
+/**
+ * Detect whether we are running in a CI environment.
+ *
+ * @param env - Environment variables (defaults to `process.env`).
+ */
+export function isCi(env: NodeJS.ProcessEnv = process.env): boolean {
+  return CI_ENV_VARS.some((name) => env[name] !== undefined && env[name] !== "");
+}
+
+/** Normalize a SHA flag: empty/whitespace → undefined, else lowercased. */
+function normalizeSha(sha: string | undefined): string | undefined {
+  const trimmed = sha?.trim();
+  return trimmed ? trimmed.toLowerCase() : undefined;
+}
+
+/** Extract a provider name (e.g. `github`) from a git remote URL's host. */
+function providerFromRemoteUrl(url: string): string | undefined {
+  let host: string | undefined;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    // SCP-style (git@host:owner/repo) — pull the host between "@" and ":".
+    const match = url.match(/@([^:/]+)[:/]/);
+    host = match?.[1];
+  }
+  if (!host) {
+    return undefined;
+  }
+  // Drop the TLD: github.com → github, gitlab.example.com → gitlab (best effort).
+  const labels = host.split(".");
+  return labels.length >= 2 ? labels.at(-2) : host;
+}
+
+/** GitHub Actions head ref: PR source branch, else the pushed branch/tag name. */
+function githubHeadRef(env: NodeJS.ProcessEnv): string | undefined {
+  if (env.GITHUB_EVENT_NAME === "pull_request") {
+    return env.GITHUB_HEAD_REF || undefined;
+  }
+  return env.GITHUB_REF_NAME || undefined;
+}
+
+/** GitHub Actions base ref: PR target branch (pull_request events only). */
+function githubBaseRef(env: NodeJS.ProcessEnv): string | undefined {
+  if (env.GITHUB_EVENT_NAME !== "pull_request") {
+    return undefined;
+  }
+  return env.GITHUB_BASE_REF || undefined;
+}
+
+/** GitHub Actions PR number, parsed from GITHUB_REF (`refs/pull/N/merge`). */
+function githubPrNumber(env: NodeJS.ProcessEnv): number | undefined {
+  if (env.GITHUB_EVENT_NAME !== "pull_request") {
+    return undefined;
+  }
+  const raw = env.GITHUB_REF?.match(/^refs\/pull\/(\d+)\//)?.[1];
+  if (!raw) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/** Resolve the head SHA (flag → git HEAD). */
+function resolveHeadSha(
+  flags: VcsFlags,
+  cwd: string,
+  auto: boolean
+): string | undefined {
+  const fromFlag = normalizeSha(flags["head-sha"]);
+  if (fromFlag) {
+    return fromFlag;
+  }
+  if (!auto) {
+    return undefined;
+  }
+  try {
+    return getHeadCommit(cwd).toLowerCase();
+  } catch (err) {
+    log.debug("Could not determine HEAD commit", err);
+    return undefined;
+  }
+}
+
+/** Resolve the head repo name (flag → GitHub env → git remote). */
+function resolveHeadRepoName(
+  flags: VcsFlags,
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+  auto: boolean
+): string | undefined {
+  return (
+    flags["head-repo-name"] ||
+    (auto ? env.GITHUB_REPOSITORY || getRepositoryName(cwd) : undefined)
+  );
+}
+
+/** Resolve the base SHA (flag → merge-base with base ref). */
+function resolveBaseSha(
+  flags: VcsFlags,
+  baseRef: string | undefined,
+  cwd: string,
+  auto: boolean
+): string | undefined {
+  const fromFlag = normalizeSha(flags["base-sha"]);
+  if (fromFlag) {
+    return fromFlag;
+  }
+  if (!(auto && baseRef)) {
+    return undefined;
+  }
+  // Best effort: try the remote-tracking ref first, then the bare name.
+  const sha =
+    getMergeBase(`origin/${baseRef}`, cwd) ?? getMergeBase(baseRef, cwd);
+  return sha?.toLowerCase();
+}
+
+/**
+ * Collect VCS metadata from flags and (optionally) git/CI introspection.
+ *
+ * @param flags - The parsed git-metadata flags.
+ * @param cwd - Working directory of the command.
+ * @param env - Environment variables.
+ * @param autoCollect - When false, only explicit flag values are used.
+ */
+export function collectVcsMetadata(
+  flags: VcsFlags,
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  autoCollect: boolean
+): VcsInfo {
+  const remoteUrl = autoCollect ? getRemoteUrl(cwd) : undefined;
+
+  const headSha = resolveHeadSha(flags, cwd, autoCollect);
+  const vcsProvider =
+    flags["vcs-provider"] ||
+    (autoCollect && remoteUrl ? providerFromRemoteUrl(remoteUrl) : undefined);
+  const headRepoName = resolveHeadRepoName(flags, env, cwd, autoCollect);
+  const headRef =
+    flags["head-ref"] ||
+    (autoCollect ? githubHeadRef(env) || getCurrentBranch(cwd) : undefined);
+  const baseRepoName = flags["base-repo-name"] || undefined;
+
+  const baseRefFromUser = flags["base-ref"] !== undefined;
+  const baseShaFromUser = flags["base-sha"] !== undefined;
+  let baseRef =
+    flags["base-ref"] || (autoCollect ? githubBaseRef(env) : undefined);
+  let baseSha = resolveBaseSha(flags, baseRef, cwd, autoCollect);
+
+  // If base == head and both were auto-inferred, the PR comparison is
+  // meaningless — drop base_sha/base_ref but keep head_sha (matches legacy).
+  if (
+    !(baseShaFromUser || baseRefFromUser) &&
+    baseSha &&
+    headSha &&
+    baseSha === headSha
+  ) {
+    log.debug("Base SHA equals HEAD SHA and both auto-inferred; dropping base");
+    baseSha = undefined;
+    baseRef = undefined;
+  }
+
+  const prNumber =
+    flags["pr-number"] ?? (autoCollect ? githubPrNumber(env) : undefined);
+
+  return {
+    headSha,
+    baseSha,
+    vcsProvider,
+    headRepoName,
+    baseRepoName,
+    headRef,
+    baseRef,
+    prNumber,
+  };
+}
+
+/**
+ * Flatten {@link VcsInfo} into the snake_case fields merged into the build
+ * assemble body. Empty/undefined values are omitted.
+ */
+export function vcsInfoToBody(vcs: VcsInfo): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  if (vcs.headSha) {
+    body.head_sha = vcs.headSha;
+  }
+  if (vcs.baseSha) {
+    body.base_sha = vcs.baseSha;
+  }
+  if (vcs.vcsProvider) {
+    body.provider = vcs.vcsProvider;
+  }
+  if (vcs.headRepoName) {
+    body.head_repo_name = vcs.headRepoName;
+  }
+  if (vcs.baseRepoName) {
+    body.base_repo_name = vcs.baseRepoName;
+  }
+  if (vcs.headRef) {
+    body.head_ref = vcs.headRef;
+  }
+  if (vcs.baseRef) {
+    body.base_ref = vcs.baseRef;
+  }
+  if (vcs.prNumber !== undefined) {
+    body.pr_number = vcs.prNumber;
+  }
+  return body;
+}

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -195,6 +195,51 @@ export function getRepositoryName(cwd?: string): string | undefined {
   }
 }
 
+/**
+ * Get the raw URL of the "origin" remote.
+ *
+ * @param cwd - Working directory
+ * @returns The remote URL, or undefined when there is no origin remote
+ */
+export function getRemoteUrl(cwd?: string): string | undefined {
+  try {
+    return git(["remote", "get-url", "origin"], cwd);
+  } catch {
+    return;
+  }
+}
+
+/**
+ * Get the current branch name.
+ *
+ * @param cwd - Working directory
+ * @returns The branch name, or undefined when detached (HEAD) or not a repo
+ */
+export function getCurrentBranch(cwd?: string): string | undefined {
+  try {
+    const ref = git(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+    return ref && ref !== "HEAD" ? ref : undefined;
+  } catch {
+    return;
+  }
+}
+
+/**
+ * Compute the merge-base SHA of HEAD and the given ref.
+ *
+ * @param ref - The ref to find the common ancestor with (e.g. a base branch)
+ * @param cwd - Working directory
+ * @returns The merge-base commit SHA, or undefined when it can't be determined
+ *   (unknown ref, shallow clone, not a repo).
+ */
+export function getMergeBase(ref: string, cwd?: string): string | undefined {
+  try {
+    return git(["merge-base", "HEAD", ref], cwd) || undefined;
+  } catch {
+    return;
+  }
+}
+
 /** SSH remote URL pattern: git@host:owner/repo.git */
 const SSH_REMOTE_RE = /:([^/][^:]+?)(?:\.git)?$/;
 

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -233,8 +233,33 @@ export function getCurrentBranch(cwd?: string): string | undefined {
  *   (unknown ref, shallow clone, not a repo).
  */
 export function getMergeBase(ref: string, cwd?: string): string | undefined {
+  // Reject option-like refs (a leading "-" would be parsed by git as a flag).
+  if (ref.startsWith("-")) {
+    return;
+  }
   try {
     return git(["merge-base", "HEAD", ref], cwd) || undefined;
+  } catch {
+    return;
+  }
+}
+
+/**
+ * Get the short name of the "origin" remote's default branch.
+ *
+ * Reads `refs/remotes/origin/HEAD` (populated by `git clone`/`git remote set-head`).
+ *
+ * @param cwd - Working directory
+ * @returns The default branch name (e.g. "main"), or undefined when unknown
+ *   (not set, shallow clone, or not a repo).
+ */
+export function getRemoteDefaultBranch(cwd?: string): string | undefined {
+  try {
+    const ref = git(["symbolic-ref", "refs/remotes/origin/HEAD"], cwd);
+    const prefix = "refs/remotes/origin/";
+    return ref.startsWith(prefix)
+      ? ref.slice(prefix.length) || undefined
+      : undefined;
   } catch {
     return;
   }

--- a/test/commands/build/upload.test.ts
+++ b/test/commands/build/upload.test.ts
@@ -147,9 +147,10 @@ describe("build upload", () => {
     const harness = createContext();
     const func = await uploadCommand.loader();
 
+    const sha = "abcdef01".repeat(5); // 40 hex chars
     await func.call(
       harness.context,
-      { "head-sha": "ABCDEF", "head-ref": "main", "pr-number": 9 },
+      { "head-sha": sha, "head-ref": "main", "pr-number": 9 },
       apk
     );
 
@@ -158,7 +159,7 @@ describe("build upload", () => {
     };
     // env has no CI vars, so only explicit flags are collected.
     expect(meta.metadata.vcs).toEqual({
-      head_sha: "abcdef",
+      head_sha: sha,
       head_ref: "main",
       pr_number: 9,
     });

--- a/test/commands/build/upload.test.ts
+++ b/test/commands/build/upload.test.ts
@@ -142,6 +142,28 @@ describe("build upload", () => {
     expect(meta.metadata.installGroups).toEqual(["qa", "beta"]);
   });
 
+  test("folds explicit git-metadata flags into the assemble body", async () => {
+    const apk = await writeApk();
+    const harness = createContext();
+    const func = await uploadCommand.loader();
+
+    await func.call(
+      harness.context,
+      { "head-sha": "ABCDEF", "head-ref": "main", "pr-number": 9 },
+      apk
+    );
+
+    const meta = uploadSpy.mock.calls[0]?.[0] as {
+      metadata: { vcs?: Record<string, unknown> };
+    };
+    // env has no CI vars, so only explicit flags are collected.
+    expect(meta.metadata.vcs).toEqual({
+      head_sha: "abcdef",
+      head_ref: "main",
+      pr_number: 9,
+    });
+  });
+
   test("rejects an unsupported file with a non-zero exit", async () => {
     const bad = join(tmpDir, "notes.txt");
     await writeFile(bad, "not a build");

--- a/test/lib/api/preprod-artifacts.test.ts
+++ b/test/lib/api/preprod-artifacts.test.ts
@@ -264,6 +264,30 @@ describe("uploadBuild", () => {
     }
   });
 
+  test("flattens vcs fields into the top level of the assemble body", async () => {
+    apiRequestToRegionMock.mockResolvedValue({
+      data: { state: "ok", artifactUrl: "https://sentry.io/artifact/9" },
+      headers: new Headers(),
+    });
+
+    await uploadBuild({
+      org: "my-org",
+      project: "my-project",
+      content,
+      metadata: { vcs: { head_sha: "abc", provider: "github", pr_number: 3 } },
+    });
+
+    const body = apiRequestToRegionMock.mock.calls.at(-1)?.[2]?.body as Record<
+      string,
+      unknown
+    >;
+    // Flattened alongside checksum/chunks — not nested under a "vcs" key.
+    expect(body.head_sha).toBe("abc");
+    expect(body.provider).toBe("github");
+    expect(body.pr_number).toBe(3);
+    expect(body).not.toHaveProperty("vcs");
+  });
+
   test("omits optional metadata fields when unset", async () => {
     apiRequestToRegionMock.mockResolvedValue({
       data: { state: "ok", artifactUrl: "https://sentry.io/artifact/3" },

--- a/test/lib/build/vcs.test.ts
+++ b/test/lib/build/vcs.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for VCS metadata collection.
+ *
+ * `git.js` is mocked so collection is deterministic (no dependency on the
+ * checkout's real branch/remote). Covers flag precedence, GitHub Actions env
+ * inference, the base==head skip, and the flattened body mapping.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+
+const gitMock = vi.hoisted(() => ({
+  getHeadCommit: vi.fn(() => "a".repeat(40)),
+  getRemoteUrl: vi.fn(() => "https://github.com/acme/app.git"),
+  getRepositoryName: vi.fn(() => "acme/app"),
+  getCurrentBranch: vi.fn(() => "feature/x"),
+  getMergeBase: vi.fn(() => "b".repeat(40)),
+}));
+
+vi.mock("../../../src/lib/git.js", () => gitMock);
+
+import {
+  collectVcsMetadata,
+  isCi,
+  vcsInfoToBody,
+} from "../../../src/lib/build/vcs.js";
+
+describe("isCi", () => {
+  test("true when a CI variable is set", () => {
+    expect(isCi({ GITHUB_ACTIONS: "true" })).toBe(true);
+    expect(isCi({ CI: "1" })).toBe(true);
+  });
+
+  test("false with no CI variables (and ignores empty values)", () => {
+    expect(isCi({})).toBe(false);
+    expect(isCi({ CI: "" })).toBe(false);
+  });
+});
+
+describe("vcsInfoToBody", () => {
+  test("flattens to snake_case and renames provider", () => {
+    expect(
+      vcsInfoToBody({
+        headSha: "h",
+        vcsProvider: "github",
+        headRepoName: "o/r",
+        prNumber: 5,
+      })
+    ).toEqual({
+      head_sha: "h",
+      provider: "github",
+      head_repo_name: "o/r",
+      pr_number: 5,
+    });
+  });
+
+  test("omits empty fields", () => {
+    expect(vcsInfoToBody({})).toEqual({});
+  });
+
+  test("keeps pr_number 0", () => {
+    expect(vcsInfoToBody({ prNumber: 0 })).toEqual({ pr_number: 0 });
+  });
+});
+
+describe("collectVcsMetadata", () => {
+  test("uses explicit flags and skips git introspection when autoCollect is false", () => {
+    const vcs = collectVcsMetadata(
+      { "head-sha": "DEAD", "head-ref": "main", "pr-number": 7 },
+      "/repo",
+      {},
+      false
+    );
+
+    expect(vcs.headSha).toBe("dead"); // normalized to lowercase
+    expect(vcs.headRef).toBe("main");
+    expect(vcs.prNumber).toBe(7);
+    expect(gitMock.getHeadCommit).not.toHaveBeenCalled();
+    expect(gitMock.getRemoteUrl).not.toHaveBeenCalled();
+  });
+
+  test("infers metadata from a GitHub Actions pull_request run", () => {
+    const env: NodeJS.ProcessEnv = {
+      GITHUB_EVENT_NAME: "pull_request",
+      GITHUB_HEAD_REF: "feature/x",
+      GITHUB_BASE_REF: "main",
+      GITHUB_REPOSITORY: "acme/app",
+      GITHUB_REF: "refs/pull/42/merge",
+    };
+
+    const vcs = collectVcsMetadata({}, "/repo", env, true);
+
+    expect(vcs.headRef).toBe("feature/x");
+    expect(vcs.baseRef).toBe("main");
+    expect(vcs.headRepoName).toBe("acme/app");
+    expect(vcs.prNumber).toBe(42);
+    expect(vcs.vcsProvider).toBe("github");
+    expect(vcs.headSha).toBe("a".repeat(40));
+    expect(vcs.baseSha).toBe("b".repeat(40));
+  });
+
+  test("drops base_sha/base_ref when base equals head and both were auto-inferred", () => {
+    gitMock.getHeadCommit.mockReturnValueOnce("c".repeat(40));
+    gitMock.getMergeBase.mockReturnValueOnce("c".repeat(40));
+
+    const vcs = collectVcsMetadata(
+      {},
+      "/repo",
+      { GITHUB_EVENT_NAME: "pull_request", GITHUB_BASE_REF: "main" },
+      true
+    );
+
+    expect(vcs.headSha).toBe("c".repeat(40));
+    expect(vcs.baseSha).toBeUndefined();
+    expect(vcs.baseRef).toBeUndefined();
+  });
+});

--- a/test/lib/build/vcs.test.ts
+++ b/test/lib/build/vcs.test.ts
@@ -52,9 +52,11 @@ describe("isCi", () => {
     expect(isCi({ CI: "1" })).toBe(true);
   });
 
-  test("false with no CI variables (and ignores empty values)", () => {
+  test("false with no CI variables (and ignores opt-out values)", () => {
     expect(isCi({})).toBe(false);
     expect(isCi({ CI: "" })).toBe(false);
+    expect(isCi({ CI: "false" })).toBe(false);
+    expect(isCi({ CI: "0" })).toBe(false);
   });
 });
 
@@ -185,6 +187,22 @@ describe("collectVcsMetadata", () => {
       true
     );
     expect(vcs.baseSha).toBe("d".repeat(40));
+  });
+
+  test("computes base_sha via merge-base with an explicit --base-ref", () => {
+    gitMock.getMergeBase.mockReturnValueOnce("e".repeat(40));
+    const vcs = collectVcsMetadata(
+      { "base-ref": "release/2.0" },
+      "/repo",
+      {},
+      true
+    );
+    expect(vcs.baseRef).toBe("release/2.0");
+    expect(vcs.baseSha).toBe("e".repeat(40));
+    expect(gitMock.getMergeBase).toHaveBeenCalledWith(
+      "origin/release/2.0",
+      "/repo"
+    );
   });
 
   test("derives provider from an SCP-style remote and GHE hosts", () => {

--- a/test/lib/build/vcs.test.ts
+++ b/test/lib/build/vcs.test.ts
@@ -6,7 +6,10 @@
  * inference, the base==head skip, and the flattened body mapping.
  */
 
-import { describe, expect, test, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const gitMock = vi.hoisted(() => ({
   getHeadCommit: vi.fn(() => "a".repeat(40)),
@@ -14,15 +17,34 @@ const gitMock = vi.hoisted(() => ({
   getRepositoryName: vi.fn(() => "acme/app"),
   getCurrentBranch: vi.fn(() => "feature/x"),
   getMergeBase: vi.fn(() => "b".repeat(40)),
+  getRemoteDefaultBranch: vi.fn(() => "main"),
 }));
 
 vi.mock("../../../src/lib/git.js", () => gitMock);
 
+import { ValidationError } from "../../../src/lib/errors.js";
 import {
   collectVcsMetadata,
   isCi,
   vcsInfoToBody,
 } from "../../../src/lib/build/vcs.js";
+
+// The git mock is shared across tests; clear call history (keeps default
+// implementations) so `.not.toHaveBeenCalled()` assertions are per-test.
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/** Temp dirs holding GitHub event payloads, cleaned up after each test. */
+const eventDirs: string[] = [];
+afterEach(() => {
+  while (eventDirs.length > 0) {
+    const dir = eventDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
 
 describe("isCi", () => {
   test("true when a CI variable is set", () => {
@@ -64,14 +86,15 @@ describe("vcsInfoToBody", () => {
 
 describe("collectVcsMetadata", () => {
   test("uses explicit flags and skips git introspection when autoCollect is false", () => {
+    const sha = "abcdef01".repeat(5); // 40 hex chars
     const vcs = collectVcsMetadata(
-      { "head-sha": "DEAD", "head-ref": "main", "pr-number": 7 },
+      { "head-sha": sha.toUpperCase(), "head-ref": "main", "pr-number": 7 },
       "/repo",
       {},
       false
     );
 
-    expect(vcs.headSha).toBe("dead"); // normalized to lowercase
+    expect(vcs.headSha).toBe(sha); // normalized to lowercase
     expect(vcs.headRef).toBe("main");
     expect(vcs.prNumber).toBe(7);
     expect(gitMock.getHeadCommit).not.toHaveBeenCalled();
@@ -112,5 +135,65 @@ describe("collectVcsMetadata", () => {
     expect(vcs.headSha).toBe("c".repeat(40));
     expect(vcs.baseSha).toBeUndefined();
     expect(vcs.baseRef).toBeUndefined();
+  });
+
+  test("prefers head/base SHAs from the GitHub Actions event payload", () => {
+    const dir = mkdtempSync(join(tmpdir(), "vcs-event-"));
+    eventDirs.push(dir);
+    const eventPath = join(dir, "event.json");
+    const headSha = "1".repeat(40);
+    const baseSha = "2".repeat(40);
+    writeFileSync(
+      eventPath,
+      JSON.stringify({
+        pull_request: { head: { sha: headSha }, base: { sha: baseSha } },
+      })
+    );
+
+    const vcs = collectVcsMetadata(
+      {},
+      "/repo",
+      { GITHUB_EVENT_NAME: "pull_request", GITHUB_EVENT_PATH: eventPath },
+      true
+    );
+
+    // Event payload wins over `git rev-parse HEAD` / merge-base.
+    expect(vcs.headSha).toBe(headSha);
+    expect(vcs.baseSha).toBe(baseSha);
+    expect(gitMock.getHeadCommit).not.toHaveBeenCalled();
+    expect(gitMock.getMergeBase).not.toHaveBeenCalled();
+  });
+
+  test("an empty --head-sha explicitly clears and suppresses auto-inference", () => {
+    const vcs = collectVcsMetadata({ "head-sha": "" }, "/repo", {}, true);
+    expect(vcs.headSha).toBeUndefined();
+    expect(gitMock.getHeadCommit).not.toHaveBeenCalled();
+  });
+
+  test("rejects a malformed --head-sha", () => {
+    expect(() =>
+      collectVcsMetadata({ "head-sha": "not-a-sha" }, "/repo", {}, false)
+    ).toThrow(ValidationError);
+  });
+
+  test("lowercases an auto merge-base base SHA", () => {
+    gitMock.getMergeBase.mockReturnValueOnce("D".repeat(40));
+    const vcs = collectVcsMetadata(
+      {},
+      "/repo",
+      { GITHUB_EVENT_NAME: "push" },
+      true
+    );
+    expect(vcs.baseSha).toBe("d".repeat(40));
+  });
+
+  test("derives provider from an SCP-style remote and GHE hosts", () => {
+    gitMock.getRemoteUrl.mockReturnValueOnce("git@github.com:acme/app.git");
+    expect(collectVcsMetadata({}, "/repo", {}, true).vcsProvider).toBe("github");
+
+    gitMock.getRemoteUrl.mockReturnValueOnce("https://acme.ghe.com/o/r.git");
+    expect(collectVcsMetadata({}, "/repo", {}, true).vcsProvider).toBe(
+      "github_enterprise"
+    );
   });
 });


### PR DESCRIPTION
Third PR of the **build/Emerge** workstream (after `build download` #1170, `build upload` #1172). Brings `build upload` to VCS parity and lays the groundwork `snapshots` will reuse.

## What
`build upload` now attaches VCS metadata to the assemble request. Per the server's flattened `VcsInfo`, these are **top-level** body fields (omit-if-empty): `head_sha`, `base_sha`, `provider`, `head_repo_name`, `base_repo_name`, `head_ref`, `base_ref`, `pr_number`.

**Precedence (mirrors the legacy `collect_git_metadata`):**
- **Explicit flags always win:** `--head-sha`, `--base-sha`, `--vcs-provider`, `--head-repo-name`, `--base-repo-name`, `--head-ref`, `--base-ref`, `--pr-number`.
- **Auto-collection** runs in CI (unless `--no-git-metadata`) or when `--force-git-metadata` is set:
  - GitHub Actions env: `GITHUB_HEAD_REF`/`GITHUB_BASE_REF` (pull_request), `GITHUB_REPOSITORY`, PR number from `GITHUB_REF` (`refs/pull/N/merge`), head ref from `GITHUB_REF_NAME` for pushes.
  - Local git: HEAD sha, current branch, remote → provider + repo name, and a best-effort `merge-base` for `base_sha`.
- Base is dropped when it equals head and both were auto-inferred (meaningless comparison), matching legacy.

## Files
- `src/lib/build/vcs.ts` — `collectVcsMetadata`, `isCi`, `vcsInfoToBody` (per-field resolver helpers keep complexity low).
- `src/lib/git.ts` — additive helpers: `getRemoteUrl`, `getCurrentBranch`, `getMergeBase` (execFile, no shell; match the module's existing style).
- `src/lib/api/preprod-artifacts.ts` — `BuildUploadMetadata.vcs` flattened into the assemble body.
- `src/commands/build/upload.ts` — 10 git flags + collection wired in.
- Tests (15 new): flag precedence, GitHub Actions PR inference, base==head skip, `vcsInfoToBody` mapping, and a command-level assertion that flags reach the body.

## Notes / follow-ups
- `base_repo_name` fork auto-detection and non-GitHub CI providers are not yet inferred (explicit flags still work); a follow-up can extend inference. `base_sha` auto-inference is best-effort (skipped on shallow clones / unknown refs).

`typecheck`, `lint`, `check:deps`, `check:fragments` all pass.