### PR TITLE
fix(init): retry transient auth validation once

### DIFF
--- a/src/lib/init/init-service-auth.ts
+++ b/src/lib/init/init-service-auth.ts
@@ -1,3 +1,4 @@
+import { MastraClientError } from "@mastra/client-js";
 import { enrich401Detail } from "../api/infrastructure.js";
 import { ApiError, HostScopeError } from "../errors.js";
 import { isSaaSTrustOrigin, normalizeOrigin } from "../sentry-urls.js";
@@ -15,6 +16,32 @@ export const WORKFLOW_CREATE_RUN_ENDPOINT = `${WORKFLOW_ENDPOINT}/create-run`;
 export const WORKFLOW_RESUME_ASYNC_ENDPOINT = `${WORKFLOW_ENDPOINT}/resume-async`;
 export const WORKFLOW_START_ASYNC_ENDPOINT = `${WORKFLOW_ENDPOINT}/start-async`;
 const MASTRA_HTTP_401_RE = /HTTP error!\s*status:\s*401\b/i;
+const INIT_SERVICE_AUTH_RETRY_DELAY_MS = 250;
+const RETRYABLE_AUTH_UPSTREAM_CODES = new Set([
+  "AUTH_UPSTREAM_TIMEOUT",
+  "AUTH_UPSTREAM_UNAVAILABLE",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isRetryableInitServiceAuthFailure(err: unknown): boolean {
+  if (
+    !(
+      err instanceof MastraClientError &&
+      err.status === 503 &&
+      isRecord(err.body)
+    )
+  ) {
+    return false;
+  }
+  return (
+    err.body.safeToRetry === true &&
+    typeof err.body.code === "string" &&
+    RETRYABLE_AUTH_UPSTREAM_CODES.has(err.body.code)
+  );
+}
 
 function classifyInitServiceAuthFailure(
   err: unknown,
@@ -41,6 +68,30 @@ export async function withInitServiceAuthClassification<T>(
   } catch (err) {
     throw classifyInitServiceAuthFailure(err, endpoint) ?? err;
   }
+}
+
+/**
+ * Retry one request only when the server proves auth failed before workflow
+ * execution. Generic 5xx and ambiguous transport failures are never replayed.
+ */
+export async function withInitServiceAuthRetry<T>(
+  operation: () => Promise<T>,
+  endpoint: string,
+  onRetry?: () => void | Promise<void>
+): Promise<T> {
+  try {
+    return await withInitServiceAuthClassification(operation, endpoint);
+  } catch (err) {
+    if (!isRetryableInitServiceAuthFailure(err)) {
+      throw err;
+    }
+  }
+
+  await onRetry?.();
+  await new Promise((resolve) =>
+    setTimeout(resolve, INIT_SERVICE_AUTH_RETRY_DELAY_MS)
+  );
+  return withInitServiceAuthClassification(operation, endpoint);
 }
 
 export function assertHostedInitServiceAcceptsTokenHost(): void {

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -55,7 +55,7 @@ import {
   WORKFLOW_CREATE_RUN_ENDPOINT,
   WORKFLOW_RESUME_ASYNC_ENDPOINT,
   WORKFLOW_START_ASYNC_ENDPOINT,
-  withInitServiceAuthClassification,
+  withInitServiceAuthRetry,
 } from "./init-service-auth.js";
 import { handleInteractive } from "./interactive.js";
 import { resolveInitContext } from "./preflight.js";
@@ -614,6 +614,20 @@ type ResumeRetryArgs = {
   progressRotation?: ProgressRotationHandle;
 };
 
+function reportInitServiceAuthRetry(
+  endpoint: string,
+  spin: SpinnerHandle
+): void {
+  setTag("wizard.auth_retry", "true");
+  addBreadcrumb({
+    category: "wizard.auth",
+    message: "Retrying after transient auth service failure",
+    level: "warning",
+    data: { endpoint },
+  });
+  spin.message("Authentication service delayed, retrying...");
+}
+
 /**
  * Detect Mastra's "not suspended" conflict — means the server already
  * processed this step (our previous request succeeded but the response was
@@ -740,11 +754,21 @@ async function resumeWithRecovery(
     ui,
     progressRotation,
   } = args;
+  let authRetryShown = false;
   try {
     const raw = await withTimeout(
-      withInitServiceAuthClassification(
+      withInitServiceAuthRetry(
         () => run.resumeAsync({ step: stepId, resumeData, tracingOptions }),
-        WORKFLOW_RESUME_ASYNC_ENDPOINT
+        WORKFLOW_RESUME_ASYNC_ENDPOINT,
+        () => {
+          authRetryShown = true;
+          reportInitServiceAuthRetry(WORKFLOW_RESUME_ASYNC_ENDPOINT, spin);
+          ui.setOverlay?.({
+            kind: "health",
+            message: "Authentication service delayed, retrying...",
+            retryCount: 1,
+          });
+        }
       ),
       API_TIMEOUT_MS,
       "Workflow resume"
@@ -808,6 +832,10 @@ async function resumeWithRecovery(
       return recovered;
     }
     throw err;
+  } finally {
+    if (authRetryShown) {
+      ui.clearOverlay?.();
+    }
   }
 }
 
@@ -927,10 +955,12 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     const fileCache = await preReadCommonFiles(directory, dirListing);
     ui.setIntroMode?.(false);
     spin.message("Connecting to wizard...");
-    run = await withInitServiceAuthClassification(
+    run = await withInitServiceAuthRetry(
       () => workflow.createRun(),
-      WORKFLOW_CREATE_RUN_ENDPOINT
+      WORKFLOW_CREATE_RUN_ENDPOINT,
+      () => reportInitServiceAuthRetry(WORKFLOW_CREATE_RUN_ENDPOINT, spin)
     );
+    spin.message("Starting wizard...");
     // Large shared context (dirListing, fileCache, existingSentry)
     // travels via Mastra's workflow `initialState` instead of `inputData`.
     // Keeping it on state means the server stores it exactly once per run
@@ -940,7 +970,7 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     // error. See getsentry/cli-init-api#98.
     result = assertWorkflowResult(
       await withTimeout(
-        withInitServiceAuthClassification(
+        withInitServiceAuthRetry(
           () =>
             run.startAsync({
               inputData: {
@@ -957,7 +987,8 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
               },
               tracingOptions,
             }),
-          WORKFLOW_START_ASYNC_ENDPOINT
+          WORKFLOW_START_ASYNC_ENDPOINT,
+          () => reportInitServiceAuthRetry(WORKFLOW_START_ASYNC_ENDPOINT, spin)
         ),
         API_TIMEOUT_MS,
         "Workflow start"

--- a/test/lib/init/init-service-auth.test.ts
+++ b/test/lib/init/init-service-auth.test.ts
@@ -1,0 +1,132 @@
+import { MastraClientError } from "@mastra/client-js";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { ApiError } from "../../../src/lib/errors.js";
+import {
+  WORKFLOW_RESUME_ASYNC_ENDPOINT,
+  withInitServiceAuthRetry,
+} from "../../../src/lib/init/init-service-auth.js";
+
+function serviceError(
+  body: Record<string, unknown>,
+  status = 503
+): MastraClientError {
+  return new MastraClientError(
+    status,
+    "Service Unavailable",
+    `HTTP error! status: ${status} - ${JSON.stringify(body)}`,
+    body
+  );
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("withInitServiceAuthRetry", () => {
+  test.each([
+    "AUTH_UPSTREAM_TIMEOUT",
+    "AUTH_UPSTREAM_UNAVAILABLE",
+  ])("retries %s once and returns the second result", async (code) => {
+    vi.useFakeTimers();
+    const operation = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(serviceError({ code, safeToRetry: true }))
+      .mockResolvedValueOnce("ok");
+    const onRetry = vi.fn();
+
+    const resultPromise = withInitServiceAuthRetry(
+      operation,
+      WORKFLOW_RESUME_ASYNC_ENDPOINT,
+      onRetry
+    );
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(resultPromise).resolves.toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  test("stops after the single retry when the upstream is still unavailable", async () => {
+    vi.useFakeTimers();
+    const error = serviceError({
+      code: "AUTH_UPSTREAM_TIMEOUT",
+      safeToRetry: true,
+    });
+    const operation = vi.fn<() => Promise<string>>().mockRejectedValue(error);
+
+    const resultPromise = withInitServiceAuthRetry(
+      operation,
+      WORKFLOW_RESUME_ASYNC_ENDPOINT
+    );
+    const rejection = expect(resultPromise).rejects.toBe(error);
+    await vi.advanceTimersByTimeAsync(250);
+
+    await rejection;
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  test.each([
+    {
+      name: "generic 503",
+      error: serviceError({ error: "Internal Server Error" }),
+    },
+    {
+      name: "server-declared non-retryable failure",
+      error: serviceError({
+        code: "AUTH_UPSTREAM_TIMEOUT",
+        safeToRetry: false,
+      }),
+    },
+    {
+      name: "unknown server code",
+      error: serviceError({
+        code: "AUTH_UPSTREAM_OTHER",
+        safeToRetry: true,
+      }),
+    },
+    {
+      name: "recognized code with a non-503 status",
+      error: serviceError(
+        {
+          code: "AUTH_UPSTREAM_TIMEOUT",
+          safeToRetry: true,
+        },
+        500
+      ),
+    },
+    {
+      name: "ambiguous network failure",
+      error: new TypeError("fetch failed"),
+    },
+  ])("does not retry a $name", async ({ error }) => {
+    const operation = vi.fn<() => Promise<string>>().mockRejectedValue(error);
+
+    await expect(
+      withInitServiceAuthRetry(operation, WORKFLOW_RESUME_ASYNC_ENDPOINT)
+    ).rejects.toBe(error);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  test("still classifies a 401 without retrying", async () => {
+    const operation = vi.fn<() => Promise<string>>().mockRejectedValue(
+      serviceError(
+        {
+          error: "Unauthorized: invalid token",
+        },
+        401
+      )
+    );
+
+    const error = await withInitServiceAuthRetry(
+      operation,
+      WORKFLOW_RESUME_ASYNC_ENDPOINT
+    ).catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error).toMatchObject({
+      endpoint: WORKFLOW_RESUME_ASYNC_ENDPOINT,
+      status: 401,
+    });
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/lib/init/wizard-runner.test.ts
+++ b/test/lib/init/wizard-runner.test.ts
@@ -1,4 +1,4 @@
-import { MastraClient } from "@mastra/client-js";
+import { MastraClient, MastraClientError } from "@mastra/client-js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as Sentry from "@sentry/node-core/light";
 import {
@@ -333,6 +333,20 @@ function lastError(): string | undefined {
 function initService401Error(): Error {
   return new Error(
     'HTTP error! status: 401 - {"error":"Unauthorized: invalid token"}'
+  );
+}
+
+function retryableInitServiceAuthError(): MastraClientError {
+  const body = {
+    code: "AUTH_UPSTREAM_TIMEOUT",
+    error: "Sentry authentication service timed out",
+    safeToRetry: true,
+  };
+  return new MastraClientError(
+    503,
+    "Service Unavailable",
+    `HTTP error! status: 503 - ${JSON.stringify(body)}`,
+    body
   );
 }
 
@@ -1087,6 +1101,30 @@ describe("runWizard — resumeWithRetry stale-step recovery", () => {
     return selected;
   }
 
+  test("retries a pre-workflow auth timeout once without run-state recovery", async () => {
+    vi.useFakeTimers();
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["tool-step"]],
+      steps: { "tool-step": { suspendPayload: toolPayload } },
+    };
+    let resumeCount = 0;
+    makeStaleStepRun(() => {
+      resumeCount += 1;
+      if (resumeCount === 1) {
+        return Promise.reject(retryableInitServiceAuthError());
+      }
+      return Promise.resolve({ status: "success" });
+    });
+
+    const run = runWizard(makeOptions());
+    await vi.advanceTimersByTimeAsync(250);
+    await run;
+
+    expect(resumeCount).toBe(2);
+    expect(runByIdMock).not.toHaveBeenCalled();
+  });
+
   test("recovers from a sparse 409 stale-resume conflict", async () => {
     mockStartResult = {
       status: "suspended",
@@ -1379,6 +1417,42 @@ describe("runWizard — additional coverage", () => {
 
     expect(spinnerMock.stop).toHaveBeenCalledWith("Connection failed", 1);
     expect(lastCancelMessage()).toBe("Setup failed");
+  });
+
+  test("retries a create-run auth timeout exactly once", async () => {
+    vi.useFakeTimers();
+    const run = {
+      runId: "test-run-id",
+      startAsync: startAsyncMock,
+      resumeAsync: vi.fn(),
+    };
+    const createRunMock = vi
+      .fn()
+      .mockRejectedValueOnce(retryableInitServiceAuthError())
+      .mockResolvedValueOnce(run);
+    getWorkflowSpy.mockImplementation(
+      () => ({ createRun: createRunMock, runById: runByIdMock }) as any
+    );
+
+    const wizard = runWizard(makeOptions());
+    await vi.advanceTimersByTimeAsync(250);
+    await wizard;
+
+    expect(createRunMock).toHaveBeenCalledTimes(2);
+    expect(startAsyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries a start-async auth timeout exactly once", async () => {
+    vi.useFakeTimers();
+    startAsyncMock
+      .mockRejectedValueOnce(retryableInitServiceAuthError())
+      .mockResolvedValueOnce({ status: "success" });
+
+    const wizard = runWizard(makeOptions());
+    await vi.advanceTimersByTimeAsync(250);
+    await wizard;
+
+    expect(startAsyncMock).toHaveBeenCalledTimes(2);
   });
 
   test("classifies init service 401 as expected OAuth auth state", async () => {


### PR DESCRIPTION
## Summary

Adds one narrowly authorized retry for transient authentication-service failures returned by the init Worker.

The retry gate requires all of the following:

- a real `MastraClientError` parsed from an HTTP response;
- status 503;
- `safeToRetry: true`; and
- code `AUTH_UPSTREAM_TIMEOUT` or `AUTH_UPSTREAM_UNAVAILABLE`.

It applies to create-run, start-async, and resume-async, waits 250 ms, and then makes exactly one second attempt. The underlying Mastra client remains configured with `retries: 0`, so there are no hidden retries and the hard maximum is two total attempts.

Generic 5xx responses, upstream rate limiting, 401/403, unknown codes, and ambiguous network errors are never replayed. For resume requests, a retryable auth failure is known to happen before Mastra executes; it therefore retries directly instead of entering the existing stale/ambiguous run-state recovery path.

The CLI emits a breadcrumb/tag for the retry and shows a temporary health overlay during resume. Overlay cleanup runs in `finally` for both success and failure.

## Server contract

This is coordinated with [getsentry/cli-init-api#194](https://github.com/getsentry/cli-init-api/pull/194), which emits the structured 503 only from auth middleware before the workflow handler. Either deploy order is backward compatible, but server first is preferred.

The failure was observed in [CLI-17A](https://sentry.sentry.io/issues/7415001837/): one auth call in the run reached the Worker five-second validation deadline while the other calls completed normally. The server PR switches to the lightweight token-validation endpoint, captures the timeout, and tags run ID/endpoint before auth.

## Safety properties

- create/start/resume integration tests assert exactly two calls after one retryable failure.
- A persistent retryable failure is attempted twice, never three times.
- Resume does not poll `runById` for this pre-workflow failure.
- Look-alike structural errors cannot authorize replay; the error must be a `MastraClientError` carrying the parsed server body.
- The existing 401 classification and user guidance remain unchanged.

## Test plan

- `pnpm exec vitest run test/lib/init/init-service-auth.test.ts test/lib/init/wizard-runner.test.ts` — 68 tests pass.
- `pnpm run typecheck` — passes after generating the API schema required by a fresh worktree.
- `pnpm run lint` — 918 files pass.
- Broad suite under `TZ=UTC`, excluding the known bash completion simulation: 399 files, 8,462 tests pass, 14 skipped.
- The unmodified broad command reached 8,475 passing tests and 8 unrelated failures. All eight reproduce on `main`: six time-range assertions assume UTC while the local timezone is Europe/Madrid; two bash completion simulations return an empty completion in this shell environment.
- `git diff --check` passes.
- Three independent review passes completed; the replay gate was tightened from a structural look-alike to a real SDK error during review.
