### PR TITLE
fix(alerts): read issue alert rules from org-scoped /workflows/

### DIFF
--- a/src/lib/api/alerts.ts
+++ b/src/lib/api/alerts.ts
@@ -6,6 +6,7 @@
  * - Metric alerts: threshold-based rules that trigger on metric queries (org-wide)
  */
 
+import { ApiError } from "../errors.js";
 import { resolveOrgRegion } from "../region.js";
 import {
   apiRequestToRegion,
@@ -16,7 +17,7 @@ import {
 
 // Types
 
-/** A single issue alert rule (event-based, project-scoped) */
+/** A single issue alert rule (event-based) */
 export type IssueAlertRule = {
   id: string;
   name: string;
@@ -30,6 +31,12 @@ export type IssueAlertRule = {
   owner: string | null;
   projects: string[];
   dateCreated: string;
+  /**
+   * Detector IDs the workflow is attached to. Returned by the org-scoped
+   * `/workflows/` endpoint; used to filter out unattached org-level workflows
+   * (a workflow with no detectors is not an issue alert rule).
+   */
+  detectorIds?: Array<string | number>;
 };
 
 /** A single metric alert rule (threshold-based, org-scoped) */
@@ -49,6 +56,27 @@ export type MetricAlertRule = {
 };
 
 // Issue alerts
+//
+// Issue alert rules are read from the org-scoped `/organizations/{org}/workflows/`
+// endpoint (filtered by `projectSlug`). The legacy project-scoped
+// `/projects/{org}/{project}/rules/` endpoint was deprecated on 2026-05-14 and
+// now returns HTTP 410 during recurring brownouts (getsentry/cli#1182). The
+// workflows endpoint returns rule-shaped payloads, so the existing
+// `IssueAlertRule` shape is preserved. Mutations (create/update/delete) still
+// use the legacy endpoint pending a follow-up migration.
+
+/**
+ * Keep only workflows that are attached to a detector.
+ *
+ * A `projectSlug`-filtered workflows response can also include unattached
+ * org-level workflows; those are not issue alert rules, so we drop any entry
+ * with no `detectorIds`. Mirrors the sentry-mcp filter of the same name.
+ */
+function filterAttachedIssueAlertRules(
+  rules: IssueAlertRule[]
+): IssueAlertRule[] {
+  return rules.filter((rule) => (rule.detectorIds ?? []).length > 0);
+}
 
 /**
  * List issue alert rules for a project with cursor-based pagination.
@@ -66,14 +94,28 @@ export async function listIssueAlertsPaginated(
   const regionUrl = await resolveOrgRegion(orgSlug);
   const { data, headers } = await apiRequestToRegion<IssueAlertRule[]>(
     regionUrl,
-    `/projects/${orgSlug}/${projectSlug}/rules/`,
-    { params: { per_page: options.perPage, cursor: options.cursor } }
+    `/organizations/${orgSlug}/workflows/`,
+    {
+      params: {
+        projectSlug,
+        sortBy: "-id",
+        per_page: options.perPage,
+        cursor: options.cursor,
+      },
+    }
   );
   const { nextCursor } = parseLinkHeader(headers.get("link") ?? null);
-  return { data, nextCursor };
+  return { data: filterAttachedIssueAlertRules(data), nextCursor };
 }
 
-/** Single GET for project issue alert rule (typed or full JSON for PUT). */
+/**
+ * Single GET for a project issue alert rule as full JSON (used as the edit
+ * baseline for PUT).
+ *
+ * NOTE: still uses the deprecated project-scoped `/rules/` endpoint. It backs
+ * the mutation path (`getIssueAlertRuleDocument` → edit), which is migrating to
+ * `/workflows/` in a follow-up (getsentry/cli#1182).
+ */
 async function fetchIssueAlertRuleJson(
   orgSlug: string,
   projectSlug: string,
@@ -90,18 +132,35 @@ async function fetchIssueAlertRuleJson(
 /**
  * Get a single issue alert rule by ID.
  *
+ * Reads from the org-scoped `/workflows/` endpoint, filtered by project and id.
+ *
  * @param orgSlug - Organization slug
  * @param projectSlug - Project slug
  * @param ruleId - Alert rule ID
  * @returns The issue alert rule
+ * @throws {ApiError} 404 if no attached rule matches the id in the project
  */
 export async function getIssueAlertRule(
   orgSlug: string,
   projectSlug: string,
   ruleId: string
 ): Promise<IssueAlertRule> {
-  const data = await fetchIssueAlertRuleJson(orgSlug, projectSlug, ruleId);
-  return data as IssueAlertRule;
+  const regionUrl = await resolveOrgRegion(orgSlug);
+  const { data } = await apiRequestToRegion<IssueAlertRule[]>(
+    regionUrl,
+    `/organizations/${orgSlug}/workflows/`,
+    { params: { projectSlug, id: ruleId, per_page: 1 } }
+  );
+  const rule = filterAttachedIssueAlertRules(data)[0];
+  if (!rule) {
+    throw new ApiError(
+      `Issue alert rule '${ruleId}' not found`,
+      404,
+      undefined,
+      `/organizations/${orgSlug}/workflows/`
+    );
+  }
+  return rule;
 }
 
 // Metric alerts

--- a/test/commands/alert/issues/list.test.ts
+++ b/test/commands/alert/issues/list.test.ts
@@ -87,7 +87,7 @@ describe("alert issues list pagination", () => {
   test("hasMore is false when limit is reached without next cursor", async () => {
     globalThis.fetch = mockFetch(async (input, init) => {
       const req = new Request(input, init);
-      if (req.url.includes("/projects/test-org/test-project/rules/")) {
+      if (req.url.includes("/organizations/test-org/workflows/")) {
         return new Response(
           JSON.stringify([
             {
@@ -101,6 +101,7 @@ describe("alert issues list pagination", () => {
               environment: null,
               owner: null,
               projects: ["test-project"],
+              detectorIds: [1],
               dateCreated: "2026-01-01T00:00:00Z",
             },
           ]),
@@ -134,7 +135,7 @@ describe("alert issues list pagination", () => {
   test("empty query page keeps hasMore when next cursor exists", async () => {
     globalThis.fetch = mockFetch(async (input, init) => {
       const req = new Request(input, init);
-      if (req.url.includes("/projects/test-org/test-project/rules/")) {
+      if (req.url.includes("/organizations/test-org/workflows/")) {
         return new Response(
           JSON.stringify([
             {
@@ -148,6 +149,7 @@ describe("alert issues list pagination", () => {
               environment: null,
               owner: null,
               projects: ["test-project"],
+              detectorIds: [1],
               dateCreated: "2026-01-01T00:00:00Z",
             },
           ]),
@@ -222,7 +224,7 @@ describe("alert issues list pagination", () => {
           name: "My Project",
         });
       }
-      if (url.pathname.includes("/rules/")) {
+      if (url.pathname.includes("/workflows/")) {
         throw new Error("rule fetch should not be called for --web");
       }
       return new Response(JSON.stringify({ detail: "Not found" }), {
@@ -276,7 +278,7 @@ describe("alert issues list pagination", () => {
           name: "My Project",
         });
       }
-      if (url.pathname.includes("/rules/")) {
+      if (url.pathname.includes("/workflows/")) {
         throw new Error("rule fetch should not be called for --web");
       }
       return new Response(JSON.stringify({ detail: "Not found" }), {
@@ -317,7 +319,7 @@ describe("alert issues list pagination", () => {
           name: "Issues Project",
         });
       }
-      if (url.pathname === "/api/0/projects/org-one/issues/rules/") {
+      if (url.pathname === "/api/0/organizations/org-one/workflows/") {
         return Response.json([
           {
             id: "issues-rule",
@@ -330,6 +332,7 @@ describe("alert issues list pagination", () => {
             environment: null,
             owner: null,
             projects: ["issues"],
+            detectorIds: [1],
             dateCreated: "2026-01-01T00:00:00Z",
           },
         ]);
@@ -388,6 +391,7 @@ describe("alert issues list pagination", () => {
       environment: "prod",
       owner: null,
       projects: ["myproj"],
+      detectorIds: [1],
       dateCreated: "2026-01-01T00:00:00Z",
     });
 
@@ -395,7 +399,7 @@ describe("alert issues list pagination", () => {
       const req = new Request(input, init);
       const url = new URL(req.url);
       const ruleMatch = url.pathname.match(
-        /\/api\/0\/projects\/([^/]+)\/myproj\/rules\//
+        /\/api\/0\/organizations\/([^/]+)\/workflows\//
       );
       if (ruleMatch) {
         return Response.json([rule(ruleMatch[1] as string)]);
@@ -451,7 +455,7 @@ describe("alert issues list pagination", () => {
       const req = new Request(input, init);
       const url = new URL(req.url);
       const ruleMatch = url.pathname.match(
-        /\/api\/0\/projects\/([^/]+)\/myproj\/rules\//
+        /\/api\/0\/organizations\/([^/]+)\/workflows\//
       );
       if (ruleMatch) {
         const org = ruleMatch[1] as string;
@@ -472,6 +476,7 @@ describe("alert issues list pagination", () => {
             environment: null,
             owner: null,
             projects: ["myproj"],
+            detectorIds: [1],
             dateCreated: "2026-01-01T00:00:00Z",
           },
         ]);
@@ -536,7 +541,7 @@ describe("alert issues list pagination", () => {
           name: "Test Project",
         });
       }
-      if (url.pathname === "/api/0/projects/test-org/test-project/rules/") {
+      if (url.pathname === "/api/0/organizations/test-org/workflows/") {
         return new Response(JSON.stringify({ detail: "scope denied" }), {
           status: 403,
         });
@@ -561,7 +566,7 @@ describe("alert issues list pagination", () => {
     ).rejects.toMatchObject({
       name: "ApiError",
       status: 403,
-      endpoint: "/projects/test-org/test-project/rules/",
+      endpoint: "/organizations/test-org/workflows/",
     } satisfies Partial<ApiError>);
   });
 
@@ -582,6 +587,7 @@ describe("alert issues list pagination", () => {
       environment: null,
       owner: null,
       projects: ["myproj"],
+      detectorIds: [1],
       dateCreated: "2026-01-01T00:00:00Z",
     });
 
@@ -589,7 +595,7 @@ describe("alert issues list pagination", () => {
       const req = new Request(input, init);
       const url = new URL(req.url);
       const ruleMatch = url.pathname.match(
-        /\/api\/0\/projects\/([^/]+)\/myproj\/rules\//
+        /\/api\/0\/organizations\/([^/]+)\/workflows\//
       );
       if (ruleMatch) {
         const org = ruleMatch[1] as string;

--- a/test/lib/api/alerts.test.ts
+++ b/test/lib/api/alerts.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   deleteIssueAlertRule,
   deleteMetricAlertRule,
+  getIssueAlertRule,
+  listIssueAlertsPaginated,
 } from "../../../src/lib/api/alerts.js";
 import { DEFAULT_SENTRY_URL } from "../../../src/lib/constants.js";
 import { setAuthToken } from "../../../src/lib/db/auth.js";
@@ -40,6 +42,70 @@ describe("deleteIssueAlertRule", () => {
     await expect(
       deleteIssueAlertRule("test-org", "test-project", "42")
     ).resolves.toBeUndefined();
+  });
+});
+
+/** Minimal workflow/rule payload from the org-scoped `/workflows/` endpoint. */
+function workflowRule(overrides: Record<string, unknown>) {
+  return {
+    id: "1",
+    name: "Rule",
+    status: "active",
+    actionMatch: "any",
+    conditions: [],
+    actions: [],
+    frequency: 30,
+    environment: null,
+    owner: null,
+    projects: [],
+    detectorIds: [7],
+    dateCreated: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("listIssueAlertsPaginated", () => {
+  test("reads from org-scoped /workflows/ and drops unattached workflows", async () => {
+    globalThis.fetch = mockFetch(async (input, init) => {
+      const url = new URL(new Request(input!, init).url);
+      expect(url.pathname).toBe("/api/0/organizations/test-org/workflows/");
+      expect(url.searchParams.get("projectSlug")).toBe("test-project");
+      return Response.json([
+        workflowRule({ id: "1", name: "Attached", detectorIds: [7] }),
+        workflowRule({ id: "2", name: "Unattached", detectorIds: [] }),
+      ]);
+    });
+
+    const { data } = await listIssueAlertsPaginated("test-org", "test-project");
+    expect(data).toHaveLength(1);
+    expect(data[0]?.id).toBe("1");
+  });
+});
+
+describe("getIssueAlertRule", () => {
+  test("reads from /workflows/ filtered by project and id", async () => {
+    globalThis.fetch = mockFetch(async (input, init) => {
+      const url = new URL(new Request(input!, init).url);
+      expect(url.pathname).toBe("/api/0/organizations/test-org/workflows/");
+      expect(url.searchParams.get("projectSlug")).toBe("test-project");
+      expect(url.searchParams.get("id")).toBe("42");
+      return Response.json([workflowRule({ id: "42", name: "My Rule" })]);
+    });
+
+    const rule = await getIssueAlertRule("test-org", "test-project", "42");
+    expect(rule.id).toBe("42");
+    expect(rule.name).toBe("My Rule");
+  });
+
+  test("throws 404 ApiError when no attached rule matches", async () => {
+    globalThis.fetch = mockFetch(async () =>
+      // Only an unattached workflow comes back → filtered out → not found.
+      Response.json([workflowRule({ id: "42", detectorIds: [] })])
+    );
+
+    await expect(
+      getIssueAlertRule("test-org", "test-project", "42")
+    ).rejects.toMatchObject({ name: "ApiError", status: 404 });
   });
 });
 


### PR DESCRIPTION
## What & why

The project-scoped `/projects/{org}/{project}/rules/` endpoint was **deprecated on 2026-05-14** and now returns **HTTP 410 during recurring brownouts** (every ~2h), breaking `sentry alert issues list` and `view` for users. Fixes the read path per #1182.

## Change

Migrate the **read** functions in `src/lib/api/alerts.ts` to the org-scoped `/organizations/{org}/workflows/` endpoint, mirroring the proven `sentry-mcp` implementation:

- `listIssueAlertsPaginated` → `GET /organizations/{org}/workflows/?projectSlug={project}&sortBy=-id`
- `getIssueAlertRule` → `GET /organizations/{org}/workflows/?projectSlug={project}&id={id}&per_page=1`, throwing a 404 `ApiError` when no attached rule matches (keeps `isNotFoundApiError` resolution working).

The workflows endpoint returns **rule-shaped payloads**, so the existing `IssueAlertRule` type is preserved. Added `detectorIds` to the type and a `filterAttachedIssueAlertRules` helper to drop unattached org-level workflows (a `projectSlug`-filtered response can include them).

## Scope

**Reads only.** Mutations (`create`/`edit`/`delete`) still use the legacy endpoint and are a tracked follow-up — the workflows create/update body shape differs and has no MCP reference yet. `getReplayRecordingSegments` / `getTraceItemDetail` are out of scope (not deprecated; blocked on getsentry/sentry#118963).

## Test plan

- `tsc --noEmit` + `biome check`: clean.
- Unit: alert/api/command suites pass; added HTTP-level tests for the workflows list, single-get, and the 404 path; updated `list.test.ts` mocks to the workflows endpoint with `detectorIds`.
- **Live** (real org, branch source): `alert issues list` returns attached rules; `alert issues view <id>` returns the rule; a bogus id yields `Issue alert rule '…' not found` — no 410 exposure.

Refs #1182