### PR TITLE
fix(upgrade): bound untrusted patch newSize to prevent pre-verification OOM

### DIFF
--- a/src/lib/bspatch.ts
+++ b/src/lib/bspatch.ts
@@ -45,6 +45,17 @@ const TRDIFF10_MAGIC = "TRDIFF10";
 /** Header size in bytes (magic + 3 × i64) */
 const HEADER_SIZE = 32;
 
+/**
+ * Upper bound on the declared output size (`newSize`) a patch may claim.
+ *
+ * The header's `newSize` is attacker-controlled and used to preallocate the
+ * output buffer BEFORE the patch content is verified, so an unbounded value
+ * would let a malicious or corrupt patch force an out-of-memory allocation.
+ * 2 GiB is far above any realistic binary (sentry-cli binaries are ~30 MB);
+ * legitimate patched outputs never approach it.
+ */
+export const MAX_OUTPUT_SIZE = 2_147_483_648; // 2 GiB
+
 /** Parsed TRDIFF10 header fields */
 export type PatchHeader = {
   /** Compressed size of the control block (bytes) */
@@ -112,6 +123,14 @@ export function parsePatchHeader(patch: Uint8Array): PatchHeader {
 
   if (controlLen < 0 || diffLen < 0 || newSize < 0) {
     throw new Error("Corrupt patch: negative length in header");
+  }
+
+  // Bound the attacker-controlled newSize before it is used to preallocate
+  // the output buffer (applyReaderToMemory) — see MAX_OUTPUT_SIZE.
+  if (newSize > MAX_OUTPUT_SIZE) {
+    throw new Error(
+      `Corrupt patch: declared output size ${newSize} exceeds maximum ${MAX_OUTPUT_SIZE} bytes`
+    );
   }
 
   const totalCompressed = HEADER_SIZE + controlLen + diffLen;

--- a/test/lib/bspatch.test.ts
+++ b/test/lib/bspatch.test.ts
@@ -21,6 +21,7 @@ import {
   applyPatch,
   applyPatchChainInMemory,
   applyPatchToMemory,
+  MAX_OUTPUT_SIZE,
   parsePatchHeader,
 } from "../../src/lib/bspatch.js";
 
@@ -148,6 +149,30 @@ describe("parsePatchHeader: fixtures", () => {
     buf[8] = 1; // non-zero low byte → magnitude > 0
     buf[15] = 0x80; // Set sign bit → negative controlLen
     expect(() => parsePatchHeader(buf)).toThrow("negative");
+  });
+
+  test("rejects an attacker-controlled newSize above MAX_OUTPUT_SIZE", () => {
+    // The header's newSize is used to preallocate the output buffer before the
+    // patch content is verified. An unbounded value lets a malicious/corrupt
+    // patch force an OOM via `new Uint8Array(newSize)` in applyReaderToMemory.
+    // Regression test: a header claiming newSize > MAX_OUTPUT_SIZE must be
+    // rejected here, before any allocation.
+    const buf = new Uint8Array(64);
+    buf.set(new TextEncoder().encode("TRDIFF10"));
+    writeI64LE(buf, 8, 0); // controlLen = 0
+    writeI64LE(buf, 16, 0); // diffLen = 0
+    writeI64LE(buf, 24, MAX_OUTPUT_SIZE + 1); // newSize just over the cap
+    expect(() => parsePatchHeader(buf)).toThrow("exceeds maximum");
+  });
+
+  test("accepts a newSize at MAX_OUTPUT_SIZE (boundary)", () => {
+    const buf = new Uint8Array(64);
+    buf.set(new TextEncoder().encode("TRDIFF10"));
+    writeI64LE(buf, 8, 0);
+    writeI64LE(buf, 16, 0);
+    writeI64LE(buf, 24, MAX_OUTPUT_SIZE); // exactly the cap — allowed
+    const header = parsePatchHeader(buf);
+    expect(header.newSize).toBe(MAX_OUTPUT_SIZE);
   });
 });
 


### PR DESCRIPTION
## What

The TRDIFF10 patch header's `newSize` field is attacker-controlled, and `applyReaderToMemory` uses it to preallocate the output buffer (`new Uint8Array(newSize)`) **before** the patch content is verified. With no upper bound, a malicious or corrupt patch declaring a huge `newSize` (e.g. 8 GiB) forces an out-of-memory allocation — a crash (or worse) reachable from any patch the CLI downloads or loads from cache.

## Fix

Adds `MAX_OUTPUT_SIZE` (2 GiB) and enforces it in `parsePatchHeader`, rejecting any `newSize` above the cap **before any allocation**. 2 GiB is far above any realistic sentry-cli binary (~30 MB), so legitimate patched outputs never approach the cap.

This mirrors the same fix we made in the Lore gateway's ported copy of this file (where an adversarial security review flagged the identical bug).

## Tests

- A header claiming `newSize = MAX_OUTPUT_SIZE + 1` is rejected (`"exceeds maximum"`).
- A header at `newSize = MAX_OUTPUT_SIZE` (boundary) is still accepted.
- **Mutation-verified:** removing the guard turns the over-cap test RED while the boundary test stays GREEN (sharp boundary).

## Verification

- 17/17 `test/lib/bspatch.test.ts` pass, `tsc --noEmit` clean, `biome check` clean.