### PR TITLE
ref(api): Adopt SDK types for the projects domain

### DIFF
--- a/packages/cli/src/lib/api/projects.ts
+++ b/packages/cli/src/lib/api/projects.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  createOrganizationProject,
   createTeamProject,
   listOrganizationProjects,
   listProjectKeys,
@@ -27,7 +28,6 @@ import {
 } from "../db/project-cache.js";
 import { getCachedOrganizations } from "../db/regions.js";
 import { type AuthGuardSuccess, withAuthGuard } from "../errors.js";
-import { resolveOrgRegion } from "../region.js";
 import { getApiBaseUrl } from "../sentry-client.js";
 import { buildProjectUrl } from "../sentry-urls.js";
 import { isAllDigits } from "../utils.js";
@@ -234,9 +234,17 @@ export async function createProjectWithDsn(
   return { project, dsn, url };
 }
 
-/** Raw response shape from the org-scoped project creation endpoint. */
+/**
+ * Response from the org-scoped project creation endpoint.
+ *
+ * `createOrganizationProject` returns a standard project plus `team_slug` — the
+ * personal team the server auto-creates for the caller. `team_slug` is returned
+ * by the API but absent from the OpenAPI spec, so it is declared here as a typed
+ * overlay on the SDK-derived `SentryProject` (same convention as
+ * `SentryProject.organization`/`status`; a backend `@extend_schema` candidate).
+ */
 type ProjectWithAutoTeam = SentryProject & {
-  /** The personal team auto-created by the server for the requesting user. */
+  /** Personal team auto-created by the server (returned, not in the OpenAPI spec). */
   team_slug: string;
 };
 
@@ -284,11 +292,16 @@ export async function createProjectWithAutoTeam(
   orgSlug: string,
   body: CreateProjectBody
 ): Promise<CreatedAutoTeamProjectDetails> {
-  const regionUrl = await resolveOrgRegion(orgSlug);
-  const { data } = await apiRequestToRegion<ProjectWithAutoTeam>(
-    regionUrl,
-    `/organizations/${orgSlug}/projects/`,
-    { method: "POST", body }
+  const config = await getOrgSdkConfig(orgSlug);
+  const result = await createOrganizationProject({
+    ...config,
+    path: { organization_id_or_slug: orgSlug },
+    body,
+  });
+  // `team_slug` is returned but not in the spec — see the ProjectWithAutoTeam overlay.
+  const data = unwrapResult<ProjectWithAutoTeam>(
+    result,
+    "Failed to create project"
   );
   const dsn = await tryGetPrimaryDsn(orgSlug, data.slug);
   const url = buildProjectUrl(orgSlug, data.slug);
@@ -470,8 +483,11 @@ export async function findProjectByDsnKey(
   const regions = regionsResult.ok ? regionsResult.value : ([] as Region[]);
 
   if (regions.length === 0) {
-    // Fall back to default region for self-hosted
-    // This uses an internal query parameter not in the public API
+    // Escape hatch (intentionally raw, not an SDK call): the `?query=dsn:` filter
+    // on `/projects/` is an internal search param absent from the OpenAPI spec,
+    // so the SDK provides no typed operation for it. Kept as a documented raw
+    // call until the param is promoted (backend `@extend_schema` candidate).
+    // Fall back to the default region for self-hosted.
     const { data: projects } = await apiRequestToRegion<SentryProject[]>(
       getApiBaseUrl(),
       "/projects/",
@@ -485,6 +501,8 @@ export async function findProjectByDsnKey(
     regions.map((region) =>
       limit(async () => {
         try {
+          // Same `?query=dsn:` escape hatch as above (see the region-fallback
+          // branch) — internal search param, no typed SDK operation yet.
           const { data } = await apiRequestToRegion<SentryProject[]>(
             region.url,
             "/projects/",
@@ -527,21 +545,18 @@ export async function getProject(
 ): Promise<SentryProject> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  // `collapse` is server-supported but not in the OpenAPI spec, so the
-  // SDK types `query` as `never` on `GetProjectData`. Double-cast
-  // via `unknown` to bypass the stricter argument type while still
-  // sending the param at runtime. Same intent as the `per_page` cast
-  // used above.
-  const result = (await sdkGetProject({
+  // `collapse=organization` is server-supported but absent from the OpenAPI
+  // spec, so the SDK types `query` as `never` on `GetProjectData`. Cast just
+  // this param to send it at runtime; the trimmed `{id, slug}` payload it
+  // yields is modeled by the `SentryProject.organization` overlay.
+  const result = await sdkGetProject({
     ...config,
     path: {
       organization_id_or_slug: orgSlug,
       project_id_or_slug: projectSlug,
     },
-    query: { collapse: "organization" },
-  } as unknown as Parameters<typeof sdkGetProject>[0])) as
-    | { data: unknown; error: undefined }
-    | { data: undefined; error: unknown };
+    query: { collapse: "organization" } as never,
+  });
 
   return unwrapResult<SentryProject>(result, "Failed to get project");
 }

--- a/packages/cli/src/types/sentry.ts
+++ b/packages/cli/src/types/sentry.ts
@@ -88,7 +88,14 @@ export type SentryProject = Partial<SdkProjectListItem> & {
     name?: string;
     [key: string]: unknown;
   };
-  /** Project status (returned by API but not in the OpenAPI spec) */
+  /**
+   * Project status (returned by API but not in the OpenAPI spec).
+   *
+   * Overlay convention: the SDK type (`SdkProjectListItem`) carries every
+   * documented field; this overlay adds ONLY fields the API returns but the
+   * spec omits, each a backend `@extend_schema` candidate. Keep it minimal —
+   * do not restate fields the SDK already types.
+   */
   status?: string;
 };
 


### PR DESCRIPTION
## What

A small, bounded **testbed** for the CLI type-cleanup effort — the follow-up to the `@sentry/api` bump (#1194, which renamed call sites but reduced no code). This slice uses the SDK *as intended* for the **projects** domain and establishes the overlay convention the remaining domains will follow. It intentionally does **not** touch all the types.

Projects was chosen because it exercises every realistic case in one cohesive, low-blast-radius slice (all imports flow through the `types/index.ts` barrel): clean SDK adoption, an undocumented-field overlay, the `?collapse` response variant, and a genuine escape hatch.

## Changes

- **Convert `createProjectWithAutoTeam`** from a raw `apiRequestToRegion` POST to the SDK **`createOrganizationProject`** function (same `getOrgSdkConfig` + `unwrapResult` pattern as the rest of the file). `team_slug` (returned by the API but absent from the OpenAPI spec) is kept as a documented typed overlay.
- **Simplify `getProject`**: collapse the whole-argument + result double-cast to a single localized `query: { collapse: 'organization' } as never`. The `collapse` param is server-supported but not in the spec; the trimmed `organization` payload is modeled by the `SentryProject.organization` overlay.
- **Annotate `findProjectByDsnKey`**: its internal `?query=dsn:` filter is not in the public API, so it stays a raw call — now clearly documented as an intentional escape hatch and a backend `@extend_schema` promotion candidate (rather than a silent cast).
- **Codify the overlay convention** on `SentryProject`: the SDK type carries every *documented* field; an overlay adds **only** fields the API returns but the spec omits (`organization`, `status`, `team_slug`), each a backend `@extend_schema` candidate.

## Why not remove more types

Full removal is blocked by four things, none of them CLI-side: loosely-typed endpoints (SDK type thinner than hand-written), undocumented-but-returned fields, `expand`/`collapse` response variants, and private endpoints. These are captured as a backend unlock worklist and are out of scope here.

## Test plan

- `tsc --noEmit`: clean
- `biome check`: clean
- Unit tests: api/types/commands (2738) + api-client coverage / create-sentry-project / project-create (151) — all green. `createProjectWithAutoTeam` coverage asserts the POST target + `team_slug` return, unchanged.
- **Live** (branch source, org `bete-dev`): `project view` returns the project with both the `status` and `organization` overlays intact — behavior unchanged.

No behavior change.