### PR TITLE
fix(release): make set-commits --clear actually clear commits

### DIFF
--- a/src/commands/release/set-commits.ts
+++ b/src/commands/release/set-commits.ts
@@ -10,7 +10,6 @@ import {
   setCommitsAuto,
   setCommitsLocal,
   setCommitsWithRefs,
-  updateRelease,
 } from "../../lib/api-client.js";
 import { buildCommand, numberParser } from "../../lib/command.js";
 import { getDatabase } from "../../lib/db/index.js";
@@ -278,11 +277,13 @@ export const setCommitsCommand = buildCommand({
       cwd
     );
 
-    // Clear mode: remove all commits regardless of other flags
+    // Clear mode: remove all commits regardless of other flags.
+    // The server only clears commits when it receives an explicitly-empty
+    // `refs` array — an empty `commits` list is treated as "no change" and
+    // silently no-ops. setCommitsWithRefs sends `{ refs: [] }`, which triggers
+    // release.clear_commits() server-side.
     if (flags.clear) {
-      const release = await updateRelease(org, version, {
-        commits: [],
-      });
+      const release = await setCommitsWithRefs(org, version, []);
       yield new CommandOutput(release);
       return;
     }

--- a/test/commands/release/set-commits.test.ts
+++ b/test/commands/release/set-commits.test.ts
@@ -208,6 +208,46 @@ describe("release set-commits --commit", () => {
   });
 });
 
+describe("release set-commits --clear", () => {
+  let setCommitsWithRefsSpy: ReturnType<typeof spyOn>;
+  let resolveOrgSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    setCommitsWithRefsSpy = vi.spyOn(apiClient, "setCommitsWithRefs");
+    resolveOrgSpy = vi.spyOn(resolveTarget, "resolveOrg");
+  });
+
+  afterEach(() => {
+    setCommitsWithRefsSpy.mockRestore();
+    resolveOrgSpy.mockRestore();
+  });
+
+  // The server only clears commits when it receives an explicitly-empty
+  // `refs` array; an empty `commits` list silently no-ops. This guards
+  // against regressing back to the `updateRelease({ commits: [] })` path.
+  test("sends an empty refs array to clear commits", async () => {
+    resolveOrgSpy.mockResolvedValue({ org: "my-org" });
+    setCommitsWithRefsSpy.mockResolvedValue(sampleRelease);
+
+    const { context } = createMockContext();
+    const func = await setCommitsCommand.loader();
+    await func.call(
+      context,
+      {
+        auto: false,
+        local: false,
+        clear: true,
+        commit: undefined,
+        "initial-depth": 20,
+        json: true,
+      },
+      "1.0.0"
+    );
+
+    expect(setCommitsWithRefsSpy).toHaveBeenCalledWith("my-org", "1.0.0", []);
+  });
+});
+
 describe("release set-commits --auto", () => {
   let setCommitsAutoSpy: ReturnType<typeof spyOn>;
   let resolveOrgSpy: ReturnType<typeof spyOn>;


### PR DESCRIPTION
## Summary

`sentry release set-commits <version> --clear` reported success but left the commits attached in Sentry. This makes `--clear` actually remove them.

Reported in the last comment of #1156 (against the nightly build): "`sentry release set-commits org/version --clear` doesn't seem to work."

## What changed

`--clear` used to send `{ commits: [] }` via `updateRelease`. But the Sentry release PUT endpoint (`organization_release_details.py`) only runs `release.clear_commits()` when it receives an explicitly-empty `refs` array — an empty `commits` list is falsy server-side and hits no branch, so it silently no-ops:

```python
commit_list = result.get("commits")
if commit_list:            # [] is falsy -> skipped
    release.set_commits(commit_list)

refs = result.get("refs")
if not refs:
    ...
    else:
        if result.get("refs") == []:   # only True when refs:[] is sent
            release.clear_commits()
```

Now `--clear` routes through the existing `setCommitsWithRefs(org, version, [])`, which sends `{ refs: [] }` and triggers `clear_commits()`. This also drops the now-unused `updateRelease` import from the command.

## Test plan

- `pnpm vitest run test/commands/release/set-commits.test.ts` — 15 pass (1 new: asserts `--clear` calls `setCommitsWithRefs` with an empty refs array).
- Lint + biome clean on both touched files.

Made with [Cursor](https://cursor.com)