### PR TITLE
fix(init): terminate verification process trees

### DIFF
--- a/src/lib/init/verify-setup.ts
+++ b/src/lib/init/verify-setup.ts
@@ -12,7 +12,7 @@
  * or fatal error patterns in stderr indicate failure.
  */
 
-import { type ChildProcess, spawn } from "node:child_process";
+import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 import { captureException } from "@sentry/node-core/light";
 import { createSpotlightBuffer } from "@spotlightjs/spotlight/sdk";
@@ -25,6 +25,18 @@ import type { WizardUI } from "./ui/types.js";
 
 /** Verification timeout in seconds. */
 const VERIFY_TIMEOUT_S = 15;
+
+/** Grace period before escalating verification process cleanup to SIGKILL. */
+const PROCESS_SHUTDOWN_GRACE_MS = 5000;
+
+/** Maximum time to wait after force-killing the verification process tree. */
+const PROCESS_FORCE_SHUTDOWN_MS = 1000;
+
+/** Poll interval while waiting for a verification process tree to exit. */
+const PROCESS_EXIT_POLL_MS = 50;
+
+/** Maximum time for a Windows taskkill invocation to complete. */
+const WINDOWS_TREE_KILL_TIMEOUT_MS = 1000;
 
 /**
  * Patterns in stderr/stdout that indicate a fatal startup failure.
@@ -187,34 +199,114 @@ function buildVerifyEnv(
   return env;
 }
 
-/** Gracefully kill a child process with SIGTERM → grace period → SIGKILL. */
-async function cleanupChild(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null) {
-    return;
+/** Send a signal to the verification child and all of its descendants. */
+function signalProcessTree(
+  child: ChildProcess,
+  signal: NodeJS.Signals
+): boolean {
+  const pid = child.pid;
+  if (pid === undefined) {
+    return false;
   }
+
   try {
-    child.kill("SIGTERM");
-    let graceTimer: ReturnType<typeof setTimeout> | undefined;
-    const exited = await Promise.race([
-      new Promise<true>((r) => child.on("close", () => r(true))),
-      new Promise<false>((r) => {
-        graceTimer = setTimeout(() => r(false), 5000);
-      }),
-    ]);
-    clearTimeout(graceTimer);
-    if (!exited && child.exitCode === null) {
-      try {
-        child.kill("SIGKILL");
-      } catch {
-        logger.debug("Child exited before SIGKILL");
+    if (process.platform === "win32") {
+      const args = ["/PID", String(pid), "/T"];
+      if (signal === "SIGKILL") {
+        args.push("/F");
       }
-      // Await close so child.exitCode is populated for crash detection.
-      if (child.exitCode === null) {
-        await new Promise<void>((r) => child.on("close", () => r()));
+      const taskkill = spawnSync("taskkill", args, {
+        stdio: "ignore",
+        timeout: WINDOWS_TREE_KILL_TIMEOUT_MS,
+        windowsHide: true,
+      });
+      return !(taskkill.error || taskkill.status !== 0);
+    }
+    // Verification children are spawned detached on POSIX, making their PID
+    // the process-group ID. A negative PID signals the whole group, including
+    // shell pipelines, concurrently tasks, and framework watchers.
+    process.kill(-pid, signal);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ESRCH") {
+      logger.debug(`Failed to signal verification process tree with ${signal}`);
+    }
+    return false;
+  }
+}
+
+/** Fall back to signaling only the direct child process. */
+function signalDirectChild(child: ChildProcess, signal: NodeJS.Signals): void {
+  try {
+    child.kill(signal);
+  } catch {
+    logger.debug(`Verification child exited before receiving ${signal}`);
+  }
+}
+
+/** Check whether the POSIX verification process group is still alive. */
+function isPosixProcessGroupAlive(child: ChildProcess): boolean {
+  const pid = child.pid;
+  if (pid === undefined) {
+    return false;
+  }
+
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+/** Wait for a POSIX verification process group to exit, bounded by a timeout. */
+async function waitForPosixProcessGroupExit(
+  child: ChildProcess,
+  timeoutMs: number
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (isPosixProcessGroupAlive(child)) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      return false;
+    }
+    await new Promise<void>((resolveDelay) => {
+      setTimeout(resolveDelay, Math.min(PROCESS_EXIT_POLL_MS, remainingMs));
+    });
+  }
+  return true;
+}
+
+/** Gracefully kill a process tree with SIGTERM → grace period → SIGKILL. */
+async function cleanupProcessTree(child: ChildProcess): Promise<void> {
+  try {
+    if (process.platform === "win32") {
+      if (signalProcessTree(child, "SIGTERM")) {
+        return;
       }
+      if (!signalProcessTree(child, "SIGKILL")) {
+        signalDirectChild(child, "SIGKILL");
+      }
+      return;
+    }
+
+    signalProcessTree(child, "SIGTERM");
+    const exited = await waitForPosixProcessGroupExit(
+      child,
+      PROCESS_SHUTDOWN_GRACE_MS
+    );
+    if (!exited) {
+      signalProcessTree(child, "SIGKILL");
+      await waitForPosixProcessGroupExit(child, PROCESS_FORCE_SHUTDOWN_MS);
     }
   } catch (error) {
-    logger.debug("Failed to kill verification child", error);
+    logger.debug("Failed to kill verification process tree", error);
+  } finally {
+    // Descendants can inherit these pipes. Destroying our ends guarantees the
+    // verification cleanup itself never waits indefinitely for `close`.
+    child.stdout?.destroy();
+    child.stderr?.destroy();
   }
 }
 
@@ -272,6 +364,9 @@ export async function verifySetup(
     const [cmd = "", ...cmdArgs] = detected.args;
     child = spawn(cmd, cmdArgs, {
       cwd,
+      // On POSIX this creates a dedicated process group whose entire tree can
+      // be terminated without touching the CLI's own process group.
+      detached: process.platform !== "win32",
       env: childEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -286,10 +381,8 @@ export async function verifySetup(
   // cleanup instead of silently continuing the wizard.
   let signalReceived: NodeJS.Signals | null = null;
   const safeKill = (sig: NodeJS.Signals) => {
-    try {
-      child.kill(sig);
-    } catch {
-      logger.debug(`Child already exited when forwarding ${sig}`);
+    if (!signalProcessTree(child, sig)) {
+      signalDirectChild(child, sig);
     }
   };
   const onSigint = () => {
@@ -312,12 +405,20 @@ export async function verifySetup(
       r({ kind: "exited" as const, code: code ?? 1 })
     );
   });
+  const childErrored = new Promise<{ kind: "spawn_error"; error: Error }>(
+    (resolveError) => {
+      child.once("error", (error) => {
+        resolveError({ kind: "spawn_error", error });
+      });
+    }
+  );
 
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const outcome = await Promise.race([
     envelopeReceived.then(() => ({ kind: "envelope" as const })),
     startupPromise,
     childExited,
+    childErrored,
     new Promise<{ kind: "timeout" }>((r) => {
       timeoutHandle = setTimeout(
         () => r({ kind: "timeout" as const }),
@@ -330,11 +431,11 @@ export async function verifySetup(
     clearTimeout(timeoutHandle);
   }
 
-  // Capture the exit code before cleanup — cleanupChild sends SIGTERM/SIGKILL
-  // which would set exitCode to 143/137, masking a natural crash code.
+  // Capture the exit code before cleanup — terminating the process tree would
+  // set exitCode to 143/137, masking a natural crash code.
   const preCleanupExitCode = child.exitCode;
 
-  await cleanupChild(child);
+  await cleanupProcessTree(child);
   if (subscriptionId) {
     buffer.unsubscribe(subscriptionId);
   }
@@ -369,6 +470,7 @@ type VerifyOutcome =
   | { kind: "envelope" }
   | StartupOutcome
   | { kind: "exited"; code: number }
+  | { kind: "spawn_error"; error: Error }
   | { kind: "timeout" };
 
 type ReportContext = {
@@ -398,6 +500,12 @@ function reportOutcome(outcome: VerifyOutcome, ctx: ReportContext): void {
 
   if (outcome.kind === "started") {
     ui.log.success("Verified — app started successfully");
+    return;
+  }
+
+  if (outcome.kind === "spawn_error") {
+    logger.debug("Failed to spawn verification child", outcome.error);
+    ui.log.warn("Skipping verification — could not start the dev command.");
     return;
   }
 

--- a/src/lib/init/verify-setup.ts
+++ b/src/lib/init/verify-setup.ts
@@ -26,10 +26,10 @@ import type { WizardUI } from "./ui/types.js";
 /** Verification timeout in seconds. */
 const VERIFY_TIMEOUT_S = 15;
 
-/** Grace period before escalating verification process cleanup to SIGKILL. */
+/** POSIX grace period before escalating verification cleanup to SIGKILL. */
 const PROCESS_SHUTDOWN_GRACE_MS = 5000;
 
-/** Maximum time to wait after force-killing the verification process tree. */
+/** Maximum POSIX wait after force-killing the verification process tree. */
 const PROCESS_FORCE_SHUTDOWN_MS = 1000;
 
 /** Poll interval while waiting for a verification process tree to exit. */
@@ -199,8 +199,8 @@ function buildVerifyEnv(
   return env;
 }
 
-/** Send a signal to the verification child and all of its descendants. */
-function signalProcessTree(
+/** Signal the POSIX process group or force-terminate the Windows process tree. */
+function terminateProcessTree(
   child: ChildProcess,
   signal: NodeJS.Signals
 ): boolean {
@@ -211,16 +211,29 @@ function signalProcessTree(
 
   try {
     if (process.platform === "win32") {
-      const args = ["/PID", String(pid), "/T"];
-      if (signal === "SIGKILL") {
-        args.push("/F");
-      }
+      // Verification children are disposable. Force the complete tree in one
+      // bounded call because Windows cannot reliably reproduce POSIX process-
+      // group signaling or discover descendants after their parent exits.
+      const args = ["/PID", String(pid), "/T", "/F"];
       const taskkill = spawnSync("taskkill", args, {
         stdio: "ignore",
         timeout: WINDOWS_TREE_KILL_TIMEOUT_MS,
         windowsHide: true,
       });
-      return !(taskkill.error || taskkill.status !== 0);
+      if (taskkill.error) {
+        logger.debug(
+          `Failed to terminate Windows verification process tree while handling ${signal}`,
+          taskkill.error
+        );
+        return false;
+      }
+      if (taskkill.status !== 0) {
+        logger.debug(
+          `taskkill exited with status ${taskkill.status} while handling ${signal} for the verification process tree`
+        );
+        return false;
+      }
+      return true;
     }
     // Verification children are spawned detached on POSIX, making their PID
     // the process-group ID. A negative PID signals the whole group, including
@@ -278,26 +291,23 @@ async function waitForPosixProcessGroupExit(
   return true;
 }
 
-/** Gracefully kill a process tree with SIGTERM → grace period → SIGKILL. */
+/** Terminate the process tree, with a grace period on POSIX. */
 async function cleanupProcessTree(child: ChildProcess): Promise<void> {
   try {
     if (process.platform === "win32") {
-      if (signalProcessTree(child, "SIGTERM")) {
-        return;
-      }
-      if (!signalProcessTree(child, "SIGKILL")) {
+      if (!terminateProcessTree(child, "SIGKILL")) {
         signalDirectChild(child, "SIGKILL");
       }
       return;
     }
 
-    signalProcessTree(child, "SIGTERM");
+    terminateProcessTree(child, "SIGTERM");
     const exited = await waitForPosixProcessGroupExit(
       child,
       PROCESS_SHUTDOWN_GRACE_MS
     );
     if (!exited) {
-      signalProcessTree(child, "SIGKILL");
+      terminateProcessTree(child, "SIGKILL");
       await waitForPosixProcessGroupExit(child, PROCESS_FORCE_SHUTDOWN_MS);
     }
   } catch (error) {
@@ -381,7 +391,7 @@ export async function verifySetup(
   // cleanup instead of silently continuing the wizard.
   let signalReceived: NodeJS.Signals | null = null;
   const safeKill = (sig: NodeJS.Signals) => {
-    if (!signalProcessTree(child, sig)) {
+    if (!terminateProcessTree(child, sig)) {
       signalDirectChild(child, sig);
     }
   };

--- a/test/lib/init/verify-setup-windows.mocked.test.ts
+++ b/test/lib/init/verify-setup-windows.mocked.test.ts
@@ -1,0 +1,139 @@
+/** Windows process-tree cleanup tests with child_process mocked before import. */
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { TEST_TMP_DIR } from "../../constants.js";
+import { createMockUI } from "./ui/mock-ui.js";
+
+const mocks = vi.hoisted(() => ({
+  childKillCalls: [] as NodeJS.Signals[],
+  spawnCalls: [] as Array<{ options: { detached?: boolean } }>,
+  taskkillCalls: [] as Array<{
+    command: string;
+    args: string[];
+    options: { timeout?: number };
+  }>,
+  taskkillStatuses: [] as number[],
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  const { EventEmitter } = await import("node:events");
+  const { PassThrough } = await import("node:stream");
+
+  return {
+    ...actual,
+    spawn: vi.fn(
+      (_command: string, _args: string[], options: { detached?: boolean }) => {
+        mocks.spawnCalls.push({ options });
+        const child = new EventEmitter() as EventEmitter & {
+          exitCode: number | null;
+          kill: (signal: NodeJS.Signals) => boolean;
+          pid: number;
+          stderr: PassThrough;
+          stdout: PassThrough;
+        };
+        child.pid = 4321;
+        child.exitCode = null;
+        child.stdout = new PassThrough();
+        child.stderr = new PassThrough();
+        child.kill = (signal) => {
+          mocks.childKillCalls.push(signal);
+          return true;
+        };
+        queueMicrotask(() => {
+          child.stderr.write("SyntaxError: Windows verification fixture\n");
+        });
+        return child;
+      }
+    ),
+    spawnSync: vi.fn(
+      (command: string, args: string[], options: { timeout?: number }) => {
+        mocks.taskkillCalls.push({ command, args, options });
+        return {
+          error: undefined,
+          pid: 0,
+          output: [],
+          signal: null,
+          status: mocks.taskkillStatuses.shift() ?? 0,
+          stderr: null,
+          stdout: null,
+        };
+      }
+    ),
+  };
+});
+
+vi.mock("@sentry/node-core/light", () => ({
+  captureException: vi.fn(),
+}));
+
+import { verifySetup } from "../../../src/lib/init/verify-setup.js";
+
+const originalPlatform = process.platform;
+let tmpDir: string;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true,
+  });
+}
+
+beforeEach(async () => {
+  setPlatform("win32");
+  mocks.childKillCalls.length = 0;
+  mocks.spawnCalls.length = 0;
+  mocks.taskkillCalls.length = 0;
+  mocks.taskkillStatuses.length = 0;
+  tmpDir = await mkdtemp(join(TEST_TMP_DIR, "verify-setup-windows-test-"));
+  await writeFile(
+    join(tmpDir, "package.json"),
+    JSON.stringify({ scripts: { dev: "node server.js" } })
+  );
+});
+
+afterEach(async () => {
+  setPlatform(originalPlatform);
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("verifySetup Windows cleanup", () => {
+  test("terminates the process tree with bounded taskkill", async () => {
+    const { ui } = createMockUI();
+
+    await verifySetup(
+      { status: "success", result: { platform: "javascript-nextjs" } },
+      ui,
+      tmpDir
+    );
+
+    expect(mocks.spawnCalls[0]?.options.detached).toBe(false);
+    expect(mocks.taskkillCalls).toEqual([
+      {
+        command: "taskkill",
+        args: ["/PID", "4321", "/T"],
+        options: expect.objectContaining({ timeout: 1000 }),
+      },
+    ]);
+    expect(mocks.childKillCalls).toEqual([]);
+  });
+
+  test("forces the tree and falls back to the child when taskkill fails", async () => {
+    mocks.taskkillStatuses.push(1, 1);
+    const { ui } = createMockUI();
+
+    await verifySetup(
+      { status: "success", result: { platform: "javascript-nextjs" } },
+      ui,
+      tmpDir
+    );
+
+    expect(mocks.taskkillCalls.map(({ args }) => args)).toEqual([
+      ["/PID", "4321", "/T"],
+      ["/PID", "4321", "/T", "/F"],
+    ]);
+    expect(mocks.childKillCalls).toEqual(["SIGKILL"]);
+  });
+});

--- a/test/lib/init/verify-setup-windows.mocked.test.ts
+++ b/test/lib/init/verify-setup-windows.mocked.test.ts
@@ -3,6 +3,7 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { logger } from "../../../src/lib/logger.js";
 import { TEST_TMP_DIR } from "../../constants.js";
 import { createMockUI } from "./ui/mock-ui.js";
 
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => ({
     args: string[];
     options: { timeout?: number };
   }>,
+  taskkillErrors: [] as Array<Error | undefined>,
   taskkillStatuses: [] as number[],
 }));
 
@@ -52,7 +54,7 @@ vi.mock("node:child_process", async (importOriginal) => {
       (command: string, args: string[], options: { timeout?: number }) => {
         mocks.taskkillCalls.push({ command, args, options });
         return {
-          error: undefined,
+          error: mocks.taskkillErrors.shift(),
           pid: 0,
           output: [],
           signal: null,
@@ -86,6 +88,7 @@ beforeEach(async () => {
   mocks.childKillCalls.length = 0;
   mocks.spawnCalls.length = 0;
   mocks.taskkillCalls.length = 0;
+  mocks.taskkillErrors.length = 0;
   mocks.taskkillStatuses.length = 0;
   tmpDir = await mkdtemp(join(TEST_TMP_DIR, "verify-setup-windows-test-"));
   await writeFile(
@@ -95,12 +98,13 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   setPlatform(originalPlatform);
   await rm(tmpDir, { recursive: true, force: true });
 });
 
 describe("verifySetup Windows cleanup", () => {
-  test("terminates the process tree with bounded taskkill", async () => {
+  test("force-terminates the process tree with bounded taskkill", async () => {
     const { ui } = createMockUI();
 
     await verifySetup(
@@ -113,15 +117,16 @@ describe("verifySetup Windows cleanup", () => {
     expect(mocks.taskkillCalls).toEqual([
       {
         command: "taskkill",
-        args: ["/PID", "4321", "/T"],
+        args: ["/PID", "4321", "/T", "/F"],
         options: expect.objectContaining({ timeout: 1000 }),
       },
     ]);
     expect(mocks.childKillCalls).toEqual([]);
   });
 
-  test("forces the tree and falls back to the child when taskkill fails", async () => {
-    mocks.taskkillStatuses.push(1, 1);
+  test("logs a non-zero status and falls back to the direct child", async () => {
+    mocks.taskkillStatuses.push(1);
+    const debugSpy = vi.spyOn(logger, "debug");
     const { ui } = createMockUI();
 
     await verifySetup(
@@ -131,9 +136,37 @@ describe("verifySetup Windows cleanup", () => {
     );
 
     expect(mocks.taskkillCalls.map(({ args }) => args)).toEqual([
-      ["/PID", "4321", "/T"],
       ["/PID", "4321", "/T", "/F"],
     ]);
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining("taskkill exited with status 1")
+    );
+    expect(mocks.childKillCalls).toEqual(["SIGKILL"]);
+  });
+
+  test("logs a taskkill timeout and falls back to the direct child", async () => {
+    const timeoutError = Object.assign(
+      new Error("spawnSync taskkill ETIMEDOUT"),
+      {
+        code: "ETIMEDOUT",
+      }
+    );
+    mocks.taskkillErrors.push(timeoutError);
+    const debugSpy = vi.spyOn(logger, "debug");
+    const { ui } = createMockUI();
+
+    await verifySetup(
+      { status: "success", result: { platform: "javascript-nextjs" } },
+      ui,
+      tmpDir
+    );
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Failed to terminate Windows verification process tree"
+      ),
+      timeoutError
+    );
     expect(mocks.childKillCalls).toEqual(["SIGKILL"]);
   });
 });

--- a/test/lib/init/verify-setup.test.ts
+++ b/test/lib/init/verify-setup.test.ts
@@ -1,0 +1,204 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { verifySetup } from "../../../src/lib/init/verify-setup.js";
+import { TEST_TMP_DIR } from "../../constants.js";
+import { createMockUI } from "./ui/mock-ui.js";
+
+vi.mock("@sentry/node-core/light", () => ({
+  captureException: vi.fn(),
+}));
+
+type FixtureProcesses = {
+  shellPid: number;
+  parentPid: number;
+  childPid: number;
+};
+
+let tmpDir: string;
+let fixtureProcesses: FixtureProcesses | undefined;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(TEST_TMP_DIR, "verify-setup-test-"));
+});
+
+afterEach(async () => {
+  if (fixtureProcesses) {
+    for (const pid of [
+      fixtureProcesses.shellPid,
+      fixtureProcesses.parentPid,
+      fixtureProcesses.childPid,
+    ]) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // The verification cleanup should already have terminated the fixture.
+      }
+    }
+  }
+  await rm(tmpDir, { recursive: true, force: true });
+  fixtureProcesses = undefined;
+});
+
+/** Return whether a process currently exists. */
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}
+
+/** Wait for a short, bounded interval. */
+async function wait(ms: number): Promise<void> {
+  await new Promise<void>((resolveDelay) => {
+    setTimeout(resolveDelay, ms);
+  });
+}
+
+/** Wait briefly for a killed process to be reaped by the operating system. */
+async function waitForProcessExit(pid: number): Promise<boolean> {
+  const deadline = Date.now() + 2000;
+  while (processExists(pid)) {
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    await wait(25);
+  }
+  return true;
+}
+
+/** Write a shell-based dev script that leaves a process tree holding stdio. */
+async function writeProcessTreeFixture(ignoreSigterm = false): Promise<void> {
+  await writeFile(
+    join(tmpDir, "package.json"),
+    JSON.stringify({
+      scripts: {
+        // `&&` deliberately makes detectDevCommand wrap this in `sh -c`,
+        // matching scripts that use concurrently or chained commands.
+        dev: 'node verify-parent.mjs && node -e "process.exit(0)"',
+      },
+    })
+  );
+  const sigtermHandler = ignoreSigterm
+    ? 'process.on("SIGTERM", () => {});'
+    : "";
+  await writeFile(
+    join(tmpDir, "verify-parent.mjs"),
+    `
+      import { spawn } from "node:child_process";
+      import { writeFileSync } from "node:fs";
+
+      ${sigtermHandler}
+      const child = spawn(
+        process.execPath,
+        [
+          "-e",
+          ${JSON.stringify(`${sigtermHandler} setInterval(() => {}, 1000);`)},
+        ],
+        { stdio: "inherit" }
+      );
+      writeFileSync(
+        "processes.json",
+        JSON.stringify({
+          shellPid: process.ppid,
+          parentPid: process.pid,
+          childPid: child.pid,
+        })
+      );
+      process.stderr.write("SyntaxError: verification fixture\\n");
+      setInterval(() => {}, 1000);
+    `
+  );
+}
+
+/** Poll for the fixture's PID file while verification is still running. */
+async function readFixtureProcesses(): Promise<FixtureProcesses> {
+  const path = join(tmpDir, "processes.json");
+  const deadline = Date.now() + 2000;
+  while (true) {
+    try {
+      return JSON.parse(await readFile(path, "utf8")) as FixtureProcesses;
+    } catch (error) {
+      if (
+        (error as NodeJS.ErrnoException).code !== "ENOENT" ||
+        Date.now() >= deadline
+      ) {
+        throw error;
+      }
+      await wait(25);
+    }
+  }
+}
+
+describe("verifySetup", () => {
+  test("does not fail init when the detected command cannot be spawned", async () => {
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { dev: "missing-sentry-test-command" } })
+    );
+    const { ui, calls } = createMockUI();
+
+    await expect(
+      verifySetup(
+        { status: "success", result: { platform: "javascript-nextjs" } },
+        ui,
+        tmpDir
+      )
+    ).resolves.toBeUndefined();
+
+    expect(calls).toContainEqual({
+      kind: "log.warn",
+      message: "Skipping verification — could not start the dev command.",
+    });
+  });
+
+  test.skipIf(process.platform === "win32")(
+    "terminates shell descendants that inherit the verification pipes",
+    async () => {
+      await writeProcessTreeFixture();
+
+      const { ui, calls } = createMockUI();
+      const verification = verifySetup(
+        { status: "success", result: { platform: "javascript-nextjs" } },
+        ui,
+        tmpDir
+      );
+      fixtureProcesses = await readFixtureProcesses();
+      await verification;
+
+      expect(await waitForProcessExit(fixtureProcesses.shellPid)).toBe(true);
+      expect(await waitForProcessExit(fixtureProcesses.parentPid)).toBe(true);
+      expect(await waitForProcessExit(fixtureProcesses.childPid)).toBe(true);
+      fixtureProcesses = undefined;
+      expect(calls).toContainEqual({
+        kind: "log.warn",
+        message:
+          "Could not verify — startup error: SyntaxError: verification fixture",
+      });
+    }
+  );
+
+  test.skipIf(process.platform === "win32")(
+    "force-kills descendants that ignore SIGTERM",
+    async () => {
+      await writeProcessTreeFixture(true);
+
+      const { ui } = createMockUI();
+      const verification = verifySetup(
+        { status: "success", result: { platform: "javascript-nextjs" } },
+        ui,
+        tmpDir
+      );
+      fixtureProcesses = await readFixtureProcesses();
+      await verification;
+
+      expect(await waitForProcessExit(fixtureProcesses.shellPid)).toBe(true);
+      expect(await waitForProcessExit(fixtureProcesses.parentPid)).toBe(true);
+      expect(await waitForProcessExit(fixtureProcesses.childPid)).toBe(true);
+      fixtureProcesses = undefined;
+    },
+    10_000
+  );
+});


### PR DESCRIPTION
## Summary

Post-init verification currently kills only the direct shell process and waits for its close event. Package scripts that launch concurrently, framework dev servers, or file watchers leave descendants holding stdout and stderr open, so sentry init can remain stuck on Verifying setup even though the remote workflow already succeeded.

This starts the verification command in a dedicated POSIX process group and terminates the complete tree during cleanup and signal forwarding. POSIX cleanup is bounded: it sends SIGTERM, escalates to SIGKILL after five seconds, and destroys the local pipe ends so inherited descriptors cannot keep the CLI alive. Windows force-terminates the disposable verification tree with a bounded `taskkill /T /F` invocation and falls back to the direct child if that fails.

The verification path now also handles asynchronous child-process spawn errors. A missing or invalid dev command produces a best-effort verification warning instead of crashing a successful init run.

## Safety properties

- Shell pipelines, concurrently tasks, framework servers, and watchers are terminated as one process tree.
- POSIX descendants that ignore SIGTERM are force-killed after the grace period.
- Cleanup never waits indefinitely for ChildProcess close.
- SIGINT and SIGTERM are forwarded to the POSIX process group; Windows force-terminates the disposable tree before the signal is re-emitted by the CLI.
- Windows `taskkill` calls have their own one-second timeout, debug diagnostics, and direct-child fallback.
- Spawn failures remain non-fatal because verification runs after setup has succeeded.

## Test plan

- `pnpm exec vitest run test/lib/init/verify-setup.test.ts test/lib/init/verify-setup-windows.mocked.test.ts test/lib/dev-script.test.ts test/lib/init/wizard-runner.test.ts` — 75 tests pass, including forced Windows tree cleanup, timeout/status diagnostics, and direct-child fallback.
- `TZ=UTC pnpm exec vitest run test/lib test/commands test/types test/script --coverage --exclude test/lib/completions.property.test.ts` — 400 files, 8,459 tests pass, 14 skipped.
- `pnpm exec tsc --noEmit` — passes.
- `pnpm run lint` — 919 files pass.
- `SENTRY_CLIENT_ID=test-build-only pnpm tsx script/build.ts --single` — darwin-arm64 build passes.
- `git diff --check` — passes.

The unmodified broad test command reaches 8,470 passing tests and 8 unrelated failures. Six time-range assertions assume UTC while the local timezone is Europe/Madrid. Two Bash completion simulations fail on the system Bash 3.2 because the generated script uses extglob syntax without enabling extglob; neither area is touched by this PR.
