### PR TITLE
fix(ci): use temp config dir in npm smoke test to prevent WASM SQLite crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -819,21 +819,22 @@ jobs:
           node-version: ${{ matrix.node == '24' && env.NODE_VERSION_24 || matrix.node == '20' && env.NODE_VERSION_20 || env.NODE_VERSION_22 }}
       - name: Smoke test (Node.js)
         env:
-          # Clear auth tokens so the CLI doesn't attempt API calls or
-          # telemetry uploads during the smoke test. On main, the job
-          # inherits SENTRY_AUTH_TOKEN from the `production` environment
-          # (needed by the Bundle step); without clearing it here, the
-          # CLI tries to initialize telemetry → SQLite, which crashes on
-          # the WASM fallback path (Node 20) because the runner's home
-          # directory may not have a writable ~/.sentry config dir yet.
+          # Clear auth tokens — on main the job inherits SENTRY_AUTH_TOKEN
+          # from the production environment (for the Bundle step's sourcemap
+          # upload). The smoke tests must not use it.
           SENTRY_AUTH_TOKEN: ""
           SENTRY_TOKEN: ""
+          # Use a temp config dir so the WASM SQLite driver (Node 20) can
+          # create and open the database reliably. The runner's ~/.sentry
+          # may not exist under the switched Node 20 runtime.
+          SENTRY_CONFIG_DIR: ${{ runner.temp }}/.sentry-smoke
         run: node dist/bin.cjs --help
       - name: Smoke test (Node.js — deep)
         shell: bash
         env:
           SENTRY_AUTH_TOKEN: ""
           SENTRY_TOKEN: ""
+          SENTRY_CONFIG_DIR: ${{ runner.temp }}/.sentry-smoke
         run: |
           # auth status without a token exercises SQLite init, schema
           # migrations, telemetry lazy import, and the CJS require chain.


### PR DESCRIPTION
## Problem

The `Build npm Package (smoke Node 20)` job fails on **main** with:

```
Fatal: SQLite3Error: unable to open database file
```

This persisted after #1278 (which cleared auth tokens but didn't fix the root cause).

## Root Cause

The WASM SQLite driver (used on Node 20 since `node:sqlite` is unavailable before 22.15) cannot open the database file at `~/.sentry/cli.db` when the smoke test runs after switching from Node 22 to Node 20. The runner's home directory state from the Node 22 build step may include a `~/.sentry` directory with permissions or lock state incompatible with the WASM driver's Node.js VFS layer (which uses `fs.openSync`/`mkdirSync` for locking, unlike the native driver).

**Why PRs pass but main fails:** On PR runs, the `production` environment is not activated (conditional on line 782), so `SENTRY_AUTH_TOKEN` is empty and the CLI takes a lighter code path. On main, the token leaks from the Bundle step, causing earlier database initialization before the `--help` fast path can avoid it.

## Fix

1. **Clear auth tokens** in both smoke test steps (from #1278)
2. **Set `SENTRY_CONFIG_DIR`** to `${{ runner.temp }}/.sentry-smoke` so the WASM driver creates a fresh database in a known-writable temp directory, avoiding any state left by the Node 22 build step

This matches the approach used in test infrastructure (`useTestConfigDir`) — isolate the config directory to prevent cross-runtime state interference.