### PR TITLE
docs: note `sentry cli setup` for package manager installs

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -84,6 +84,12 @@ Install globally with your preferred package manager (the npm/pnpm/yarn packages
   bun="bun add -g sentry"
 />
 
+Unlike the install script and Homebrew, package manager installs don't set up shell completions or agent skills. Run `sentry cli setup` once to enable them:
+
+```bash
+sentry cli setup
+```
+
 Or run directly without installing:
 
 <PackageManagerCode


### PR DESCRIPTION
## Summary

Package manager installs (`npm`/`pnpm`/`yarn`/`bun -g`) place the binary on PATH but — unlike the install script and Homebrew — never run `sentry cli setup`. As a result, shell completions and agent skills are silently missing for those users, with nothing in the docs pointing them to the fix.

This adds a short note in the **Package Managers** section of the getting-started guide directing those users to run `sentry cli setup` once.

## Why here / why this wording

- Scoped to the Package Managers section because that's the only audience affected — curl and Homebrew installs already run setup automatically.
- Explicitly contrasts with the install script / Homebrew so curl/brew readers know it doesn't apply to them.
- States the concrete gap (completions + agent skills) rather than a generic pitch, and omits auth (setup doesn't touch credentials, so it's not relevant to a reader here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)