### PR TITLE
fix(seer): Read sentry_run_id instead of the deprecated run_id

### DIFF
--- a/src/commands/issue/plan.ts
+++ b/src/commands/issue/plan.ts
@@ -55,7 +55,6 @@ type NoSolutionContext = {
 
 /** Return type for issue plan — includes state metadata and solution data */
 type PlanData = {
-  /** The autofix run ID (UUID from state.sentry_run_id, falling back to the legacy numeric state.run_id). */
   run_id: string | number;
   status: string;
   /** The solution data (without the artifact wrapper). Null when no solution is available. */

--- a/src/commands/issue/plan.ts
+++ b/src/commands/issue/plan.ts
@@ -26,6 +26,7 @@ import {
   extractNoSolutionReason,
   extractRootCauses,
   extractSolution,
+  getAutofixRunId,
   type SolutionArtifact,
 } from "../../types/seer.js";
 import {
@@ -54,7 +55,8 @@ type NoSolutionContext = {
 
 /** Return type for issue plan — includes state metadata and solution data */
 type PlanData = {
-  run_id: number;
+  /** The autofix run ID (UUID from state.sentry_run_id, falling back to the legacy numeric state.run_id). */
+  run_id: string | number | undefined;
   status: string;
   /** The solution data (without the artifact wrapper). Null when no solution is available. */
   solution: SolutionArtifact["data"] | null;
@@ -141,7 +143,7 @@ function buildNoSolutionContext(
 function buildPlanData(state: AutofixState): PlanData {
   const solution = extractSolution(state);
   const data: PlanData = {
-    run_id: state.run_id,
+    run_id: getAutofixRunId(state),
     status: state.status,
     solution: solution?.data ?? null,
   };
@@ -235,7 +237,13 @@ export const planCommand = buildCommand({
         }
       }
 
-      await triggerSolutionPlanning(org, numericId, state.run_id);
+      const runId = getAutofixRunId(state);
+      if (runId === undefined) {
+        throw new Error(
+          "Autofix state is missing a run ID. Check the issue in Sentry web UI."
+        );
+      }
+      await triggerSolutionPlanning(org, numericId, runId);
 
       // Poll until solution is ready or terminal
       const finalState = await pollAutofixState({

--- a/src/commands/issue/plan.ts
+++ b/src/commands/issue/plan.ts
@@ -26,7 +26,7 @@ import {
   extractNoSolutionReason,
   extractRootCauses,
   extractSolution,
-  getAutofixRunId,
+  requireAutofixRunId,
   type SolutionArtifact,
 } from "../../types/seer.js";
 import {
@@ -56,7 +56,7 @@ type NoSolutionContext = {
 /** Return type for issue plan — includes state metadata and solution data */
 type PlanData = {
   /** The autofix run ID (UUID from state.sentry_run_id, falling back to the legacy numeric state.run_id). */
-  run_id: string | number | undefined;
+  run_id: string | number;
   status: string;
   /** The solution data (without the artifact wrapper). Null when no solution is available. */
   solution: SolutionArtifact["data"] | null;
@@ -143,7 +143,7 @@ function buildNoSolutionContext(
 function buildPlanData(state: AutofixState): PlanData {
   const solution = extractSolution(state);
   const data: PlanData = {
-    run_id: getAutofixRunId(state),
+    run_id: requireAutofixRunId(state),
     status: state.status,
     solution: solution?.data ?? null,
   };
@@ -237,13 +237,7 @@ export const planCommand = buildCommand({
         }
       }
 
-      const runId = getAutofixRunId(state);
-      if (runId === undefined) {
-        throw new Error(
-          "Autofix state is missing a run ID. Check the issue in Sentry web UI."
-        );
-      }
-      await triggerSolutionPlanning(org, numericId, runId);
+      await triggerSolutionPlanning(org, numericId, requireAutofixRunId(state));
 
       // Poll until solution is ready or terminal
       const finalState = await pollAutofixState({

--- a/src/lib/api/seer.ts
+++ b/src/lib/api/seer.ts
@@ -54,9 +54,7 @@ function normalizeAgentStatus(status: string): string {
  *
  * @param orgSlug - The organization slug
  * @param issueId - The numeric Sentry issue ID
- * @returns The trigger response with `sentry_run_id` (current UUID) and the
- *   legacy `run_id` (numeric), which is slated for removal — treat it as
- *   optional, not guaranteed to be present
+ * @returns The trigger response with `sentry_run_id` and the legacy `run_id`
  * @throws {ApiError} On API errors (402 = no budget, 403 = not enabled)
  */
 export async function triggerRootCauseAnalysis(
@@ -114,20 +112,11 @@ export async function getAutofixState(
  * Trigger solution planning for an existing autofix run.
  *
  * Posts to the agent-based autofix endpoint with `step: "solution"` and
- * the existing run ID (from {@link requireAutofixRunId}). The agent continues
- * from root cause analysis to generating a solution plan.
- *
- * The request body has two distinct, separately-validated fields: `run_id`
- * (an integer field, deprecated) and `sentry_run_id` (a UUID field, takes
- * precedence when both are given). A UUID string sent under `run_id` fails
- * server-side validation, so the value must go under the field matching its
- * type — string runIds (current `sentry_run_id`s) go under `sentry_run_id`,
- * numeric runIds (legacy `run_id`s) go under `run_id`.
+ * the existing run ID (from {@link requireAutofixRunId}).
  *
  * @param orgSlug - The organization slug
  * @param issueId - The numeric Sentry issue ID
- * @param runId - The autofix run ID (see {@link requireAutofixRunId}) — a UUID
- *   string for current runs, or a legacy number for older ones
+ * @param runId - The autofix run ID (see {@link requireAutofixRunId})
  * @returns The response from the API
  */
 export async function triggerSolutionPlanning(
@@ -137,6 +126,7 @@ export async function triggerSolutionPlanning(
 ): Promise<unknown> {
   const regionUrl = await resolveOrgRegion(orgSlug);
 
+  // A UUID sent under run_id (an IntegerField) fails server-side validation.
   const runIdBodyField =
     typeof runId === "string" ? { sentry_run_id: runId } : { run_id: runId };
 

--- a/src/lib/api/seer.ts
+++ b/src/lib/api/seer.ts
@@ -68,18 +68,14 @@ export async function triggerRootCauseAnalysis(
   const { data } = await apiRequestToRegion<{
     run_id?: number;
     sentry_run_id: string | null;
-  }>(
-    regionUrl,
-    `/organizations/${orgSlug}/issues/${issueId}/autofix/`,
-    {
-      method: "POST",
-      params: EXPLORER_MODE_PARAMS,
-      body: {
-        step: "root_cause",
-        referrer: "api.cli",
-      },
-    }
-  );
+  }>(regionUrl, `/organizations/${orgSlug}/issues/${issueId}/autofix/`, {
+    method: "POST",
+    params: EXPLORER_MODE_PARAMS,
+    body: {
+      step: "root_cause",
+      referrer: "api.cli",
+    },
+  });
   return data;
 }
 
@@ -118,7 +114,7 @@ export async function getAutofixState(
  * Trigger solution planning for an existing autofix run.
  *
  * Posts to the agent-based autofix endpoint with `step: "solution"` and
- * the existing run ID (from {@link getAutofixRunId}). The agent continues
+ * the existing run ID (from {@link requireAutofixRunId}). The agent continues
  * from root cause analysis to generating a solution plan.
  *
  * The request body has two distinct, separately-validated fields: `run_id`
@@ -130,7 +126,7 @@ export async function getAutofixState(
  *
  * @param orgSlug - The organization slug
  * @param issueId - The numeric Sentry issue ID
- * @param runId - The autofix run ID (see {@link getAutofixRunId}) — a UUID
+ * @param runId - The autofix run ID (see {@link requireAutofixRunId}) — a UUID
  *   string for current runs, or a legacy number for older ones
  * @returns The response from the API
  */

--- a/src/lib/api/seer.ts
+++ b/src/lib/api/seer.ts
@@ -54,9 +54,9 @@ function normalizeAgentStatus(status: string): string {
  *
  * @param orgSlug - The organization slug
  * @param issueId - The numeric Sentry issue ID
- * @returns The trigger response with `sentry_run_id` (current UUID, null for
- *   very old runs) and the legacy `run_id` (numeric), which is slated for
- *   removal — treat it as optional, not guaranteed to be present
+ * @returns The trigger response with `sentry_run_id` (current UUID) and the
+ *   legacy `run_id` (numeric), which is slated for removal — treat it as
+ *   optional, not guaranteed to be present
  * @throws {ApiError} On API errors (402 = no budget, 403 = not enabled)
  */
 export async function triggerRootCauseAnalysis(

--- a/src/lib/api/seer.ts
+++ b/src/lib/api/seer.ts
@@ -54,16 +54,21 @@ function normalizeAgentStatus(status: string): string {
  *
  * @param orgSlug - The organization slug
  * @param issueId - The numeric Sentry issue ID
- * @returns The trigger response with run_id
+ * @returns The trigger response with `sentry_run_id` (current UUID, null for
+ *   very old runs) and the legacy `run_id` (numeric), which is slated for
+ *   removal — treat it as optional, not guaranteed to be present
  * @throws {ApiError} On API errors (402 = no budget, 403 = not enabled)
  */
 export async function triggerRootCauseAnalysis(
   orgSlug: string,
   issueId: string
-): Promise<{ run_id: number }> {
+): Promise<{ run_id?: number; sentry_run_id: string | null }> {
   const regionUrl = await resolveOrgRegion(orgSlug);
 
-  const { data } = await apiRequestToRegion<{ run_id: number }>(
+  const { data } = await apiRequestToRegion<{
+    run_id?: number;
+    sentry_run_id: string | null;
+  }>(
     regionUrl,
     `/organizations/${orgSlug}/issues/${issueId}/autofix/`,
     {
@@ -113,20 +118,31 @@ export async function getAutofixState(
  * Trigger solution planning for an existing autofix run.
  *
  * Posts to the agent-based autofix endpoint with `step: "solution"` and
- * the existing `run_id`. The agent continues from root cause analysis
- * to generating a solution plan.
+ * the existing run ID (from {@link getAutofixRunId}). The agent continues
+ * from root cause analysis to generating a solution plan.
+ *
+ * The request body has two distinct, separately-validated fields: `run_id`
+ * (an integer field, deprecated) and `sentry_run_id` (a UUID field, takes
+ * precedence when both are given). A UUID string sent under `run_id` fails
+ * server-side validation, so the value must go under the field matching its
+ * type — string runIds (current `sentry_run_id`s) go under `sentry_run_id`,
+ * numeric runIds (legacy `run_id`s) go under `run_id`.
  *
  * @param orgSlug - The organization slug
  * @param issueId - The numeric Sentry issue ID
- * @param runId - The autofix run ID
+ * @param runId - The autofix run ID (see {@link getAutofixRunId}) — a UUID
+ *   string for current runs, or a legacy number for older ones
  * @returns The response from the API
  */
 export async function triggerSolutionPlanning(
   orgSlug: string,
   issueId: string,
-  runId: number
+  runId: string | number
 ): Promise<unknown> {
   const regionUrl = await resolveOrgRegion(orgSlug);
+
+  const runIdBodyField =
+    typeof runId === "string" ? { sentry_run_id: runId } : { run_id: runId };
 
   const { data } = await apiRequestToRegion(
     regionUrl,
@@ -136,7 +152,7 @@ export async function triggerSolutionPlanning(
       params: EXPLORER_MODE_PARAMS,
       body: {
         step: "solution",
-        run_id: runId,
+        ...runIdBodyField,
         referrer: "api.cli",
       },
     }

--- a/src/types/seer.ts
+++ b/src/types/seer.ts
@@ -172,13 +172,9 @@ export type SolutionArtifact = z.infer<typeof SolutionArtifactSchema>;
 
 export const AutofixStateSchema = z
   .object({
-    /** Legacy numeric run identifier. Deprecated in favor of {@link sentry_run_id}, kept for older API responses. */
+    /** @deprecated Use sentry_run_id instead. */
     run_id: z.number().optional(),
-    /**
-     * Current run identifier (UUID string). Preferred over the legacy `run_id`
-     * field. The API returns this as explicit `null` (not an omitted key) for
-     * legacy runs predating SeerRun mirroring.
-     */
+    /** Null for legacy runs predating this field. */
     sentry_run_id: z.string().nullable().optional(),
     status: z.string(),
     updated_at: z.string().optional(),
@@ -249,19 +245,8 @@ export function isTerminalStatus(status: string): boolean {
   return TERMINAL_STATUSES.includes(status as AutofixStatus);
 }
 
-/**
- * Get the run identifier from autofix state, preferring the current
- * `sentry_run_id` field (a UUID string) over the deprecated numeric
- * `run_id` field.
- *
- * The API dual-writes both fields on every non-null autofix state, so a
- * missing run ID here means the response is malformed, not a legitimate
- * in-progress state — callers should treat it as an error, not a value to
- * pass through.
- *
- * @param state - The autofix state
- * @throws {Error} If neither `sentry_run_id` nor `run_id` is present
- */
+// Both fields are always present on a non-null autofix state, so a missing
+// run ID means a malformed response, not an in-progress state.
 export function requireAutofixRunId(state: AutofixState): string | number {
   const runId = state.sentry_run_id ?? state.run_id;
   if (runId === undefined) {

--- a/src/types/seer.ts
+++ b/src/types/seer.ts
@@ -172,7 +172,14 @@ export type SolutionArtifact = z.infer<typeof SolutionArtifactSchema>;
 
 export const AutofixStateSchema = z
   .object({
-    run_id: z.number(),
+    /** Legacy numeric run identifier. Deprecated in favor of {@link sentry_run_id}, kept for older API responses. */
+    run_id: z.number().optional(),
+    /**
+     * Current run identifier (UUID string). Preferred over the legacy `run_id`
+     * field. The API returns this as explicit `null` (not an omitted key) for
+     * legacy runs predating SeerRun mirroring.
+     */
+    sentry_run_id: z.string().nullable().optional(),
     status: z.string(),
     updated_at: z.string().optional(),
     request: z
@@ -240,6 +247,20 @@ export type AutofixUpdatePayload =
  */
 export function isTerminalStatus(status: string): boolean {
   return TERMINAL_STATUSES.includes(status as AutofixStatus);
+}
+
+/**
+ * Get the run identifier from autofix state, preferring the current
+ * `sentry_run_id` field (a UUID string) over the deprecated numeric
+ * `run_id` field.
+ *
+ * @param state - The autofix state
+ * @returns The run ID, or undefined if neither field is present
+ */
+export function getAutofixRunId(
+  state: AutofixState
+): string | number | undefined {
+  return state.sentry_run_id ?? state.run_id;
 }
 
 /** Container that may hold root cause analysis data (legacy format) */

--- a/src/types/seer.ts
+++ b/src/types/seer.ts
@@ -245,13 +245,13 @@ export function isTerminalStatus(status: string): boolean {
   return TERMINAL_STATUSES.includes(status as AutofixStatus);
 }
 
-// Both fields are always present on a non-null autofix state, so a missing
-// run ID means a malformed response, not an in-progress state.
+// At least one of sentry_run_id/run_id is always present on a non-null
+// autofix state, so a missing run ID means a malformed response.
 export function requireAutofixRunId(state: AutofixState): string | number {
   const runId = state.sentry_run_id ?? state.run_id;
   if (runId === undefined) {
     throw new Error(
-      "Autofix state is missing a run ID (no sentry_run_id or run_id). Check the issue in Sentry web UI."
+      "Unexpected autofix response: missing both sentry_run_id and run_id."
     );
   }
   return runId;

--- a/src/types/seer.ts
+++ b/src/types/seer.ts
@@ -254,13 +254,22 @@ export function isTerminalStatus(status: string): boolean {
  * `sentry_run_id` field (a UUID string) over the deprecated numeric
  * `run_id` field.
  *
+ * The API dual-writes both fields on every non-null autofix state, so a
+ * missing run ID here means the response is malformed, not a legitimate
+ * in-progress state — callers should treat it as an error, not a value to
+ * pass through.
+ *
  * @param state - The autofix state
- * @returns The run ID, or undefined if neither field is present
+ * @throws {Error} If neither `sentry_run_id` nor `run_id` is present
  */
-export function getAutofixRunId(
-  state: AutofixState
-): string | number | undefined {
-  return state.sentry_run_id ?? state.run_id;
+export function requireAutofixRunId(state: AutofixState): string | number {
+  const runId = state.sentry_run_id ?? state.run_id;
+  if (runId === undefined) {
+    throw new Error(
+      "Autofix state is missing a run ID (no sentry_run_id or run_id). Check the issue in Sentry web UI."
+    );
+  }
+  return runId;
 }
 
 /** Container that may hold root cause analysis data (legacy format) */

--- a/test/lib/api-client.seer.test.ts
+++ b/test/lib/api-client.seer.test.ts
@@ -110,7 +110,7 @@ describe("getAutofixState", () => {
       return new Response(
         JSON.stringify({
           autofix: {
-            run_id: 12_345,
+            sentry_run_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
             status: "processing",
             blocks: [],
             updated_at: "2025-01-01T00:00:00Z",
@@ -125,13 +125,36 @@ describe("getAutofixState", () => {
 
     const result = await getAutofixState("test-org", "123456789");
 
-    expect(result?.run_id).toBe(12_345);
+    expect(result?.sentry_run_id).toBe("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
     expect(result?.status).toBe("PROCESSING");
     expect(capturedRequest?.method).toBe("GET");
     expect(capturedRequest?.url).toContain(
       "/organizations/test-org/issues/123456789/autofix/"
     );
     expect(capturedRequest?.url).toContain("mode=explorer");
+  });
+
+  test("still parses legacy run_id when sentry_run_id is absent", async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          autofix: {
+            run_id: 12_345,
+            status: "processing",
+            blocks: [],
+            updated_at: "2025-01-01T00:00:00Z",
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+
+    const result = await getAutofixState("test-org", "123456789");
+
+    expect(result?.run_id).toBe(12_345);
+    expect(result?.sentry_run_id).toBeUndefined();
   });
 
   test("normalizes agent status values to uppercase", async () => {
@@ -271,6 +294,39 @@ describe("triggerSolutionPlanning", () => {
     expect(capturedBody).toEqual({
       step: "solution",
       run_id: 12_345,
+      referrer: "api.cli",
+    });
+  });
+
+  test("sends a UUID run ID under the sentry_run_id body field, not run_id", async () => {
+    let capturedBody: unknown;
+
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      capturedBody = await new Request(input, init).json();
+
+      return new Response(
+        JSON.stringify({
+          run_id: 12_345,
+          sentry_run_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        }),
+        {
+          status: 202,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    };
+
+    await triggerSolutionPlanning(
+      "test-org",
+      "123456789",
+      "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    );
+
+    // sentry_run_id is a UUIDField server-side; run_id is an IntegerField.
+    // Sending the UUID under run_id would fail server-side validation.
+    expect(capturedBody).toEqual({
+      step: "solution",
+      sentry_run_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
       referrer: "api.cli",
     });
   });

--- a/test/types/seer.test.ts
+++ b/test/types/seer.test.ts
@@ -11,6 +11,7 @@ import {
   extractNoSolutionReason,
   extractRootCauses,
   extractSolution,
+  getAutofixRunId,
   isTerminalStatus,
   type RootCause,
   TERMINAL_STATUSES,
@@ -46,6 +47,27 @@ describe("isTerminalStatus", () => {
     expect(TERMINAL_STATUSES).toContain("ERROR");
     expect(TERMINAL_STATUSES).toContain("CANCELLED");
     expect(TERMINAL_STATUSES).not.toContain("PROCESSING");
+  });
+});
+
+describe("getAutofixRunId", () => {
+  test("prefers sentry_run_id over legacy run_id", () => {
+    const state: AutofixState = {
+      sentry_run_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      run_id: 123,
+      status: "COMPLETED",
+    };
+    expect(getAutofixRunId(state)).toBe("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+  });
+
+  test("falls back to legacy run_id when sentry_run_id is absent", () => {
+    const state: AutofixState = { run_id: 123, status: "COMPLETED" };
+    expect(getAutofixRunId(state)).toBe(123);
+  });
+
+  test("returns undefined when neither field is present", () => {
+    const state: AutofixState = { status: "COMPLETED" };
+    expect(getAutofixRunId(state)).toBeUndefined();
   });
 });
 

--- a/test/types/seer.test.ts
+++ b/test/types/seer.test.ts
@@ -11,9 +11,9 @@ import {
   extractNoSolutionReason,
   extractRootCauses,
   extractSolution,
-  getAutofixRunId,
   isTerminalStatus,
   type RootCause,
+  requireAutofixRunId,
   TERMINAL_STATUSES,
 } from "../../src/types/seer.js";
 
@@ -50,24 +50,26 @@ describe("isTerminalStatus", () => {
   });
 });
 
-describe("getAutofixRunId", () => {
+describe("requireAutofixRunId", () => {
   test("prefers sentry_run_id over legacy run_id", () => {
     const state: AutofixState = {
       sentry_run_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
       run_id: 123,
       status: "COMPLETED",
     };
-    expect(getAutofixRunId(state)).toBe("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    expect(requireAutofixRunId(state)).toBe(
+      "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    );
   });
 
   test("falls back to legacy run_id when sentry_run_id is absent", () => {
     const state: AutofixState = { run_id: 123, status: "COMPLETED" };
-    expect(getAutofixRunId(state)).toBe(123);
+    expect(requireAutofixRunId(state)).toBe(123);
   });
 
-  test("returns undefined when neither field is present", () => {
+  test("throws when neither field is present", () => {
     const state: AutofixState = { status: "COMPLETED" };
-    expect(getAutofixRunId(state)).toBeUndefined();
+    expect(() => requireAutofixRunId(state)).toThrow(/missing a run ID/);
   });
 });
 

--- a/test/types/seer.test.ts
+++ b/test/types/seer.test.ts
@@ -69,7 +69,7 @@ describe("requireAutofixRunId", () => {
 
   test("throws when neither field is present", () => {
     const state: AutofixState = { status: "COMPLETED" };
-    expect(() => requireAutofixRunId(state)).toThrow(/missing a run ID/);
+    expect(() => requireAutofixRunId(state)).toThrow(/missing both/);
   });
 });
 


### PR DESCRIPTION
The autofix API is migrating run identifiers from a legacy numeric `run_id` to a UUID `sentry_run_id`, and the numeric field is slated for eventual removal. The CLI read `run_id` directly off autofix state and forwarded it when continuing a run, which would silently break once that field disappears from responses.

Added `requireAutofixRunId()` to prefer `sentry_run_id`, falling back to `run_id` for older responses, and used it everywhere the CLI reads a run identifier (`issue plan`'s output and its continue-run call). The API dual-writes both fields on every non-null autofix state, so a missing run ID is a malformed response, not a legitimate in-progress state — the helper throws in that case rather than letting `undefined` flow into the CLI's JSON output.

The continue-run request sends the ID under whichever body field matches its type: `sentry_run_id` (a UUID field) or `run_id` (an integer field). The server validates these as two distinct, differently-typed fields, so a UUID sent under `run_id` would be rejected outright.

Verified against the live API: GET/POST responses return both fields as expected (int `run_id`, UUID `sentry_run_id`), and a real continue-run POST with a UUID under `sentry_run_id` returns 202.