### PR TITLE
fix(issue): reject issue-1-style command-token args

### DIFF
--- a/packages/cli/src/commands/issue/list.ts
+++ b/packages/cli/src/commands/issue/list.ts
@@ -19,6 +19,7 @@ import { extractRequiredScopes } from "../../lib/api-scope.js";
 import {
   looksLikeIssueShortId,
   parseOrgProjectArg,
+  rejectIssueCommandTokenListTarget,
 } from "../../lib/arg-parsing.js";
 
 import { getActiveEnvVarName, isEnvTokenActive } from "../../lib/db/auth.js";
@@ -1531,6 +1532,10 @@ export const listCommand = buildListCommand("issue", {
       ...rawFlags,
       sort: rawFlags.sort ?? defaultIssueSort(),
     };
+
+    if (target) {
+      rejectIssueCommandTokenListTarget(target);
+    }
 
     const parsed = parseOrgProjectArg(target);
 

--- a/packages/cli/src/lib/arg-parsing.ts
+++ b/packages/cli/src/lib/arg-parsing.ts
@@ -7,7 +7,7 @@
  */
 
 import type { LogSortDirection } from "./api/logs.js";
-import { ContextError, ValidationError } from "./errors.js";
+import { ContextError, ValidationError, validationError } from "./errors.js";
 import { validateResourceId } from "./input-validation.js";
 
 import type { ParsedSentryUrl } from "./sentry-url-parser.js";
@@ -87,6 +87,82 @@ const LINE_SPLIT_PATTERN = /\r?\n/;
  */
 export function looksLikeIssueShortId(str: string): boolean {
   return ISSUE_SHORT_ID_PATTERN.test(str);
+}
+
+/** Matches purely numeric issue suffixes (e.g. `1` in `issue-1`). */
+const NUMERIC_SUFFIX_RE = /^\d+$/;
+
+/** Issue command tokens agents often mistake for project slugs in dash args. */
+const CLI_COMMAND_TOKEN_NOUNS = new Set(["issue", "issues"]);
+
+/**
+ * Check if a slug is an issue command token (e.g. "issue", "issues").
+ *
+ * Used to detect when agents pass command-like tokens as project prefixes in
+ * dash-separated issue args (`issue-1` → project `issue`, suffix `1`). Only
+ * combined with a purely numeric suffix — alphanumeric suffixes like `api-G`
+ * are valid issue short IDs, and other CLI nouns like `api` or `release` may
+ * be real project slugs even with numeric suffixes (`api-1`, `release-123`).
+ *
+ * Matching is case-sensitive on the slug: uppercase prefixes like `ISSUE` in
+ * `ISSUE-1` are valid short IDs, not mistaken lowercase command tokens.
+ */
+export function isIssueCommandToken(slug: string): boolean {
+  return CLI_COMMAND_TOKEN_NOUNS.has(slug);
+}
+
+/**
+ * Reject dash-parsed args where the project segment is an issue command token
+ * and the suffix is purely numeric (e.g. `issue-1`, `my-org/issue-1`).
+ *
+ * @throws {ValidationError} When the project segment is `issue`/`issues` and the
+ *   suffix is purely numeric
+ */
+function rejectIssueCommandTokenWithNumericSuffix(
+  arg: string,
+  projectSlug: string,
+  suffix: string
+): void {
+  if (!(isIssueCommandToken(projectSlug) && NUMERIC_SUFFIX_RE.test(suffix))) {
+    return;
+  }
+  const normalizedProject = projectSlug.toLowerCase();
+  throw validationError(
+    `"${arg}" looks like a command token plus a suffix, not an issue short ID.\n` +
+      `  Parsed as project '${normalizedProject}' + suffix '${suffix}', but '${normalizedProject}' is an issue command name.`,
+    [
+      "sentry issue view PROJECT-1",
+      "sentry issue explain PROJECT-1",
+      "sentry issue explain 123456789",
+      "sentry issue explain my-org/project/PROJECT-G",
+    ],
+    "issue"
+  );
+}
+
+/**
+ * Reject org/project list targets that look like `issue-1` command tokens.
+ *
+ * `parseOrgProjectArg` treats bare `issue-1` as a single project slug; this
+ * applies the same guard as `parseIssueArg` for bare and `org/issue-1` forms.
+ *
+ * @throws {ValidationError} When the target matches an issue command token with
+ *   a purely numeric suffix
+ */
+export function rejectIssueCommandTokenListTarget(target: string): void {
+  const trimmed = target.trim();
+  const dashIdx = trimmed.lastIndexOf("-");
+  if (dashIdx === -1) {
+    return;
+  }
+  const suffix = trimmed.slice(dashIdx + 1);
+  if (!NUMERIC_SUFFIX_RE.test(suffix)) {
+    return;
+  }
+  const prefix = trimmed.slice(0, dashIdx);
+  const slashIdx = prefix.lastIndexOf("/");
+  const projectSegment = slashIdx === -1 ? prefix : prefix.slice(slashIdx + 1);
+  rejectIssueCommandTokenWithNumericSuffix(trimmed, projectSegment, suffix);
 }
 
 // ---------------------------------------------------------------------------
@@ -824,6 +900,8 @@ function parseAfterSlash(
       );
     }
 
+    rejectIssueCommandTokenWithNumericSuffix(arg, project, suffix);
+
     // "my-org/cli-G" or "sentry/spotlight-electron-4Y"
     // Lowercase the project slug — Sentry slugs are always lowercase.
     return { type: "explicit", org, project: project.toLowerCase(), suffix };
@@ -1011,6 +1089,8 @@ function parseWithDash(arg: string): ParsedIssueArg {
       "issue"
     );
   }
+
+  rejectIssueCommandTokenWithNumericSuffix(arg, projectSlug, suffix);
 
   // "cli-G" or "spotlight-electron-4Y"
   // Lowercase the project slug since Sentry slugs are always lowercase.

--- a/packages/cli/test/lib/arg-parsing.test.ts
+++ b/packages/cli/test/lib/arg-parsing.test.ts
@@ -15,6 +15,7 @@ import {
   parseIssueArg,
   parseOrgProjectArg,
   parseSlashSeparatedArg,
+  rejectIssueCommandTokenListTarget,
   splitNewlineArg,
 } from "../../src/lib/arg-parsing.js";
 import { stripDsnOrgPrefix } from "../../src/lib/dsn/index.js";
@@ -413,6 +414,75 @@ describe("parseIssueArg", () => {
       expect(() => parseIssueArg("sentry/")).toThrow(
         "Missing issue ID after slash"
       );
+    });
+
+    test("issue-1 throws ValidationError for issue command token prefix", () => {
+      expect(() => parseIssueArg("issue-1")).toThrow(ValidationError);
+      expect(() => parseIssueArg("issue-1")).toThrow(
+        "looks like a command token plus a suffix"
+      );
+    });
+
+    test("my-org/issue-1 throws ValidationError for org-qualified issue command token", () => {
+      expect(() => parseIssueArg("my-org/issue-1")).toThrow(ValidationError);
+    });
+
+    test("ISSUE-1 parses as project-search (uppercase short ID, not command token)", () => {
+      expect(parseIssueArg("ISSUE-1")).toEqual({
+        type: "project-search",
+        projectSlug: "issue",
+        suffix: "1",
+      });
+    });
+
+    test("my-org/api-G parses as explicit org/project-suffix", () => {
+      expect(parseIssueArg("my-org/api-G")).toEqual({
+        type: "explicit",
+        org: "my-org",
+        project: "api",
+        suffix: "G",
+      });
+    });
+
+    test("api-G parses as project-search", () => {
+      expect(parseIssueArg("api-G")).toEqual({
+        type: "project-search",
+        projectSlug: "api",
+        suffix: "G",
+      });
+    });
+
+    test("api-1 parses as project-search for projects named api", () => {
+      expect(parseIssueArg("api-1")).toEqual({
+        type: "project-search",
+        projectSlug: "api",
+        suffix: "1",
+      });
+    });
+
+    test("release-123 parses as project-search for projects named release", () => {
+      expect(parseIssueArg("release-123")).toEqual({
+        type: "project-search",
+        projectSlug: "release",
+        suffix: "123",
+      });
+    });
+
+    test("my-org/api-1 parses as explicit for org-qualified api project", () => {
+      expect(parseIssueArg("my-org/api-1")).toEqual({
+        type: "explicit",
+        org: "my-org",
+        project: "api",
+        suffix: "1",
+      });
+    });
+
+    test("cli-g still parses as project-search", () => {
+      expect(parseIssueArg("cli-g")).toEqual({
+        type: "project-search",
+        projectSlug: "cli",
+        suffix: "G",
+      });
     });
 
     test("just slash throws error", () => {
@@ -1023,6 +1093,44 @@ describe("looksLikeIssueShortId", () => {
     test("123 (pure numeric)", () => {
       expect(looksLikeIssueShortId("123")).toBe(false);
     });
+  });
+});
+
+describe("rejectIssueCommandTokenListTarget", () => {
+  test("issue-1 throws ValidationError", () => {
+    expect(() => rejectIssueCommandTokenListTarget("issue-1")).toThrow(
+      ValidationError
+    );
+    expect(() => rejectIssueCommandTokenListTarget("issue-1")).toThrow(
+      "looks like a command token plus a suffix"
+    );
+  });
+
+  test("my-org/issue-1 throws ValidationError", () => {
+    expect(() => rejectIssueCommandTokenListTarget("my-org/issue-1")).toThrow(
+      ValidationError
+    );
+  });
+
+  test("whitespace-padded issue-1 throws ValidationError", () => {
+    expect(() => rejectIssueCommandTokenListTarget(" issue-1 ")).toThrow(
+      ValidationError
+    );
+    expect(() =>
+      rejectIssueCommandTokenListTarget(" my-org/issue-1\n")
+    ).toThrow(ValidationError);
+  });
+
+  test("api-1 does not throw", () => {
+    expect(() => rejectIssueCommandTokenListTarget("api-1")).not.toThrow();
+  });
+
+  test("my-org/cli does not throw", () => {
+    expect(() => rejectIssueCommandTokenListTarget("my-org/cli")).not.toThrow();
+  });
+
+  test("ISSUE-1 does not throw (uppercase short ID, not command token)", () => {
+    expect(() => rejectIssueCommandTokenListTarget("ISSUE-1")).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## Summary

Split out from #1205 (closed in favor of 4 focused PRs).

- Reject `issue-1`-style args early with a `ValidationError` when the dash prefix is the issue command name (`issue`, `issues`) and the suffix is purely numeric (CLI-A0, 6 observed agent-misparse events like `sentry issue explain issue-1`).
- Only triggers on purely numeric suffixes — alphanumeric suffixes like `api-G` and other CLI nouns with numeric suffixes (`api-1`, `release-123`) are untouched, since those are valid project-search patterns.
- Wires the same guard into `issue list` targets (bare `issue-1` and `my-org/issue-1`).

## Test plan

- [x] `vitest run test/lib/arg-parsing.test.ts test/commands/issue/list.test.ts`
- [x] `bun run lint:fix && bun run typecheck`
- [ ] `sentry issue explain issue-1` → `ValidationError` with correct format hints

Made with [Cursor](https://cursor.com)