### PR TITLE
fix(ci): clear auth tokens in npm smoke test to prevent WASM SQLite crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -818,6 +818,16 @@ jobs:
           # exact patched version from the central env block here.
           node-version: ${{ matrix.node == '24' && env.NODE_VERSION_24 || matrix.node == '20' && env.NODE_VERSION_20 || env.NODE_VERSION_22 }}
       - name: Smoke test (Node.js)
+        env:
+          # Clear auth tokens so the CLI doesn't attempt API calls or
+          # telemetry uploads during the smoke test. On main, the job
+          # inherits SENTRY_AUTH_TOKEN from the `production` environment
+          # (needed by the Bundle step); without clearing it here, the
+          # CLI tries to initialize telemetry → SQLite, which crashes on
+          # the WASM fallback path (Node 20) because the runner's home
+          # directory may not have a writable ~/.sentry config dir yet.
+          SENTRY_AUTH_TOKEN: ""
+          SENTRY_TOKEN: ""
         run: node dist/bin.cjs --help
       - name: Smoke test (Node.js — deep)
         shell: bash


### PR DESCRIPTION
## Problem

The `Build npm Package (smoke Node 20)` job has been failing on **main** with:

```
Fatal: SQLite3Error: unable to open database file
```

Both recent main commits show this failure:
- [`b5902f2`](https://github.com/getsentry/cli/actions/runs/29922616622) (fix(local): Handle standalone span items...)
- [`b6e89b5`](https://github.com/getsentry/cli/actions/runs/29758252383) (fix(init): retry transient auth validation once)

The PRs that merged into main **passed CI**, but the same code fails on main.

## Root Cause

The `build-npm` job uses `environment: production` (line 782) so the Bundle step can access `SENTRY_AUTH_TOKEN` for sourcemap uploads. This token **leaks into all subsequent steps** in the job.

When the first smoke test runs `node dist/bin.cjs --help` on Node 20:
1. The CLI detects `SENTRY_AUTH_TOKEN` in the environment
2. It initializes telemetry, which triggers SQLite database initialization
3. On Node 20, the WASM SQLite fallback driver is used (no `node:sqlite` before 22.15)
4. The WASM driver's `_nodejs_open` fails because the runner's `~/.sentry` config directory doesn't exist yet for the switched Node 20 runtime

**Why PRs pass but main fails:** On PR runs, `environment: production` resolves to empty (the conditional on line 782 only activates for `main` / `release/*` branches), so `SENTRY_AUTH_TOKEN` is empty. Without a token, the CLI skips telemetry init and never opens the database.

## Fix

Explicitly clear `SENTRY_AUTH_TOKEN` and `SENTRY_TOKEN` in the first smoke test step's `env:` block — matching what the deep smoke test step already does (lines 835-836).

This is the minimal, correct fix. The smoke tests are consumer-perspective tests that should run without auth credentials.