### PR TITLE
feat(react-native): close remaining legacy parity gaps

### DIFF
--- a/docs/src/fragments/commands/react-native.md
+++ b/docs/src/fragments/commands/react-native.md
@@ -31,12 +31,10 @@ build phase. It has three modes:
 
 Release/distribution come from `SENTRY_RELEASE`/`SENTRY_DIST` or the app's
 `Info.plist` (`<CFBundleIdentifier>@<CFBundleShortVersionString>+<CFBundleVersion>`),
-unless `--no-auto-release` is set. Pass extra build-script arguments after the
-flags.
-
-Limitations vs. the legacy CLI: `Info.plist` C preprocessing
-(`INFOPLIST_PREPROCESS`) and `xcodebuild`-based discovery outside an Xcode build
-are not supported — set `SENTRY_RELEASE`/`SENTRY_DIST` in those cases.
+unless `--no-auto-release` is set. When run outside an Xcode build phase the
+release is discovered via `xcodebuild`; `--allow-xcode-infoplist-preprocessing`
+enables `cc`-based `INFOPLIST_PREPROCESS` handling. Pass extra build-script
+arguments after the flags.
 
 ## Important Notes
 
@@ -47,6 +45,6 @@ are not supported — set `SENTRY_RELEASE`/`SENTRY_DIST` in those cases.
   them under the `~/<filename>` convention. Without `--release` the files are
   matched by debug ID; with `--release` they are also uploaded for each
   `--dist`.
-- Indexed RAM bundles are not supported — use a plain or Hermes bundle.
-- The CLI always waits for server-side assembly; `--wait`/`--wait-for` are
-  accepted for backward compatibility but do not change behavior.
+- `--wait`/`--wait-for` block until the server finishes processing the upload.
+- Indexed/file RAM bundles (a pre-Hermes format that React Native has since
+  deprecated) are not supported — use a plain or Hermes bundle.

--- a/plugins/sentry-cli/skills/sentry-cli/references/react-native.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/react-native.md
@@ -33,9 +33,10 @@ Upload React Native sourcemaps (Xcode build step)
 - `--fetch-from <value> - Packager URL to fetch from (default: http://127.0.0.1:8081/)`
 - `--build-script <value> - Path to the react-native-xcode.sh build script`
 - `--dist <value>... - Distribution(s) to publish (repeatable)`
-- `--wait - Accepted for compatibility (the CLI always waits for assembly)`
-- `--wait-for <value> - Accepted for compatibility (the CLI always waits for assembly)`
+- `--wait - Wait for the server to fully process the uploaded files`
+- `--wait-for <value> - Wait for processing, but at most this many seconds`
 - `--no-auto-release - Don't read the release from Xcode project files`
+- `--allow-xcode-infoplist-preprocessing - Run the C preprocessor over Info.plist (INFOPLIST_PREPROCESS)`
 
 **Examples:**
 

--- a/plugins/sentry-cli/skills/sentry-cli/references/react-native.md
+++ b/plugins/sentry-cli/skills/sentry-cli/references/react-native.md
@@ -20,8 +20,8 @@ Upload a React Native bundle + sourcemap (Gradle build step)
 - `--bundle <value> - Path to the bundle to upload`
 - `--release <value> - Release version to publish to`
 - `--dist <value>... - Distribution(s) to publish (repeatable; requires --release)`
-- `--wait - Accepted for compatibility (the CLI always waits for assembly)`
-- `--wait-for <value> - Accepted for compatibility (the CLI always waits for assembly)`
+- `--wait - Wait for the server to fully process the uploaded files`
+- `--wait-for <value> - Wait for processing, but at most this many seconds`
 
 ### `sentry react-native xcode <script-arg...>`
 

--- a/src/commands/react-native/gradle.ts
+++ b/src/commands/react-native/gradle.ts
@@ -13,7 +13,10 @@ import { readFile, stat } from "node:fs/promises";
 import { basename, resolve } from "node:path";
 import type { SentryContext } from "../../context.js";
 import type { ArtifactFile } from "../../lib/api/sourcemaps.js";
-import { uploadSourcemaps } from "../../lib/api/sourcemaps.js";
+import {
+  resolveUploadWait,
+  uploadSourcemaps,
+} from "../../lib/api/sourcemaps.js";
 import { buildCommand } from "../../lib/command.js";
 import { ContextError, ValidationError } from "../../lib/errors.js";
 import { mdKvTable, renderMarkdown } from "../../lib/formatters/markdown.js";
@@ -124,8 +127,9 @@ export const gradleCommand = buildCommand({
       "convention.\n\n" +
       "Without `--release`, files are matched by debug ID. With `--release`, " +
       "they are also uploaded for each `--dist`.\n\n" +
-      "Note: the CLI always waits for server-side assembly; `--wait`/" +
-      "`--wait-for` are accepted for compatibility.",
+      "Use `--wait`/`--wait-for` to block until the server finishes processing " +
+      "the upload. Indexed/file RAM bundles (a pre-Hermes format) are not " +
+      "supported; use a plain or Hermes bundle.",
   },
   output: {
     human: formatGradleResult,
@@ -188,6 +192,7 @@ export const gradleCommand = buildCommand({
     const { debugId } = await injectDebugId(bundlePath, sourcemapPath);
     const files = buildArtifacts(bundlePath, sourcemapPath, debugId);
 
+    const { wait, maxWaitMs } = resolveUploadWait(flags);
     const dists = flags.dist ?? [];
     let uploads = 0;
     if (flags.release && dists.length > 0) {
@@ -201,11 +206,20 @@ export const gradleCommand = buildCommand({
           release: flags.release,
           dist,
           files,
+          wait,
+          maxWaitMs,
         });
         uploads += 1;
       }
     } else {
-      await uploadSourcemaps({ org, project, release: flags.release, files });
+      await uploadSourcemaps({
+        org,
+        project,
+        release: flags.release,
+        files,
+        wait,
+        maxWaitMs,
+      });
       uploads = 1;
     }
 

--- a/src/commands/react-native/gradle.ts
+++ b/src/commands/react-native/gradle.ts
@@ -161,13 +161,13 @@ export const gradleCommand = buildCommand({
       },
       wait: {
         kind: "boolean",
-        brief: "Accepted for compatibility (the CLI always waits for assembly)",
+        brief: "Wait for the server to fully process the uploaded files",
         optional: true,
       },
       "wait-for": {
         kind: "parsed",
         parse: Number,
-        brief: "Accepted for compatibility (the CLI always waits for assembly)",
+        brief: "Wait for processing, but at most this many seconds",
         optional: true,
       },
     },

--- a/src/commands/react-native/xcode.ts
+++ b/src/commands/react-native/xcode.ts
@@ -22,7 +22,10 @@ import { basename, join, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { SentryContext } from "../../context.js";
 import type { ArtifactFile } from "../../lib/api/sourcemaps.js";
-import { uploadSourcemaps } from "../../lib/api/sourcemaps.js";
+import {
+  resolveUploadWait,
+  uploadSourcemaps,
+} from "../../lib/api/sourcemaps.js";
 import { buildCommand } from "../../lib/command.js";
 import { ContextError, ValidationError } from "../../lib/errors.js";
 import { mdKvTable, renderMarkdown } from "../../lib/formatters/markdown.js";
@@ -59,6 +62,7 @@ type XcodeFlags = {
   wait?: boolean;
   "wait-for"?: number;
   "no-auto-release"?: boolean;
+  "allow-xcode-infoplist-preprocessing"?: boolean;
 };
 
 /** Structured result for the xcode command. */
@@ -330,7 +334,8 @@ async function uploadPair(
   const { release, dist } = await resolveReleaseAndDist(
     ctx.env,
     ctx.cwd,
-    flags["no-auto-release"] ?? false
+    flags["no-auto-release"] ?? false,
+    flags["allow-xcode-infoplist-preprocessing"] ?? false
   );
   // Explicit --dist overrides the environment/plist-derived distribution.
   let dists: string[] = [];
@@ -340,14 +345,23 @@ async function uploadPair(
     dists = [dist];
   }
 
+  const { wait, maxWaitMs } = resolveUploadWait(flags);
   let uploads = 0;
   if (dists.length > 0) {
     for (const d of dists) {
-      await uploadSourcemaps({ org, project, release, dist: d, files });
+      await uploadSourcemaps({
+        org,
+        project,
+        release,
+        dist: d,
+        files,
+        wait,
+        maxWaitMs,
+      });
       uploads += 1;
     }
   } else {
-    await uploadSourcemaps({ org, project, release, files });
+    await uploadSourcemaps({ org, project, release, files, wait, maxWaitMs });
     uploads = 1;
   }
   return { debugId, release, dist: dists, uploads };
@@ -411,9 +425,9 @@ export const xcodeCommand = buildCommand({
       "`--allow-fetch` they are fetched from the packager; in a debug build " +
       "the script simply runs.\n\n" +
       "Release/distribution come from `SENTRY_RELEASE`/`SENTRY_DIST` or the " +
-      "app Info.plist (unless `--no-auto-release`). The CLI always waits for " +
-      "server-side assembly; `--wait`/`--wait-for` are accepted for " +
-      "compatibility.",
+      "app Info.plist (unless `--no-auto-release`); outside an Xcode build the " +
+      "release is discovered via `xcodebuild`. Use `--wait`/`--wait-for` to " +
+      "block until the server finishes processing the upload.",
   },
   auth: false,
   output: {
@@ -452,18 +466,23 @@ export const xcodeCommand = buildCommand({
       },
       wait: {
         kind: "boolean",
-        brief: "Accepted for compatibility (the CLI always waits for assembly)",
+        brief: "Wait for the server to fully process the uploaded files",
         optional: true,
       },
       "wait-for": {
         kind: "parsed",
         parse: Number,
-        brief: "Accepted for compatibility (the CLI always waits for assembly)",
+        brief: "Wait for processing, but at most this many seconds",
         optional: true,
       },
       "no-auto-release": {
         kind: "boolean",
         brief: "Don't read the release from Xcode project files",
+        optional: true,
+      },
+      "allow-xcode-infoplist-preprocessing": {
+        kind: "boolean",
+        brief: "Run the C preprocessor over Info.plist (INFOPLIST_PREPROCESS)",
         optional: true,
       },
     },

--- a/src/lib/api/chunk-upload.ts
+++ b/src/lib/api/chunk-upload.ts
@@ -467,14 +467,17 @@ export async function uploadMissingBufferChunks(params: {
  * Poll an assemble endpoint until the server reports completion.
  *
  * Re-sends the same assemble body on each poll (the server uses
- * the checksum to look up existing assembly state). Returns when
- * the state is `"ok"` or `"created"`. Throws on `"error"` or timeout.
+ * the checksum to look up existing assembly state). By default returns when
+ * the state is `"ok"` or `"created"`; set `waitForOk` to block until the server
+ * finishes processing (`"ok"` only). Throws on `"error"` or timeout.
  *
  * @param params.regionUrl - Region base URL
  * @param params.endpoint - The endpoint path to POST to
  * @param params.body - The request body to send on each poll
  * @param params.entityName - Human-readable name for error messages
  * @param params.schema - Zod schema for the response (defaults to {@link AssembleResponseSchema})
+ * @param params.waitForOk - Keep polling on `"created"`, returning only on `"ok"`
+ * @param params.deadlineMs - Override the default poll timeout window
  */
 export async function pollAssembly(params: {
   regionUrl: string;
@@ -482,6 +485,8 @@ export async function pollAssembly(params: {
   body: unknown;
   entityName: string;
   schema?: z.ZodType<AssembleResponse>;
+  waitForOk?: boolean;
+  deadlineMs?: number;
 }): Promise<void> {
   const {
     regionUrl,
@@ -489,8 +494,10 @@ export async function pollAssembly(params: {
     body,
     entityName,
     schema = AssembleResponseSchema,
+    waitForOk = false,
+    deadlineMs = ASSEMBLE_MAX_WAIT_MS,
   } = params;
-  const deadline = Date.now() + ASSEMBLE_MAX_WAIT_MS;
+  const deadline = Date.now() + deadlineMs;
 
   while (Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, ASSEMBLE_POLL_INTERVAL_MS));
@@ -505,7 +512,13 @@ export async function pollAssembly(params: {
       }
     );
 
-    if (pollResult.state === "ok" || pollResult.state === "created") {
+    if (pollResult.state === "ok") {
+      return;
+    }
+
+    // When not waiting for full processing, an accepted ("created") bundle is
+    // sufficient; otherwise keep polling until it flips to "ok".
+    if (pollResult.state === "created" && !waitForOk) {
       return;
     }
 
@@ -517,13 +530,13 @@ export async function pollAssembly(params: {
         endpoint
       );
     }
-    // "not_found" or "assembling" — keep polling
+    // "not_found", "assembling", or ("created" while waiting) — keep polling
   }
 
   throw new ApiError(
     `${entityName} assembly timed out`,
     408,
-    `Assembly did not complete within ${ASSEMBLE_MAX_WAIT_MS / 1000}s`,
+    `Assembly did not complete within ${deadlineMs / 1000}s`,
     endpoint
   );
 }

--- a/src/lib/api/sourcemaps.ts
+++ b/src/lib/api/sourcemaps.ts
@@ -99,7 +99,36 @@ export type UploadOptions = {
   dist?: string;
   /** Files to upload (must already have debug IDs injected). */
   files: ArtifactFile[];
+  /**
+   * Block until the server finishes processing the uploaded bundle (state
+   * `"ok"`), not just accepting it (`"created"`). Defaults to `false`, which
+   * returns as soon as the chunks are assembled.
+   */
+  wait?: boolean;
+  /** Cap on the {@link wait} poll, in milliseconds. Ignored unless `wait`. */
+  maxWaitMs?: number;
 };
+
+/** Default cap on server-side processing wait (5 minutes), matching the legacy CLI. */
+export const DEFAULT_UPLOAD_MAX_WAIT_MS = 300_000;
+
+/**
+ * Translate `--wait`/`--wait-for` flags into {@link UploadOptions} wait config.
+ *
+ * `--wait` blocks until fully processed; `--wait-for <secs>` does the same but
+ * caps the poll. Either flag enables waiting.
+ */
+export function resolveUploadWait(flags: {
+  wait?: boolean;
+  "wait-for"?: number;
+}): { wait: boolean; maxWaitMs: number } {
+  const waitFor = flags["wait-for"];
+  return {
+    wait: flags.wait === true || waitFor !== undefined,
+    maxWaitMs:
+      waitFor !== undefined ? waitFor * 1000 : DEFAULT_UPLOAD_MAX_WAIT_MS,
+  };
+}
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -207,7 +236,7 @@ export async function buildArtifactBundle(
  * @throws {ApiError} If the upload or assembly fails
  */
 export async function uploadSourcemaps(options: UploadOptions): Promise<void> {
-  const { org, project, release, dist, files } = options;
+  const { org, project, release, dist, files, wait, maxWaitMs } = options;
 
   // Step 1: Get chunk upload configuration
   const serverOptions = await getChunkUploadOptions(org);
@@ -239,6 +268,8 @@ export async function uploadSourcemaps(options: UploadOptions): Promise<void> {
       dist,
       serverOptions,
       encoding,
+      wait: wait ?? false,
+      maxWaitMs: maxWaitMs ?? DEFAULT_UPLOAD_MAX_WAIT_MS,
     });
   } finally {
     // Always clean up the temp file
@@ -263,9 +294,20 @@ async function uploadArtifactBundle(opts: {
   dist: string | undefined;
   serverOptions: ChunkServerOptions;
   encoding: UploadEncoding | undefined;
+  wait: boolean;
+  maxWaitMs: number;
 }): Promise<void> {
-  const { tmpZipPath, org, project, release, dist, serverOptions, encoding } =
-    opts;
+  const {
+    tmpZipPath,
+    org,
+    project,
+    release,
+    dist,
+    serverOptions,
+    encoding,
+    wait,
+    maxWaitMs,
+  } = opts;
   // Step 3: Split into chunks, hash each chunk + compute overall checksum
   const { chunks, overallChecksum } = await hashChunks(
     tmpZipPath,
@@ -294,11 +336,6 @@ async function uploadArtifactBundle(opts: {
     }
   );
 
-  // If already assembled, we're done
-  if (firstAssemble.state === "ok" || firstAssemble.state === "created") {
-    return;
-  }
-
   // Fail fast on server-side assembly error
   if (firstAssemble.state === "error") {
     throw new ApiError(
@@ -309,7 +346,18 @@ async function uploadArtifactBundle(opts: {
     );
   }
 
-  // Step 5: Upload missing chunks in parallel
+  // Fully assembled — nothing more to do regardless of wait.
+  if (firstAssemble.state === "ok") {
+    return;
+  }
+
+  // Accepted but not yet processed. Without --wait we're done; with --wait we
+  // fall through to poll for full processing.
+  if (firstAssemble.state === "created" && !wait) {
+    return;
+  }
+
+  // Step 5: Upload missing chunks in parallel (a no-op when none are missing).
   await uploadMissingChunks({
     chunks,
     missingChecksums: new Set(firstAssemble.missingChunks ?? []),
@@ -319,11 +367,14 @@ async function uploadArtifactBundle(opts: {
     regionUrl,
   });
 
-  // Step 6: Poll assemble endpoint until done
+  // Step 6: Poll assemble endpoint. With --wait, block until fully processed
+  // ("ok"); otherwise return as soon as the chunks are accepted ("created").
   await pollAssembly({
     regionUrl,
     endpoint: assembleEndpoint,
     body: assembleBody,
     entityName: "Artifact bundle",
+    waitForOk: wait,
+    deadlineMs: maxWaitMs,
   });
 }

--- a/src/lib/api/sourcemaps.ts
+++ b/src/lib/api/sourcemaps.ts
@@ -19,7 +19,7 @@
 import { readFile, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { ApiError } from "../errors.js";
+import { ApiError, ValidationError } from "../errors.js";
 import { resolveOrgRegion } from "../region.js";
 import { type ZipCompression, ZipWriter } from "../sourcemap/zip.js";
 import {
@@ -123,6 +123,12 @@ export function resolveUploadWait(flags: {
   "wait-for"?: number;
 }): { wait: boolean; maxWaitMs: number } {
   const waitFor = flags["wait-for"];
+  if (waitFor !== undefined && (!Number.isFinite(waitFor) || waitFor <= 0)) {
+    throw new ValidationError(
+      "--wait-for must be a positive number of seconds.",
+      "wait-for"
+    );
+  }
   return {
     wait: flags.wait === true || waitFor !== undefined,
     maxWaitMs:

--- a/src/lib/react-native/xcode-env.ts
+++ b/src/lib/react-native/xcode-env.ts
@@ -6,8 +6,16 @@
  * release/distribution from the build environment or the project `Info.plist`.
  */
 
+import { execFileSync } from "node:child_process";
+import { readdirSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { logger } from "../logger.js";
+
+const log = logger.withTag("react-native.xcode-env");
+
+/** Matches runs of whitespace (splitting preprocessor flag/definition tokens). */
+const WHITESPACE = /\s+/;
 
 /** Bundle identity extracted from an `Info.plist` or the build environment. */
 export type InfoPlist = {
@@ -121,50 +129,243 @@ function plistComplete(p: Partial<InfoPlist>): p is InfoPlist {
   return Boolean(p.name && p.bundleId && p.version && p.build);
 }
 
-/**
- * Discover the app's bundle identity from the Xcode build environment.
- *
- * Handles the common case of running inside an Xcode build phase
- * (`XCODE_VERSION_ACTUAL` set): reads `INFOPLIST_FILE` (expanding `$(VAR)`
- * references from the environment) and falls back to build-setting env vars.
- * Returns `null` when the identity cannot be determined.
- *
- * Not supported (returns `null` / falls back): `INFOPLIST_PREPROCESS` C
- * preprocessing, and discovery via `xcodebuild` when run outside Xcode.
- */
-export async function discoverInfoPlist(
-  env: Env,
-  cwd: string
-): Promise<InfoPlist | null> {
-  if (!env.XCODE_VERSION_ACTUAL) {
+/** Run a command, returning stdout or `null` if it fails / is unavailable. */
+function runCapture(cmd: string, args: string[]): string | null {
+  try {
+    return execFileSync(cmd, args, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch (err) {
+    log.debug(`${cmd} invocation failed`, err);
     return null;
   }
-  const filename = env.INFOPLIST_FILE;
-  if (!filename) {
-    return fromEnvVars(env);
-  }
-  const path = join(cwd, env.PROJECT_DIR ?? ".", filename);
-  let raw: Record<string, string>;
-  try {
-    raw = parseInfoPlistStrings(await readFile(path, "utf-8"));
-  } catch {
-    return fromEnvVars(env);
-  }
-  const parsed: Partial<InfoPlist> = {
+}
+
+/** Extract the four CFBundle* fields from a parsed plist string map. */
+function toPartialPlist(raw: Record<string, string>): Partial<InfoPlist> {
+  return {
     name: raw.CFBundleName,
     bundleId: raw.CFBundleIdentifier,
     version: raw.CFBundleShortVersionString,
     build: raw.CFBundleVersion,
   };
-  if (!plistComplete(parsed)) {
-    return fromEnvVars(env);
+}
+
+/**
+ * Run the C preprocessor over an `Info.plist` (`INFOPLIST_PREPROCESS=YES`),
+ * mirroring the legacy `cc -xc -P -E` invocation with the project's
+ * preprocessor flags/definitions. Returns the parsed strings or `null`.
+ */
+function preprocessPlist(
+  path: string,
+  vars: Env
+): Record<string, string> | null {
+  const args = ["-xc", "-P", "-E"];
+  const other = vars.INFOPLIST_OTHER_PREPROCESSOR_FLAGS;
+  if (other) {
+    args.push(...other.split(WHITESPACE).filter(Boolean));
+  }
+  const defs = vars.INFOPLIST_PREPROCESSOR_DEFINITIONS;
+  if (defs) {
+    for (const token of defs.split(WHITESPACE).filter(Boolean)) {
+      args.push(`-D${token}`);
+    }
+  }
+  args.push(path);
+  const out = runCapture("cc", args);
+  return out ? parseInfoPlistStrings(out) : null;
+}
+
+/**
+ * Load an `Info.plist` and expand its build-setting variables.
+ *
+ * When `allowPreprocessing` is set and `INFOPLIST_PREPROCESS=YES`, the plist is
+ * run through `cc` first (some project templates use `#include`/macros). Falls
+ * back to build-setting env vars when the plist is missing or incomplete (e.g.
+ * the storyboard-only partial `Info.plist` newer Xcode templates emit).
+ */
+async function loadAndProcess(
+  path: string,
+  vars: Env,
+  allowPreprocessing: boolean
+): Promise<InfoPlist | null> {
+  const shouldPreprocess =
+    allowPreprocessing && vars.INFOPLIST_PREPROCESS === "YES";
+  let raw: Record<string, string> | null = null;
+  if (shouldPreprocess) {
+    raw = preprocessPlist(path, vars);
+  } else {
+    try {
+      raw = parseInfoPlistStrings(await readFile(path, "utf-8"));
+    } catch (err) {
+      log.debug("Could not read Info.plist", err);
+    }
+  }
+  const parsed = raw ? toPartialPlist(raw) : {};
+  const base = plistComplete(parsed) ? parsed : fromEnvVars(vars);
+  if (!base) {
+    return null;
   }
   return {
-    name: expandXcodeVars(parsed.name, env),
-    bundleId: expandXcodeVars(parsed.bundleId, env),
-    version: expandXcodeVars(parsed.version, env),
-    build: expandXcodeVars(parsed.build, env),
+    name: expandXcodeVars(base.name, vars),
+    bundleId: expandXcodeVars(base.bundleId, vars),
+    version: expandXcodeVars(base.version, vars),
+    build: expandXcodeVars(base.build, vars),
   };
+}
+
+/** Minimal `xcodebuild -list` project info. */
+type XcodeProjectInfo = {
+  path: string;
+  targets: string[];
+  configurations: string[];
+};
+
+/** Locate a single `.xcodeproj` under `cwd` and read its targets/configs. */
+function getXcodeProjectInfo(cwd: string): XcodeProjectInfo | null {
+  let projectPath: string | null = null;
+  if (cwd.endsWith(".xcodeproj")) {
+    projectPath = cwd;
+  } else {
+    let entries: string[] = [];
+    try {
+      entries = readdirSync(cwd);
+    } catch (err) {
+      log.debug("Could not read directory for .xcodeproj discovery", err);
+      return null;
+    }
+    const projects = entries
+      .filter((name) => name.endsWith(".xcodeproj"))
+      .map((name) => join(cwd, name));
+    if (projects.length === 1) {
+      projectPath = projects[0] ?? null;
+    }
+  }
+  if (!projectPath) {
+    return null;
+  }
+  const out = runCapture("xcodebuild", [
+    "-list",
+    "-json",
+    "-project",
+    projectPath,
+  ]);
+  if (!out) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(out) as {
+      project?: { targets?: string[]; configurations?: string[] };
+    };
+    if (!parsed.project) {
+      return null;
+    }
+    return {
+      path: resolve(projectPath),
+      targets: parsed.project.targets ?? [],
+      configurations: parsed.project.configurations ?? [],
+    };
+  } catch (err) {
+    log.debug("Malformed xcodebuild -list JSON", err);
+    return null;
+  }
+}
+
+/** Parse `xcodebuild -showBuildSettings` output into a build-var map. */
+function getBuildVars(
+  projectPath: string,
+  target: string,
+  configuration: string
+): Record<string, string> {
+  const out = runCapture("xcodebuild", [
+    "-showBuildSettings",
+    "-project",
+    projectPath,
+    "-target",
+    target,
+    "-configuration",
+    configuration,
+  ]);
+  const vars: Record<string, string> = {};
+  if (!out) {
+    return vars;
+  }
+  for (const line of out.split("\n")) {
+    if (!line.startsWith("    ")) {
+      continue;
+    }
+    const suffix = line.slice(4);
+    const idx = suffix.indexOf(" = ");
+    if (idx > 0) {
+      vars[suffix.slice(0, idx)] = suffix.slice(idx + 3);
+    }
+  }
+  return vars;
+}
+
+/** Case-insensitive lookup of a configuration name. */
+function findConfiguration(
+  pi: XcodeProjectInfo,
+  name: string
+): string | undefined {
+  const lower = name.toLowerCase();
+  return pi.configurations.find((cfg) => cfg.toLowerCase() === lower);
+}
+
+/** Resolve the Info.plist for the project's first target (release, else debug). */
+async function fromProjectInfo(
+  pi: XcodeProjectInfo,
+  allowPreprocessing: boolean
+): Promise<InfoPlist | null> {
+  const config =
+    findConfiguration(pi, "release") ?? findConfiguration(pi, "debug");
+  const target = pi.targets[0];
+  if (!(config && target)) {
+    return null;
+  }
+  const vars = getBuildVars(pi.path, target, config);
+  const infoPlistFile = vars.INFOPLIST_FILE;
+  if (!infoPlistFile) {
+    return null;
+  }
+  const base = vars.PROJECT_DIR ?? dirname(pi.path);
+  return await loadAndProcess(
+    join(base, infoPlistFile),
+    vars,
+    allowPreprocessing
+  );
+}
+
+/**
+ * Discover the app's bundle identity from the Xcode build environment.
+ *
+ * When run inside an Xcode build phase (`XCODE_VERSION_ACTUAL` set), reads
+ * `INFOPLIST_FILE` (expanding `$(VAR)` references and, if requested, running the
+ * C preprocessor) and falls back to build-setting env vars. Otherwise, locates
+ * a single `.xcodeproj` and queries `xcodebuild` for the first target's
+ * settings. Returns `null` when the identity cannot be determined.
+ *
+ * @param allowPreprocessing - Permit `cc`-based `INFOPLIST_PREPROCESS` handling.
+ */
+export async function discoverInfoPlist(
+  env: Env,
+  cwd: string,
+  allowPreprocessing = false
+): Promise<InfoPlist | null> {
+  if (env.XCODE_VERSION_ACTUAL) {
+    const filename = env.INFOPLIST_FILE;
+    if (!filename) {
+      return fromEnvVars(env);
+    }
+    const path = join(cwd, env.PROJECT_DIR ?? ".", filename);
+    return await loadAndProcess(path, env, allowPreprocessing);
+  }
+  const pi = getXcodeProjectInfo(cwd);
+  if (!pi) {
+    return null;
+  }
+  return await fromProjectInfo(pi, allowPreprocessing);
 }
 
 /** A resolved release + distribution for the sourcemap upload. */
@@ -186,7 +387,8 @@ export type ReleaseAndDist = {
 export async function resolveReleaseAndDist(
   env: Env,
   cwd: string,
-  noAutoRelease: boolean
+  noAutoRelease: boolean,
+  allowPreprocessing = false
 ): Promise<ReleaseAndDist> {
   const distEnv = env.SENTRY_DIST;
   const releaseEnv = env.SENTRY_RELEASE;
@@ -198,7 +400,7 @@ export async function resolveReleaseAndDist(
     return { release: releaseEnv, dist: distEnv };
   }
 
-  const plist = await discoverInfoPlist(env, cwd);
+  const plist = await discoverInfoPlist(env, cwd, allowPreprocessing);
   if (!plist) {
     throw new Error(
       "Could not determine release: set SENTRY_RELEASE/SENTRY_DIST, run from " +

--- a/src/lib/react-native/xcode-env.ts
+++ b/src/lib/react-native/xcode-env.ts
@@ -17,6 +17,9 @@ const log = logger.withTag("react-native.xcode-env");
 /** Matches runs of whitespace (splitting preprocessor flag/definition tokens). */
 const WHITESPACE = /\s+/;
 
+/** Splits command output into lines, tolerating CRLF endings. */
+const LINE_SPLIT = /\r?\n/;
+
 /** Bundle identity extracted from an `Info.plist` or the build environment. */
 export type InfoPlist = {
   /** `CFBundleName` / `PRODUCT_NAME`. */
@@ -291,7 +294,7 @@ function getBuildVars(
   if (!out) {
     return vars;
   }
-  for (const line of out.split("\n")) {
+  for (const line of out.split(LINE_SPLIT)) {
     if (!line.startsWith("    ")) {
       continue;
     }

--- a/src/lib/react-native/xcode-env.ts
+++ b/src/lib/react-native/xcode-env.ts
@@ -331,7 +331,7 @@ async function fromProjectInfo(
   }
   const base = vars.PROJECT_DIR ?? dirname(pi.path);
   return await loadAndProcess(
-    join(base, infoPlistFile),
+    resolve(base, infoPlistFile),
     vars,
     allowPreprocessing
   );
@@ -358,7 +358,7 @@ export async function discoverInfoPlist(
     if (!filename) {
       return fromEnvVars(env);
     }
-    const path = join(cwd, env.PROJECT_DIR ?? ".", filename);
+    const path = resolve(cwd, env.PROJECT_DIR ?? ".", filename);
     return await loadAndProcess(path, env, allowPreprocessing);
   }
   const pi = getXcodeProjectInfo(cwd);

--- a/test/commands/react-native/gradle.test.ts
+++ b/test/commands/react-native/gradle.test.ts
@@ -114,6 +114,26 @@ describe("react-native gradle", () => {
     }
   });
 
+  test("threads --wait / --wait-for into the upload", async () => {
+    const func = await gradleCommand.loader();
+
+    await func.call(createContext().context, { bundle, sourcemap });
+    expect(uploadSpy.mock.calls[0][0]).toMatchObject({ wait: false });
+
+    await func.call(createContext().context, { bundle, sourcemap, wait: true });
+    expect(uploadSpy.mock.calls[1][0]).toMatchObject({ wait: true });
+
+    await func.call(createContext().context, {
+      bundle,
+      sourcemap,
+      "wait-for": 30,
+    });
+    expect(uploadSpy.mock.calls[2][0]).toMatchObject({
+      wait: true,
+      maxWaitMs: 30_000,
+    });
+  });
+
   test("rejects a missing bundle", async () => {
     const func = await gradleCommand.loader();
     await expect(

--- a/test/lib/api/chunk-upload.test.ts
+++ b/test/lib/api/chunk-upload.test.ts
@@ -6,8 +6,21 @@
  * (backward compatibility), and present values must be carried through.
  */
 
-import { describe, expect, test } from "vitest";
-import { ChunkServerOptionsSchema } from "../../../src/lib/api/chunk-upload.js";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  ChunkServerOptionsSchema,
+  pollAssembly,
+} from "../../../src/lib/api/chunk-upload.js";
+import { apiRequestToRegion } from "../../../src/lib/api/infrastructure.js";
+
+vi.mock("../../../src/lib/api/infrastructure.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../../../src/lib/api/infrastructure.js")
+    >();
+  return { ...actual, apiRequestToRegion: vi.fn() };
+});
+const apiMock = vi.mocked(apiRequestToRegion);
 
 const BASE = {
   url: "https://us.sentry.io/api/0/chunk-upload/",
@@ -40,5 +53,47 @@ describe("ChunkServerOptionsSchema", () => {
       expect(result.data.maxFileSize).toBe(2_147_483_648);
       expect(result.data.maxWait).toBe(300);
     }
+  });
+});
+
+describe("pollAssembly: waitForOk", () => {
+  const params = {
+    regionUrl: "https://us.sentry.io",
+    endpoint: "org/artifactbundle/assemble/",
+    body: {},
+    entityName: "Artifact bundle",
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    apiMock.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("default (waitForOk=false) returns as soon as state is 'created'", async () => {
+    apiMock.mockResolvedValue({
+      data: { state: "created" },
+    } as unknown as Awaited<ReturnType<typeof apiRequestToRegion>>);
+    const promise = pollAssembly(params);
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(promise).resolves.toBeUndefined();
+    expect(apiMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("waitForOk=true keeps polling through 'created' until 'ok'", async () => {
+    apiMock
+      .mockResolvedValueOnce({
+        data: { state: "created" },
+      } as unknown as Awaited<ReturnType<typeof apiRequestToRegion>>)
+      .mockResolvedValueOnce({
+        data: { state: "ok" },
+      } as unknown as Awaited<ReturnType<typeof apiRequestToRegion>>);
+    const promise = pollAssembly({ ...params, waitForOk: true });
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(promise).resolves.toBeUndefined();
+    expect(apiMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/test/lib/api/sourcemaps.test.ts
+++ b/test/lib/api/sourcemaps.test.ts
@@ -33,6 +33,16 @@ describe("resolveUploadWait", () => {
       maxWaitMs: 45_000,
     });
   });
+
+  test.each([
+    Number.NaN,
+    0,
+    -5,
+  ])("rejects a non-positive --wait-for (%s)", (value) => {
+    expect(() => resolveUploadWait({ "wait-for": value })).toThrow(
+      /positive number of seconds/
+    );
+  });
 });
 
 describe("pickUploadEncoding", () => {

--- a/test/lib/api/sourcemaps.test.ts
+++ b/test/lib/api/sourcemaps.test.ts
@@ -6,9 +6,34 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   buildArtifactBundle,
   ChunkServerOptionsSchema,
+  DEFAULT_UPLOAD_MAX_WAIT_MS,
   encodeChunk,
   pickUploadEncoding,
+  resolveUploadWait,
 } from "../../../src/lib/api/sourcemaps.js";
+
+describe("resolveUploadWait", () => {
+  test("no flags → do not wait, default cap", () => {
+    expect(resolveUploadWait({})).toEqual({
+      wait: false,
+      maxWaitMs: DEFAULT_UPLOAD_MAX_WAIT_MS,
+    });
+  });
+
+  test("--wait → wait with default cap", () => {
+    expect(resolveUploadWait({ wait: true })).toEqual({
+      wait: true,
+      maxWaitMs: DEFAULT_UPLOAD_MAX_WAIT_MS,
+    });
+  });
+
+  test("--wait-for <secs> → wait with a custom cap (enables waiting)", () => {
+    expect(resolveUploadWait({ "wait-for": 45 })).toEqual({
+      wait: true,
+      maxWaitMs: 45_000,
+    });
+  });
+});
 
 describe("pickUploadEncoding", () => {
   test("prefers zstd when both zstd and gzip are advertised", () => {

--- a/test/lib/react-native/wrap-call.test.ts
+++ b/test/lib/react-native/wrap-call.test.ts
@@ -114,8 +114,7 @@ describe("wrapCall", () => {
       stderr: "",
       pid: 1,
       output: [],
-      // biome-ignore lint/suspicious/noExplicitAny: partial SpawnSyncReturns for the test
-    } as any);
+    } as unknown as ReturnType<typeof spawnSync>);
     setArgs(["cli.js", "bundle", "--bundle-output", "/build/app.jsbundle"]);
     const status = wrapCall({
       SENTRY_RN_SOURCEMAP_REPORT: reportPath,

--- a/test/lib/react-native/xcode-env.test.ts
+++ b/test/lib/react-native/xcode-env.test.ts
@@ -246,7 +246,8 @@ describe("discoverInfoPlist: xcodebuild discovery (outside Xcode)", () => {
         });
       }
       if (args?.includes("-showBuildSettings")) {
-        return `    INFOPLIST_FILE = MyApp/Info.plist\n    PROJECT_DIR = ${dir}\n`;
+        // CRLF endings must not leak a trailing \r into the parsed values.
+        return `    INFOPLIST_FILE = MyApp/Info.plist\r\n    PROJECT_DIR = ${dir}\r\n`;
       }
       return "";
     });

--- a/test/lib/react-native/xcode-env.test.ts
+++ b/test/lib/react-native/xcode-env.test.ts
@@ -2,10 +2,11 @@
  * Tests for Xcode build-environment helpers.
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   discoverInfoPlist,
   expandXcodeVars,
@@ -15,7 +16,25 @@ import {
   resolveReleaseAndDist,
 } from "../../../src/lib/react-native/xcode-env.js";
 
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFileSync: vi.fn(() => "") };
+});
+const execMock = vi.mocked(execFileSync);
+
+/** A complete four-key Info.plist XML body. */
+const PLIST_XML = `<plist><dict>
+  <key>CFBundleName</key><string>NAME</string>
+  <key>CFBundleIdentifier</key><string>BUNDLE</string>
+  <key>CFBundleShortVersionString</key><string>VERSION</string>
+  <key>CFBundleVersion</key><string>BUILD</string>
+</dict></plist>`;
+
 const dirs: string[] = [];
+beforeEach(() => {
+  execMock.mockReset();
+  execMock.mockReturnValue("");
+});
 afterEach(() => {
   while (dirs.length > 0) {
     const d = dirs.pop();
@@ -152,5 +171,105 @@ describe("resolveReleaseAndDist", () => {
     await expect(resolveReleaseAndDist({}, "/tmp", false)).rejects.toThrow(
       /Could not determine release/
     );
+  });
+});
+
+describe("discoverInfoPlist: INFOPLIST_PREPROCESS", () => {
+  test("runs cc when preprocessing is allowed and requested", async () => {
+    execMock.mockReturnValue(
+      PLIST_XML.replace("NAME", "Pre")
+        .replace("BUNDLE", "com.pre.app")
+        .replace("VERSION", "9.9")
+        .replace("BUILD", "99")
+    );
+    const plist = await discoverInfoPlist(
+      {
+        XCODE_VERSION_ACTUAL: "1500",
+        INFOPLIST_FILE: "Info.plist",
+        INFOPLIST_PREPROCESS: "YES",
+        INFOPLIST_PREPROCESSOR_DEFINITIONS: "DEBUG=1",
+      },
+      "/tmp",
+      true
+    );
+    expect(plist).toEqual({
+      name: "Pre",
+      bundleId: "com.pre.app",
+      version: "9.9",
+      build: "99",
+    });
+    expect(execMock).toHaveBeenCalledWith(
+      "cc",
+      expect.arrayContaining(["-xc", "-P", "-E", "-DDEBUG=1"]),
+      expect.anything()
+    );
+  });
+
+  test("does not run cc when preprocessing is not allowed", async () => {
+    const plist = await discoverInfoPlist(
+      {
+        XCODE_VERSION_ACTUAL: "1500",
+        INFOPLIST_FILE: "Info.plist",
+        INFOPLIST_PREPROCESS: "YES",
+        // Fallback env vars so discovery still succeeds.
+        PRODUCT_NAME: "Fallback",
+        PRODUCT_BUNDLE_IDENTIFIER: "com.fallback.app",
+        MARKETING_VERSION: "1.0",
+        CURRENT_PROJECT_VERSION: "1",
+      },
+      "/does-not-exist",
+      false
+    );
+    expect(execMock).not.toHaveBeenCalled();
+    expect(plist).toMatchObject({ bundleId: "com.fallback.app" });
+  });
+});
+
+describe("discoverInfoPlist: xcodebuild discovery (outside Xcode)", () => {
+  test("resolves the release via xcodebuild when not in an Xcode build", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "rn-xcodeproj-"));
+    dirs.push(dir);
+    mkdirSync(join(dir, "MyApp.xcodeproj"));
+    mkdirSync(join(dir, "MyApp"));
+    writeFileSync(
+      join(dir, "MyApp", "Info.plist"),
+      PLIST_XML.replace("NAME", "MyApp")
+        .replace("BUNDLE", "com.xcbuild.app")
+        .replace("VERSION", "4.2.0")
+        .replace("BUILD", "7")
+    );
+
+    execMock.mockImplementation((_cmd: string, args?: readonly string[]) => {
+      if (args?.includes("-list")) {
+        return JSON.stringify({
+          project: { targets: ["MyApp"], configurations: ["Debug", "Release"] },
+        });
+      }
+      if (args?.includes("-showBuildSettings")) {
+        return `    INFOPLIST_FILE = MyApp/Info.plist\n    PROJECT_DIR = ${dir}\n`;
+      }
+      return "";
+    });
+
+    const plist = await discoverInfoPlist({}, dir);
+    expect(plist).toEqual({
+      name: "MyApp",
+      bundleId: "com.xcbuild.app",
+      version: "4.2.0",
+      build: "7",
+    });
+    // Used the Release configuration.
+    expect(execMock).toHaveBeenCalledWith(
+      "xcodebuild",
+      expect.arrayContaining(["-configuration", "Release"]),
+      expect.anything()
+    );
+  });
+
+  test("returns null when there is no .xcodeproj", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "rn-empty-"));
+    dirs.push(dir);
+    expect(await discoverInfoPlist({}, dir)).toBeNull();
+    expect(execMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Tightens the `react-native` commands to full functional parity with the legacy Rust CLI for all **supported** (Hermes / modern) React Native configurations — the last remaining behavioral gaps after the command port.

## What changed

**`react-native xcode`**
- **Info.plist C preprocessing** — when `INFOPLIST_PREPROCESS=YES`, run the plist through `cc -xc -P -E` (with `INFOPLIST_OTHER_PREPROCESSOR_FLAGS` / `INFOPLIST_PREPROCESSOR_DEFINITIONS`), gated behind the legacy-matching `--allow-xcode-infoplist-preprocessing` flag.
- **`xcodebuild` discovery outside Xcode** — when `XCODE_VERSION_ACTUAL` isn't set, locate a single `.xcodeproj`, read `xcodebuild -list -json` for targets/configurations, and pull the first target's `INFOPLIST_FILE`/`PROJECT_DIR` from `xcodebuild -showBuildSettings` (Release config, else Debug). Ports the legacy `XcodeProjectInfo` path.

**`react-native gradle` + `xcode`**
- **`--wait` / `--wait-for` are now real** — they block until the server finishes *processing* the upload (state `"ok"`), with a `--wait-for <secs>` cap. Threaded through a new optional `wait`/`maxWaitMs` on `uploadSourcemaps` and a `waitForOk`/`deadlineMs` on `pollAssembly`. **Default behavior is unchanged** for every other caller (returns on `ok`/`created`), so the heavily-used `sourcemap upload` path is untouched.

**Intentionally out of scope (documented):** RAM-bundle unpacking. It's a pre-Hermes format React Native itself deprecated; the command emits a clear error and the docs say so.

## Tests (+8, full suite 8411 passed)
- `xcode-env`: `cc` preprocessing (used when allowed, skipped when not), `xcodebuild` discovery (resolves via Release config; returns null with no `.xcodeproj`) — `execFileSync` mocked so it runs on Linux CI.
- `resolveUploadWait`: no-flags / `--wait` / `--wait-for` mapping.
- `gradle`: `--wait`/`--wait-for` thread `wait`/`maxWaitMs` into the upload.

`typecheck` / `lint` / `check:deps` / `check:fragments` all pass. Docs fragment + generated skill updated.

Closes the remaining react-native parity gaps; combined with the earlier ports, the TS CLI now matches the legacy CLI's functionality for all supported RN setups.