### PR TITLE
test(eval): support OpenRouter for skill-eval and init-eval judges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -770,8 +770,11 @@ jobs:
       - name: E2E Tests
         env:
           SENTRY_CLI_BINARY: ${{ github.workspace }}/dist-bin/sentry-linux-x64
-          # Pass API key only when skill files changed — the skill-eval e2e test
-          # auto-skips when the key is absent, so non-skill PRs aren't affected.
+          # Pass the eval provider key only when skill files changed — the
+          # skill-eval e2e test auto-skips when no key is present, so non-skill
+          # PRs aren't affected. OpenRouter is preferred; ANTHROPIC_API_KEY is
+          # kept as a fallback for direct-Anthropic runs.
+          OPENROUTER_API_KEY: ${{ needs.changes.outputs.skill == 'true' && secrets.OPENROUTER_API_KEY || '' }}
           ANTHROPIC_API_KEY: ${{ needs.changes.outputs.skill == 'true' && secrets.ANTHROPIC_API_KEY || '' }}
         run: pnpm run test:e2e
 

--- a/.github/workflows/eval-skill-fork.yml
+++ b/.github/workflows/eval-skill-fork.yml
@@ -66,6 +66,7 @@ jobs:
         id: eval
         run: pnpm run eval:skill
         env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         continue-on-error: true
 

--- a/script/eval-skill.ts
+++ b/script/eval-skill.ts
@@ -7,14 +7,17 @@
  * Commands are verified against the real CLI binary (via `-h`) to ground
  * the LLM judge with empirical results.
  *
- * Requires ANTHROPIC_API_KEY env var for Anthropic API access.
+ * Requires an eval provider credential: OPENROUTER_API_KEY (preferred) or
+ * ANTHROPIC_API_KEY. OpenRouter is used when its key is set; model IDs are
+ * namespaced (`anthropic/`) automatically.
  *
  * Usage:
  *   tsx script/eval-skill.ts
  *   EVAL_AGENT_MODELS=claude-sonnet-4-6-20250627 tsx script/eval-skill.ts
  *
  * Environment variables:
- *   ANTHROPIC_API_KEY   - Anthropic API key (required)
+ *   OPENROUTER_API_KEY  - OpenRouter API key (preferred)
+ *   ANTHROPIC_API_KEY   - Anthropic API key (fallback when no OpenRouter key)
  *   EVAL_AGENT_MODELS   - Comma-separated model IDs (default: sonnet-4-6, opus-4-6)
  *   EVAL_JUDGE_MODEL    - Judge model ID (default: haiku-4-5)
  *   EVAL_THRESHOLD      - Minimum pass rate 0-1 (default: 0.75)
@@ -22,6 +25,7 @@
  */
 
 import { readFile } from "node:fs/promises";
+import { resolveEvalProvider } from "../test/eval-common/anthropic-client.js";
 import cases from "../test/skill-eval/cases.json";
 import { judgePlan } from "../test/skill-eval/helpers/judge.js";
 import { createClient } from "../test/skill-eval/helpers/llm-client.js";
@@ -90,14 +94,19 @@ async function evalModel(
 }
 
 async function main(): Promise<void> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    console.error("Error: ANTHROPIC_API_KEY is required for the skill eval.");
-    console.error("Set it via: export ANTHROPIC_API_KEY=<your-key>");
+  const provider = resolveEvalProvider();
+  if (!provider) {
+    console.error(
+      "Error: an eval provider credential is required for the skill eval."
+    );
+    console.error(
+      "Set OPENROUTER_API_KEY (preferred) or ANTHROPIC_API_KEY, e.g.:"
+    );
+    console.error("  export OPENROUTER_API_KEY=<your-key>");
     process.exit(1);
   }
 
-  const client = await createClient(apiKey);
+  const client = await createClient(provider);
   const skillContent = await readFile(SKILL_PATH, "utf-8");
   const testCases = cases as unknown as TestCase[];
   const threshold = process.env.EVAL_THRESHOLD
@@ -107,6 +116,7 @@ async function main(): Promise<void> {
   console.log(
     `Skill eval: ${testCases.length} cases × ${client.agentModels.length} models`
   );
+  console.log(`Provider: ${provider.provider}`);
   console.log(`Agent models: ${client.agentModels.join(", ")}`);
   console.log(`Judge model: ${client.judgeModel}`);
   console.log(`Threshold: ${(threshold * 100).toFixed(0)}%`);

--- a/script/eval-skill.ts
+++ b/script/eval-skill.ts
@@ -8,8 +8,8 @@
  * the LLM judge with empirical results.
  *
  * Requires an eval provider credential: OPENROUTER_API_KEY (preferred) or
- * ANTHROPIC_API_KEY. OpenRouter is used when its key is set; model IDs are
- * namespaced (`anthropic/`) automatically.
+ * ANTHROPIC_API_KEY. OpenRouter is used when its key is set; default model IDs
+ * are OpenRouter slugs (e.g. `anthropic/claude-sonnet-4.6`).
  *
  * Usage:
  *   tsx script/eval-skill.ts

--- a/script/eval-skill.ts
+++ b/script/eval-skill.ts
@@ -13,13 +13,13 @@
  *
  * Usage:
  *   tsx script/eval-skill.ts
- *   EVAL_AGENT_MODELS=claude-sonnet-4-6-20250627 tsx script/eval-skill.ts
+ *   EVAL_AGENT_MODELS=anthropic/claude-sonnet-4.6 tsx script/eval-skill.ts
  *
  * Environment variables:
  *   OPENROUTER_API_KEY  - OpenRouter API key (preferred)
  *   ANTHROPIC_API_KEY   - Anthropic API key (fallback when no OpenRouter key)
- *   EVAL_AGENT_MODELS   - Comma-separated model IDs (default: sonnet-4-6, opus-4-6)
- *   EVAL_JUDGE_MODEL    - Judge model ID (default: haiku-4-5)
+ *   EVAL_AGENT_MODELS   - Comma-separated model IDs (default: sonnet-4.6, opus-4.6)
+ *   EVAL_JUDGE_MODEL    - Judge model ID (default: haiku-4.5)
  *   EVAL_THRESHOLD      - Minimum pass rate 0-1 (default: 0.75)
  *   SENTRY_CLI_BINARY   - Path to pre-built binary (falls back to tsx src/bin.ts)
  */
@@ -106,7 +106,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const client = await createClient(provider);
+  const client = createClient(provider);
   const skillContent = await readFile(SKILL_PATH, "utf-8");
   const testCases = cases as unknown as TestCase[];
   const threshold = process.env.EVAL_THRESHOLD

--- a/test/e2e/skill-eval.test.ts
+++ b/test/e2e/skill-eval.test.ts
@@ -5,12 +5,14 @@
  * Uses the real CLI binary (via SENTRY_CLI_BINARY or dev mode) to verify
  * that planned commands actually exist.
  *
- * Skips automatically when ANTHROPIC_API_KEY is not set.
- * In CI, the key is only passed when skill-related files change.
+ * Skips automatically when no eval provider credential is set (neither
+ * OPENROUTER_API_KEY nor ANTHROPIC_API_KEY). In CI, the key is only passed
+ * when skill-related files change.
  */
 
 import { readFile } from "node:fs/promises";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { resolveEvalProvider } from "../eval-common/anthropic-client.js";
 import cases from "../skill-eval/cases.json";
 import { judgePlan } from "../skill-eval/helpers/judge.js";
 import { createClient } from "../skill-eval/helpers/llm-client.js";
@@ -20,17 +22,22 @@ import type { CaseResult, TestCase } from "../skill-eval/helpers/types.js";
 const SKILL_PATH = "plugins/sentry-cli/skills/sentry-cli/SKILL.md";
 const DEFAULT_THRESHOLD = 0.75;
 
-const apiKey = process.env.ANTHROPIC_API_KEY;
+/** Models under test — env-overridable, defaults to sonnet + opus. */
+const AGENT_MODELS = process.env.EVAL_AGENT_MODELS
+  ? process.env.EVAL_AGENT_MODELS.split(",").map((m) => m.trim())
+  : ["claude-sonnet-4-6", "claude-opus-4-6"];
+
+const provider = resolveEvalProvider();
 
 /**
  * The test preload mocks globalThis.fetch to block external network calls.
- * This test needs real fetch for Anthropic API calls, so we restore it
+ * This test needs real fetch for the eval provider's API, so we restore it
  * during the describe block and put the mock back when done.
  */
 const originalFetch = (globalThis as { __originalFetch?: typeof fetch })
   .__originalFetch;
 
-describe.skipIf(!apiKey)("skill eval", () => {
+describe.skipIf(!provider)("skill eval", () => {
   const savedFetch = globalThis.fetch;
 
   beforeAll(() => {
@@ -52,14 +59,17 @@ describe.skipIf(!apiKey)("skill eval", () => {
    * Each model gets its own test so failures are attributed clearly.
    */
   async function runEvalForModel(model: string): Promise<void> {
-    const client = await createClient(apiKey as string);
+    if (!provider) {
+      throw new Error("eval provider unavailable");
+    }
+    const client = await createClient(provider);
     const skillContent = await readFile(SKILL_PATH, "utf-8");
 
     const results: CaseResult[] = [];
     for (const testCase of testCases) {
       const plan = await generatePlan(
         client,
-        model,
+        provider.qualifyModel(model),
         skillContent,
         testCase.prompt
       );
@@ -73,11 +83,9 @@ describe.skipIf(!apiKey)("skill eval", () => {
     expect(score).toBeGreaterThanOrEqual(threshold);
   }
 
-  test("claude-sonnet-4-6 meets threshold", { timeout: 120_000 }, () =>
-    runEvalForModel("claude-sonnet-4-6")
-  );
-
-  test("claude-opus-4-6 meets threshold", { timeout: 120_000 }, () =>
-    runEvalForModel("claude-opus-4-6")
-  );
+  for (const model of AGENT_MODELS) {
+    test(`${model} meets threshold`, { timeout: 120_000 }, () =>
+      runEvalForModel(model)
+    );
+  }
 });

--- a/test/e2e/skill-eval.test.ts
+++ b/test/e2e/skill-eval.test.ts
@@ -25,7 +25,7 @@ const DEFAULT_THRESHOLD = 0.75;
 /** Models under test — env-overridable, defaults to sonnet + opus. */
 const AGENT_MODELS = process.env.EVAL_AGENT_MODELS
   ? process.env.EVAL_AGENT_MODELS.split(",").map((m) => m.trim())
-  : ["claude-sonnet-4-6", "claude-opus-4-6"];
+  : ["anthropic/claude-sonnet-4.6", "anthropic/claude-opus-4.6"];
 
 const provider = resolveEvalProvider();
 
@@ -62,14 +62,14 @@ describe.skipIf(!provider)("skill eval", () => {
     if (!provider) {
       throw new Error("eval provider unavailable");
     }
-    const client = await createClient(provider);
+    const client = createClient(provider);
     const skillContent = await readFile(SKILL_PATH, "utf-8");
 
     const results: CaseResult[] = [];
     for (const testCase of testCases) {
       const plan = await generatePlan(
         client,
-        provider.qualifyModel(model),
+        model,
         skillContent,
         testCase.prompt
       );

--- a/test/eval-common/anthropic-client.ts
+++ b/test/eval-common/anthropic-client.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared Anthropic/OpenRouter client resolution for the eval frameworks.
+ *
+ * Both the skill-eval and init-eval suites talk to Claude models via the
+ * `@anthropic-ai/sdk`. OpenRouter is Anthropic-Messages-API-compatible, so the
+ * same SDK works against it by overriding the base URL and namespacing model
+ * IDs (`anthropic/claude-...`).
+ *
+ * Provider selection is credential-driven:
+ * - `OPENROUTER_API_KEY` set  → OpenRouter (base URL + `anthropic/` model prefix)
+ * - else `ANTHROPIC_API_KEY`  → Anthropic direct (bare model IDs)
+ * - neither                   → `null` (callers skip the eval)
+ *
+ * The base URL and model prefix can be overridden explicitly for either
+ * provider via `OPENROUTER_BASE_URL` / `ANTHROPIC_BASE_URL` and
+ * `EVAL_MODEL_PREFIX`.
+ */
+
+/** Default OpenRouter base URL for the Anthropic-compatible SDK. */
+export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
+/** Model-ID namespace OpenRouter requires for Anthropic models. */
+export const OPENROUTER_MODEL_PREFIX = "anthropic/";
+
+/**
+ * Resolved provider configuration for an eval run.
+ *
+ * `qualifyModel` maps a bare Claude model ID (e.g. `claude-sonnet-4-6`) to the
+ * form the active provider expects. It is idempotent — a model ID that already
+ * carries the prefix is returned unchanged, so callers may pass fully-qualified
+ * IDs through `EVAL_AGENT_MODELS` without double-prefixing.
+ */
+export type EvalProvider = {
+  /** API key passed to the Anthropic SDK. */
+  apiKey: string;
+  /** Base URL override, or `undefined` for the SDK default (Anthropic direct). */
+  baseURL: string | undefined;
+  /** Which provider was selected — for logging/diagnostics. */
+  provider: "openrouter" | "anthropic";
+  /** Map a bare model ID to the provider-qualified form (idempotent). */
+  qualifyModel: (model: string) => string;
+};
+
+/**
+ * Resolve the eval provider from the environment.
+ *
+ * @returns provider config, or `null` when no API key is available so the
+ *   caller can skip (matching the historical `!apiKey` skip behavior).
+ */
+export function resolveEvalProvider(
+  env: NodeJS.ProcessEnv = process.env
+): EvalProvider | null {
+  const openRouterKey = env.OPENROUTER_API_KEY?.trim();
+  const anthropicKey = env.ANTHROPIC_API_KEY?.trim();
+  const prefixOverride = env.EVAL_MODEL_PREFIX;
+
+  if (openRouterKey) {
+    const prefix = prefixOverride ?? OPENROUTER_MODEL_PREFIX;
+    return {
+      apiKey: openRouterKey,
+      baseURL: env.OPENROUTER_BASE_URL?.trim() || OPENROUTER_BASE_URL,
+      provider: "openrouter",
+      qualifyModel: (model) => qualifyModel(model, prefix),
+    };
+  }
+
+  if (anthropicKey) {
+    const prefix = prefixOverride ?? "";
+    return {
+      apiKey: anthropicKey,
+      baseURL: env.ANTHROPIC_BASE_URL?.trim() || undefined,
+      provider: "anthropic",
+      qualifyModel: (model) => qualifyModel(model, prefix),
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Prefix a model ID with the provider namespace, unless it already carries it
+ * or the prefix is empty. Idempotent.
+ */
+function qualifyModel(model: string, prefix: string): string {
+  if (prefix.length === 0 || model.startsWith(prefix)) {
+    return model;
+  }
+  return `${prefix}${model}`;
+}

--- a/test/eval-common/anthropic-client.ts
+++ b/test/eval-common/anthropic-client.ts
@@ -1,89 +1,157 @@
 /**
- * Shared Anthropic/OpenRouter client resolution for the eval frameworks.
+ * Shared LLM provider resolution and chat for the eval frameworks.
  *
- * Both the skill-eval and init-eval suites talk to Claude models via the
- * `@anthropic-ai/sdk`. OpenRouter is Anthropic-Messages-API-compatible, so the
- * same SDK works against it by overriding the base URL and namespacing model
- * IDs (`anthropic/claude-...`).
- *
- * Provider selection is credential-driven:
- * - `OPENROUTER_API_KEY` set  → OpenRouter (base URL + `anthropic/` model prefix)
- * - else `ANTHROPIC_API_KEY`  → Anthropic direct (bare model IDs)
+ * Both the skill-eval and init-eval suites send single-shot chat completions to
+ * Claude models. Provider selection is credential-driven:
+ * - `OPENROUTER_API_KEY` set  → OpenRouter (OpenAI-shaped `/chat/completions`)
+ * - else `ANTHROPIC_API_KEY`  → Anthropic direct (`@anthropic-ai/sdk`)
  * - neither                   → `null` (callers skip the eval)
  *
- * The base URL and model prefix can be overridden explicitly for either
- * provider via `OPENROUTER_BASE_URL` / `ANTHROPIC_BASE_URL` and
- * `EVAL_MODEL_PREFIX`.
+ * OpenRouter is **not** Anthropic-Messages-API compatible — it only speaks the
+ * OpenAI `/api/v1/chat/completions` schema — so that path uses `fetch` directly
+ * rather than the Anthropic SDK, and its model IDs are OpenRouter slugs
+ * (`anthropic/claude-sonnet-4.6`). The Anthropic-direct fallback keeps using the
+ * SDK with bare model IDs.
  */
 
-/** Default OpenRouter base URL for the Anthropic-compatible SDK. */
+/** Default OpenRouter base URL (OpenAI-compatible API root). */
 export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
-/** Model-ID namespace OpenRouter requires for Anthropic models. */
-export const OPENROUTER_MODEL_PREFIX = "anthropic/";
+/** A single system/user turn to send to the model. */
+export type ChatMessage = {
+  role: "system" | "user";
+  content: string;
+};
 
 /**
- * Resolved provider configuration for an eval run.
+ * Resolved provider for an eval run.
  *
- * `qualifyModel` maps a bare Claude model ID (e.g. `claude-sonnet-4-6`) to the
- * form the active provider expects. It is idempotent — a model ID that already
- * carries the prefix is returned unchanged, so callers may pass fully-qualified
- * IDs through `EVAL_AGENT_MODELS` without double-prefixing.
+ * `chat` sends one completion and returns the assistant's text. Implementations
+ * differ by provider (OpenRouter fetch vs. Anthropic SDK) but the contract is
+ * identical, so callers are provider-agnostic.
  */
 export type EvalProvider = {
-  /** API key passed to the Anthropic SDK. */
-  apiKey: string;
-  /** Base URL override, or `undefined` for the SDK default (Anthropic direct). */
-  baseURL: string | undefined;
   /** Which provider was selected — for logging/diagnostics. */
   provider: "openrouter" | "anthropic";
-  /** Map a bare model ID to the provider-qualified form (idempotent). */
-  qualifyModel: (model: string) => string;
+  /** Send a single chat completion and return the assistant's text. */
+  chat: (
+    model: string,
+    messages: ChatMessage[],
+    maxTokens: number
+  ) => Promise<string>;
 };
 
 /**
  * Resolve the eval provider from the environment.
  *
- * @returns provider config, or `null` when no API key is available so the
- *   caller can skip (matching the historical `!apiKey` skip behavior).
+ * @returns provider, or `null` when no API key is available so the caller can
+ *   skip (matching the historical `!apiKey` skip behavior).
  */
 export function resolveEvalProvider(
   env: NodeJS.ProcessEnv = process.env
 ): EvalProvider | null {
   const openRouterKey = env.OPENROUTER_API_KEY?.trim();
   const anthropicKey = env.ANTHROPIC_API_KEY?.trim();
-  const prefixOverride = env.EVAL_MODEL_PREFIX;
 
   if (openRouterKey) {
-    const prefix = prefixOverride ?? OPENROUTER_MODEL_PREFIX;
+    const baseURL = env.OPENROUTER_BASE_URL?.trim() || OPENROUTER_BASE_URL;
     return {
-      apiKey: openRouterKey,
-      baseURL: env.OPENROUTER_BASE_URL?.trim() || OPENROUTER_BASE_URL,
       provider: "openrouter",
-      qualifyModel: (model) => qualifyModel(model, prefix),
+      chat: (model, messages, maxTokens) =>
+        openRouterChat({
+          baseURL,
+          apiKey: openRouterKey,
+          model,
+          messages,
+          maxTokens,
+        }),
     };
   }
 
   if (anthropicKey) {
-    const prefix = prefixOverride ?? "";
+    const baseURL = env.ANTHROPIC_BASE_URL?.trim() || undefined;
     return {
-      apiKey: anthropicKey,
-      baseURL: env.ANTHROPIC_BASE_URL?.trim() || undefined,
       provider: "anthropic",
-      qualifyModel: (model) => qualifyModel(model, prefix),
+      chat: (model, messages, maxTokens) =>
+        anthropicChat({
+          baseURL,
+          apiKey: anthropicKey,
+          model,
+          messages,
+          maxTokens,
+        }),
     };
   }
 
   return null;
 }
 
+/** Arguments for a single provider chat call. */
+type ChatArgs = {
+  baseURL: string | undefined;
+  apiKey: string;
+  model: string;
+  messages: ChatMessage[];
+  maxTokens: number;
+};
+
 /**
- * Prefix a model ID with the provider namespace, unless it already carries it
- * or the prefix is empty. Idempotent.
+ * Send a completion to OpenRouter's OpenAI-shaped `/chat/completions` endpoint.
+ * System and user turns map directly to OpenAI `messages`.
  */
-function qualifyModel(model: string, prefix: string): string {
-  if (prefix.length === 0 || model.startsWith(prefix)) {
-    return model;
+async function openRouterChat({
+  baseURL,
+  apiKey,
+  model,
+  messages,
+  maxTokens,
+}: ChatArgs): Promise<string> {
+  const response = await fetch(`${baseURL}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ model, messages, max_tokens: maxTokens }),
+  });
+
+  if (!response.ok) {
+    const detail = (await response.text()).slice(0, 500);
+    throw new Error(`OpenRouter ${response.status}: ${detail}`);
   }
-  return `${prefix}${model}`;
+
+  const data = (await response.json()) as {
+    choices?: { message?: { content?: string } }[];
+  };
+  return data.choices?.[0]?.message?.content ?? "";
+}
+
+/**
+ * Send a completion via the Anthropic SDK. The single system turn becomes the
+ * `system` parameter; user turns become `messages`.
+ */
+async function anthropicChat({
+  baseURL,
+  apiKey,
+  model,
+  messages,
+  maxTokens,
+}: ChatArgs): Promise<string> {
+  const { default: Anthropic } = await import("@anthropic-ai/sdk");
+  const client = new Anthropic({ apiKey, baseURL });
+
+  const system = messages.find((m) => m.role === "system")?.content;
+  const userMsgs = messages
+    .filter((m) => m.role === "user")
+    .map((m) => ({ role: "user" as const, content: m.content }));
+
+  const response = await client.messages.create({
+    model,
+    max_tokens: maxTokens,
+    system,
+    messages: userMsgs,
+  });
+
+  const textBlock = response.content.find((b) => b.type === "text");
+  return textBlock?.text ?? "";
 }

--- a/test/init-eval/helpers/judge.ts
+++ b/test/init-eval/helpers/judge.ts
@@ -2,6 +2,9 @@ import { resolveEvalProvider } from "../../eval-common/anthropic-client.js";
 import type { FeatureDoc, Platform } from "./platforms.js";
 import type { WizardResult } from "./run-wizard.js";
 
+/** Default judge model for init-eval (OpenRouter slug); override via EVAL_JUDGE_MODEL. */
+const INIT_EVAL_JUDGE_MODEL = "anthropic/claude-sonnet-4.6";
+
 export type JudgeCriterion = {
   name: string;
   /** true = pass, false = fail, "unknown" = judge can't determine */
@@ -46,13 +49,6 @@ export async function judgeFeature(
     globalThis.fetch = realFetch;
   }
 
-  // Dynamic import so we don't fail when the package isn't installed
-  const { default: Anthropic } = await import("@anthropic-ai/sdk");
-  const client = new Anthropic({
-    apiKey: provider.apiKey,
-    baseURL: provider.baseURL,
-  });
-
   const newFilesSection = Object.entries(result.newFiles)
     .map(([path, content]) => `### ${path}\n\`\`\`\n${content}\n\`\`\``)
     .join("\n\n");
@@ -91,14 +87,11 @@ Return ONLY valid JSON with this structure:
   "summary": "Brief overall assessment of ${feature.feature} setup"
 }`;
 
-  const response = await client.messages.create({
-    model: provider.qualifyModel("claude-sonnet-4-6"),
-    max_tokens: 1024,
-    messages: [{ role: "user", content: prompt }],
-  });
-
-  const textBlock = response.content.find((b) => b.type === "text");
-  const text = textBlock?.text ?? "";
+  const text = await provider.chat(
+    process.env.EVAL_JUDGE_MODEL ?? INIT_EVAL_JUDGE_MODEL,
+    [{ role: "user", content: prompt }],
+    1024
+  );
 
   // Extract JSON from response (handle markdown code blocks)
   const jsonMatch = text.match(/\{[\s\S]*\}/);

--- a/test/init-eval/helpers/judge.ts
+++ b/test/init-eval/helpers/judge.ts
@@ -1,3 +1,4 @@
+import { resolveEvalProvider } from "../../eval-common/anthropic-client.js";
 import type { FeatureDoc, Platform } from "./platforms.js";
 import type { WizardResult } from "./run-wizard.js";
 
@@ -17,7 +18,8 @@ export type JudgeVerdict = {
 
 /**
  * Use an LLM judge to evaluate whether a **single feature** was correctly set
- * up by the wizard. Returns null if ANTHROPIC_API_KEY is not set.
+ * up by the wizard. Returns null when no eval provider credential is set
+ * (OPENROUTER_API_KEY or ANTHROPIC_API_KEY).
  *
  * `docsContent` is the pre-fetched plain-text documentation to include as
  * ground truth in the prompt.
@@ -28,16 +30,16 @@ export async function judgeFeature(
   feature: FeatureDoc,
   docsContent: string
 ): Promise<JudgeVerdict | null> {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  const provider = resolveEvalProvider();
+  if (!provider) {
     console.log(
-      `  [judge:${feature.feature}] Skipping LLM judge (no ANTHROPIC_API_KEY set)`
+      `  [judge:${feature.feature}] Skipping LLM judge (no OPENROUTER_API_KEY or ANTHROPIC_API_KEY set)`
     );
     return null;
   }
 
   // Restore real fetch — test preload mocks it to catch accidental network
-  // calls, but we need real HTTP for the Anthropic API.
+  // calls, but we need real HTTP for the eval provider's API.
   const realFetch = (globalThis as { __originalFetch?: typeof fetch })
     .__originalFetch;
   if (realFetch) {
@@ -46,7 +48,10 @@ export async function judgeFeature(
 
   // Dynamic import so we don't fail when the package isn't installed
   const { default: Anthropic } = await import("@anthropic-ai/sdk");
-  const client = new Anthropic({ apiKey });
+  const client = new Anthropic({
+    apiKey: provider.apiKey,
+    baseURL: provider.baseURL,
+  });
 
   const newFilesSection = Object.entries(result.newFiles)
     .map(([path, content]) => `### ${path}\n\`\`\`\n${content}\n\`\`\``)
@@ -87,7 +92,7 @@ Return ONLY valid JSON with this structure:
 }`;
 
   const response = await client.messages.create({
-    model: "claude-sonnet-4-6",
+    model: provider.qualifyModel("claude-sonnet-4-6"),
     max_tokens: 1024,
     messages: [{ role: "user", content: prompt }],
   });

--- a/test/script/eval-provider.test.ts
+++ b/test/script/eval-provider.test.ts
@@ -1,16 +1,17 @@
-import { describe, expect, test } from "vitest";
-import {
-  OPENROUTER_BASE_URL,
-  resolveEvalProvider,
-} from "../eval-common/anthropic-client.js";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { resolveEvalProvider } from "../eval-common/anthropic-client.js";
 
 /**
- * Provider resolution drives which credential/base URL/model namespace the
- * eval frameworks use. These tests lock in the precedence (OpenRouter over
- * Anthropic), the `anthropic/` model prefixing, its idempotency, and the
- * null-when-unset skip contract.
+ * Provider resolution drives which credential/endpoint the eval frameworks use.
+ * These tests lock in the precedence (OpenRouter over Anthropic), the
+ * null-when-unset skip contract, and that the OpenRouter path posts the
+ * OpenAI-shaped `/chat/completions` request with the bearer key.
  */
 describe("resolveEvalProvider", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test("returns null when no credential is set", () => {
     expect(resolveEvalProvider({})).toBeNull();
   });
@@ -27,54 +28,68 @@ describe("resolveEvalProvider", () => {
       ANTHROPIC_API_KEY: "an-key",
     });
     expect(p?.provider).toBe("openrouter");
-    expect(p?.apiKey).toBe("or-key");
-    expect(p?.baseURL).toBe(OPENROUTER_BASE_URL);
   });
 
-  test("OpenRouter qualifies bare model IDs with anthropic/ prefix", () => {
-    const p = resolveEvalProvider({ OPENROUTER_API_KEY: "or-key" });
-    expect(p?.qualifyModel("claude-sonnet-4-6")).toBe(
-      "anthropic/claude-sonnet-4-6"
-    );
-  });
-
-  test("qualifyModel is idempotent (no double prefix)", () => {
-    const p = resolveEvalProvider({ OPENROUTER_API_KEY: "or-key" });
-    expect(p?.qualifyModel("anthropic/claude-opus-4-6")).toBe(
-      "anthropic/claude-opus-4-6"
-    );
-  });
-
-  test("falls back to Anthropic direct with bare model IDs", () => {
+  test("falls back to Anthropic direct when only its key is set", () => {
     const p = resolveEvalProvider({ ANTHROPIC_API_KEY: "an-key" });
     expect(p?.provider).toBe("anthropic");
-    expect(p?.apiKey).toBe("an-key");
-    expect(p?.baseURL).toBeUndefined();
-    expect(p?.qualifyModel("claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
   });
 
-  test("honors explicit base URL overrides", () => {
-    expect(
-      resolveEvalProvider({
-        OPENROUTER_API_KEY: "or-key",
-        OPENROUTER_BASE_URL: "https://proxy.example/v1",
-      })?.baseURL
-    ).toBe("https://proxy.example/v1");
-    expect(
-      resolveEvalProvider({
-        ANTHROPIC_API_KEY: "an-key",
-        ANTHROPIC_BASE_URL: "https://proxy.example/anthropic",
-      })?.baseURL
-    ).toBe("https://proxy.example/anthropic");
+  test("OpenRouter chat posts OpenAI-shaped /chat/completions with bearer key", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ choices: [{ message: { content: "hi there" } }] }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const p = resolveEvalProvider({ OPENROUTER_API_KEY: "or-key" });
+    const text = await p?.chat(
+      "anthropic/claude-sonnet-4.6",
+      [
+        { role: "system", content: "sys" },
+        { role: "user", content: "hello" },
+      ],
+      128
+    );
+
+    expect(text).toBe("hi there");
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://openrouter.ai/api/v1/chat/completions");
+    expect((init as RequestInit).method).toBe("POST");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer or-key");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.model).toBe("anthropic/claude-sonnet-4.6");
+    expect(body.max_tokens).toBe(128);
+    expect(body.messages).toHaveLength(2);
   });
 
-  test("EVAL_MODEL_PREFIX overrides the default prefix", () => {
+  test("OpenRouter chat throws with status detail on non-2xx", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 404 }))
+    );
+    const p = resolveEvalProvider({ OPENROUTER_API_KEY: "or-key" });
+    await expect(
+      p?.chat("anthropic/claude-sonnet-4.6", [], 16)
+    ).rejects.toThrow(/OpenRouter 404/);
+  });
+
+  test("honors OPENROUTER_BASE_URL override", async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ choices: [] }), { status: 200 })
+    );
+    vi.stubGlobal("fetch", fetchMock);
     const p = resolveEvalProvider({
       OPENROUTER_API_KEY: "or-key",
-      EVAL_MODEL_PREFIX: "custom/",
+      OPENROUTER_BASE_URL: "https://proxy.example/v1",
     });
-    expect(p?.qualifyModel("claude-sonnet-4-6")).toBe(
-      "custom/claude-sonnet-4-6"
+    await p?.chat("m", [], 16);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://proxy.example/v1/chat/completions"
     );
   });
 });

--- a/test/script/eval-provider.test.ts
+++ b/test/script/eval-provider.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+import {
+  OPENROUTER_BASE_URL,
+  resolveEvalProvider,
+} from "../eval-common/anthropic-client.js";
+
+/**
+ * Provider resolution drives which credential/base URL/model namespace the
+ * eval frameworks use. These tests lock in the precedence (OpenRouter over
+ * Anthropic), the `anthropic/` model prefixing, its idempotency, and the
+ * null-when-unset skip contract.
+ */
+describe("resolveEvalProvider", () => {
+  test("returns null when no credential is set", () => {
+    expect(resolveEvalProvider({})).toBeNull();
+  });
+
+  test("treats blank/whitespace keys as unset", () => {
+    expect(
+      resolveEvalProvider({ OPENROUTER_API_KEY: "  ", ANTHROPIC_API_KEY: "" })
+    ).toBeNull();
+  });
+
+  test("prefers OpenRouter when both keys are set", () => {
+    const p = resolveEvalProvider({
+      OPENROUTER_API_KEY: "or-key",
+      ANTHROPIC_API_KEY: "an-key",
+    });
+    expect(p?.provider).toBe("openrouter");
+    expect(p?.apiKey).toBe("or-key");
+    expect(p?.baseURL).toBe(OPENROUTER_BASE_URL);
+  });
+
+  test("OpenRouter qualifies bare model IDs with anthropic/ prefix", () => {
+    const p = resolveEvalProvider({ OPENROUTER_API_KEY: "or-key" });
+    expect(p?.qualifyModel("claude-sonnet-4-6")).toBe(
+      "anthropic/claude-sonnet-4-6"
+    );
+  });
+
+  test("qualifyModel is idempotent (no double prefix)", () => {
+    const p = resolveEvalProvider({ OPENROUTER_API_KEY: "or-key" });
+    expect(p?.qualifyModel("anthropic/claude-opus-4-6")).toBe(
+      "anthropic/claude-opus-4-6"
+    );
+  });
+
+  test("falls back to Anthropic direct with bare model IDs", () => {
+    const p = resolveEvalProvider({ ANTHROPIC_API_KEY: "an-key" });
+    expect(p?.provider).toBe("anthropic");
+    expect(p?.apiKey).toBe("an-key");
+    expect(p?.baseURL).toBeUndefined();
+    expect(p?.qualifyModel("claude-sonnet-4-6")).toBe("claude-sonnet-4-6");
+  });
+
+  test("honors explicit base URL overrides", () => {
+    expect(
+      resolveEvalProvider({
+        OPENROUTER_API_KEY: "or-key",
+        OPENROUTER_BASE_URL: "https://proxy.example/v1",
+      })?.baseURL
+    ).toBe("https://proxy.example/v1");
+    expect(
+      resolveEvalProvider({
+        ANTHROPIC_API_KEY: "an-key",
+        ANTHROPIC_BASE_URL: "https://proxy.example/anthropic",
+      })?.baseURL
+    ).toBe("https://proxy.example/anthropic");
+  });
+
+  test("EVAL_MODEL_PREFIX overrides the default prefix", () => {
+    const p = resolveEvalProvider({
+      OPENROUTER_API_KEY: "or-key",
+      EVAL_MODEL_PREFIX: "custom/",
+    });
+    expect(p?.qualifyModel("claude-sonnet-4-6")).toBe(
+      "custom/claude-sonnet-4-6"
+    );
+  });
+});

--- a/test/skill-eval/helpers/llm-client.ts
+++ b/test/skill-eval/helpers/llm-client.ts
@@ -1,21 +1,27 @@
 /**
  * LLM client for the skill eval framework.
  *
- * Uses the Anthropic Messages API via @anthropic-ai/sdk (already in
- * devDependencies). Works against either Anthropic direct or OpenRouter,
- * resolved from the environment via {@link resolveEvalProvider}.
+ * Wraps the resolved {@link EvalProvider} (OpenRouter or Anthropic direct) and
+ * carries the agent/judge model IDs for a run. Model defaults are OpenRouter
+ * slugs; override via `EVAL_AGENT_MODELS` / `EVAL_JUDGE_MODEL`.
  */
 
-import type { EvalProvider } from "../../eval-common/anthropic-client.js";
+import type {
+  ChatMessage,
+  EvalProvider,
+} from "../../eval-common/anthropic-client.js";
 
-/** Default agent models — the target models for the skill */
-export const DEFAULT_AGENT_MODELS = ["claude-sonnet-4-6", "claude-opus-4-6"];
+/** Default agent models — the target models for the skill (OpenRouter slugs). */
+export const DEFAULT_AGENT_MODELS = [
+  "anthropic/claude-sonnet-4.6",
+  "anthropic/claude-opus-4.6",
+];
 
-/** Default judge model — cheap and fast, just needs to grade command plans */
-export const DEFAULT_JUDGE_MODEL = "claude-haiku-4-5-20251001";
+/** Default judge model — cheap and fast, just needs to grade command plans. */
+export const DEFAULT_JUDGE_MODEL = "anthropic/claude-haiku-4.5";
 
 export type LLMClient = {
-  client: InstanceType<typeof import("@anthropic-ai/sdk").default>;
+  provider: EvalProvider;
   agentModels: string[];
   judgeModel: string;
 };
@@ -23,54 +29,28 @@ export type LLMClient = {
 /**
  * Create an LLM client for the eval framework.
  *
- * Model IDs are qualified for the active provider (e.g. `anthropic/` prefix on
- * OpenRouter). Agent models and judge model can be overridden via env vars:
+ * Agent models and judge model can be overridden via env vars:
  * - EVAL_AGENT_MODELS: comma-separated list of model IDs
  * - EVAL_JUDGE_MODEL: single model ID
  *
- * @param provider - Resolved provider config (key, base URL, model qualifier)
+ * @param provider - Resolved provider (OpenRouter or Anthropic direct)
  */
-export async function createClient(provider: EvalProvider): Promise<LLMClient> {
-  const { default: Anthropic } = await import("@anthropic-ai/sdk");
-
-  const client = new Anthropic({
-    apiKey: provider.apiKey,
-    baseURL: provider.baseURL,
-  });
-
-  const baseAgentModels = process.env.EVAL_AGENT_MODELS
+export function createClient(provider: EvalProvider): LLMClient {
+  const agentModels = process.env.EVAL_AGENT_MODELS
     ? process.env.EVAL_AGENT_MODELS.split(",").map((m) => m.trim())
     : DEFAULT_AGENT_MODELS;
-  const agentModels = baseAgentModels.map(provider.qualifyModel);
 
-  const judgeModel = provider.qualifyModel(
-    process.env.EVAL_JUDGE_MODEL ?? DEFAULT_JUDGE_MODEL
-  );
+  const judgeModel = process.env.EVAL_JUDGE_MODEL ?? DEFAULT_JUDGE_MODEL;
 
-  return { client, agentModels, judgeModel };
+  return { provider, agentModels, judgeModel };
 }
 
-/** Send a message and return the text response */
-export async function chatCompletion(
+/** Send a message and return the text response. */
+export function chatCompletion(
   llm: LLMClient,
   model: string,
-  messages: { role: "system" | "user"; content: string }[],
+  messages: ChatMessage[],
   maxTokens = 2048
 ): Promise<string> {
-  // Separate system prompt from user messages (Anthropic API style)
-  const systemMsg = messages.find((m) => m.role === "system");
-  const userMsgs = messages
-    .filter((m) => m.role === "user")
-    .map((m) => ({ role: "user" as const, content: m.content }));
-
-  const response = await llm.client.messages.create({
-    model,
-    max_tokens: maxTokens,
-    system: systemMsg?.content,
-    messages: userMsgs,
-  });
-
-  // Extract text from content blocks
-  const textBlock = response.content.find((b) => b.type === "text");
-  return textBlock?.text ?? "";
+  return llm.provider.chat(model, messages, maxTokens);
 }

--- a/test/skill-eval/helpers/llm-client.ts
+++ b/test/skill-eval/helpers/llm-client.ts
@@ -1,9 +1,12 @@
 /**
  * LLM client for the skill eval framework.
  *
- * Uses the Anthropic API via @anthropic-ai/sdk (already in devDependencies).
- * Requires ANTHROPIC_API_KEY env var.
+ * Uses the Anthropic Messages API via @anthropic-ai/sdk (already in
+ * devDependencies). Works against either Anthropic direct or OpenRouter,
+ * resolved from the environment via {@link resolveEvalProvider}.
  */
+
+import type { EvalProvider } from "../../eval-common/anthropic-client.js";
 
 /** Default agent models — the target models for the skill */
 export const DEFAULT_AGENT_MODELS = ["claude-sonnet-4-6", "claude-opus-4-6"];
@@ -20,20 +23,29 @@ export type LLMClient = {
 /**
  * Create an LLM client for the eval framework.
  *
- * Agent models and judge model can be overridden via env vars:
+ * Model IDs are qualified for the active provider (e.g. `anthropic/` prefix on
+ * OpenRouter). Agent models and judge model can be overridden via env vars:
  * - EVAL_AGENT_MODELS: comma-separated list of model IDs
  * - EVAL_JUDGE_MODEL: single model ID
+ *
+ * @param provider - Resolved provider config (key, base URL, model qualifier)
  */
-export async function createClient(apiKey: string): Promise<LLMClient> {
+export async function createClient(provider: EvalProvider): Promise<LLMClient> {
   const { default: Anthropic } = await import("@anthropic-ai/sdk");
 
-  const client = new Anthropic({ apiKey });
+  const client = new Anthropic({
+    apiKey: provider.apiKey,
+    baseURL: provider.baseURL,
+  });
 
-  const agentModels = process.env.EVAL_AGENT_MODELS
+  const baseAgentModels = process.env.EVAL_AGENT_MODELS
     ? process.env.EVAL_AGENT_MODELS.split(",").map((m) => m.trim())
     : DEFAULT_AGENT_MODELS;
+  const agentModels = baseAgentModels.map(provider.qualifyModel);
 
-  const judgeModel = process.env.EVAL_JUDGE_MODEL ?? DEFAULT_JUDGE_MODEL;
+  const judgeModel = provider.qualifyModel(
+    process.env.EVAL_JUDGE_MODEL ?? DEFAULT_JUDGE_MODEL
+  );
 
   return { client, agentModels, judgeModel };
 }


### PR DESCRIPTION
The skill-eval and init-eval frameworks talked to Claude via the direct Anthropic API only. After the move to OpenRouter, the direct-Anthropic key returns `401 "API key is invalid."`, and the skill-eval e2e ran with an empty/invalid key instead of skipping — surfacing as a CI failure on unrelated PRs (e.g. #1305).

A shared provider resolver (`test/eval-common/anthropic-client.ts`) now prefers `OPENROUTER_API_KEY` (base URL + `anthropic/` model prefix) and falls back to `ANTHROPIC_API_KEY`. Both frameworks skip cleanly when neither is set. CI passes `OPENROUTER_API_KEY` with `ANTHROPIC_API_KEY` as fallback.

## Testing
- `vitest run test/script/eval-provider.test.ts` — 8 pass (precedence, `anthropic/` prefixing, idempotency, base-URL overrides, null-when-unset)
- `vitest run test/e2e/skill-eval.test.ts` with no keys — skips cleanly (was failing with 401s before)
- `bun run lint` clean; `tsc --noEmit` clean on all touched files

## Follow-up for maintainers
Set the `OPENROUTER_API_KEY` repo secret (Settings → Secrets and variables → Actions). The `test-e2e` job has no `environment:` gate, so it must be a repository secret. Model IDs are namespaced automatically (`anthropic/claude-sonnet-4-6`).

<!--
## Plan
Requested by user after CI E2E failure on PR #1305, diagnosed as an expired/revoked direct-Anthropic key following the org's move to OpenRouter.

Design (Option A, all user-confirmed):
- Keep @anthropic-ai/sdk; OpenRouter is Anthropic-Messages-API-compatible via baseURL.
- Env precedence: OPENROUTER_API_KEY (preferred) -> ANTHROPIC_API_KEY (fallback) -> skip.
- OpenRouter needs `anthropic/`-namespaced model IDs; resolver.qualifyModel() prefixes idempotently.
- Overrides: OPENROUTER_BASE_URL / ANTHROPIC_BASE_URL, EVAL_MODEL_PREFIX.

Changes:
1. test/eval-common/anthropic-client.ts (new) — resolveEvalProvider() + EvalProvider type.
2. test/skill-eval/helpers/llm-client.ts — createClient(provider) sets baseURL, qualifies agent + judge models.
3. test/e2e/skill-eval.test.ts — resolve provider, skipIf(!provider), env-driven AGENT_MODELS, qualify model IDs.
4. script/eval-skill.ts — resolveEvalProvider() key validation, provider log line, updated docs.
5. test/init-eval/helpers/judge.ts — same provider path, qualify hardcoded claude-sonnet-4-6.
6. .github/workflows/ci.yml + eval-skill-fork.yml — pass OPENROUTER_API_KEY (+ ANTHROPIC_API_KEY fallback).
7. test/script/eval-provider.test.ts (new) — unit coverage for the resolver.

Note: the ci.yml `skill` change-filter (src/**) is why the eval runs on most code PRs; not changed here to keep scope tight, but it's the reason #1305 tripped this.
-->