### PR TITLE
test(deps): add content assertions for Sentry tree-shaking patches

### DIFF
--- a/script/check-patches.ts
+++ b/script/check-patches.ts
@@ -112,6 +112,15 @@ for (const [key, patchPath] of Object.entries(patches)) {
  * `--help-all` via `checkForReservedAliases(aliases, ["h", "H"])`. After our
  * patch that becomes `["h"]`. The presence of `"H"` in that call is a reliable
  * signal that the patch did NOT apply (in either the ESM or CJS bundle).
+ *
+ * @sentry/core and @sentry/node-core: these are tree-shaking patches that strip
+ * unused re-exports (AI/integration modules) from the build barrels so esbuild
+ * excludes them from the bundle. They edit bundler-generated barrels and are
+ * therefore especially prone to silent context drift on a version bump. Each
+ * marker is a re-export the patch removes (present in the pristine package,
+ * absent once patched); its presence means the strip did NOT apply and the
+ * bundle will re-bloat with the AI integrations — re-introducing the dangling
+ * re-export class the patch guards against.
  */
 const CONTENT_ASSERTIONS: ReadonlyArray<{
   /** Installed file to inspect, relative to repo root. */
@@ -132,6 +141,30 @@ const CONTENT_ASSERTIONS: ReadonlyArray<{
     staleMarker: 'checkForReservedAliases(aliases, ["h", "H"])',
     description:
       "@stricli/core CJS: -H alias not freed (api -H/--header will crash)",
+  },
+  {
+    file: "node_modules/@sentry/core/build/cjs/index.js",
+    staleMarker: "exports.instrumentOpenAiClient",
+    description:
+      "@sentry/core CJS: tree-shaking strip not applied (AI integrations re-bundled)",
+  },
+  {
+    file: "node_modules/@sentry/core/build/esm/index.js",
+    staleMarker: "from './tracing/openai/index.js'",
+    description:
+      "@sentry/core ESM: tree-shaking strip not applied (AI integrations re-bundled)",
+  },
+  {
+    file: "node_modules/@sentry/node-core/build/cjs/light/index.js",
+    staleMarker: "exports.dedupeIntegration",
+    description:
+      "@sentry/node-core CJS light: integration re-export strip not applied",
+  },
+  {
+    file: "node_modules/@sentry/node-core/build/esm/light/index.js",
+    staleMarker: "dedupeIntegration",
+    description:
+      "@sentry/node-core ESM light: integration re-export strip not applied",
   },
 ];
 


### PR DESCRIPTION
## Why

Follow-up to #1173 (bumping the patched deps and regenerating patches). An adversarial review of that PR surfaced a safety-net gap: `script/check-patches.ts` content-asserts **only** the `@stricli/core` `-H` patch. The two `@sentry` **tree-shaking** patches — which edit bundler-generated barrels and are the most prone to silent context drift on a version bump — had no content assertion.

Because the patch keys are exact-pinned, the likely future failure mode is *"version matches but the patch didn't apply"*: on the next Sentry bump someone updates the key/version and regenerates, but the apply silently fails due to context drift. `check:patches` compares the same version to itself → **reports clean**, while the bundle silently re-bloats with all the AI integrations and could re-introduce the exact dangling-re-export class #1173 fixed.

## What

Add stale-marker content assertions for both Sentry patches, in both module formats:

| File | Stale marker (removed by patch) |
|------|--------------------------------|
| `@sentry/core` CJS | `exports.instrumentOpenAiClient` |
| `@sentry/core` ESM | `from './tracing/openai/index.js'` |
| `@sentry/node-core` light CJS | `exports.dedupeIntegration` |
| `@sentry/node-core` light ESM | `dedupeIntegration` |

Each marker is a re-export the patch removes — present in the pristine package, absent once patched. Its presence means the strip did not apply.

## Verification (red/green)

- **Green**: `pnpm run check:patches` passes against the correctly-patched install.
- **Red**: swapping an unpatched barrel in place makes it fail hard —
  `✗ @sentry/core CJS: tree-shaking strip not applied (AI integrations re-bundled) … exit 1`.
- All four markers confirmed **present** in the pristine (unpatched) 10.60.0 nested copies and **absent** in the patched top-level install.
- `biome check` ✓ · `tsc --noEmit` ✓.