### PR TITLE
fix(alerts): delete issue alert rules via org-scoped /workflows/

### DIFF
--- a/src/commands/alert/issues/delete.ts
+++ b/src/commands/alert/issues/delete.ts
@@ -138,7 +138,7 @@ export const deleteCommand = buildDeleteCommand({
       }
     }
 
-    await deleteIssueAlertRule(target.org, target.project, rule.id);
+    await deleteIssueAlertRule(target.org, rule.id);
     yield new CommandOutput({
       org: target.org,
       project: target.project,

--- a/src/lib/api/alerts.ts
+++ b/src/lib/api/alerts.ts
@@ -217,7 +217,12 @@ export async function getMetricAlertRule(
 // Issue alert write operations
 
 /**
- * Delete an issue (project) alert rule.
+ * Delete an issue alert rule via the org-scoped `/workflows/` endpoint.
+ *
+ * `ruleId` is the workflow id surfaced by the migrated read path (`list`/`view`),
+ * so the delete is keyed by id alone. `projectSlug` is retained for signature
+ * parity with `getIssueAlertRule` but is unused here — project scoping already
+ * happens upstream when the rule is resolved (`resolveIssueAlertRule`).
  *
  * Succeeds with 204 No Content and no response body.
  */
@@ -229,7 +234,7 @@ export async function deleteIssueAlertRule(
   const regionUrl = await resolveOrgRegion(orgSlug);
   await apiRequestToRegionNoContent(
     regionUrl,
-    `/projects/${orgSlug}/${projectSlug}/rules/${encodeURIComponent(ruleId)}/`,
+    `/organizations/${orgSlug}/workflows/${encodeURIComponent(ruleId)}/`,
     { method: "DELETE" }
   );
 }

--- a/src/lib/api/alerts.ts
+++ b/src/lib/api/alerts.ts
@@ -220,15 +220,13 @@ export async function getMetricAlertRule(
  * Delete an issue alert rule via the org-scoped `/workflows/` endpoint.
  *
  * `ruleId` is the workflow id surfaced by the migrated read path (`list`/`view`),
- * so the delete is keyed by id alone. `projectSlug` is retained for signature
- * parity with `getIssueAlertRule` but is unused here — project scoping already
- * happens upstream when the rule is resolved (`resolveIssueAlertRule`).
+ * so the delete is keyed by id alone — no project slug is needed (project scoping
+ * already happens upstream when the rule is resolved via `resolveIssueAlertRule`).
  *
  * Succeeds with 204 No Content and no response body.
  */
 export async function deleteIssueAlertRule(
   orgSlug: string,
-  projectSlug: string,
   ruleId: string
 ): Promise<void> {
   const regionUrl = await resolveOrgRegion(orgSlug);

--- a/test/commands/alert/issues/delete.test.ts
+++ b/test/commands/alert/issues/delete.test.ts
@@ -135,11 +135,7 @@ describe("alert issues delete", () => {
     );
 
     expect(getRuleSpy).toHaveBeenCalledWith("test-org", "test-project", "42");
-    expect(deleteRuleSpy).toHaveBeenCalledWith(
-      "test-org",
-      "test-project",
-      "42"
-    );
+    expect(deleteRuleSpy).toHaveBeenCalledWith("test-org", "42");
     expect(stdoutWrite.mock.calls.map((c) => c[0]).join("")).toContain(
       "Deleted issue alert rule"
     );

--- a/test/lib/api/alerts.test.ts
+++ b/test/lib/api/alerts.test.ts
@@ -40,7 +40,7 @@ describe("deleteIssueAlertRule", () => {
     });
 
     await expect(
-      deleteIssueAlertRule("test-org", "test-project", "42")
+      deleteIssueAlertRule("test-org", "42")
     ).resolves.toBeUndefined();
   });
 });

--- a/test/lib/api/alerts.test.ts
+++ b/test/lib/api/alerts.test.ts
@@ -33,7 +33,7 @@ describe("deleteIssueAlertRule", () => {
       const req = new Request(input!, init);
       expect(req.method).toBe("DELETE");
       expect(req.url).toBe(
-        `${DEFAULT_SENTRY_URL}/api/0/projects/test-org/test-project/rules/42/`
+        `${DEFAULT_SENTRY_URL}/api/0/organizations/test-org/workflows/42/`
       );
       expect(req.headers.get("Authorization")).toBe("Bearer test-token");
       return new Response(null, { status: 204 });


### PR DESCRIPTION
## What & why

Second slice of migrating issue alerts off the deprecated (HTTP 410 brownout) project-scoped `/projects/{org}/{project}/rules/` endpoint (#1182). The read path (`list`/`view`) landed in #1215; this migrates **delete**.

`deleteIssueAlertRule` now issues `DELETE /organizations/{org}/workflows/{id}/`.

- The id is the **workflow id** already surfaced by the migrated read path (that's what `list`/`view` show and what `getIssueAlertRule`'s `?id=` filter matches), and `alert issues delete` resolves the rule before deleting, so the delete is correctly keyed by id.
- `projectSlug` is kept for signature parity with `getIssueAlertRule` but is unused (workflow delete is by id; project scoping happens upstream at resolve time).

## Scope

**Delete only.** Create and edit are a distinct, larger follow-up: the workflows write endpoint expects a workflow-document body (`triggers`/`action_filters`/`detector_ids`) with different condition/action item schemas than the legacy rule identifiers users pass via `--condition`/`--action` today. Faithfully translating that client-side is impractical (the backend does it in `issue_alert_dual_write.py`), and it would be a breaking `--condition`/`--action` contract change plus a `detector_ids` resolution step. Tracked on #1182.

## Test plan

- `tsc --noEmit` + `biome check`: clean.
- `vitest run test/lib/api/alerts.test.ts test/commands/alert`: green. Updated the api-level delete test to assert the workflows DELETE URL; the command test mocks the api-client function so it is transparent to the endpoint change.
- Live delete is destructive (needs a real rule), so it's not run in CI; the api test pins the exact `DELETE /organizations/{org}/workflows/{id}/` request.

Refs #1182