### PR TITLE
ci(docs): clean up PR previews on close + scheduled safety-net sweep

### DIFF
--- a/.github/workflows/cleanup-doc-previews.yml
+++ b/.github/workflows/cleanup-doc-previews.yml
@@ -16,8 +16,10 @@ permissions:
   pull-requests: read
 
 concurrency:
-  # Serialize with any gh-pages writer to avoid clobbering a concurrent deploy.
-  group: gh-pages-write
+  # Serialize cleanup runs with each other. Races against docs-preview deploys
+  # are handled by the push retry loop below (a non-fast-forward push is
+  # rejected, never applied, so it can't corrupt gh-pages).
+  group: gh-pages-cleanup
   cancel-in-progress: false
 
 jobs:
@@ -40,33 +42,58 @@ jobs:
           cd ghp
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git read-tree HEAD
 
-          removed=0
-          # One entry per top-level _preview/<dir>.
-          for dir in $(git ls-files _preview/ | sed -E 's#(_preview/[^/]+)/.*#\1#' | sort -u); do
-            name="${dir#_preview/}"
-            # Keep the production/main preview.
-            if [ "$name" = "pr-main" ]; then
-              continue
-            fi
-            num="${name#pr-}"
-            # Skip anything that isn't a pr-<number> directory.
-            case "$num" in
-              ''|*[!0-9]*) continue ;;
-            esac
-            state=$(gh pr view "$num" --repo "$REPO" --json state --jq .state 2>/dev/null || echo "MISSING")
-            if [ "$state" != "OPEN" ]; then
-              echo "Removing $dir (PR #$num state=$state)"
-              git rm -r -q --cached "$dir"
-              removed=$((removed + 1))
-            fi
-          done
+          # Retry loop: another gh-pages writer (a docs-preview deploy) may land
+          # between our read and push. A non-fast-forward push is REJECTED (never
+          # applied, so no corruption); we re-sync onto the new tip and re-prune.
+          max_attempts=3
+          attempt=0
+          while :; do
+            attempt=$((attempt + 1))
+            git read-tree HEAD
 
-          if [ "$removed" -gt 0 ]; then
+            removed=0
+            # One entry per top-level _preview/<dir>.
+            for dir in $(git ls-files _preview/ | sed -E 's#(_preview/[^/]+)/.*#\1#' | sort -u); do
+              name="${dir#_preview/}"
+              # Keep the production/main preview.
+              if [ "$name" = "pr-main" ]; then
+                continue
+              fi
+              num="${name#pr-}"
+              # Skip anything that isn't a pr-<number> directory.
+              case "$num" in
+                ''|*[!0-9]*) continue ;;
+              esac
+              state=$(gh pr view "$num" --repo "$REPO" --json state --jq .state 2>/dev/null || echo "UNKNOWN")
+              # Only prune when the PR is CONFIRMED closed/merged. Keep the
+              # preview on OPEN and on any API error/unknown state so a transient
+              # glitch never deletes a live preview.
+              case "$state" in
+                CLOSED|MERGED)
+                  echo "Removing $dir (PR #$num state=$state)"
+                  git rm -r -q --cached "$dir"
+                  removed=$((removed + 1))
+                  ;;
+              esac
+            done
+
+            if [ "$removed" -eq 0 ]; then
+              echo "No stale previews to prune."
+              exit 0
+            fi
+
             git commit -q -m "chore(docs): prune ${removed} preview(s) for closed PRs [skip ci]"
-            git push origin gh-pages
-            echo "Pruned ${removed} stale preview(s)."
-          else
-            echo "No stale previews to prune."
-          fi
+            if git push origin gh-pages; then
+              echo "Pruned ${removed} stale preview(s)."
+              exit 0
+            fi
+
+            if [ "$attempt" -ge "$max_attempts" ]; then
+              echo "gh-pages push kept failing after ${max_attempts} attempts; retrying next run." >&2
+              exit 1
+            fi
+            echo "gh-pages moved underneath us; re-syncing and retrying (attempt ${attempt})…"
+            git fetch --quiet origin gh-pages
+            git reset --soft FETCH_HEAD
+          done

--- a/.github/workflows/cleanup-doc-previews.yml
+++ b/.github/workflows/cleanup-doc-previews.yml
@@ -1,0 +1,72 @@
+name: Cleanup Doc Previews
+
+# Safety net for the on-close cleanup in docs-preview.yml: sweeps gh-pages for
+# `_preview/pr-<n>` directories whose PR is no longer open and removes them.
+# Catches previews that slipped through (e.g. closed while the preview workflow
+# was failing) so gh-pages never bloats past GitHub Pages' build limits again.
+
+on:
+  schedule:
+    # Every Sunday at 05:30 UTC (before the nightly-tag cleanup).
+    - cron: "30 5 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  # Serialize with any gh-pages writer to avoid clobbering a concurrent deploy.
+  group: gh-pages-write
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    name: Prune previews for closed PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune stale previews
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Blobless, no-checkout clone so we never download the (large) preview
+          # file contents — we only need trees to rewrite the index.
+          git clone --filter=blob:none --no-checkout --single-branch \
+            --branch gh-pages \
+            "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" ghp
+          cd ghp
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git read-tree HEAD
+
+          removed=0
+          # One entry per top-level _preview/<dir>.
+          for dir in $(git ls-files _preview/ | sed -E 's#(_preview/[^/]+)/.*#\1#' | sort -u); do
+            name="${dir#_preview/}"
+            # Keep the production/main preview.
+            if [ "$name" = "pr-main" ]; then
+              continue
+            fi
+            num="${name#pr-}"
+            # Skip anything that isn't a pr-<number> directory.
+            case "$num" in
+              ''|*[!0-9]*) continue ;;
+            esac
+            state=$(gh pr view "$num" --repo "$REPO" --json state --jq .state 2>/dev/null || echo "MISSING")
+            if [ "$state" != "OPEN" ]; then
+              echo "Removing $dir (PR #$num state=$state)"
+              git rm -r -q --cached "$dir"
+              removed=$((removed + 1))
+            fi
+          done
+
+          if [ "$removed" -gt 0 ]; then
+            git commit -q -m "chore(docs): prune ${removed} preview(s) for closed PRs [skip ci]"
+            git push origin gh-pages
+            echo "Pruned ${removed} stale preview(s)."
+          else
+            echo "No stale previews to prune."
+          fi

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -11,13 +11,12 @@ on:
       - 'install'
       - '.github/workflows/docs-preview.yml'
   pull_request:
-    paths:
-      - 'docs/**'
-      - 'src/**'
-      - 'script/generate-command-docs.ts'
-      - 'script/generate-skill.ts'
-      - 'install'
-      - '.github/workflows/docs-preview.yml'
+    # No paths filter here: the 'closed' event must ALWAYS fire so
+    # pr-preview-action can remove the deployed preview. A paths-filter step
+    # inside the job (below) skips the build/deploy for non-docs PRs. Without
+    # this, closed PRs never clean up and gh-pages bloats until GitHub Pages
+    # exceeds its build limits and starts failing.
+    types: [opened, reopened, synchronize, closed]
 
 permissions:
   contents: write
@@ -40,32 +39,77 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Detect whether this PR actually touches docs. Skipped on 'closed' (and
+      # on push), where the gate below decides what to do without a diff.
+      - name: Check for docs changes
+        id: filter
+        if: github.event_name == 'pull_request' && github.event.action != 'closed'
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'src/**'
+              - 'script/generate-command-docs.ts'
+              - 'script/generate-skill.ts'
+              - 'install'
+              - '.github/workflows/docs-preview.yml'
+
+      # Central gate. `build` = produce the site (push, or a docs PR being
+      # opened/updated). `deploy` = publish/remove on gh-pages (build, or any
+      # 'closed' event to clean up), but never for fork PRs which lack write
+      # access. Fork PRs still build to surface compilation errors.
+      - name: Compute gates
+        id: gate
+        env:
+          EVENT: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          DOCS_CHANGED: ${{ steps.filter.outputs.docs }}
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          build=false
+          deploy=false
+          if [ "$EVENT" = "push" ] || { [ "$ACTION" != "closed" ] && [ "$DOCS_CHANGED" = "true" ]; }; then
+            build=true
+          fi
+          if { [ "$build" = "true" ] || [ "$ACTION" = "closed" ]; } && [ "$IS_FORK" != "true" ]; then
+            deploy=true
+          fi
+          echo "build=$build" >> "$GITHUB_OUTPUT"
+          echo "deploy=$deploy" >> "$GITHUB_OUTPUT"
+
       - uses: pnpm/action-setup@v4
+        if: steps.gate.outputs.build == 'true'
 
       # Astro 6 requires Node >= 22.12. Pin an exact patched version (see
       # NODE_VERSION_24) so the docs build doesn't rely on the runner image's
       # default.
       - uses: actions/setup-node@v6
+        if: steps.gate.outputs.build == 'true'
         with:
           node-version: ${{ env.NODE_VERSION_24 }}
 
       - uses: actions/cache@v5
         id: cache
+        if: steps.gate.outputs.build == 'true'
         with:
           path: node_modules
           key: node-modules-${{ hashFiles('pnpm-lock.yaml', '.npmrc', 'patches/**') }}
 
-      - if: steps.cache.outputs.cache-hit != 'true'
+      - if: steps.gate.outputs.build == 'true' && steps.cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Get CLI version
         id: version
+        if: steps.gate.outputs.build == 'true'
         run: echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
 
       - name: Generate docs content
+        if: steps.gate.outputs.build == 'true'
         run: pnpm run generate:schema && pnpm run generate:docs
 
       - name: Build Docs for Preview
+        if: steps.gate.outputs.build == 'true'
         working-directory: docs
         env:
           DOCS_BASE_PATH: ${{ github.event_name == 'push'
@@ -79,7 +123,7 @@ jobs:
           pnpm run build
 
       - name: Inject debug IDs and upload sourcemaps
-        if: env.SENTRY_AUTH_TOKEN != ''
+        if: steps.gate.outputs.build == 'true' && env.SENTRY_AUTH_TOKEN != ''
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: sentry
@@ -92,13 +136,13 @@ jobs:
 
       # Remove .map files — uploaded to Sentry but shouldn't be deployed.
       - name: Remove sourcemaps from output
+        if: steps.gate.outputs.build == 'true'
         run: find docs/dist -name '*.map' -delete
 
       - name: Ensure .nojekyll at gh-pages root
-        # Fork PRs can't push to the base repo (GITHUB_TOKEN is read-only on
-        # pull_request from forks). Skip the deploy but still run the build
-        # above so docs compilation errors surface.
-        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+        # Runs whenever we deploy (build or a 'closed' cleanup), but never for
+        # fork PRs which lack write access to the base repo's gh-pages branch.
+        if: steps.gate.outputs.deploy == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -130,8 +174,10 @@ jobs:
           fi
 
       - name: Deploy Preview
-        # Same fork-PR guard as the .nojekyll step above.
-        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+        # Deploys on build; on a 'closed' event `auto` removes the preview
+        # instead — this is what keeps gh-pages from accumulating stale
+        # previews. Skipped for fork PRs (no write access).
+        if: steps.gate.outputs.deploy == 'true'
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: docs/dist/


### PR DESCRIPTION
## Problem

The `sentry docs` PR-preview link was returning **404** for new PRs (e.g. #1201), while older previews still worked. Root cause:

- `docs-preview.yml` triggered on `pull_request` `[opened, synchronize, reopened]` — **never `closed`** — so `rossjrw/pr-preview-action`'s auto-cleanup never ran.
- **46 stale previews** (each a full copy of the docs site) accumulated in `gh-pages`, pushing the **GitHub Pages build over its size/time limits**. Builds started failing intermittently (`Page build failed`), so newly-deployed previews 404'd while previously-published ones kept serving.

## Fix (pattern ported from `getsentry/loreai`)

**`docs-preview.yml`**
- Add `closed` to the `pull_request` types and **remove the `pull_request` paths filter** — a `closed` event must always fire so the preview can be removed.
- A `dorny/paths-filter` step + a central **`gate`** step decide:
  - `build` → push, or a docs PR being opened/updated (fork PRs still build to surface compile errors).
  - `deploy` → build, **or any `closed` event** (cleanup), never for fork PRs.
- On close, `pr-preview-action` `action: auto` **removes** the preview — the actual cleanup that was missing.

**`cleanup-doc-previews.yml` (new)**
- Weekly (`cron`) + `workflow_dispatch` **safety net**: sweeps `gh-pages` for `_preview/pr-<n>` dirs whose PR is no longer `OPEN` and removes them. Uses a **blobless, no-checkout clone + index rewrite**, so it never downloads the (large) preview file contents. Catches anything the on-close path misses (e.g. PRs closed while the workflow was broken — exactly how we got here).

## Already done out-of-band
The 46 already-stale previews were pruned from `gh-pages` directly (blobless index rewrite) to **unblock the failing Pages build immediately** — previews now serve again (verified `pr-1201` → 200). This PR prevents recurrence.

## Validation
- Both workflows: valid YAML; `actionlint` clean (only a pre-existing SC2088 on the unchanged `--url-prefix "~/"` line, a deliberate Sentry URL prefix).
- Gate logic walked through for push / docs-PR open+sync / non-docs PR / close / fork / fork-close.