### PR TITLE
fix(init): extend API timeout to 210 seconds

### DIFF
--- a/src/lib/init/constants.ts
+++ b/src/lib/init/constants.ts
@@ -11,7 +11,7 @@ export const SENTRY_DOCS_URL = "https://docs.sentry.io/platforms/";
 export const MAX_FILE_BYTES = 262_144; // 256KB per file
 export const MAX_OUTPUT_BYTES = 65_536; // 64KB stdout/stderr truncation
 export const DEFAULT_COMMAND_TIMEOUT_MS = 120_000; // 2 minutes
-export const API_TIMEOUT_MS = 180_000; // 3 minutes timeout for Mastra API calls
+export const API_TIMEOUT_MS = 210_000; // 3.5 minutes timeout for Mastra API calls
 
 // Exit codes returned by the remote workflow.
 // These are internal to the workflow protocol — they're mapped to EXIT.*

--- a/test/lib/init/wizard-runner.test.ts
+++ b/test/lib/init/wizard-runner.test.ts
@@ -1275,7 +1275,10 @@ describe("runWizard — resumeWithRetry stale-step recovery", () => {
     });
 
     const run = runWizard(makeOptions());
-    await vi.advanceTimersByTimeAsync(180_000);
+    await vi.advanceTimersByTimeAsync(209_999);
+    expect(runByIdMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
     await run;
 
     expect(formatResultSpy).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Extends the Sentry Init Mastra API timeout from 180 seconds to 210 seconds.

A recent Next.js run completed the server-side Plan code changes step in 192.97 seconds, but the CLI crossed its 180-second deadline before the result arrived. The additional 30 seconds covers that observed case while the underlying Docs MCP latency is tracked separately in getsentry/cli-init-api#199.

The recovery test now proves the exact boundary: recovery has not started at 209,999 ms and starts after the final millisecond.

## Test plan

- `pnpm exec vitest run test/lib/init/wizard-runner.test.ts` — 56 tests pass
- `pnpm run lint` — 917 files pass
- `pnpm run generate:schema && pnpm run typecheck` — passes
- `git diff --check` — passes
