### PR TITLE
fix(init): preserve welcome banner alignment

### DIFF
--- a/src/lib/init/ui/ink-app.tsx
+++ b/src/lib/init/ui/ink-app.tsx
@@ -625,13 +625,15 @@ function IntroScreen({
     bannerRows.length === 0 || bannerLinesWidth(bannerRows) <= bodyWidth
       ? bannerRows
       : bannerLinesForWidth(bodyWidth);
+  // Center the banner as one unit; centering rows separately shifts shorter rows.
+  const bannerWidth = bannerLinesWidth(banner);
 
   return (
     <Box alignItems="center" flexDirection="column" width={bodyWidth}>
       <Box
-        alignItems="center"
         flexDirection="column"
         marginBottom={welcomePrompt ? 2 : 1}
+        width={bannerWidth}
       >
         {banner.map((row, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: positional banner rows

--- a/test/lib/init/ui/ink-app.snapshot.test.tsx
+++ b/test/lib/init/ui/ink-app.snapshot.test.tsx
@@ -15,6 +15,10 @@ import { render } from "ink";
 import { createElement } from "react";
 import { describe, expect, test } from "vitest";
 import {
+  bannerLinesWidth,
+  FULL_BANNER_LINES,
+} from "../../../../src/lib/banner.js";
+import {
   App,
   formatFeedbackBanner,
 } from "../../../../src/lib/init/ui/ink-app.js";
@@ -305,6 +309,31 @@ describe("Ink App snapshot", () => {
     expect(frame).not.toMatch(FILES_TAB_RE);
     expect(frame).toContain(FEEDBACK_BANNER_TEXT);
     expect(hasForcedWhiteForeground(withoutFeedbackBanner(frame))).toBe(false);
+  });
+
+  test("welcome banner preserves row alignment while centering the art", async () => {
+    const store = new WizardStore({ bannerRows: FULL_BANNER_LINES });
+    setWelcomePrompt(store);
+
+    const terminalColumns = 120;
+    const frame = stripAnsi(
+      (await renderApp(store, terminalColumns)).allOutput()
+    );
+    const lines = frame.split(LINE_SPLIT_RE);
+    const bannerOrigin = Math.floor(
+      (terminalColumns - bannerLinesWidth(FULL_BANNER_LINES)) / 2
+    );
+
+    for (const { content } of FULL_BANNER_LINES) {
+      const visibleContent = content.trimStart();
+      const leadingSpaces = content.length - visibleContent.length;
+      const renderedRow = lines.find((line) => line.includes(visibleContent));
+
+      expect(renderedRow).toBeDefined();
+      expect(renderedRow?.indexOf(visibleContent)).toBe(
+        bannerOrigin + leadingSpaces
+      );
+    }
   });
 
   test("intro banner shrinks to fit narrow terminals (never wraps)", async () => {


### PR DESCRIPTION
## Summary

The `sentry init` welcome screen centered every block-art row independently. Because the top row is narrower than the rest, the arch shifted to the right relative to the wordmark.

Center the banner using its widest row so the artwork keeps its authored indentation while the responsive variants remain unchanged. Add an Ink regression test that verifies every row position and the centered banner origin.

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm vitest run test/lib/init/ui/ink-app.snapshot.test.tsx --coverage.enabled=false`
- [x] `pnpm run typecheck`
- [x] `git diff --check`