### PR TITLE
chore(deps): bump @sentry/api to 0.253.0 and adopt token operationIds

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@clack/prompts": "0.11.0",
     "@hono/node-server": "^2.0.6",
     "@mastra/client-js": "^1.26.0",
-    "@sentry/api": "^0.180.0",
+    "@sentry/api": "^0.253.0",
     "@sentry/core": "10.63.0",
     "@sentry/node-core": "10.63.0",
     "@sentry/sqlish": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^1.26.0
         version: 1.26.0(express@5.2.1)(zod@3.25.76)
       '@sentry/api':
-        specifier: ^0.180.0
-        version: 0.180.0(zod@3.25.76)
+        specifier: ^0.253.0
+        version: 0.253.0(zod@3.25.76)
       '@sentry/core':
         specifier: 10.63.0
         version: 10.63.0(patch_hash=e663994979ff877a26ab6d4dea5968fbaee4ccdfdeb85623983535a572678940)
@@ -728,8 +728,8 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
-  '@sentry/api@0.180.0':
-    resolution: {integrity: sha512-Qv0bJnRgpnlKDFM/V86AR/CdJNOU4JO2tno1BnZjR+ACM9gcyt/Y6xow7YeD6vHLzvguW0SiwqnX/lt4DSmFUQ==}
+  '@sentry/api@0.253.0':
+    resolution: {integrity: sha512-g6zU6Qa7HaqEAhcPkrAF2yIF9Th3UBxNIM2HjFt9eTLWT+cHqO1zvgPe8yl5IXVpn4xwZmytbdome43ba+FgSQ==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.24.0
@@ -3225,7 +3225,7 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@sentry/api@0.180.0(zod@3.25.76)':
+  '@sentry/api@0.253.0(zod@3.25.76)':
     optionalDependencies:
       zod: 3.25.76
 

--- a/src/lib/api/dashboards.ts
+++ b/src/lib/api/dashboards.ts
@@ -6,10 +6,10 @@
  */
 
 import {
-  createANewDashboardForAnOrganization,
-  editAnOrganization_sCustomDashboard,
-  listAnOrganization_sCustomDashboards,
-  retrieveAnOrganization_sCustomDashboard,
+  createOrganizationDashboard,
+  getOrganizationDashboard,
+  listOrganizationDashboards,
+  updateOrganizationDashboard,
 } from "@sentry/api";
 // biome-ignore lint/performance/noNamespaceImport: Sentry SDK recommends namespace import
 import * as Sentry from "@sentry/node-core/light";
@@ -66,7 +66,7 @@ export async function listDashboardsPaginated(
 ): Promise<PaginatedResponse<DashboardListItem[]>> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await listAnOrganization_sCustomDashboards({
+  const result = await listOrganizationDashboards({
     ...config,
     path: { organization_id_or_slug: orgSlug },
     query: { per_page: options.perPage, cursor: options.cursor },
@@ -91,7 +91,7 @@ export async function getDashboard(
 ): Promise<DashboardDetail> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await retrieveAnOrganization_sCustomDashboard({
+  const result = await getOrganizationDashboard({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,
@@ -118,11 +118,11 @@ export async function createDashboard(
 ): Promise<DashboardDetail> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await createANewDashboardForAnOrganization({
+  const result = await createOrganizationDashboard({
     ...config,
     path: { organization_id_or_slug: orgSlug },
     body: body as unknown as Parameters<
-      typeof createANewDashboardForAnOrganization
+      typeof createOrganizationDashboard
     >[0]["body"],
   });
 
@@ -151,14 +151,14 @@ export async function updateDashboard(
 ): Promise<DashboardDetail> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await editAnOrganization_sCustomDashboard({
+  const result = await updateOrganizationDashboard({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,
       dashboard_id: dashboardId as unknown as number,
     },
     body: body as unknown as Parameters<
-      typeof editAnOrganization_sCustomDashboard
+      typeof updateOrganizationDashboard
     >[0]["body"],
   });
 

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -5,10 +5,10 @@
  */
 
 import {
-  listAnIssue_sEvents,
-  retrieveAnEventForAProject,
-  retrieveAnIssueEvent,
-  resolveAnEventId as sdkResolveAnEventId,
+  getOrganizationIssueEvent,
+  getProjectEvent,
+  listOrganizationIssueEvents,
+  resolveOrganizationEventId as sdkResolveAnEventId,
 } from "@sentry/api";
 import pLimit from "p-limit";
 
@@ -40,7 +40,7 @@ export async function getLatestEvent(
 ): Promise<SentryEvent> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await retrieveAnIssueEvent({
+  const result = await getOrganizationIssueEvent({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,
@@ -63,7 +63,7 @@ export async function getEvent(
 ): Promise<SentryEvent> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await retrieveAnEventForAProject({
+  const result = await getProjectEvent({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,
@@ -199,7 +199,7 @@ export type ListIssueEventsOptions = {
 /**
  * List events for a specific issue.
  *
- * Uses the SDK's `listAnIssue_sEvents` endpoint with region-aware routing.
+ * Uses the SDK's `listOrganizationIssueEvents` endpoint with region-aware routing.
  * When `limit` exceeds {@link API_MAX_PER_PAGE} (100), auto-paginates through
  * multiple API calls to fill the requested limit, bounded by
  * {@link MAX_PAGINATION_PAGES}.
@@ -235,7 +235,7 @@ export async function listIssueEvents(
   let nextCursor: string | undefined;
 
   for (let page = 0; page < MAX_PAGINATION_PAGES; page += 1) {
-    const result = await listAnIssue_sEvents({
+    const result = await listOrganizationIssueEvents({
       ...config,
       path: {
         organization_id_or_slug: orgSlug,
@@ -251,7 +251,7 @@ export async function listIssueEvents(
         // `per_page` is accepted at runtime but absent from the generated query
         // type, so widen via cast.
         per_page: perPage,
-      } as Parameters<typeof listAnIssue_sEvents>[0]["query"],
+      } as Parameters<typeof listOrganizationIssueEvents>[0]["query"],
     });
 
     const paginated = unwrapPaginatedResult(

--- a/src/lib/api/issues.ts
+++ b/src/lib/api/issues.ts
@@ -4,8 +4,8 @@
  * Functions for listing, retrieving, and updating Sentry issues.
  */
 
-import type { ListAnOrganizationSissuesData } from "@sentry/api";
-import { listAnOrganization_sIssues } from "@sentry/api";
+import type { ListOrganizationIssuesData } from "@sentry/api";
+import { listOrganizationIssues } from "@sentry/api";
 
 import type { SentryIssue } from "../../types/index.js";
 import type { IssueSubstatus } from "../../types/sentry.js";
@@ -38,7 +38,7 @@ const TRAILING_SLASH_RE = /\/$/;
  * Uses the SDK type directly for compile-time safety against parameter drift.
  */
 export type IssueSort = NonNullable<
-  NonNullable<ListAnOrganizationSissuesData["query"]>["sort"]
+  NonNullable<ListOrganizationIssuesData["query"]>["sort"]
 >;
 
 /**
@@ -53,7 +53,7 @@ export type IssueSort = NonNullable<
  * - `'base'` — base group fields (rarely useful to collapse)
  */
 export type IssueCollapseField = NonNullable<
-  NonNullable<ListAnOrganizationSissuesData["query"]>["collapse"]
+  NonNullable<ListOrganizationIssuesData["query"]>["collapse"]
 >[number];
 
 /**
@@ -121,7 +121,7 @@ export const ISSUE_DETAIL_COLLAPSE: IssueCollapseField[] = [
 /**
  * List issues for a project with pagination control.
  *
- * Uses the @sentry/api SDK's `listAnOrganization_sIssues` for type-safe
+ * Uses the @sentry/api SDK's `listOrganizationIssues` for type-safe
  * query parameters, and extracts pagination from the response Link header.
  *
  * @param orgSlug - Organization slug
@@ -164,7 +164,7 @@ export async function listIssuesPaginated(
 
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await listAnOrganization_sIssues({
+  const result = await listOrganizationIssues({
     ...config,
     path: { organization_id_or_slug: orgSlug },
     query: {

--- a/src/lib/api/logs.ts
+++ b/src/lib/api/logs.ts
@@ -5,7 +5,7 @@
  * including trace-associated logs.
  */
 
-import { queryExploreEventsInTableFormat } from "@sentry/api";
+import { listOrganizationEvents } from "@sentry/api";
 // biome-ignore lint/performance/noNamespaceImport: Sentry SDK recommends namespace import
 import * as Sentry from "@sentry/node-core/light";
 import type { z } from "zod";
@@ -153,7 +153,7 @@ export async function listLogs(
       ]
     : LOG_FIELDS;
 
-  const result = await queryExploreEventsInTableFormat({
+  const result = await listOrganizationEvents({
     ...config,
     path: { organization_id_or_slug: orgSlug },
     query: {
@@ -227,7 +227,7 @@ async function getLogsBatch(
       ]
     : DETAILED_LOG_FIELDS;
 
-  const result = await queryExploreEventsInTableFormat({
+  const result = await listOrganizationEvents({
     ...config,
     path: { organization_id_or_slug: orgSlug },
     query: {

--- a/src/lib/api/monitors.ts
+++ b/src/lib/api/monitors.ts
@@ -7,7 +7,7 @@
  * envelope transport (`src/lib/envelope/`), not this module.
  */
 
-import { retrieveMonitorsForAnOrganization } from "@sentry/api";
+import { listOrganizationMonitors } from "@sentry/api";
 
 import type { SentryMonitor } from "../../types/index.js";
 
@@ -33,7 +33,7 @@ export async function listMonitors(orgSlug: string): Promise<SentryMonitor[]> {
   const config = await getOrgSdkConfig(orgSlug);
 
   const { data: allResults } = await autoPaginate(async (cursor) => {
-    const result = await retrieveMonitorsForAnOrganization({
+    const result = await listOrganizationMonitors({
       ...config,
       path: { organization_id_or_slug: orgSlug },
       query: { cursor, per_page: API_MAX_PER_PAGE } as {
@@ -64,7 +64,7 @@ export async function listMonitorsPaginated(
 ): Promise<PaginatedResponse<SentryMonitor[]>> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await retrieveMonitorsForAnOrganization({
+  const result = await listOrganizationMonitors({
     ...config,
     path: { organization_id_or_slug: orgSlug },
     query: {

--- a/src/lib/api/organizations.ts
+++ b/src/lib/api/organizations.ts
@@ -5,8 +5,8 @@
  */
 
 import {
-  retrieveAnOrganization,
-  listYourOrganizations as sdkListOrganizations,
+  getOrganization as sdkGetOrganization,
+  listOrganizations as sdkListOrganizations,
 } from "@sentry/api";
 
 import {
@@ -209,7 +209,7 @@ export async function getOrganization(
 ): Promise<SentryOrganization> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await retrieveAnOrganization({
+  const result = await sdkGetOrganization({
     ...config,
     path: { organization_id_or_slug: orgSlug },
   });

--- a/src/lib/api/projects.ts
+++ b/src/lib/api/projects.ts
@@ -5,11 +5,11 @@
  */
 
 import {
-  createANewProject,
-  deleteAProject,
-  listAnOrganization_sProjects,
-  listAProject_sClientKeys,
-  retrieveAProject,
+  createTeamProject,
+  listOrganizationProjects,
+  listProjectKeys,
+  deleteProject as sdkDeleteProject,
+  getProject as sdkGetProject,
 } from "@sentry/api";
 
 import pLimit from "p-limit";
@@ -57,7 +57,7 @@ export async function listProjects(orgSlug: string): Promise<SentryProject[]> {
   const config = await getOrgSdkConfig(orgSlug);
 
   const { data: allResults } = await autoPaginate(async (cursor) => {
-    const result = await listAnOrganization_sProjects({
+    const result = await listOrganizationProjects({
       ...config,
       path: { organization_id_or_slug: orgSlug },
       query: { cursor, per_page: API_MAX_PER_PAGE } as {
@@ -99,7 +99,7 @@ export async function listProjectsPaginated(
 ): Promise<PaginatedResponse<SentryProject[]>> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await listAnOrganization_sProjects({
+  const result = await listOrganizationProjects({
     ...config,
     path: { organization_id_or_slug: orgSlug },
     query: {
@@ -142,7 +142,7 @@ export async function createProject(
   body: CreateProjectBody
 ): Promise<SentryProject> {
   const config = await getOrgSdkConfig(orgSlug);
-  const result = await createANewProject({
+  const result = await createTeamProject({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,
@@ -311,7 +311,7 @@ export async function deleteProject(
   projectSlug: string
 ): Promise<void> {
   const config = await getOrgSdkConfig(orgSlug);
-  const result = await deleteAProject({
+  const result = await sdkDeleteProject({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,
@@ -528,18 +528,18 @@ export async function getProject(
   const config = await getOrgSdkConfig(orgSlug);
 
   // `collapse` is server-supported but not in the OpenAPI spec, so the
-  // SDK types `query` as `never` on `RetrieveAProjectData`. Double-cast
+  // SDK types `query` as `never` on `GetProjectData`. Double-cast
   // via `unknown` to bypass the stricter argument type while still
   // sending the param at runtime. Same intent as the `per_page` cast
   // used above.
-  const result = (await retrieveAProject({
+  const result = (await sdkGetProject({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,
       project_id_or_slug: projectSlug,
     },
     query: { collapse: "organization" },
-  } as unknown as Parameters<typeof retrieveAProject>[0])) as
+  } as unknown as Parameters<typeof sdkGetProject>[0])) as
     | { data: unknown; error: undefined }
     | { data: undefined; error: unknown };
 
@@ -586,7 +586,7 @@ export async function getProjectKeys(
 ): Promise<ProjectKey[]> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await listAProject_sClientKeys({
+  const result = await listProjectKeys({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,

--- a/src/lib/api/releases.ts
+++ b/src/lib/api/releases.ts
@@ -6,14 +6,14 @@
  */
 
 import {
-  createADeploy,
-  createANewReleaseForAnOrganization,
-  deleteAnOrganization_sRelease,
-  listAnOrganization_sReleases,
-  listAProject_sEnvironments,
-  listARelease_sDeploys,
-  retrieveAnOrganization_sRelease,
-  updateAnOrganization_sRelease,
+  createOrganizationRelease,
+  createOrganizationReleaseDeploy,
+  deleteOrganizationRelease,
+  getOrganizationRelease,
+  listOrganizationReleaseDeploys,
+  listOrganizationReleases,
+  listProjectEnvironments as sdkListProjectEnvironments,
+  updateOrganizationRelease,
 } from "@sentry/api";
 import type { SentryDeploy, SentryRelease } from "../../types/index.js";
 import { ApiError, ValidationError } from "../errors.js";
@@ -66,7 +66,7 @@ export async function listReleasesPaginated(
 ): Promise<PaginatedResponse<SentryRelease[]>> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await listAnOrganization_sReleases({
+  const result = await listOrganizationReleases({
     ...config,
     path: { organization_id_or_slug: orgSlug },
     // Most query params are supported at runtime but absent from the OpenAPI spec
@@ -161,7 +161,7 @@ export async function getRelease(
 ): Promise<SentryRelease> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await retrieveAnOrganization_sRelease({
+  const result = await getOrganizationRelease({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,
@@ -219,11 +219,11 @@ export async function createRelease(
 
   // Cast body through unknown — the SDK's body type requires `projects: string[]`
   // as non-optional, but the API accepts it as optional at runtime.
-  const result = await createANewReleaseForAnOrganization({
+  const result = await createOrganizationRelease({
     ...config,
     path: { organization_id_or_slug: orgSlug },
     body: body as unknown as Parameters<
-      typeof createANewReleaseForAnOrganization
+      typeof createOrganizationRelease
     >[0]["body"],
   });
 
@@ -263,14 +263,14 @@ export async function updateRelease(
 ): Promise<SentryRelease> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await updateAnOrganization_sRelease({
+  const result = await updateOrganizationRelease({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,
       version,
     },
     body: body as unknown as Parameters<
-      typeof updateAnOrganization_sRelease
+      typeof updateOrganizationRelease
     >[0]["body"],
   });
 
@@ -292,7 +292,7 @@ export async function deleteRelease(
 ): Promise<void> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await deleteAnOrganization_sRelease({
+  const result = await deleteOrganizationRelease({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,
@@ -316,7 +316,7 @@ export async function listReleaseDeploys(
 ): Promise<SentryDeploy[]> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await listARelease_sDeploys({
+  const result = await listOrganizationReleaseDeploys({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,
@@ -351,13 +351,15 @@ export async function createReleaseDeploy(
 ): Promise<SentryDeploy> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await createADeploy({
+  const result = await createOrganizationReleaseDeploy({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,
       version,
     },
-    body: body as unknown as Parameters<typeof createADeploy>[0]["body"],
+    body: body as unknown as Parameters<
+      typeof createOrganizationReleaseDeploy
+    >[0]["body"],
   });
 
   return unwrapResult<SentryDeploy>(result, "Failed to create deploy");
@@ -569,7 +571,7 @@ export async function listProjectEnvironments(
   projectSlug: string
 ): Promise<ProjectEnvironment[]> {
   const config = await getOrgSdkConfig(orgSlug);
-  const result = await listAProject_sEnvironments({
+  const result = await sdkListProjectEnvironments({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,

--- a/src/lib/api/repositories.ts
+++ b/src/lib/api/repositories.ts
@@ -4,7 +4,7 @@
  * Functions for listing Sentry repositories in an organization.
  */
 
-import { listAnOrganization_sRepositories } from "@sentry/api";
+import { listOrganizationRepos } from "@sentry/api";
 
 import type { SentryRepository } from "../../types/index.js";
 import { getCachedRepos, setCachedRepos } from "../db/repo-cache.js";
@@ -34,7 +34,7 @@ export async function listRepositories(
 ): Promise<SentryRepository[]> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await listAnOrganization_sRepositories({
+  const result = await listOrganizationRepos({
     ...config,
     path: { organization_id_or_slug: orgSlug },
   });
@@ -59,7 +59,7 @@ export async function listRepositoriesPaginated(
 ): Promise<PaginatedResponse<SentryRepository[]>> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await listAnOrganization_sRepositories({
+  const result = await listOrganizationRepos({
     ...config,
     path: { organization_id_or_slug: orgSlug },
     query: {

--- a/src/lib/api/teams.ts
+++ b/src/lib/api/teams.ts
@@ -5,10 +5,10 @@
  */
 
 import {
-  addAnOrganizationMemberToATeam,
-  createANewTeam,
-  listAnOrganization_sTeams,
-  listAProject_sTeams,
+  addOrganizationMemberTeam,
+  createOrganizationTeam,
+  listOrganizationTeams,
+  listProjectTeams as sdkListProjectTeams,
 } from "@sentry/api";
 // biome-ignore lint/performance/noNamespaceImport: Sentry SDK recommends namespace import
 import * as Sentry from "@sentry/node-core/light";
@@ -31,7 +31,7 @@ import {
 export async function listTeams(orgSlug: string): Promise<SentryTeam[]> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await listAnOrganization_sTeams({
+  const result = await listOrganizationTeams({
     ...config,
     path: { organization_id_or_slug: orgSlug },
   });
@@ -53,7 +53,7 @@ export async function listTeamsPaginated(
 ): Promise<PaginatedResponse<SentryTeam[]>> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await listAnOrganization_sTeams({
+  const result = await listOrganizationTeams({
     ...config,
     path: { organization_id_or_slug: orgSlug },
     query: {
@@ -80,7 +80,7 @@ export async function listProjectTeams(
   projectSlug: string
 ): Promise<SentryTeam[]> {
   const config = await getOrgSdkConfig(orgSlug);
-  const result = await listAProject_sTeams({
+  const result = await sdkListProjectTeams({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,
@@ -107,7 +107,7 @@ export async function createTeam(
   slug: string
 ): Promise<SentryTeam> {
   const config = await getOrgSdkConfig(orgSlug);
-  const result = await createANewTeam({
+  const result = await createOrganizationTeam({
     ...config,
     path: { organization_id_or_slug: orgSlug },
     body: { slug },
@@ -142,7 +142,7 @@ export async function addMemberToTeam(
   memberId: string
 ): Promise<void> {
   const config = await getOrgSdkConfig(orgSlug);
-  const result = await addAnOrganizationMemberToATeam({
+  const result = await addOrganizationMemberTeam({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,

--- a/src/lib/region.ts
+++ b/src/lib/region.ts
@@ -5,7 +5,7 @@
  * using cached data when available or fetching from the API when needed.
  */
 
-import { retrieveAnOrganization } from "@sentry/api";
+import { getOrganization } from "@sentry/api";
 import { getConfiguredSentryUrl } from "./constants.js";
 import { getOrgByNumericId, getOrgRegion, setOrgRegion } from "./db/regions.js";
 import { stripDsnOrgPrefix } from "./dsn/index.js";
@@ -74,7 +74,7 @@ async function resolveOrgRegionUncached(orgSlug: string): Promise<string> {
   const config = getSdkConfig(baseUrl);
 
   const result = await withAuthGuard(async () => {
-    const response = await retrieveAnOrganization({
+    const response = await getOrganization({
       ...config,
       path: { organization_id_or_slug: orgSlug },
     });

--- a/src/lib/sentry-client.ts
+++ b/src/lib/sentry-client.ts
@@ -710,7 +710,7 @@ export function getControlSiloUrl(): string {
  * @example
  * ```ts
  * const config = getSdkConfig("https://us.sentry.io");
- * const result = await listYourOrganizations({ ...config });
+ * const result = await listOrganizations({ ...config });
  * ```
  */
 export function getSdkConfig(regionUrl: string) {

--- a/src/types/sentry.ts
+++ b/src/types/sentry.ts
@@ -16,7 +16,7 @@
 import type {
   IssueEventDetailsResponse,
   DeployResponse as SdkDeployResponse,
-  RetrieveAnIssueResponse as SdkIssueDetail,
+  GetOrganizationIssueResponse as SdkIssueDetail,
   ListOrganizations as SdkOrganizationList,
   ProjectKey as SdkProjectKey,
   OrganizationProjectResponseDict as SdkProjectList,
@@ -25,8 +25,8 @@ import type {
 } from "@sentry/api";
 import {
   zBaseTeam,
+  zGetOrganizationIssueResponse,
   zGroupEventsResponseDict,
-  zRetrieveAnIssueResponse,
 } from "@sentry/api/zod";
 import { z } from "zod";
 
@@ -118,7 +118,7 @@ export const ISSUE_STATUSES = [
 export type IssueStatus = (typeof ISSUE_STATUSES)[number];
 
 // Note: a reverse exhaustiveness check (SDK → ISSUE_STATUSES) is not possible here
-// because RetrieveAnIssueResponses is a union of all HTTP response types, one of which
+// because GetOrganizationIssueResponses is a union of all HTTP response types, one of which
 // has `status: string` (loose), making SdkIssueDetail["status"] resolve to `string`.
 // The `satisfies` above catches the forward direction (invalid values in our tuple).
 
@@ -184,7 +184,7 @@ export type SentryIssue = Omit<Partial<SdkIssueDetail>, "metadata"> & {
  * present in most responses; optionality reflects the TypeScript type.
  */
 /**
- * Derived from the auto-generated `zRetrieveAnIssueResponse` schema.
+ * Derived from the auto-generated `zGetOrganizationIssueResponse` schema.
  *
  * The generated schema makes all API-documented fields required. We widen it
  * with `.partial()` so only the core identifiers (id, shortId, title) are
@@ -192,7 +192,7 @@ export type SentryIssue = Omit<Partial<SdkIssueDetail>, "metadata"> & {
  * Extra fields not in the OpenAPI spec (substatus, priority, isUnhandled,
  * seerFixabilityScore) are added via `.extend()`.
  */
-export const SentryIssueSchema = zRetrieveAnIssueResponse
+export const SentryIssueSchema = zGetOrganizationIssueResponse
   .pick({
     id: true,
     shortId: true,
@@ -214,37 +214,37 @@ export const SentryIssueSchema = zRetrieveAnIssueResponse
     id: z.string().describe("Numeric issue ID"),
     shortId: z.string().describe("Human-readable short ID (e.g. PROJ-ABC)"),
     title: z.string().describe("Issue title"),
-    culprit: zRetrieveAnIssueResponse.shape.culprit
+    culprit: zGetOrganizationIssueResponse.shape.culprit
       .optional()
       .describe("Culprit string"),
-    count: zRetrieveAnIssueResponse.shape.count
+    count: zGetOrganizationIssueResponse.shape.count
       .optional()
       .describe("Total event count"),
-    userCount: zRetrieveAnIssueResponse.shape.userCount
+    userCount: zGetOrganizationIssueResponse.shape.userCount
       .optional()
       .describe("Number of affected users"),
-    firstSeen: zRetrieveAnIssueResponse.shape.firstSeen
+    firstSeen: zGetOrganizationIssueResponse.shape.firstSeen
       .optional()
       .describe("First occurrence (ISO 8601)"),
-    lastSeen: zRetrieveAnIssueResponse.shape.lastSeen
+    lastSeen: zGetOrganizationIssueResponse.shape.lastSeen
       .optional()
       .describe("Most recent occurrence (ISO 8601)"),
-    level: zRetrieveAnIssueResponse.shape.level
+    level: zGetOrganizationIssueResponse.shape.level
       .optional()
       .describe("Severity level"),
-    status: zRetrieveAnIssueResponse.shape.status
+    status: zGetOrganizationIssueResponse.shape.status
       .optional()
       .describe("Issue status"),
-    permalink: zRetrieveAnIssueResponse.shape.permalink
+    permalink: zGetOrganizationIssueResponse.shape.permalink
       .optional()
       .describe("URL to the issue in Sentry"),
-    project: zRetrieveAnIssueResponse.shape.project
+    project: zGetOrganizationIssueResponse.shape.project
       .optional()
       .describe("Project info"),
-    metadata: zRetrieveAnIssueResponse.shape.metadata
+    metadata: zGetOrganizationIssueResponse.shape.metadata
       .optional()
       .describe("Issue metadata"),
-    assignedTo: zRetrieveAnIssueResponse.shape.assignedTo
+    assignedTo: zGetOrganizationIssueResponse.shape.assignedTo
       .optional()
       .describe("Assigned user or team"),
     priority: z.string().optional().describe("Triage priority"),

--- a/test/commands/project/list.test.ts
+++ b/test/commands/project/list.test.ts
@@ -685,7 +685,7 @@ describe("handleProjectSearch", () => {
         );
       }
 
-      // getProject (SDK retrieveAProject) hits /projects/{org}/{slug}/
+      // getProject (SDK getProject) hits /projects/{org}/{slug}/
       // Return 404 to simulate project not found
       return new Response(JSON.stringify({ detail: "Not found" }), {
         status: 404,

--- a/test/lib/api-client.coverage.test.ts
+++ b/test/lib/api-client.coverage.test.ts
@@ -1909,7 +1909,7 @@ describe("events.ts (findEventAcrossOrgs)", () => {
           }
         );
       }
-      // resolveAnEventId
+      // resolveOrganizationEventId
       if (req.url.includes("/eventids/")) {
         return new Response(JSON.stringify(resolved), {
           status: 200,

--- a/test/lib/api-schema.test.ts
+++ b/test/lib/api-schema.test.ts
@@ -83,11 +83,11 @@ describe("getEndpointsByResource", () => {
 
 describe("getEndpoint", () => {
   test("finds specific endpoint by operationId substring", () => {
-    const ep = getEndpoint("issues", "Retrieve an Issue");
+    const ep = getEndpoint("issues", "getOrganizationIssue");
     expect(ep).toBeDefined();
     expect(ep?.resource).toBe("issues");
     expect(ep?.method).toBe("GET");
-    expect(ep?.fn).toBe("retrieveAnIssue");
+    expect(ep?.fn).toBe("getOrganizationIssue");
   });
 
   test("is case-insensitive", () => {


### PR DESCRIPTION
## What

Bumps `@sentry/api` `^0.180.0` → `^0.253.0` and migrates every SDK call site from the old normalizer-derived names to the clean token `operationId`s produced by the [operationId migration](https://github.com/getsentry/sentry-api-schema/issues/76).

Examples of the rename (34 symbols across 12 files):
- `retrieveAnOrganization` → `getOrganization`
- `listAnOrganization_sIssues` → `listOrganizationIssues`
- `queryExploreEventsInTableFormat` → `listOrganizationEvents`
- `retrieveAnOrganization_sRelease` → `getOrganizationRelease`
- `createANewProject` → `createTeamProject`, `listAProject_sClientKeys` → `listProjectKeys`, etc.

## Aliasing for name collisions

A few new tokens (`getOrganization`, `getProject`, `deleteProject`, `listProjectEnvironments`, `listProjectTeams`) collide with the CLI's own wrapper functions of the same name — the old verbose names never did. Those SDK imports are aliased (`getOrganization as sdkGetOrganization`, …), following the `sdk*` aliasing convention already used elsewhere in the codebase.

## Notes

- **No behavior change** — pure rename + version bump. The response/param shapes the CLI uses are unchanged across 0.180→0.253 (the earlier 0.180 bump already handled downstream type/shape adaptations).
- `generate:sdk` is unaffected (it generates the CLI's own command SDK, not from `@sentry/api`).

## Test plan

- `tsc --noEmit`: clean
- unit tests: API-lib (223), types + commands (2250) — all green