### PR TITLE
feat(init): measure interactive prompt wait time

### DIFF
--- a/src/lib/init/interactive.ts
+++ b/src/lib/init/interactive.ts
@@ -10,6 +10,7 @@
  * `LoggingUI` (CI / npm fallback).
  */
 
+import { setTag } from "@sentry/node-core/light";
 import chalk from "chalk";
 import { WizardError } from "../errors.js";
 import {
@@ -198,6 +199,7 @@ async function handleMultiSelect(
   }
   hints.push(`${bar}  ${chalk.dim("space=toggle, a=all, enter=confirm")}`);
 
+  setTag("wizard.features.offered", available.join(","));
   const selected = await ui.multiselect<string>({
     message: `${payload.prompt}\n${hints.join("\n")}`,
     options: optional.map((feature) => {
@@ -213,7 +215,9 @@ async function handleMultiSelect(
   });
 
   const chosen = abortIfCancelled(selected);
-  return { features: prependRequiredFeature(chosen, hasRequired) };
+  const features = prependRequiredFeature(chosen, hasRequired);
+  setTag("wizard.features.selected", features.join(","));
+  return { features };
 }
 
 async function handleConfirm(

--- a/src/lib/init/ui/ink-ui.ts
+++ b/src/lib/init/ui/ink-ui.ts
@@ -56,6 +56,10 @@ import { setTag } from "@sentry/node-core/light";
 import { FULL_BANNER_LINES } from "../../banner.js";
 import { CLI_VERSION } from "../../constants.js";
 import { stripAnsi } from "../../formatters/plain-detect.js";
+import {
+  createWizardPromptTelemetry,
+  type WizardPromptKind,
+} from "../../telemetry.js";
 import { formatFeedbackHint, type InitFeedbackOutcome } from "../feedback.js";
 import { formatFailureReport, formatSuccessReport } from "./ink-report.js";
 import { LEARN_SEQUENCE } from "./learn-content.js";
@@ -81,8 +85,14 @@ type CreateInkUIOptions = {
 
 type PendingWelcome = {
   promise: Promise<"continue" | Cancelled>;
+  tracedPromise?: Promise<"continue" | Cancelled>;
   resolve: (value: "continue" | Cancelled) => void;
   settled: boolean;
+};
+
+type InkPromptOptions = {
+  initialWelcome?: PendingWelcome;
+  telemetry?: ReturnType<typeof createWizardPromptTelemetry>;
 };
 
 /** Tip rotation cadence in the sidebar — slow enough to read each tip. */
@@ -273,6 +283,7 @@ export async function createInkUI(
   if (opts.initialWelcome && initialWelcome) {
     seedWelcomePrompt(store, opts.initialWelcome, initialWelcome);
   }
+  const promptTelemetry = createWizardPromptTelemetry();
 
   // Open a fresh /dev/tty so Ink's `readable` event listener
   // actually fires — see the module docstring for the Bun bug
@@ -305,7 +316,10 @@ export async function createInkUI(
   try {
     const instance = app.mountApp(store, renderOptions);
 
-    return new InkUI(instance, store, freshStdin, initialWelcome);
+    return new InkUI(instance, store, freshStdin, {
+      initialWelcome,
+      telemetry: promptTelemetry,
+    });
   } catch (error) {
     // Restore the terminal if Ink rendering or UI init fails,
     // otherwise the user is stuck in the alternate screen buffer.
@@ -356,6 +370,9 @@ export class InkUI implements WizardUI {
    * `process.stdin` in that case.
    */
   private readonly freshStdin: ReadStream | null;
+  private readonly promptTelemetry: ReturnType<
+    typeof createWizardPromptTelemetry
+  >;
   private tipTimer: ReturnType<typeof setInterval> | undefined;
   private learnTimer: ReturnType<typeof setInterval> | undefined;
 
@@ -401,13 +418,23 @@ export class InkUI implements WizardUI {
     instance: InkInstance,
     store: WizardStore,
     freshStdin: ReadStream | null,
-    initialWelcome?: PendingWelcome
+    promptOptions: InkPromptOptions = {}
   ) {
     this.instance = instance;
     this.store = store;
     this.freshStdin = freshStdin;
-    this.initialWelcome = initialWelcome;
-    if (initialWelcome && !initialWelcome.settled) {
+    this.initialWelcome = promptOptions.initialWelcome;
+    this.promptTelemetry =
+      promptOptions.telemetry ?? createWizardPromptTelemetry();
+    if (this.initialWelcome && !this.initialWelcome.tracedPromise) {
+      const initialWelcome = this.initialWelcome;
+      initialWelcome.tracedPromise = this.promptTelemetry.tracePrompt(
+        "welcome",
+        () => initialWelcome.promise
+      );
+    }
+    if (this.initialWelcome && !this.initialWelcome.settled) {
+      const initialWelcome = this.initialWelcome;
       this.activePromptCancel = () => {
         this.store.setPrompt(null);
         this.activePromptCancel = undefined;
@@ -469,6 +496,7 @@ export class InkUI implements WizardUI {
     stepId: string,
     status: "in_progress" | "completed" | "failed" | "skipped"
   ): void {
+    this.promptTelemetry.setActiveStep(stepId, status === "in_progress");
     this.store.setStepStatus(stepId, status);
   }
 
@@ -543,8 +571,16 @@ export class InkUI implements WizardUI {
 
   // ── Prompts ───────────────────────────────────────────────────────
 
+  /** Measures only the interval in which the prompt can accept user input. */
+  private waitForPrompt<T>(
+    kind: WizardPromptKind,
+    mount: (resolve: (value: T) => void) => void
+  ): Promise<T> {
+    return this.promptTelemetry.tracePrompt(kind, () => new Promise<T>(mount));
+  }
+
   select<T extends string>(opts: SelectOptions<T>): Promise<T | Cancelled> {
-    return new Promise((resolve) => {
+    return this.waitForPrompt<T | Cancelled>("select", (resolve) => {
       const initialIndex =
         opts.initialValue !== undefined
           ? Math.max(
@@ -584,7 +620,7 @@ export class InkUI implements WizardUI {
   multiselect<T extends string>(
     opts: MultiSelectOptions<T>
   ): Promise<T[] | Cancelled> {
-    return new Promise((resolve) => {
+    return this.waitForPrompt<T[] | Cancelled>("multiselect", (resolve) => {
       this.activePromptCancel = () => {
         this.store.setPrompt(null);
         this.activePromptCancel = undefined;
@@ -614,7 +650,7 @@ export class InkUI implements WizardUI {
   }
 
   confirm(opts: ConfirmOptions): Promise<boolean | Cancelled> {
-    return new Promise<boolean | Cancelled>((resolve) => {
+    return this.waitForPrompt<boolean | Cancelled>("confirm", (resolve) => {
       this.activePromptCancel = () => {
         this.store.setPrompt(null);
         this.activePromptCancel = undefined;
@@ -644,12 +680,19 @@ export class InkUI implements WizardUI {
       if (!this.initialWelcome.settled) {
         seedWelcomePrompt(this.store, opts, this.initialWelcome);
       }
-      return this.initialWelcome.promise.finally(() => {
+      const initialWelcome = this.initialWelcome;
+      const promptPromise =
+        initialWelcome.tracedPromise ??
+        this.promptTelemetry.tracePrompt(
+          "welcome",
+          () => initialWelcome.promise
+        );
+      return promptPromise.finally(() => {
         this.activePromptCancel = undefined;
         this.initialWelcome = undefined;
       });
     }
-    return new Promise<"continue" | Cancelled>((resolve) => {
+    return this.waitForPrompt<"continue" | Cancelled>("welcome", (resolve) => {
       this.activePromptCancel = () => {
         this.store.setPrompt(null);
         this.activePromptCancel = undefined;

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -922,6 +922,73 @@ export function recordCacheHit(cacheName: string, hit: boolean): void {
   });
 }
 
+export type WizardPromptKind = "select" | "multiselect" | "confirm" | "welcome";
+
+type WizardPromptTelemetry = {
+  setActiveStep(stepId: string, active: boolean): void;
+  tracePrompt<T>(kind: WizardPromptKind, prompt: () => Promise<T>): Promise<T>;
+};
+
+/**
+ * Track time spent waiting for human input during `sentry init`.
+ *
+ * Prompt spans make user think-time visible in the trace instead of folding it
+ * into the top-level `sentry.init` duration. The measurement is accumulated on
+ * the root span so a run can be compared both with and without user wait time.
+ */
+export function createWizardPromptTelemetry(): WizardPromptTelemetry {
+  let activeStepId: string | undefined;
+  let totalWaitMs = 0;
+
+  return {
+    setActiveStep(stepId, active) {
+      if (active) {
+        activeStepId = stepId;
+      } else if (activeStepId === stepId) {
+        activeStepId = undefined;
+      }
+    },
+    tracePrompt(kind, prompt) {
+      const stepId = activeStepId;
+      return withTracingSpan(
+        `wizard.prompt.${kind}`,
+        "ui.prompt",
+        async (span) => {
+          const startedAt = performance.now();
+          try {
+            return await prompt();
+          } finally {
+            const waitMs = Math.max(0, performance.now() - startedAt);
+            totalWaitMs += waitMs;
+
+            span.setAttributes({
+              "wizard.user_wait_ms": waitMs,
+              "wizard.user_wait_total_ms": totalWaitMs,
+            });
+            Sentry.setMeasurement(
+              "wizard.user_wait_ms",
+              totalWaitMs,
+              "millisecond",
+              Sentry.getRootSpan(span)
+            );
+            Sentry.metrics.distribution("wizard.user_wait_ms", waitMs, {
+              attributes: {
+                prompt_kind: kind,
+                ...(stepId ? { workflow_step: stepId } : {}),
+              },
+            });
+          }
+        },
+        {
+          "wizard.prompt.kind": kind,
+          "wizard.prompt.phase": stepId ? "workflow" : "preflight",
+          ...(stepId ? { "wizard.step.id": stepId } : {}),
+        }
+      );
+    },
+  };
+}
+
 /**
  * Wrap an operation with a Sentry span for tracing.
  *

--- a/test/lib/init/interactive.test.ts
+++ b/test/lib/init/interactive.test.ts
@@ -7,7 +7,9 @@
  * terminal.
  */
 
-import { describe, expect, test } from "vitest";
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as Sentry from "@sentry/node-core/light";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { WizardError } from "../../../src/lib/errors.js";
 import { handleInteractive } from "../../../src/lib/init/interactive.js";
 import type { InteractiveContext } from "../../../src/lib/init/types.js";
@@ -23,6 +25,10 @@ function makeOptions(
     ...overrides,
   };
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("handleInteractive dispatcher", () => {
   test("throws WizardError for unknown kind", async () => {
@@ -270,6 +276,36 @@ describe("handleSelect with --app flag", () => {
 });
 
 describe("handleMultiSelect", () => {
+  test("records offered and selected features for interactive prompts", async () => {
+    const setTagSpy = vi.spyOn(Sentry, "setTag");
+    const { ui, respond } = createMockUI();
+    respond.multiselect(["sessionReplay"]);
+
+    await handleInteractive(
+      {
+        type: "interactive",
+        prompt: "Select features",
+        kind: "multi-select",
+        availableFeatures: [
+          "errorMonitoring",
+          "performanceMonitoring",
+          "sessionReplay",
+        ],
+      },
+      makeOptions(),
+      ui
+    );
+
+    expect(setTagSpy).toHaveBeenCalledWith(
+      "wizard.features.offered",
+      "errorMonitoring,performanceMonitoring,sessionReplay"
+    );
+    expect(setTagSpy).toHaveBeenCalledWith(
+      "wizard.features.selected",
+      "errorMonitoring,sessionReplay"
+    );
+  });
+
   test("auto-selects all features with --yes", async () => {
     const { ui } = createMockUI();
     const result = await handleInteractive(
@@ -336,6 +372,7 @@ describe("handleMultiSelect", () => {
   });
 
   test("throws WizardCancelledError when user cancels multi-select", async () => {
+    const setTagSpy = vi.spyOn(Sentry, "setTag");
     const { ui, respond } = createMockUI();
     respond.multiselect(CANCELLED);
 
@@ -351,6 +388,14 @@ describe("handleMultiSelect", () => {
         ui
       )
     ).rejects.toThrow("Setup cancelled");
+    expect(setTagSpy).toHaveBeenCalledWith(
+      "wizard.features.offered",
+      "errorMonitoring,performanceMonitoring"
+    );
+    expect(setTagSpy).not.toHaveBeenCalledWith(
+      "wizard.features.selected",
+      expect.anything()
+    );
   });
 
   test("returns required feature without calling multiselect when only errorMonitoring available", async () => {

--- a/test/lib/init/ui/ink-ui-telemetry.test.ts
+++ b/test/lib/init/ui/ink-ui-telemetry.test.ts
@@ -1,0 +1,161 @@
+// biome-ignore lint/performance/noNamespaceImport: needed for spyOn mocking
+import * as Sentry from "@sentry/node-core/light";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { InkUI } from "../../../../src/lib/init/ui/ink-ui.js";
+import {
+  CANCELLED,
+  type Cancelled,
+} from "../../../../src/lib/init/ui/types.js";
+import { WizardStore } from "../../../../src/lib/init/ui/wizard-store.js";
+import { createWizardPromptTelemetry } from "../../../../src/lib/telemetry.js";
+
+function createUi(options: { initialWelcome?: boolean } = {}): {
+  ui: InkUI;
+  store: WizardStore;
+} {
+  const store = new WizardStore();
+  const instance = {
+    clear: vi.fn(),
+    rerender: vi.fn(),
+    unmount: vi.fn(),
+    waitUntilExit: vi.fn().mockResolvedValue(undefined),
+  };
+  if (!options.initialWelcome) {
+    return { ui: new InkUI(instance, store, null), store };
+  }
+
+  let resolvePromise!: (value: "continue" | Cancelled) => void;
+  const initialWelcome: {
+    promise: Promise<"continue" | Cancelled>;
+    tracedPromise?: Promise<"continue" | Cancelled>;
+    resolve(value: "continue" | Cancelled): void;
+    settled: boolean;
+  } = {
+    promise: new Promise<"continue" | Cancelled>((resolve) => {
+      resolvePromise = resolve;
+    }),
+    resolve(value: "continue" | Cancelled) {
+      if (initialWelcome.settled) {
+        return;
+      }
+      initialWelcome.settled = true;
+      resolvePromise(value);
+    },
+    settled: false,
+  };
+  store.setPrompt({
+    kind: "welcome",
+    options: {
+      title: "Welcome",
+      body: ["Configure Sentry"],
+      punchline: "Continue?",
+    },
+    resolve(value) {
+      store.setPrompt(null);
+      initialWelcome.resolve(value === null ? CANCELLED : value);
+    },
+  });
+  const promptTelemetry = createWizardPromptTelemetry();
+  return {
+    ui: new InkUI(instance, store, null, {
+      initialWelcome,
+      telemetry: promptTelemetry,
+    }),
+    store,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("InkUI prompt telemetry", () => {
+  test("attributes workflow prompts to the active step", async () => {
+    const metricSpy = vi.spyOn(Sentry.metrics, "distribution");
+    const startSpanSpy = vi.spyOn(Sentry, "startSpan");
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const { ui, store } = createUi();
+
+    ui.setStep("select-features", "in_progress");
+    const resultPromise = ui.multiselect({
+      message: "Choose features",
+      options: [{ label: "Tracing", value: "performanceMonitoring" }],
+    });
+    const prompt = store.getSnapshot().prompt;
+    expect(prompt?.kind).toBe("multiselect");
+    if (prompt?.kind !== "multiselect") {
+      throw new Error("Expected a multiselect prompt");
+    }
+    prompt.resolve(["performanceMonitoring"]);
+
+    await expect(resultPromise).resolves.toEqual(["performanceMonitoring"]);
+    expect(metricSpy).toHaveBeenCalledWith(
+      "wizard.user_wait_ms",
+      expect.any(Number),
+      {
+        attributes: {
+          prompt_kind: "multiselect",
+          workflow_step: "select-features",
+        },
+      }
+    );
+    expect(startSpanSpy).toHaveBeenCalledWith(
+      {
+        name: "wizard.prompt.multiselect",
+        op: "ui.prompt",
+        onlyIfParent: true,
+        attributes: {
+          "wizard.prompt.kind": "multiselect",
+          "wizard.prompt.phase": "workflow",
+          "wizard.step.id": "select-features",
+        },
+      },
+      expect.any(Function)
+    );
+
+    await ui[Symbol.asyncDispose]();
+  });
+
+  test("records the welcome prompt as preflight rather than a workflow step", async () => {
+    const metricSpy = vi.spyOn(Sentry.metrics, "distribution");
+    const startSpanSpy = vi.spyOn(Sentry, "startSpan");
+    let now = 100;
+    vi.spyOn(globalThis.performance, "now").mockImplementation(() => now);
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const { ui, store } = createUi({ initialWelcome: true });
+
+    expect(startSpanSpy).toHaveBeenCalledTimes(1);
+    const prompt = store.getSnapshot().prompt;
+    expect(prompt?.kind).toBe("welcome");
+    if (prompt?.kind !== "welcome") {
+      throw new Error("Expected a welcome prompt");
+    }
+    now = 150;
+    prompt.resolve("continue");
+    const resultPromise = ui.welcome({
+      title: "Welcome",
+      body: ["Configure Sentry"],
+      punchline: "Continue?",
+    });
+
+    await expect(resultPromise).resolves.toBe("continue");
+    expect(metricSpy).toHaveBeenCalledWith("wizard.user_wait_ms", 50, {
+      attributes: { prompt_kind: "welcome" },
+    });
+    expect(startSpanSpy).toHaveBeenCalledWith(
+      {
+        name: "wizard.prompt.welcome",
+        op: "ui.prompt",
+        onlyIfParent: true,
+        attributes: {
+          "wizard.prompt.kind": "welcome",
+          "wizard.prompt.phase": "preflight",
+        },
+      },
+      expect.any(Function)
+    );
+    expect(startSpanSpy).toHaveBeenCalledTimes(1);
+
+    await ui[Symbol.asyncDispose]();
+  });
+});

--- a/test/lib/telemetry.test.ts
+++ b/test/lib/telemetry.test.ts
@@ -21,6 +21,7 @@ import { Database } from "../../src/lib/db/sqlite.js";
 import { ApiError, AuthError, OutputError } from "../../src/lib/errors.js";
 import {
   createTracedDatabase,
+  createWizardPromptTelemetry,
   getSentryTracePropagationTargets,
   initSentry,
   isEbadfError,
@@ -942,6 +943,59 @@ describe("withTracingSpan", () => {
       "init.attr": "initial",
     });
     expect(result).toBe("success");
+  });
+});
+
+describe("createWizardPromptTelemetry", () => {
+  test("records individual prompt waits and accumulates root wait time", async () => {
+    const setMeasurementSpy = vi.spyOn(Sentry, "setMeasurement");
+    const metricSpy = vi.spyOn(Sentry.metrics, "distribution");
+    let now = 100;
+    const performanceSpy = vi
+      .spyOn(globalThis.performance, "now")
+      .mockImplementation(() => now);
+    const telemetry = createWizardPromptTelemetry();
+
+    telemetry.setActiveStep("select-features", true);
+    const firstResult = await telemetry.tracePrompt("multiselect", async () => {
+      now = 125;
+      return ["errorMonitoring"];
+    });
+    telemetry.setActiveStep("select-features", false);
+    const secondResult = await telemetry.tracePrompt("confirm", async () => {
+      now = 140;
+      return true;
+    });
+
+    expect(firstResult).toEqual(["errorMonitoring"]);
+    expect(secondResult).toBe(true);
+    expect(setMeasurementSpy).toHaveBeenNthCalledWith(
+      1,
+      "wizard.user_wait_ms",
+      25,
+      "millisecond",
+      expect.anything()
+    );
+    expect(setMeasurementSpy).toHaveBeenNthCalledWith(
+      2,
+      "wizard.user_wait_ms",
+      40,
+      "millisecond",
+      expect.anything()
+    );
+    expect(metricSpy).toHaveBeenCalledWith("wizard.user_wait_ms", 25, {
+      attributes: {
+        prompt_kind: "multiselect",
+        workflow_step: "select-features",
+      },
+    });
+    expect(metricSpy).toHaveBeenCalledWith("wizard.user_wait_ms", 15, {
+      attributes: { prompt_kind: "confirm" },
+    });
+
+    performanceSpy.mockRestore();
+    metricSpy.mockRestore();
+    setMeasurementSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
## Summary

Separates human think-time from actual `sentry init` execution time. Every real Ink prompt now emits a `ui.prompt` child span, while automatic `--yes` and non-interactive paths remain uninstrumented.

The root transaction also gets an accumulated `wizard.user_wait_ms` measurement, so active wizard time can be calculated as total duration minus user wait. Workflow prompts include the active step ID (for example `select-features`); welcome, git, and preflight prompts are marked as `preflight`.

Feature selection now records `wizard.features.offered` before the prompt and `wizard.features.selected` after the response. This preserves the offered set even when the user cancels at the feature prompt or the workflow fails later.

## Test plan

- `pnpm exec tsc --noEmit`
- `pnpm exec biome check src/lib/telemetry.ts src/lib/init/interactive.ts src/lib/init/ui/ink-ui.ts test/lib/telemetry.test.ts test/lib/init/interactive.test.ts test/lib/init/ui/ink-ui-telemetry.test.ts`
- `pnpm vitest run test/lib/init`
- `pnpm vitest run test/lib/telemetry.test.ts`