### PR TITLE
fix(resolve-target): hint numeric project IDs in 404 suggestions

### DIFF
--- a/src/lib/resolve-target.ts
+++ b/src/lib/resolve-target.ts
@@ -831,6 +831,36 @@ export async function triageProjectNotFound(
 }
 
 /**
+ * Build {@link ResolutionError} suggestions when `getProject(org, project)` 404s.
+ *
+ * @param org - Organization slug from the user's target
+ * @param project - Project segment that failed lookup (slug or numeric ID)
+ * @param similar - Fuzzy-matched project slugs in the org, if any
+ */
+function buildProjectNotFoundSuggestions(
+  org: string,
+  project: string,
+  similar: string[]
+): string[] {
+  const suggestions: string[] = [];
+  if (isAllDigits(project)) {
+    suggestions.push(
+      "Project targets use slugs (e.g. 'frontend'), not numeric project IDs",
+      `List available slugs: sentry project list ${org}/`
+    );
+  }
+  if (similar.length > 0) {
+    suggestions.push(
+      `Similar projects: ${similar.map((s) => `'${s}'`).join(", ")}`
+    );
+  }
+  suggestions.push(
+    `Check the project slug at https://sentry.io/organizations/${org}/projects/`
+  );
+  return suggestions;
+}
+
+/**
  * Fetch the numeric project ID for an explicit org/project pair.
  *
  * Throws on auth errors and 404s (user-actionable). Returns undefined
@@ -869,20 +899,11 @@ export async function fetchProjectId(
       projectResult.error.status === 404
     ) {
       const similar = await findSimilarProjects(org, project);
-      const suggestions: string[] = [];
-      if (similar.length > 0) {
-        suggestions.push(
-          `Similar projects: ${similar.map((s) => `'${s}'`).join(", ")}`
-        );
-      }
-      suggestions.push(
-        `Check the project slug at https://sentry.io/organizations/${org}/projects/`
-      );
       throw new ResolutionError(
         `Project '${project}'`,
         `not found in organization '${org}'`,
         `sentry project list ${org}/`,
-        suggestions
+        buildProjectNotFoundSuggestions(org, project, similar)
       );
     }
     return;

--- a/src/lib/resolve-target.ts
+++ b/src/lib/resolve-target.ts
@@ -845,8 +845,7 @@ function buildProjectNotFoundSuggestions(
   const suggestions: string[] = [];
   if (isAllDigits(project)) {
     suggestions.push(
-      "Project targets use slugs (e.g. 'frontend'), not numeric project IDs",
-      `List available slugs: sentry project list ${org}/`
+      "Project targets use slugs (e.g. 'frontend'), not numeric project IDs"
     );
   }
   if (similar.length > 0) {

--- a/test/lib/resolve-target.test.ts
+++ b/test/lib/resolve-target.test.ts
@@ -436,6 +436,27 @@ describe("fetchProjectId", () => {
     }
   });
 
+  test("includes numeric project ID hint on 404 for all-digit slug", async () => {
+    await setAuthToken("test-token");
+    setOrgRegion("test-org", DEFAULT_SENTRY_URL);
+    globalThis.fetch = mockFetch(
+      async () =>
+        new Response(JSON.stringify({ detail: "Not found" }), {
+          status: 404,
+        })
+    );
+
+    try {
+      await fetchProjectId("test-org", "6775615880");
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ResolutionError);
+      const msg = (error as ResolutionError).message;
+      expect(msg).toContain("not numeric project IDs");
+      expect(msg).toContain("sentry project list test-org/");
+    }
+  });
+
   test("includes project list suggestion even when listProjects fails", async () => {
     await setAuthToken("test-token");
     setOrgRegion("test-org", DEFAULT_SENTRY_URL);

--- a/test/lib/resolve-target.test.ts
+++ b/test/lib/resolve-target.test.ts
@@ -454,6 +454,7 @@ describe("fetchProjectId", () => {
       const msg = (error as ResolutionError).message;
       expect(msg).toContain("not numeric project IDs");
       expect(msg).toContain("sentry project list test-org/");
+      expect(msg.match(/sentry project list test-org\//g)).toHaveLength(1);
     }
   });
 


### PR DESCRIPTION
## Summary

Split out from #1205 (closed in favor of 4 focused PRs).

- When `fetchProjectId(org, project)` 404s and `project` is all-digits (a numeric project ID copied from a URL instead of a slug), prepend a suggestion explaining slugs vs numeric IDs and pointing to `sentry project list <org>/` (CLI-A0, ~205 events from one pattern).

## Test plan

- [x] `vitest run test/lib/resolve-target.test.ts`
- [x] `bun run lint:fix && bun run typecheck`

Made with [Cursor](https://cursor.com)