### PR TITLE
fix(init): keep Ink task progress in sync

### DIFF
--- a/src/lib/init/clack-utils.ts
+++ b/src/lib/init/clack-utils.ts
@@ -117,9 +117,8 @@ export const STEP_LABELS: Record<string, string> = {
   "detect-platform": "Detecting platform and framework",
   "ensure-sentry-project": "Setting up Sentry project",
   "select-features": "Selecting features",
-  "install-deps": "Installing dependencies",
   "plan-codemods": "Planning code modifications",
-  "apply-codemods": "Applying code modifications",
+  "apply-codemods": "Applying code modifications and installing dependencies",
   "verify-changes": "Verifying changes",
   "open-sentry-ui": "Finishing up",
 };
@@ -147,7 +146,6 @@ export const CANONICAL_STEP_ORDER: readonly string[] = [
   "select-features",
   "plan-codemods",
   "apply-codemods",
-  "install-deps",
   "verify-changes",
   "open-sentry-ui",
 ];
@@ -156,13 +154,15 @@ export const CANONICAL_STEP_ORDER: readonly string[] = [
  * Subset of {@link CANONICAL_STEP_ORDER} surfaced in the progress
  * checklist. The Ink sidebar is 36 cols wide and shares vertical
  * space with the tip card and the files-read panel, so showing all
- * 12 step rows would push the files panel off-screen on shorter
+ * 11 step rows would push the files panel off-screen on shorter
  * terminals.
  *
  * The hidden steps (`select-target-app`, `resolve-dir`,
  * `check-existing-sentry`) are plumbing — users care that "Setting up
  * Sentry project" happened, not that we resolved their working
- * directory along the way.
+ * directory along the way. Dependency installation is part of
+ * `apply-codemods`; the server removed the separate `install-deps` step in
+ * getsentry/cli-init-api#140.
  */
 export const CHECKLIST_VISIBLE_STEPS: readonly string[] = [
   "discover-context",
@@ -171,7 +171,6 @@ export const CHECKLIST_VISIBLE_STEPS: readonly string[] = [
   "select-features",
   "plan-codemods",
   "apply-codemods",
-  "install-deps",
   "verify-changes",
   "open-sentry-ui",
 ];
@@ -188,9 +187,8 @@ export const STEP_ACTIVE_LABELS: Record<string, string> = {
   "detect-platform": "Detecting framework and platform...",
   "ensure-sentry-project": "Configuring Sentry project...",
   "select-features": "Preparing feature selection...",
-  "install-deps": "Installing Sentry SDK and dependencies...",
   "plan-codemods": "Planning code changes...",
-  "apply-codemods": "Applying code modifications...",
+  "apply-codemods": "Applying code changes and installing dependencies...",
   "verify-changes": "Verifying setup...",
   "open-sentry-ui": "Finishing up...",
 };
@@ -207,9 +205,8 @@ export const STEP_LABELS_SHORT: Record<string, string> = {
   "detect-platform": "Detecting platform",
   "ensure-sentry-project": "Setting up project",
   "select-features": "Selecting features",
-  "install-deps": "Installing deps",
   "plan-codemods": "Planning changes",
-  "apply-codemods": "Applying changes",
+  "apply-codemods": "Applying changes + deps",
   "verify-changes": "Verifying changes",
   "open-sentry-ui": "Finishing up",
 };

--- a/src/lib/init/types.ts
+++ b/src/lib/init/types.ts
@@ -273,7 +273,19 @@ export type WorkflowRunResult = {
   status: "suspended" | "success" | "failed";
   suspended?: string[][];
   activeStepsPath?: Record<string, unknown>;
-  steps?: Record<string, { suspendPayload?: unknown }>;
+  steps?: Record<
+    string,
+    {
+      status?:
+        | "success"
+        | "failed"
+        | "suspended"
+        | "running"
+        | "waiting"
+        | "paused";
+      suspendPayload?: unknown;
+    }
+  >;
   suspendPayload?: unknown;
   result?: WizardOutput;
   error?: string;

--- a/src/lib/init/ui/ink-app.tsx
+++ b/src/lib/init/ui/ink-app.tsx
@@ -6,14 +6,14 @@
  *
  *   ┌─ ◆ Sentry Init Wizard ──────────────────── sentry.io ─┐
  *   │                                                         │
- *   │  ╔═══╗                    │  ╭ Did you know? ─────────╮ │
- *   │  ║ S ║  Sentry banner     │  │ <tip>                  │ │
- *   │  ╚═══╝                    │  ╰────────────────────────╯ │
- *   │  ● log line               │                             │
- *   │  ▲ log line               │  ╭ Tasks ────── 2/9 ──────╮ │
- *   │  ◐ spinner...             │  │ ◼ Discover ctx         │ │
- *   │  [PromptArea]             │  │ ▶ Install deps         │ │
- *   │                           │  │ ◻ Apply codemods       │ │
+ *   │  ╔═══╗                    │  ╭ Tasks ────── 2/8 ──────╮ │
+ *   │  ║ S ║  Sentry banner     │  │ ◼ Analyze project      │ │
+ *   │  ╚═══╝                    │  │ ▶ Apply changes         │ │
+ *   │  ● log line               │  ╰────────────────────────╯ │
+ *   │  ▲ log line               │                             │
+ *   │                           │  ╭ Did you know? ─────────╮ │
+ *   │  ◐ spinner...             │  │ Errors → context → fix │ │
+ *   │  [PromptArea]             │  │ <tip>                  │ │
  *   │                           │  ╰────────────────────────╯ │
  *   │  ● Status   Files                                       │
  *   │  ←→ switch tab                                          │
@@ -340,17 +340,17 @@ function Sidebar({
   const showTips = terminalRows >= 24;
   return (
     <Box flexDirection="column" overflow="hidden" width="40%">
+      <ProgressPanel steps={steps} />
       {showTips ? (
         <>
+          <Box height={1} />
           {learnState.complete ? (
             <TipPanel tipIndex={tipIndex} />
           ) : (
             <LearnPanel learnState={learnState} />
           )}
-          <Box height={1} />
         </>
       ) : null}
-      <ProgressPanel steps={steps} />
     </Box>
   );
 }

--- a/src/lib/init/wizard-runner.ts
+++ b/src/lib/init/wizard-runner.ts
@@ -980,6 +980,8 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
   const stepPhases = new Map<string, number>();
   const stepHistory = new Map<string, CompactPhaseHistoryEntry[]>();
 
+  syncWorkflowStepStatuses(result, ui);
+
   // Track which step the runner is currently suspended on so the
   // sidebar checklist can flip rows as the workflow advances. A
   // single step can suspend multiple times (read-files → analyze →
@@ -1054,6 +1056,7 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
           ui,
           progressRotation,
         });
+        syncWorkflowStepStatuses(result, ui);
       } finally {
         progressRotation.stop();
       }
@@ -1125,6 +1128,27 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
         ? resultFeatures.join(",")
         : String(resultFeatures)
     );
+  }
+}
+
+/**
+ * Reconcile checklist rows with Mastra's persisted step results.
+ *
+ * A step can finish entirely inside a start/resume request without ever
+ * suspending for CLI work. Those steps still appear in `result.steps`, so
+ * their server-reported status is more complete than the suspend transitions
+ * observed by the client.
+ */
+function syncWorkflowStepStatuses(
+  result: WorkflowRunResult,
+  ui: WizardUI
+): void {
+  for (const [stepId, step] of Object.entries(result.steps ?? {})) {
+    if (step.status === "success") {
+      ui.setStep?.(stepId, "completed");
+    } else if (step.status === "failed") {
+      ui.setStep?.(stepId, "failed");
+    }
   }
 }
 

--- a/test/lib/init/ui/ink-app.snapshot.test.tsx
+++ b/test/lib/init/ui/ink-app.snapshot.test.tsx
@@ -222,6 +222,16 @@ describe("Ink App snapshot", () => {
     expect(frame).toContain("2/7");
   });
 
+  test("keeps tasks above rotating tips", async () => {
+    const store = new WizardStore({
+      learnState: { blockIndex: 0, lineIndex: 0, complete: true },
+    });
+
+    const frame = stripAnsi((await renderApp(store, 120)).allOutput());
+    expect(frame).toContain("Did you know?");
+    expect(frame.indexOf("Tasks")).toBeLessThan(frame.indexOf("Did you know?"));
+  });
+
   test("renders single-column layout at narrow width", async () => {
     const store = new WizardStore();
     store.appendLog("info", "Narrow terminal");

--- a/test/lib/init/ui/wizard-store.test.ts
+++ b/test/lib/init/ui/wizard-store.test.ts
@@ -30,6 +30,12 @@ describe("WizardStore step progress", () => {
     expect(snapshot.steps.every((entry) => entry.status === "pending")).toBe(
       true
     );
+    expect(snapshot.steps.some((entry) => entry.id === "install-deps")).toBe(
+      false
+    );
+    expect(
+      snapshot.steps.find((entry) => entry.id === "apply-codemods")?.label
+    ).toBe("Applying changes + deps");
   });
 
   test("flips a step to in_progress on first call", () => {
@@ -43,9 +49,9 @@ describe("WizardStore step progress", () => {
 
   test("re-entering an in_progress step is idempotent (no flicker)", () => {
     const store = new WizardStore();
-    store.setStepStatus("install-deps", "in_progress");
+    store.setStepStatus("apply-codemods", "in_progress");
     const before = store.getSnapshot().steps;
-    store.setStepStatus("install-deps", "in_progress");
+    store.setStepStatus("apply-codemods", "in_progress");
     const after = store.getSnapshot().steps;
     // Reference equality: no update emitted, so the array is the
     // same instance. This is what the store guarantees for no-op
@@ -57,16 +63,16 @@ describe("WizardStore step progress", () => {
     const store = new WizardStore();
     // Jump straight to a later step — simulates the workflow
     // taking an `if`-branch that bypassed the earlier ones.
-    store.setStepStatus("install-deps", "in_progress");
+    store.setStepStatus("verify-changes", "in_progress");
     const steps = store.getSnapshot().steps;
-    const installIdx = CANONICAL_STEP_ORDER.indexOf("install-deps");
+    const verifyIndex = CANONICAL_STEP_ORDER.indexOf("verify-changes");
     for (const entry of steps) {
       const idx = CANONICAL_STEP_ORDER.indexOf(entry.id);
-      if (idx >= 0 && idx < installIdx) {
+      if (idx >= 0 && idx < verifyIndex) {
         expect(entry.status).toBe("skipped");
       }
     }
-    expect(steps.find((entry) => entry.id === "install-deps")?.status).toBe(
+    expect(steps.find((entry) => entry.id === "verify-changes")?.status).toBe(
       "in_progress"
     );
   });
@@ -75,7 +81,7 @@ describe("WizardStore step progress", () => {
     const store = new WizardStore();
     store.setStepStatus("discover-context", "in_progress");
     store.setStepStatus("discover-context", "completed");
-    store.setStepStatus("install-deps", "in_progress");
+    store.setStepStatus("verify-changes", "in_progress");
     const discover = store
       .getSnapshot()
       .steps.find((row) => row.id === "discover-context");
@@ -113,11 +119,11 @@ describe("WizardStore step progress", () => {
 
   test("failed transition wins over the existing status", () => {
     const store = new WizardStore();
-    store.setStepStatus("install-deps", "in_progress");
-    store.setStepStatus("install-deps", "failed");
+    store.setStepStatus("apply-codemods", "in_progress");
+    store.setStepStatus("apply-codemods", "failed");
     const entry = store
       .getSnapshot()
-      .steps.find((row) => row.id === "install-deps");
+      .steps.find((row) => row.id === "apply-codemods");
     expect(entry?.status).toBe("failed");
   });
 
@@ -139,9 +145,9 @@ describe("WizardStore step progress", () => {
     const unsubscribe = store.subscribe(() => {
       notifications += 1;
     });
-    store.setStepStatus("install-deps", "in_progress");
-    store.setStepStatus("install-deps", "in_progress"); // idempotent
-    store.setStepStatus("install-deps", "completed");
+    store.setStepStatus("apply-codemods", "in_progress");
+    store.setStepStatus("apply-codemods", "in_progress"); // idempotent
+    store.setStepStatus("apply-codemods", "completed");
     unsubscribe();
     // Two real transitions = two notifications. The middle no-op
     // does not fire a listener — saves a render in React.

--- a/test/lib/init/wizard-runner.test.ts
+++ b/test/lib/init/wizard-runner.test.ts
@@ -22,7 +22,10 @@ import {
   HostScopeError,
   WizardError,
 } from "../../../src/lib/errors.js";
-import { WizardCancelledError } from "../../../src/lib/init/clack-utils.js";
+import {
+  CHECKLIST_VISIBLE_STEPS,
+  WizardCancelledError,
+} from "../../../src/lib/init/clack-utils.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as fmt from "../../../src/lib/init/formatters.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
@@ -599,9 +602,9 @@ describe("runWizard", () => {
     };
     mockStartResult = {
       status: "suspended",
-      suspended: [["install-deps"]],
+      suspended: [["apply-codemods"]],
       steps: {
-        "install-deps": { suspendPayload: payload },
+        "apply-codemods": { suspendPayload: payload },
       },
     };
     mockResumeResults = [{ status: "success" }];
@@ -704,9 +707,9 @@ describe("runWizard", () => {
     };
     mockStartResult = {
       status: "suspended",
-      suspended: [["install-deps"]],
+      suspended: [["apply-codemods"]],
       steps: {
-        "install-deps": { suspendPayload: payload },
+        "apply-codemods": { suspendPayload: payload },
       },
     };
     executeToolSpy.mockRejectedValue(new Error("boom"));
@@ -728,9 +731,9 @@ describe("runWizard", () => {
     };
     mockStartResult = {
       status: "suspended",
-      suspended: [["install-deps"]],
+      suspended: [["apply-codemods"]],
       steps: {
-        "install-deps": { suspendPayload: payload },
+        "apply-codemods": { suspendPayload: payload },
       },
     };
     executeToolSpy.mockRejectedValue(new WizardCancelledError());
@@ -761,9 +764,9 @@ describe("runWizard", () => {
     };
     mockStartResult = {
       status: "suspended",
-      suspended: [["install-deps"]],
+      suspended: [["apply-codemods"]],
       steps: {
-        "install-deps": { suspendPayload: payload },
+        "apply-codemods": { suspendPayload: payload },
       },
     };
     executeToolSpy.mockRejectedValue(
@@ -914,9 +917,9 @@ describe("runWizard — MastraClient lifecycle", () => {
     };
     mockStartResult = {
       status: "suspended",
-      suspended: [["install-deps"]],
+      suspended: [["apply-codemods"]],
       steps: {
-        "install-deps": { suspendPayload: payload },
+        "apply-codemods": { suspendPayload: payload },
       },
     };
     executeToolSpy.mockRejectedValue(new Error("tool blew up"));
@@ -938,9 +941,9 @@ describe("runWizard — MastraClient lifecycle", () => {
     };
     mockStartResult = {
       status: "suspended",
-      suspended: [["install-deps"]],
+      suspended: [["apply-codemods"]],
       steps: {
-        "install-deps": { suspendPayload: payload },
+        "apply-codemods": { suspendPayload: payload },
       },
     };
     executeToolSpy.mockRejectedValue(new WizardCancelledError());
@@ -1627,6 +1630,93 @@ describe("runWizard — additional coverage", () => {
     expect(inProgressIdx).toBeLessThan(completedIdx);
   });
 
+  test("uses server step results for tasks that finish without suspending", async () => {
+    const payload: ToolPayload = {
+      type: "tool",
+      operation: "read-files",
+      cwd: "/tmp/test",
+      params: { paths: ["package.json"] },
+    };
+
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["detect-platform"]],
+      steps: {
+        "discover-context": { status: "success" },
+        "detect-platform": { status: "suspended", suspendPayload: payload },
+      },
+    };
+    mockResumeResults = [
+      {
+        status: "success",
+        steps: {
+          "discover-context": { status: "success" },
+          "detect-platform": { status: "success" },
+          "ensure-sentry-project": { status: "success" },
+          "select-features": { status: "success" },
+          "plan-codemods": { status: "success" },
+          "apply-codemods": { status: "success" },
+          "verify-changes": { status: "success" },
+          "open-sentry-ui": { status: "success" },
+        },
+      },
+    ];
+
+    await runWizard(makeOptions());
+
+    const stepCalls = mockUICalls.filter((call) => call.kind === "setStep");
+    for (const stepId of CHECKLIST_VISIBLE_STEPS) {
+      expect(stepCalls).toContainEqual({
+        kind: "setStep",
+        stepId,
+        status: "completed",
+      });
+    }
+    expect(stepCalls).not.toContainEqual(
+      expect.objectContaining({ stepId: "install-deps" })
+    );
+
+    const discoverCompletedIndex = stepCalls.findIndex(
+      (call) =>
+        call.kind === "setStep" &&
+        call.stepId === "discover-context" &&
+        call.status === "completed"
+    );
+    const detectStartedIndex = stepCalls.findIndex(
+      (call) =>
+        call.kind === "setStep" &&
+        call.stepId === "detect-platform" &&
+        call.status === "in_progress"
+    );
+    expect(discoverCompletedIndex).toBeLessThan(detectStartedIndex);
+  });
+
+  test("marks a server-reported failure before any step suspends", async () => {
+    mockStartResult = {
+      status: "failed",
+      error: "Framework detection failed",
+      steps: {
+        "discover-context": { status: "success" },
+        "detect-platform": { status: "failed" },
+      },
+    };
+
+    await expect(runWizard(makeOptions())).rejects.toThrow(
+      "Framework detection failed"
+    );
+
+    expect(mockUICalls).toContainEqual({
+      kind: "setStep",
+      stepId: "discover-context",
+      status: "completed",
+    });
+    expect(mockUICalls).toContainEqual({
+      kind: "setStep",
+      stepId: "detect-platform",
+      status: "failed",
+    });
+  });
+
   test("uses existing platform name in detect-platform spinner label", async () => {
     resolveInitContextSpy.mockResolvedValue(
       makeContext({ existingProject: { platform: "javascript-nextjs" } })
@@ -1800,8 +1890,8 @@ describe("runWizard — progress rotation for long-running steps", () => {
     };
     mockStartResult = {
       status: "suspended",
-      suspended: [["install-deps"]],
-      steps: { "install-deps": { suspendPayload: toolPayload } },
+      suspended: [["apply-codemods"]],
+      steps: { "apply-codemods": { suspendPayload: toolPayload } },
     };
 
     let resolveResume!: (value: unknown) => void;


### PR DESCRIPTION
## Summary

The Ink sidebar was only updating tasks when a workflow step suspended. Steps that completed entirely inside start/resume, such as Analyze project when its inputs were already cached, were therefore shown as skipped or left incomplete even though Mastra had finished them.

This reconciles the checklist from the step statuses Mastra already returns on every response. Tasks that never suspend now become green, failures are reflected even before a client-tool round trip, and the final synchronous steps can reach the completed count.

The separate Installing dependencies row was also stale: cli-init-api#140 merged installation into apply-codemods. The checklist now mirrors the real eight-step user-facing workflow and labels that phase Applying changes + deps instead of keeping a task that can never receive a server transition.

Tasks now render above the rotating tips, so different tip heights no longer move the progress list around.

## Test plan

- pnpm run lint — 920 files pass
- pnpm run typecheck — passes
- pnpm vitest run test/lib/init/ui/ink-app.snapshot.test.tsx test/lib/init/ui/wizard-store.test.ts test/lib/init/wizard-runner.test.ts — 123 tests pass
- pnpm vitest run test/lib/init test/lib/telemetry.test.ts — 538 tests pass
- TZ=UTC pnpm vitest run test/lib/time-range.test.ts — 51 tests pass
- pnpm run test:unit — 8,479 pass, 14 skipped, with eight pre-existing local-environment failures: six timezone-sensitive time-range assertions under Europe/Madrid and two bash completion shell simulations. The time-range failures pass under TZ=UTC; none of the eight touch init.
- git diff --check — passes
- Local patch coverage for executable lines — 100%