### PR TITLE
feat(init): add Cloudflare DO agent transport with server-controlled split

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/qrcode-terminal": "^0.12.2",
     "@types/react": "^19.2.17",
     "@types/semver": "^7.7.1",
+    "@types/ws": "^8.5.12",
     "@vitest/coverage-v8": "^4.1.9",
     "chalk": "^5.6.2",
     "cli-highlight": "^2.1.11",
@@ -55,6 +56,7 @@
     "uuidv7": "^1.2.1",
     "vitest": "^4.1.9",
     "wrap-ansi": "^10.0.0",
+    "ws": "^8.18.0",
     "zod": "^3.25.76"
   },
   "exports": {

--- a/plugins/sentry-cli/skills/sentry-cli/references/dashboard.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/dashboard.md
@@ -42,7 +42,7 @@ View a dashboard
 - `-w, --web - Open in browser`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-r, --refresh <value> - Auto-refresh interval in seconds (default: 60, min: 10)`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01"`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01"`
 
 **Examples:**
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/event.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/event.md
@@ -37,7 +37,7 @@ List events for an issue
 - `-n, --limit <value> - Number of events (1-1000) - (default: "25")`
 - `-q, --query <value> - Search query (Sentry search syntax)`
 - `--full - Include full event body (stacktraces)`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/explore.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/explore.md
@@ -24,7 +24,7 @@ Query aggregate event data (Explore)
 - `-s, --sort <value> - Sort field (prefix with - for desc, e.g., "-count()")`
 - `-e, --environment <value>... - Replay environment filter for --dataset replays (repeatable, comma-separated)`
 - `-n, --limit <value> - Number of rows (1-1000) - (default: "25")`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "24h")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "24h")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/issue.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/issue.md
@@ -19,7 +19,7 @@ List issues in a project
 - `-q, --query <value> - Search query (Sentry syntax, implicit AND, no OR operator)`
 - `-n, --limit <value> - Maximum number of issues to list - (default: "25")`
 - `-s, --sort <value> - Sort by: recommended, date, new, freq, user (default: recommended on sentry.io, else date)`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "90d")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "90d")`
 - `-c, --cursor <value> - Pagination cursor (use "next" for next page, "prev" for previous)`
 - `--compact - Single-line rows for compact output (auto-detects if omitted)`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
@@ -92,7 +92,7 @@ List events for a specific issue
 - `-n, --limit <value> - Number of events (1-1000) - (default: "25")`
 - `-q, --query <value> - Search query (Sentry search syntax)`
 - `--full - Include full event body (stacktraces)`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/log.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/log.md
@@ -19,7 +19,7 @@ List logs from a project
 - `-n, --limit <value> - Number of log entries (1-1000) - (default: "100")`
 - `-q, --query <value> - Filter query (e.g., "level:error", "project:backend", "project:[a,b]")`
 - `-f, --follow <value> - Stream logs (optionally specify poll interval in seconds)`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01"`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01"`
 - `-s, --sort <value> - Sort order: "newest" (default) or "oldest" - (default: "newest")`
 - `--fresh - Bypass cache, re-detect projects, and fetch fresh data`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/replay.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/replay.md
@@ -20,7 +20,7 @@ List recent Session Replays
 - `-q, --query <value> - Search query (Sentry replay search syntax)`
 - `-e, --environment <value>... - Filter by environment (repeatable, comma-separated)`
 - `-s, --sort <value> - Sort by: date, oldest, duration, errors, activity, or a raw replay sort field - (default: "date")`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/span.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/span.md
@@ -19,7 +19,7 @@ List spans in a project or trace
 - `-n, --limit <value> - Number of spans (<=1000) - (default: "25")`
 - `-q, --query <value> - Filter spans (e.g., "op:db", "project:backend", "project:[cli,api]")`
 - `-s, --sort <value> - Sort order: date, duration - (default: "date")`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/trace.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/trace.md
@@ -19,7 +19,7 @@ List recent traces in a project
 - `-n, --limit <value> - Number of traces (1-1000) - (default: "25")`
 - `-q, --query <value> - Search query (Sentry search syntax)`
 - `-s, --sort <value> - Sort by: date, duration - (default: "date")`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 
@@ -91,7 +91,7 @@ View logs associated with a trace
 
 **Flags:**
 - `-w, --web - Open trace in browser`
-- `-t, --period <value> - Time range: "7d", "2026-05-01..2026-06-01", ">=2026-05-01" - (default: "14d")`
+- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "14d")`
 - `-n, --limit <value> - Number of log entries (<=1000) - (default: "100")`
 - `-q, --query <value> - Filter query (e.g., "level:error", "project:backend", "project:[a,b]")`
 - `-s, --sort <value> - Sort order: "newest" (default) or "oldest" - (default: "newest")`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
+      '@types/ws':
+        specifier: ^8.5.12
+        version: 8.18.1
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
@@ -170,6 +173,9 @@ importers:
       wrap-ansi:
         specifier: ^10.0.0
         version: 10.0.0
+      ws:
+        specifier: ^8.18.0
+        version: 8.21.0
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -895,6 +901,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vitest/coverage-v8@4.1.9':
     resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
@@ -3380,6 +3389,10 @@ snapshots:
   '@types/semver@7.7.1': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.20.0
 
   '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
     dependencies:

--- a/src/lib/init/agent-do-runner.ts
+++ b/src/lib/init/agent-do-runner.ts
@@ -1,0 +1,657 @@
+/**
+ * Agent DO Runner — the canary transport.
+ *
+ * Drives the Cloudflare Durable Object agent over a resilient WebSocket instead
+ * of the Mastra suspend/resume HTTP loop. The DO holds the live agent context;
+ * the CLI reacts to messages:
+ *   - `tool-request` → run locally via the SAME `executeTool` registry
+ *   - `prompt`       → the SAME `handleInteractive` prompts
+ *   - `status`/`done`/`error` → spinner + final result
+ *
+ * Resilience: the run id is stable for the whole run. If the socket drops (e.g.
+ * the laptop sleeps), we reconnect to the SAME id and the DO re-sends whatever
+ * it was waiting on. Correlation is by message id; the DO ignores stale ids.
+ */
+
+import { randomUUID } from "node:crypto";
+import { setTag } from "@sentry/node-core/light";
+import { WebSocket } from "ws";
+import { EXIT, WizardError } from "../errors.js";
+import { renderInlineMarkdown } from "../formatters/markdown.js";
+import { WizardCancelledError } from "./clack-utils.js";
+import {
+  EXIT_DEPENDENCY_INSTALL_FAILED,
+  EXIT_PLATFORM_NOT_DETECTED,
+  EXIT_VERIFICATION_FAILED,
+  INIT_AGENT_DO_URL,
+} from "./constants.js";
+import { formatError, formatResult } from "./formatters.js";
+import { handleInteractive } from "./interactive.js";
+import { executeTool } from "./tools/registry.js";
+import type {
+  ApplyPatchsetPatch,
+  InteractivePayload,
+  ResolvedInitContext,
+  ToolPayload,
+  WizardOutput,
+  WorkflowRunResult,
+} from "./types.js";
+import type { SpinnerHandle, WizardUI } from "./ui/types.js";
+import { verifySetup } from "./verify-setup.js";
+
+type SpinState = { running: boolean };
+
+type ServerMessage =
+  | {
+      type: "tool-request";
+      id: string;
+      op: string;
+      params: Record<string, unknown>;
+      detail?: string;
+    }
+  | {
+      type: "prompt";
+      id: string;
+      kind: "select" | "multiselect" | "confirm";
+      prompt: string;
+      options?: { value: string; label: string }[];
+    }
+  | { type: "status"; text: string }
+  | { type: "done"; output: Record<string, unknown> }
+  | { type: "error"; message: string; exitCode?: number };
+
+/** Sentinel used to trigger a reconnect from the connection promise. */
+class ReconnectSignal extends Error {}
+
+const MAX_RECONNECT_ATTEMPTS = 40;
+const RECONNECT_MAX_BACKOFF_MS = 15_000;
+const TRAILING_SLASHES_RE = /\/+$/;
+/** WebSocket-protocol ping cadence. Cloudflare auto-answers pong without waking the DO. */
+const PING_INTERVAL_MS = 20_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function truncateForTerminal(message: string): string {
+  const maxWidth = (process.stdout.columns || 80) - 4;
+  const flat = message.replace(/`/g, "");
+  return flat.length <= maxWidth
+    ? message
+    : `${message.slice(0, maxWidth - 1)}…`;
+}
+
+function mapExitCode(workflowCode: unknown): number {
+  switch (workflowCode) {
+    case EXIT_PLATFORM_NOT_DETECTED:
+      return EXIT.CONFIG;
+    case EXIT_DEPENDENCY_INSTALL_FAILED:
+      return EXIT.WIZARD_DEPS;
+    case 40:
+    case 41:
+      return EXIT.WIZARD_CODEMOD;
+    case EXIT_VERIFICATION_FAILED:
+      return EXIT.WIZARD_VERIFY;
+    default:
+      return EXIT.WIZARD;
+  }
+}
+
+/** Map the DO's apply_patch changes to the CLI's apply-patchset patch shape. */
+function toPatches(changes: unknown): ApplyPatchsetPatch[] {
+  if (!Array.isArray(changes)) {
+    return [];
+  }
+  return changes.map((c: Record<string, unknown>) => {
+    const path = String(c.filePath ?? "");
+    if (c.action === "create") {
+      return { path, action: "create", patch: String(c.content ?? "") };
+    }
+    return {
+      path,
+      action: "modify",
+      edits: [
+        {
+          oldString: String(c.oldString ?? ""),
+          newString: String(c.newString ?? ""),
+        },
+      ],
+    };
+  });
+}
+
+/** Adapt a DO tool-request into the CLI's typed ToolPayload (or null if unknown). */
+function toToolPayload(
+  op: string,
+  params: Record<string, unknown>,
+  cwd: string,
+  context: ResolvedInitContext
+): ToolPayload | null {
+  switch (op) {
+    case "list-dir":
+      return {
+        type: "tool",
+        operation: "list-dir",
+        cwd,
+        params: {
+          path: String(params.path ?? "."),
+          ...(typeof params.maxDepth === "number"
+            ? { maxDepth: params.maxDepth }
+            : {}),
+          ...(typeof params.maxEntries === "number"
+            ? { maxEntries: params.maxEntries }
+            : {}),
+        },
+      };
+    case "read-files":
+      return {
+        type: "tool",
+        operation: "read-files",
+        cwd,
+        params: { paths: (params.paths as string[]) ?? [] },
+      };
+    case "file-exists-batch":
+      return {
+        type: "tool",
+        operation: "file-exists-batch",
+        cwd,
+        params: { paths: (params.paths as string[]) ?? [] },
+      };
+    case "run-commands":
+      return {
+        type: "tool",
+        operation: "run-commands",
+        cwd,
+        params: {
+          commands: (params.commands as string[]) ?? [],
+          ...(typeof params.timeoutMs === "number"
+            ? { timeoutMs: params.timeoutMs }
+            : {}),
+        },
+      };
+    case "apply-patchset":
+      return {
+        type: "tool",
+        operation: "apply-patchset",
+        cwd,
+        params: { patches: toPatches(params.changes ?? params.patches) },
+      };
+    case "create-sentry-project":
+      return {
+        type: "tool",
+        operation: "create-sentry-project",
+        cwd,
+        params: {
+          name: context.project ?? String(params.project ?? params.name ?? ""),
+          platform: String(params.platform ?? ""),
+        },
+      };
+    default:
+      return null;
+  }
+}
+
+function toInteractivePayload(
+  msg: Extract<ServerMessage, { type: "prompt" }>
+): InteractivePayload {
+  const values = (msg.options ?? []).map((o) => o.value);
+  if (msg.kind === "select") {
+    return {
+      type: "interactive",
+      kind: "select",
+      prompt: msg.prompt,
+      options: values,
+      apps: values.map((name) => ({ name, path: "" })),
+    };
+  }
+  if (msg.kind === "multiselect") {
+    return {
+      type: "interactive",
+      kind: "multi-select",
+      prompt: msg.prompt,
+      availableFeatures: values,
+      options: values,
+    };
+  }
+  return { type: "interactive", kind: "confirm", prompt: msg.prompt };
+}
+
+function extractPromptValue(
+  kind: Extract<ServerMessage, { type: "prompt" }>["kind"],
+  result: Record<string, unknown>
+): unknown {
+  if (kind === "select") {
+    return result.selectedApp;
+  }
+  if (kind === "multiselect") {
+    return result.features ?? [];
+  }
+  return result.action === "continue";
+}
+
+function buildFlags(context: ResolvedInitContext): Record<string, unknown> {
+  return {
+    org: context.org,
+    project: context.project,
+    team: context.team,
+    features: context.features,
+    dryRun: context.dryRun,
+    app: context.app,
+  };
+}
+
+function normalizeOutput(
+  output: Record<string, unknown>,
+  cwd: string
+): WizardOutput {
+  const changed = output.changedFiles;
+  return {
+    platform: typeof output.platform === "string" ? output.platform : undefined,
+    features: Array.isArray(output.features)
+      ? (output.features as string[])
+      : undefined,
+    changedFiles: Array.isArray(changed)
+      ? changed.map((c) =>
+          typeof c === "string"
+            ? { action: "modified", path: c }
+            : (c as { action: string; path: string })
+        )
+      : undefined,
+    sentryProjectUrl:
+      typeof output.sentryProjectUrl === "string"
+        ? output.sentryProjectUrl
+        : undefined,
+    projectDir: cwd,
+    exitCode: typeof output.exitCode === "number" ? output.exitCode : 0,
+    message: typeof output.message === "string" ? output.message : undefined,
+  };
+}
+
+type MessageCtx = {
+  ws: WebSocket;
+  context: ResolvedInitContext;
+  ui: WizardUI;
+  spin: SpinnerHandle;
+  spinState: SpinState;
+  resolveDone: (output: Record<string, unknown>) => void;
+  fail: (err: Error) => void;
+};
+
+async function handleToolRequest(
+  msg: Extract<ServerMessage, { type: "tool-request" }>,
+  ctx: MessageCtx
+): Promise<void> {
+  const { ws, context, ui, spin, spinState } = ctx;
+  const payload = toToolPayload(msg.op, msg.params, context.directory, context);
+  if (!payload) {
+    ws.send(
+      JSON.stringify({
+        type: "tool-result",
+        id: msg.id,
+        ok: false,
+        error: `Unsupported op: ${msg.op}`,
+      })
+    );
+    return;
+  }
+  if (msg.detail && spinState.running) {
+    spin.message(renderInlineMarkdown(truncateForTerminal(msg.detail)));
+  }
+  if (payload.operation === "read-files") {
+    ui.recordFilesReading?.(payload.params.paths);
+  }
+  const result = await executeTool(payload, context);
+  if (payload.operation === "read-files" && result.ok !== false) {
+    ui.markFilesAnalyzed?.(payload.params.paths);
+  }
+  ws.send(
+    JSON.stringify({
+      type: "tool-result",
+      id: msg.id,
+      ok: result.ok,
+      data: result.data,
+      error: result.error,
+    })
+  );
+}
+
+async function handlePrompt(
+  msg: Extract<ServerMessage, { type: "prompt" }>,
+  ctx: MessageCtx
+): Promise<void> {
+  const { ws, context, ui, spin, spinState } = ctx;
+  const interactive = toInteractivePayload(msg);
+  if (spinState.running) {
+    spin.stop();
+    spinState.running = false;
+  }
+  const result = await handleInteractive(interactive, context, ui);
+  spin.start("Working...");
+  spinState.running = true;
+  ws.send(
+    JSON.stringify({
+      type: "prompt-response",
+      id: msg.id,
+      value: extractPromptValue(msg.kind, result),
+    })
+  );
+}
+
+async function handleServerMessage(
+  msg: ServerMessage,
+  ctx: MessageCtx
+): Promise<void> {
+  switch (msg.type) {
+    case "status":
+      if (ctx.spinState.running) {
+        ctx.spin.message(renderInlineMarkdown(truncateForTerminal(msg.text)));
+      }
+      return;
+    case "tool-request":
+      await handleToolRequest(msg, ctx);
+      return;
+    case "prompt":
+      await handlePrompt(msg, ctx);
+      return;
+    case "done":
+      ctx.resolveDone(msg.output ?? {});
+      return;
+    case "error":
+      ctx.fail(
+        new WizardError(String(msg.message ?? "Setup failed"), {
+          exitCode: mapExitCode(msg.exitCode),
+        })
+      );
+      return;
+    default:
+      return;
+  }
+}
+
+/**
+ * Own one WebSocket connection; resolve with the `done` output, or reject.
+ * A clean-but-early close rejects with {@link ReconnectSignal} so the caller
+ * reconnects to the same run id.
+ */
+function connectOnce(args: {
+  url: string;
+  token?: string;
+  sendStart: boolean;
+  context: ResolvedInitContext;
+  ui: WizardUI;
+  spin: SpinnerHandle;
+  spinState: SpinState;
+}): Promise<Record<string, unknown>> {
+  const { url, token, sendStart, context, ui, spin, spinState } = args;
+  return new Promise<Record<string, unknown>>((resolve, reject) => {
+    const ws = new WebSocket(
+      url,
+      token ? { headers: { Authorization: `Bearer ${token}` } } : undefined
+    );
+    let settled = false;
+    let pingTimer: ReturnType<typeof setInterval> | null = null;
+    const stopPing = () => {
+      if (pingTimer) {
+        clearInterval(pingTimer);
+        pingTimer = null;
+      }
+    };
+    const settle = (fn: () => void) => {
+      if (!settled) {
+        settled = true;
+        stopPing();
+        fn();
+      }
+    };
+
+    ws.on("open", () => {
+      ui.clearOverlay?.();
+      // Keepalive: WebSocket-protocol pings keep the connection open during long
+      // LLM "thinking" gaps. Cloudflare auto-responds with pong WITHOUT waking the
+      // Durable Object, so this stays hibernation-friendly (no server-side timer).
+      pingTimer = setInterval(() => {
+        try {
+          ws.ping();
+        } catch {
+          // Socket not open; the close handler will trigger a reconnect.
+        }
+      }, PING_INTERVAL_MS);
+      if (spinState.running) {
+        spin.message("Analyzing your project...");
+      }
+      if (sendStart) {
+        ws.send(
+          JSON.stringify({
+            type: "start",
+            cwd: context.directory,
+            flags: buildFlags(context),
+          })
+        );
+      }
+    });
+
+    ws.on("message", (raw: Buffer | ArrayBuffer | Buffer[]) => {
+      let msg: ServerMessage;
+      try {
+        msg = JSON.parse(raw.toString()) as ServerMessage;
+      } catch {
+        return;
+      }
+      if (
+        typeof (msg as { type?: string }).type === "string" &&
+        (msg.type as string).startsWith("cf_agent")
+      ) {
+        return; // SDK internal state-sync frames
+      }
+      handleServerMessage(msg, {
+        ws,
+        context,
+        ui,
+        spin,
+        spinState,
+        resolveDone: (output) => settle(() => resolve(output)),
+        fail: (err) => {
+          try {
+            ws.close();
+          } catch {
+            // ignore
+          }
+          settle(() => reject(err));
+        },
+      }).catch((err: unknown) => {
+        try {
+          ws.close();
+        } catch {
+          // ignore
+        }
+        settle(() =>
+          reject(err instanceof Error ? err : new Error(String(err)))
+        );
+      });
+    });
+
+    ws.on("error", () => {
+      // A socket error is always followed by 'close'; let that path decide.
+    });
+
+    ws.on("close", () => {
+      settle(() => reject(new ReconnectSignal()));
+    });
+  });
+}
+
+async function driveWithReconnect(args: {
+  url: string;
+  context: ResolvedInitContext;
+  ui: WizardUI;
+  spin: SpinnerHandle;
+  spinState: SpinState;
+}): Promise<Record<string, unknown>> {
+  const { url, context, ui, spin, spinState } = args;
+  const token = context.authToken;
+  let started = false;
+  let attempt = 0;
+
+  for (;;) {
+    try {
+      const output = await connectOnce({
+        url,
+        token,
+        sendStart: !started,
+        context,
+        ui,
+        spin,
+        spinState,
+      });
+      return output;
+    } catch (err) {
+      if (!(err instanceof ReconnectSignal)) {
+        throw err;
+      }
+      // The DO holds the run state; on reconnect it re-sends any pending
+      // request, so we never re-send `start` after the first connection.
+      started = true;
+      attempt += 1;
+      if (attempt > MAX_RECONNECT_ATTEMPTS) {
+        throw new WizardError(
+          "Lost connection to the setup service after multiple retries."
+        );
+      }
+      const backoff = Math.min(
+        1000 * 2 ** Math.min(attempt, 4),
+        RECONNECT_MAX_BACKOFF_MS
+      );
+      ui.setOverlay?.({
+        kind: "health",
+        message: "Connection interrupted, reconnecting...",
+        retryCount: attempt,
+      });
+      if (spinState.running) {
+        spin.message("Reconnecting...");
+      }
+      await sleep(backoff);
+    }
+  }
+}
+
+async function finalize(args: {
+  result: WorkflowRunResult;
+  spin: SpinnerHandle;
+  spinState: SpinState;
+  ui: WizardUI;
+  cwd: string;
+}): Promise<void> {
+  const { result, spin, spinState, ui, cwd } = args;
+  const hasError = result.status !== "success" || result.result?.exitCode;
+  if (hasError) {
+    if (spinState.running) {
+      spin.stop("Failed", 1);
+      spinState.running = false;
+    }
+    formatError(result, ui);
+    throw new WizardError(
+      result.error ?? result.result?.message ?? "Setup returned an error",
+      { exitCode: mapExitCode(result.result?.exitCode) }
+    );
+  }
+
+  if (spinState.running) {
+    spin.message("Verifying setup...");
+  }
+  try {
+    await verifySetup(result, ui, cwd);
+  } catch {
+    // Verification is best-effort; never fail the run on a verify hiccup.
+  }
+
+  if (spinState.running) {
+    spin.stop("Done");
+    spinState.running = false;
+  }
+  formatResult(result, ui);
+}
+
+function tagSuccess(result: WorkflowRunResult): void {
+  setTag("wizard.outcome", "completed");
+  if (result.result?.platform) {
+    setTag("wizard.platform", String(result.result.platform));
+  }
+  if (result.result?.features) {
+    setTag("wizard.features", (result.result.features as string[]).join(","));
+  }
+}
+
+/**
+ * Terminal error handling for a DO run. Returns normally for a clean
+ * cancellation (exit 0); otherwise (re)throws a WizardError.
+ */
+function handleRunFailure(
+  err: unknown,
+  ui: WizardUI,
+  spin: SpinnerHandle,
+  spinState: SpinState
+): void {
+  if (spinState.running) {
+    const cancelled = err instanceof WizardCancelledError;
+    spin.stop(cancelled ? "Cancelled" : "Error", cancelled ? 0 : 1);
+    spinState.running = false;
+  }
+  if (err instanceof WizardCancelledError) {
+    setTag("wizard.outcome", "bailed");
+    ui.cancel("Setup cancelled.");
+    ui.feedback("cancelled");
+    process.exitCode = 0;
+    return;
+  }
+  setTag("wizard.outcome", "errored");
+  ui.cancel("Setup failed");
+  ui.feedback("failed");
+  if (err instanceof WizardError) {
+    throw err;
+  }
+  throw new WizardError(err instanceof Error ? err.message : String(err));
+}
+
+/**
+ * Run the wizard via the Durable Object agent (WebSocket transport). Assumes
+ * preamble + readiness + preflight already ran; `context` is resolved.
+ */
+export async function runViaAgentDO(args: {
+  context: ResolvedInitContext;
+  ui: WizardUI;
+  /** Optional WS base URL from the server routing decision (overrides the constant). */
+  agentDoUrl?: string;
+}): Promise<void> {
+  const { context, ui } = args;
+  const runId = randomUUID();
+  const base = (args.agentDoUrl ?? INIT_AGENT_DO_URL).replace(
+    TRAILING_SLASHES_RE,
+    ""
+  );
+  const url = `${base}/agents/sentry-init-agent/${runId}`;
+
+  setTag("wizard.transport", "agent-do");
+  ui.setIntroMode?.(false);
+
+  const spin = ui.spinner();
+  const spinState: SpinState = { running: true };
+  spin.start("Connecting to Sentry...");
+
+  try {
+    const output = await driveWithReconnect({
+      url,
+      context,
+      ui,
+      spin,
+      spinState,
+    });
+    const result: WorkflowRunResult = {
+      status: "success",
+      result: normalizeOutput(output, context.directory),
+    };
+    await finalize({ result, spin, spinState, ui, cwd: context.directory });
+    tagSuccess(result);
+  } catch (err) {
+    handleRunFailure(err, ui, spin, spinState);
+  }
+}

--- a/src/lib/init/agent-do-runner.ts
+++ b/src/lib/init/agent-do-runner.ts
@@ -376,13 +376,14 @@ async function handleServerMessage(
 function connectOnce(args: {
   url: string;
   token?: string;
-  sendStart: boolean;
+  /** Shared across reconnects: `start` is sent exactly once, on the FIRST open. */
+  startState: { sent: boolean };
   context: ResolvedInitContext;
   ui: WizardUI;
   spin: SpinnerHandle;
   spinState: SpinState;
 }): Promise<Record<string, unknown>> {
-  const { url, token, sendStart, context, ui, spin, spinState } = args;
+  const { url, token, startState, context, ui, spin, spinState } = args;
   return new Promise<Record<string, unknown>>((resolve, reject) => {
     const ws = new WebSocket(
       url,
@@ -419,7 +420,12 @@ function connectOnce(args: {
       if (spinState.running) {
         spin.message("Analyzing your project...");
       }
-      if (sendStart) {
+      // Send `start` exactly once — on the first socket that actually opens.
+      // A reconnect after a successful start relies on the DO re-sending its
+      // pending request, so we must NOT resend start; but if the first connect
+      // failed before opening, start was never sent and must go out now.
+      if (!startState.sent) {
+        startState.sent = true;
         ws.send(
           JSON.stringify({
             type: "start",
@@ -489,7 +495,9 @@ async function driveWithReconnect(args: {
 }): Promise<Record<string, unknown>> {
   const { url, context, ui, spin, spinState } = args;
   const token = context.authToken;
-  let started = false;
+  // `start` is sent exactly once, on the first socket that opens (tracked here so
+  // an early connect failure before `open` doesn't skip it on the retry).
+  const startState = { sent: false };
   let attempt = 0;
 
   for (;;) {
@@ -497,7 +505,7 @@ async function driveWithReconnect(args: {
       const output = await connectOnce({
         url,
         token,
-        sendStart: !started,
+        startState,
         context,
         ui,
         spin,
@@ -508,9 +516,6 @@ async function driveWithReconnect(args: {
       if (!(err instanceof ReconnectSignal)) {
         throw err;
       }
-      // The DO holds the run state; on reconnect it re-sends any pending
-      // request, so we never re-send `start` after the first connection.
-      started = true;
       attempt += 1;
       if (attempt > MAX_RECONNECT_ATTEMPTS) {
         throw new WizardError(

--- a/src/lib/init/constants.ts
+++ b/src/lib/init/constants.ts
@@ -6,6 +6,28 @@ export const MASTRA_API_URL =
 
 export const WORKFLOW_ID = "sentry-wizard";
 
+// --- Canary: Cloudflare Durable Object agent (new transport) ---
+// The DO agent runs server-side as a separate Worker; the CLI talks to it over
+// a resilient WebSocket. This coexists with the Mastra path for gradual rollout.
+export const DEFAULT_INIT_AGENT_DO_URL =
+  "wss://sentry-init-agent-do.getsentry.workers.dev";
+
+export const INIT_AGENT_DO_URL =
+  process.env.SENTRY_INIT_AGENT_DO_URL ?? DEFAULT_INIT_AGENT_DO_URL;
+
+/**
+ * Percentage (0-100) of runs routed to the DO agent. `SENTRY_INIT_AGENT_DO=1`
+ * forces it on; `=0` forces off. Default 0 (Mastra) until the canary ramps.
+ */
+export function agentDoTrafficPercent(): number {
+  const raw = process.env.SENTRY_INIT_AGENT_DO_PERCENT;
+  if (raw === undefined) {
+    return 0;
+  }
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? Math.min(100, Math.max(0, n)) : 0;
+}
+
 export const SENTRY_DOCS_URL = "https://docs.sentry.io/platforms/";
 
 export const MAX_FILE_BYTES = 262_144; // 256KB per file

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -31,6 +31,7 @@ import {
   stripColorTags,
 } from "../formatters/markdown.js";
 import { logger } from "../logger.js";
+import { runViaAgentDO } from "./agent-do-runner.js";
 import {
   abortIfCancelled,
   PROGRESS_ROTATE_INTERVAL_MS,
@@ -41,9 +42,11 @@ import {
 } from "./clack-utils.js";
 import {
   API_TIMEOUT_MS,
+  agentDoTrafficPercent,
   EXIT_DEPENDENCY_INSTALL_FAILED,
   EXIT_PLATFORM_NOT_DETECTED,
   EXIT_VERIFICATION_FAILED,
+  INIT_AGENT_DO_URL,
   MASTRA_API_URL,
   VERIFY_CHANGES_STEP,
   WORKFLOW_ID,
@@ -408,6 +411,70 @@ async function handleSuspendedStep(
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+type TransportChoice = { useAgentDo: boolean; agentDoUrl?: string };
+
+const ROUTE_DECISION_TIMEOUT_MS = 3000;
+
+/** Local fallback split, used only when the server routing decision is unavailable. */
+function localFallbackChoice(): TransportChoice {
+  const pct = agentDoTrafficPercent();
+  if (pct >= 100) {
+    return { useAgentDo: true };
+  }
+  if (pct <= 0) {
+    return { useAgentDo: false };
+  }
+  return { useAgentDo: Math.random() * 100 < pct };
+}
+
+/**
+ * Decide which transport to use. The canary split is controlled SERVER-SIDE: we
+ * ask the DO worker's `/route` endpoint, which performs the random roll against a
+ * server-held percentage. This lets the split change without shipping a new CLI.
+ *
+ * - `SENTRY_INIT_AGENT_DO=1|0` forces a transport (dev/ops override).
+ * - Otherwise the server decides. On any error we fall back to a local percent
+ *   (`SENTRY_INIT_AGENT_DO_PERCENT`) or, by default, the proven Mastra path.
+ */
+async function resolveTransport(): Promise<TransportChoice> {
+  const forced = process.env.SENTRY_INIT_AGENT_DO;
+  if (forced === "1" || forced === "true") {
+    return { useAgentDo: true };
+  }
+  if (forced === "0" || forced === "false") {
+    return { useAgentDo: false };
+  }
+
+  try {
+    let base = INIT_AGENT_DO_URL;
+    if (base.startsWith("wss:")) {
+      base = `https:${base.slice(4)}`;
+    } else if (base.startsWith("ws:")) {
+      base = `http:${base.slice(3)}`;
+    }
+    while (base.endsWith("/")) {
+      base = base.slice(0, -1);
+    }
+    const res = await customFetch(`${base}/route`, {
+      signal: AbortSignal.timeout(ROUTE_DECISION_TIMEOUT_MS),
+    });
+    if (res.ok) {
+      const data = (await res.json()) as {
+        transport?: string;
+        agentDoUrl?: string;
+      };
+      if (data.transport === "agent-do") {
+        return { useAgentDo: true, agentDoUrl: data.agentDoUrl };
+      }
+      return { useAgentDo: false };
+    }
+  } catch {
+    // Server routing unreachable — fall back to the local decision below.
+  }
+
+  return localFallbackChoice();
 }
 
 function showCancelledFeedback(ui: WizardUI): void {
@@ -857,6 +924,17 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     setTag("wizard.outcome", "bailed");
     return;
   }
+
+  // Canary split (decided server-side via the DO worker's /route endpoint, so
+  // the percentage changes without a CLI release). Preamble/readiness/preflight
+  // already ran, so both transports share the same local context. The Mastra
+  // path below is the untouched production flow.
+  const transport = await resolveTransport();
+  if (transport.useAgentDo) {
+    await runViaAgentDO({ context, ui, agentDoUrl: transport.agentDoUrl });
+    return;
+  }
+  setTag("wizard.transport", "mastra");
 
   const tracingOptions = {
     traceId: randomBytes(16).toString("hex"),


### PR DESCRIPTION
## Summary

Adds a second transport for `sentry init`: a reconnecting WebSocket client that talks to the new Cloudflare Durable Object agent (server side: getsentry/cli-init-api#187). Which transport a run uses is decided **server-side** via `/route`, so the canary split changes without shipping a new CLI. The default and fallback is the existing Mastra path, so this is a no-op for current users until the split is turned up.

Older CLIs never call `/route`, so they are unaffected — they keep using Mastra.

## Architecture

This diagram is shared with the server PR.

```mermaid
flowchart TB
  U["Developer runs: sentry init"]

  subgraph CLI["CLI (sentry binary, Node)"]
    PF["preflight: org / project / team + Sentry auth"]
    RT["resolveTransport(): GET /route"]
    ADR["agent-do-runner: reconnecting WebSocket client"]
    LT["local tools + prompts (executeTool, handleInteractive)"]
  end

  subgraph NET["Transport"]
    WS["WebSocket - live and resilient (client pings + reconnect)"]
    LEGACY["HTTP suspend/resume (Mastra, existing)"]
  end

  subgraph SRV["Server: Cloudflare Worker (agents SDK)"]
    RTE["/route: server-controlled canary split (AGENT_DO_PERCENT)"]
    DO["SentryInitAgent: Durable Object"]
    AG["one agent: analyze + gates + implement + verify"]
  end

  subgraph INF["Infra and libraries"]
    SQL["DO embedded SQLite: durable phase + pending (no D1)"]
    GW["Vercel AI Gateway via ai SDK -> LLM"]
    SAPI["Sentry API: ensure project + DSN"]
    MASTRA["Mastra worker + D1 (existing path)"]
  end

  U --> PF --> RT
  RT -->|"decision"| RTE
  RT -->|"agent-do"| ADR
  RT -->|"mastra"| LEGACY
  ADR <-->|"tool-request / prompt / result"| WS
  WS <--> DO
  DO --> AG
  AG -->|"LLM turns"| GW
  AG -->|"ensure project"| SAPI
  DO --> SQL
  ADR -.->|"runs tools locally, returns results"| LT
  LEGACY <--> MASTRA
```

## Changes

- `agent-do-runner.ts` (new): the WebSocket client. Reuses the existing `executeTool` registry and `handleInteractive` prompts, reconnects on drop (deploys / laptop sleep), and sends client-side WebSocket pings for idle keepalive (Cloudflare auto-answers pong without waking the DO).
- `wizard-runner.ts`: `resolveTransport()` asks the server `/route` and obeys; `runViaAgentDO()` drives the run. The Mastra suspend/resume path is untouched. `SENTRY_INIT_AGENT_DO=1|0` is a manual override; `SENTRY_INIT_AGENT_DO_PERCENT` is a local fallback if `/route` is unreachable.
- Adds `ws` (bundled into the single-file build).

## Test plan

- Ran against the deployed worker; server-controlled split verified at 50% and forced to 100%.
- `/verify-sentry` confirmed real errors + traces for node-express and nextjs.
- Mastra path unchanged (default when `/route` says so or is unreachable).

Paired with getsentry/cli-init-api#187 (server side).
