### PR TITLE
chore: load .env.local in tsx and cli dev scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
     ]
   },
   "scripts": {
-    "tsx": "tsx --import ./script/require-shim.mjs",
-    "cli": "tsx --import ./script/require-shim.mjs src/bin.ts",
+    "tsx": "tsx --env-file .env.local --import ./script/require-shim.mjs",
+    "cli": "tsx --env-file .env.local --import ./script/require-shim.mjs src/bin.ts",
     "dev": "pnpm run generate:schema && pnpm run generate:docs && pnpm run generate:sdk && tsx --import ./script/require-shim.mjs src/bin.ts",
     "build": "pnpm run generate:schema && pnpm run generate:docs && pnpm run generate:sdk && pnpm tsx script/build.ts --single",
     "build:all": "pnpm run generate:schema && pnpm run generate:docs && pnpm run generate:sdk && pnpm tsx script/build.ts",

--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
     ]
   },
   "scripts": {
-    "tsx": "tsx --env-file .env.local --import ./script/require-shim.mjs",
-    "cli": "tsx --env-file .env.local --import ./script/require-shim.mjs src/bin.ts",
+    "tsx": "tsx --env-file-if-exists=.env.local --import ./script/require-shim.mjs",
+    "cli": "tsx --env-file-if-exists=.env.local --import ./script/require-shim.mjs src/bin.ts",
     "dev": "pnpm run generate:schema && pnpm run generate:docs && pnpm run generate:sdk && tsx --import ./script/require-shim.mjs src/bin.ts",
     "build": "pnpm run generate:schema && pnpm run generate:docs && pnpm run generate:sdk && pnpm tsx script/build.ts --single",
     "build:all": "pnpm run generate:schema && pnpm run generate:docs && pnpm run generate:sdk && pnpm tsx script/build.ts",


### PR DESCRIPTION
## Summary

Adds `--env-file .env.local` to the `tsx` and `cli` package.json scripts so local environment variables are loaded automatically when running the CLI in dev mode.

## Changes

- `tsx` script: `tsx --env-file .env.local --import ./script/require-shim.mjs`
- `cli` script: `tsx --env-file .env.local --import ./script/require-shim.mjs src/bin.ts`

`.env.local` is gitignored, so this only affects local development.