### PR TITLE
fix(upgrade): nightly discovery hits wrong GHCR package (silent 404 → full-download fallback)

### DIFF
--- a/src/lib/delta-upgrade.ts
+++ b/src/lib/delta-upgrade.ts
@@ -41,6 +41,7 @@ import { CLI_VERSION } from "./constants.js";
 import { customFetch } from "./custom-ca.js";
 import { getConfigDir } from "./db/index.js";
 import { formatBytes } from "./formatters/numbers.js";
+import { GHCR_REPO } from "./ghcr.js";
 import { logger } from "./logger.js";
 import { makeByteProgress, type SetMessage } from "./progress.js";
 import { withTracing, withTracingSpan } from "./telemetry.js";
@@ -67,7 +68,9 @@ export type DeltaResult = {
   chainLength: number;
 };
 
-const GITHUB_REPO_REPO_NAME = "getsentry/sentry-cli";
+// GHCR publishes nightlies to ghcr.io/getsentry/cli (see src/lib/ghcr.ts
+// GHCR_REPO). Importing as a named import keeps a single source of truth and
+// avoids the silent 404 introduced when this was a string literal.
 const log = logger.withTag("delta-upgrade");
 
 const instrument: InstrumentHook = (name, fn) =>
@@ -129,7 +132,7 @@ function stableSource(): SourceStrategy {
 function nightlySource(): SourceStrategy {
   return ghcrSource({
     registry: "https://ghcr.io",
-    repo: GITHUB_REPO_REPO_NAME,
+    repo: GHCR_REPO,
     binaryName: getPlatformBinaryName(),
     targetTag: (version) => `nightly-${version}`,
     compareVersions,
@@ -274,7 +277,7 @@ export async function resolveNightlyChain(opts: {
 }): Promise<PatchChain | null> {
   const client = new OciClient({
     registry: "https://ghcr.io",
-    repo: GITHUB_REPO_REPO_NAME,
+    repo: GHCR_REPO,
     userAgent: `sentry-cli/${CLI_VERSION}`,
     fetch: customFetch,
   });


### PR DESCRIPTION
## Summary

PR #1298 (binpatch adoption) introduced a local copy of the GHCR repo constant, `GITHUB_REPO_REPO_NAME = "getsentry/sentry-cli"`. The CI publishes nightlies to `ghcr.io/getsentry/cli` (see `src/lib/ghcr.ts`'s `GHCR_REPO` and the `oras push ghcr.io/getsentry/cli:nightly` line in `.github/workflows/ci.yml:676`). The wrong package hit a 404 on every nightly discovery, and the silent error handler fell back to a full binary download. **Nightly delta upgrades have been broken since the merge.**

## Reported by

- `cursor[bot]` — HIGH severity: "Wrong GHCR repo for nightlies"
- `sentry[bot]` — HIGH severity: "incorrect repository name, causing nightly delta upgrades to silently fail"

## Fix

Import `GHCR_REPO` from `./ghcr.js` (single source of truth, already verified against the CI publish destination). Drop the duplicate local constant. Both `nightlySource()` and the test-only `resolveNightlyChain()` now use the canonical value.

## Diff

```diff
+import { GHCR_REPO } from "./ghcr.js";

-const GITHUB_REPO_REPO_NAME = "getsentry/sentry-cli";
+// GHCR publishes nightlies to ghcr.io/getsentry/cli (see src/lib/ghcr.ts
+// GHCR_REPO). Importing as a named import keeps a single source of truth and
+// avoids the silent 404 introduced when this was a string literal.

 function nightlySource(): SourceStrategy {
   return ghcrSource({
-    repo: GITHUB_REPO_REPO_NAME,
+    repo: GHCR_REPO,

 export async function resolveNightlyChain(opts: {...}): Promise<PatchChain | null> {
   const client = new OciClient({
-    repo: GITHUB_REPO_REPO_NAME,
+    repo: GHCR_REPO,
```

1 file changed, 6 insertions(+), 3 deletions(-).

## Tests

- `pnpm test:unit` — 90/90 in `test/lib/delta-upgrade.test.ts` + `test/lib/delta-upgrade.mocked.test.ts`, all green.
- `pnpm run typecheck` — exit 0.
- `pnpm run lint` — no diagnostics.

## Why follow-up, not hotfix-on-main

The change is small and surgical, but main is currently at the broken state. Hotfixing on main would invalidate #1298's review trail and bot comments; a focused PR is cleaner and gives reviewers an explicit diff to confirm before nightly discovery goes green again.

## Unrelated findings from the same PR review (deferred)

- sentry-warden[bot] MEDIUM: "filterAndSortChainTags lacks semver validation before compareVersions" — **REAL** but proper fix belongs in `binpatch` (add a `semverValid()` guard in `filterAndSortChainTags`). Tracked; opening a binpatch PR after this one ships.
- sentry-warden[bot] MEDIUM: "Patch cache directory loses restrictive 0o700 permissions" — **FALSE POSITIVE**. `binpatch/src/patch-cache.ts:78` already does `mkdir(cacheDir, { recursive: true, mode: 0o700 })`.
- sentry[bot] LOW: "resolveNightlyChain unhandled blob rejection" — REAL but only affects the **test-only** `resolveNightlyChain` (now dead code in production since `attemptDeltaUpgrade` uses `binpatch`'s `ghcrSource` which already handles errors). Not worth fixing.