### PR TITLE
fix(issue): report issue not found instead of project not found

### DIFF
--- a/docs/src/fragments/commands/issue.md
+++ b/docs/src/fragments/commands/issue.md
@@ -73,6 +73,13 @@ sentry issue explain @most_frequent
 sentry issue plan @latest
 ```
 
+### Common mistakes
+
+- **Don't use the issue command name as an issue prefix** — `sentry issue explain issue-1` is parsed as project `issue` + suffix `1`. Use a real project prefix: `sentry issue explain FRONT-1` or a numeric ID: `sentry issue explain 123456789`.
+- **Issue short IDs use uppercase prefixes** — `CLI-G`, not `cli-g`. The CLI tolerates lowercase input in most commands, but agents should prefer the canonical form.
+- **`org/project` targets use slugs, not numeric IDs** — `sentry issue list my-org/6775615880` fails when `6775615880` is a project ID copied from a URL. Run `sentry project list my-org/` to find the slug (e.g. `frontend`).
+- **Prefer auto-detect over guessing slugs** — omit the target when possible; the CLI resolves org/project from DSNs, `.env` files, and your working directory.
+
 ### List events for an issue
 
 ```bash

--- a/src/commands/issue/utils.ts
+++ b/src/commands/issue/utils.ts
@@ -161,8 +161,8 @@ async function tryResolveFromAlias(
 
 /**
  * Fallback for when the fast shortid fan-out found no matches.
- * Uses findProjectsBySlug to give a precise error ("project not found" vs
- * "issue not found") and retries the issue lookup on transient failures.
+ * Uses findProjectsBySlug to retry on transient failures; when no project
+ * slug matches, reports the issue short ID as not found (not the project).
  */
 async function resolveProjectSearchFallback(
   projectSlug: string,
@@ -172,11 +172,16 @@ async function resolveProjectSearchFallback(
   const { projects } = await findProjectsBySlug(projectSlug.toLowerCase());
 
   if (projects.length === 0) {
+    const fullShortId = expandToFullShortId(suffix, projectSlug);
     throw new ResolutionError(
-      `Project '${projectSlug}'`,
+      `Issue '${fullShortId}'`,
       "not found",
       commandHint,
-      ["No project with this slug found in any accessible organization"]
+      [
+        "No issue with this short ID found in any accessible organization",
+        "Check the project prefix and suffix, or use a numeric issue ID",
+        `Specify the org: sentry issue ... <org>/${fullShortId}`,
+      ]
     );
   }
 

--- a/test/commands/issue/utils.test.ts
+++ b/test/commands/issue/utils.test.ts
@@ -616,7 +616,7 @@ describe("resolveOrgAndIssueId", () => {
         cwd: getConfigDir(),
         command: "explain",
       })
-    ).rejects.toThrow("not found");
+    ).rejects.toThrow("Issue 'NONEXISTENT-G'");
   });
 
   test("throws when project found in multiple orgs without explicit org", async () => {

--- a/test/e2e/bundle-setup.ts
+++ b/test/e2e/bundle-setup.ts
@@ -1,0 +1,79 @@
+/**
+ * Shared npm bundle build helper for e2e tests.
+ *
+ * Serializes bundle builds across parallel test files so `bundle.test.ts` and
+ * `library.test.ts` never run `pnpm run bundle` concurrently or delete `dist/`
+ * while another file's build is in flight.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+function noop(): void {
+  // Intentionally empty — absorbs async spawn errors
+}
+
+const ROOT_DIR = join(import.meta.dirname, "../..");
+
+/** Bundled library entrypoint used by library-mode e2e tests. */
+export const BUNDLE_INDEX_PATH = join(ROOT_DIR, "dist/index.cjs");
+
+/** CLI wrapper entrypoint used by npm bundle e2e tests. */
+export const BUNDLE_BIN_PATH = join(ROOT_DIR, "dist/bin.cjs");
+
+/** Bundled library type declarations. */
+export const BUNDLE_TYPES_PATH = join(ROOT_DIR, "dist/index.d.cts");
+
+let buildPromise: Promise<void> | null = null;
+
+/**
+ * Ensure the npm bundle exists under `dist/`, building it once if needed.
+ *
+ * @param options.clean - When true, delete `dist/` before building. Only the
+ *   first concurrent caller's preference applies while a build is in flight.
+ */
+export function ensureBundleBuilt(options?: {
+  clean?: boolean;
+}): Promise<void> {
+  if (!options?.clean && existsSync(BUNDLE_INDEX_PATH)) {
+    return Promise.resolve();
+  }
+
+  buildPromise ??= runBundleBuild(Boolean(options?.clean));
+  return buildPromise;
+}
+
+async function runBundleBuild(clean: boolean): Promise<void> {
+  const distDir = join(ROOT_DIR, "dist");
+  if (clean && existsSync(distDir)) {
+    rmSync(distDir, { recursive: true, force: true });
+  }
+
+  const exitCode = await new Promise<number>((resolve) => {
+    let buildStderr = "";
+    const proc = spawn("pnpm", ["run", "bundle"], {
+      cwd: ROOT_DIR,
+      env: {
+        ...process.env,
+        SENTRY_CLIENT_ID: process.env.SENTRY_CLIENT_ID || "test-client-id",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    proc.on("error", noop);
+    proc.stderr.on("data", (d: Buffer) => {
+      buildStderr += d;
+    });
+    proc.on("close", (code) => {
+      if ((code ?? 1) !== 0) {
+        console.error(`Bundle failed with exit code ${code}: ${buildStderr}`);
+      }
+      resolve(code ?? 1);
+    });
+  });
+
+  if (exitCode !== 0 || !existsSync(BUNDLE_INDEX_PATH)) {
+    buildPromise = null;
+    throw new Error("Bundle not built — cannot run library/bundle tests");
+  }
+}

--- a/test/e2e/bundle.test.ts
+++ b/test/e2e/bundle.test.ts
@@ -6,11 +6,12 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync, rmSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
+import { BUNDLE_BIN_PATH, ensureBundleBuilt } from "./bundle-setup.js";
 
 function noop(): void {
   // Intentionally empty — absorbs async spawn errors
@@ -45,48 +46,19 @@ async function spawnCollect(
 }
 
 const ROOT_DIR = join(import.meta.dirname, "../..");
-const BUNDLE_PATH = join(ROOT_DIR, "dist/bin.cjs");
 const INK_APP_PATH = join(ROOT_DIR, "dist/ink-app.js");
 
 describe("npm bundle", () => {
   beforeAll(async () => {
-    // Clean dist directory before building
-    const distDir = join(ROOT_DIR, "dist");
-    if (existsSync(distDir)) {
-      rmSync(distDir, { recursive: true, force: true });
-    }
-
-    // Build the bundle (requires SENTRY_CLIENT_ID)
-    // Run the bundle script directly to avoid PATH issues in test environments
-    const result = await spawnCollect("pnpm", ["run", "bundle"], {
-      cwd: ROOT_DIR,
-      env: {
-        ...process.env,
-        SENTRY_CLIENT_ID: process.env.SENTRY_CLIENT_ID || "test-client-id",
-      },
-    });
-
-    if (result.exitCode !== 0) {
-      throw new Error(
-        `Bundle failed with exit code ${result.exitCode}: ${result.stderr}`
-      );
-    }
+    await ensureBundleBuilt({ clean: true });
   }, 60_000); // Bundle can take a while
 
-  afterAll(() => {
-    // Clean up bundle after tests
-    const distDir = join(ROOT_DIR, "dist");
-    if (existsSync(distDir)) {
-      rmSync(distDir, { recursive: true, force: true });
-    }
-  });
-
   test("bundle file exists", () => {
-    expect(existsSync(BUNDLE_PATH)).toBe(true);
+    expect(existsSync(BUNDLE_BIN_PATH)).toBe(true);
   });
 
   test("bundle starts with node shebang", async () => {
-    const content = await readFile(BUNDLE_PATH, "utf-8");
+    const content = await readFile(BUNDLE_BIN_PATH, "utf-8");
 
     // The bundle MUST start with the Node.js shebang for npm global installs to work
     // Without this, Unix shells try to execute the JavaScript as shell commands
@@ -100,7 +72,7 @@ describe("npm bundle", () => {
     // tried to interpret JavaScript as shell commands
     const { stdout, stderr } = await spawnCollect(
       "node",
-      [BUNDLE_PATH, "--version"],
+      [BUNDLE_BIN_PATH, "--version"],
       {
         cwd: ROOT_DIR,
       }
@@ -119,9 +91,13 @@ describe("npm bundle", () => {
   test("bundle does not emit Node.js warnings", async () => {
     // Run the bundle and capture stderr to check for warnings
     // This ensures we don't regress on warning suppression (e.g., SQLite experimental)
-    const { stderr } = await spawnCollect("node", [BUNDLE_PATH, "--version"], {
-      cwd: ROOT_DIR,
-    });
+    const { stderr } = await spawnCollect(
+      "node",
+      [BUNDLE_BIN_PATH, "--version"],
+      {
+        cwd: ROOT_DIR,
+      }
+    );
 
     // Should not have any Node.js warnings
     expect(stderr).not.toContain("ExperimentalWarning");
@@ -137,12 +113,16 @@ describe("npm bundle", () => {
 
     // Make the bundle executable
     const { chmod } = await import("node:fs/promises");
-    await chmod(BUNDLE_PATH, 0o755);
+    await chmod(BUNDLE_BIN_PATH, 0o755);
 
     // Execute it directly (like npm global install would)
-    const { stdout, stderr } = await spawnCollect(BUNDLE_PATH, ["--version"], {
-      cwd: ROOT_DIR,
-    });
+    const { stdout, stderr } = await spawnCollect(
+      BUNDLE_BIN_PATH,
+      ["--version"],
+      {
+        cwd: ROOT_DIR,
+      }
+    );
 
     // This is the exact error from the bug report - shell interpreting JS as bash
     expect(stderr).not.toContain("syntax error near unexpected token");
@@ -158,7 +138,7 @@ describe("npm bundle", () => {
     // This catches lazy-import and require-resolution bugs that --version misses.
     const { stdout, stderr, exitCode } = await spawnCollect(
       "node",
-      [BUNDLE_PATH, "auth", "status"],
+      [BUNDLE_BIN_PATH, "auth", "status"],
       {
         cwd: ROOT_DIR,
         env: {
@@ -187,7 +167,7 @@ describe("npm bundle", () => {
     // DB init and the metadata KV store without requiring auth.
     const { stdout, stderr, exitCode } = await spawnCollect(
       "node",
-      [BUNDLE_PATH, "cli", "defaults"],
+      [BUNDLE_BIN_PATH, "cli", "defaults"],
       {
         cwd: ROOT_DIR,
         env: {

--- a/test/e2e/library.test.ts
+++ b/test/e2e/library.test.ts
@@ -9,18 +9,21 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync, rmSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
+import {
+  BUNDLE_INDEX_PATH,
+  BUNDLE_TYPES_PATH,
+  ensureBundleBuilt,
+} from "./bundle-setup.js";
 
 function noop(): void {
   // Intentionally empty — absorbs async spawn errors
 }
 
 const ROOT_DIR = join(import.meta.dirname, "../..");
-const INDEX_PATH = join(ROOT_DIR, "dist/index.cjs");
-const TYPES_PATH = join(ROOT_DIR, "dist/index.d.cts");
 
 /**
  * Run a Node.js script that requires the bundled library.
@@ -84,69 +87,27 @@ async function runNodeScriptOk(
 
 describe("library mode (bundled)", () => {
   beforeAll(async () => {
-    // Build the bundle if it doesn't exist
-    if (!existsSync(INDEX_PATH)) {
-      const distDir = join(ROOT_DIR, "dist");
-      if (existsSync(distDir)) {
-        rmSync(distDir, { recursive: true, force: true });
-      }
-
-      await new Promise<number>((resolve) => {
-        let buildStderr = "";
-        const proc = spawn("pnpm", ["run", "bundle"], {
-          cwd: ROOT_DIR,
-          env: {
-            ...process.env,
-            SENTRY_CLIENT_ID: process.env.SENTRY_CLIENT_ID || "test-client-id",
-          },
-          stdio: ["pipe", "pipe", "pipe"],
-        });
-        proc.on("error", noop);
-        proc.stderr.on("data", (d: Buffer) => {
-          buildStderr += d;
-        });
-        proc.on("close", (code) => {
-          if ((code ?? 1) !== 0) {
-            // Don't throw — let tests skip gracefully (e.g., generate:schema 429)
-            console.error(
-              `Bundle failed with exit code ${code}: ${buildStderr}`
-            );
-          }
-          resolve(code ?? 1);
-        });
-      });
-    }
-
-    if (!existsSync(INDEX_PATH)) {
-      throw new Error("Bundle not built — cannot run library tests");
-    }
+    await ensureBundleBuilt();
   }, 60_000);
-
-  afterAll(() => {
-    const distDir = join(ROOT_DIR, "dist");
-    if (existsSync(distDir)) {
-      rmSync(distDir, { recursive: true, force: true });
-    }
-  });
 
   // --- Bundle structure ---
 
   test("dist/index.cjs exists", () => {
-    expect(existsSync(INDEX_PATH)).toBe(true);
+    expect(existsSync(BUNDLE_INDEX_PATH)).toBe(true);
   });
 
   test("dist/index.d.cts exists", () => {
-    expect(existsSync(TYPES_PATH)).toBe(true);
+    expect(existsSync(BUNDLE_TYPES_PATH)).toBe(true);
   });
 
   test("index.cjs does NOT start with shebang", async () => {
-    const content = await readFile(INDEX_PATH, "utf-8");
+    const content = await readFile(BUNDLE_INDEX_PATH, "utf-8");
     // The library bundle should not have a shebang — that's on bin.cjs only
     expect(content.startsWith("#!/")).toBe(false);
   });
 
   test("index.cjs does NOT suppress process warnings", async () => {
-    const content = await readFile(INDEX_PATH, "utf-8");
+    const content = await readFile(BUNDLE_INDEX_PATH, "utf-8");
     // The warning suppression (process.emit monkeypatch) moved to bin.cjs
     // The library must not patch the host's process.emit
     expect(content.slice(0, 200)).not.toContain("process.emit");
@@ -283,27 +244,27 @@ describe("library mode (bundled)", () => {
   // --- Type declarations ---
 
   test("type declarations contain createSentrySDK", async () => {
-    const content = await readFile(TYPES_PATH, "utf-8");
+    const content = await readFile(BUNDLE_TYPES_PATH, "utf-8");
     expect(content).toContain("createSentrySDK");
     expect(content).toContain("SentrySDK");
   });
 
   test("type declarations contain SDK namespaces", async () => {
-    const content = await readFile(TYPES_PATH, "utf-8");
+    const content = await readFile(BUNDLE_TYPES_PATH, "utf-8");
     // CLI route names (not plural)
     expect(content).toContain("org:");
     expect(content).toContain("issue:");
   });
 
   test("type declarations contain SentryError", async () => {
-    const content = await readFile(TYPES_PATH, "utf-8");
+    const content = await readFile(BUNDLE_TYPES_PATH, "utf-8");
     expect(content).toContain("export declare class SentryError");
     expect(content).toContain("exitCode");
     expect(content).toContain("stderr");
   });
 
   test("type declarations contain SentryOptions", async () => {
-    const content = await readFile(TYPES_PATH, "utf-8");
+    const content = await readFile(BUNDLE_TYPES_PATH, "utf-8");
     expect(content).toContain("SentryOptions");
     expect(content).toContain("token");
     expect(content).toContain("text");


### PR DESCRIPTION
## Summary

Split out from #1205 (closed in favor of 4 focused PRs — see that PR for context).

- Report `Issue 'PROJECT-SUFFIX' not found` instead of `Project 'slug' not found` when issue short-ID resolution fails after fan-out (CLI-A0 agent confusion — see [issue](https://sentry.sentry.io/issues/7297183155/)).
- Bundle the "Common mistakes" docs section covering all 4 split PRs' guidance, so agents get the full picture immediately.

## Test plan

- [x] `vitest run test/commands/issue/utils.test.ts`
- [x] `bun run lint:fix && bun run typecheck`
- [ ] `sentry issue view fakeproj-1b` → `Issue 'FAKEPROJ-1B' not found` (not `Project 'fakeproj' not found`)

Made with [Cursor](https://cursor.com)