### PR TITLE
chore: bump binpatch ^0.3.0 → ^0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/react": "^19.2.17",
     "@types/semver": "^7.7.1",
     "@vitest/coverage-v8": "^4.1.9",
-    "binpatch": "^0.3.0",
+    "binpatch": "^0.3.1",
     "chalk": "^5.6.2",
     "cli-highlight": "^2.1.11",
     "consola": "^3.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
       binpatch:
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.3.1
+        version: 0.3.1
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -1094,8 +1094,8 @@ packages:
   bare-url@2.4.5:
     resolution: {integrity: sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==}
 
-  binpatch@0.3.0:
-    resolution: {integrity: sha512-CYYEXJTUNB6LDgi5OUBScfb4Uxh9BPadQKELm1tP7Jah1WjZZHr/M+4u8kuLxkLXToWruSSQPgmc3y0ukIg3Kg==}
+  binpatch@0.3.1:
+    resolution: {integrity: sha512-KD1kWfjqXp+SaNxY71QJ16I+6NU/U8MJD1H9A9VDLqrmmslXvRi+7evICcYwftdhu+Yxd6lH1OqypfYbjfFb8g==}
     engines: {node: '>=22.5'}
 
   binpunch@1.0.0:
@@ -3589,7 +3589,7 @@ snapshots:
     dependencies:
       bare-path: 3.0.1
 
-  binpatch@0.3.0: {}
+  binpatch@0.3.1: {}
 
   binpunch@1.0.0: {}
 


### PR DESCRIPTION
Pick up the published binpatch@0.3.1:

- 0.3.1: semver-guard fix (no longer throws on malformed/incomparable nightly patch tags)
- 0.3.0: per-HTTP `InstrumentHook` for telemetry
- 0.2.0: injectable `fetch` for custom CA / proxy / test injection

Fully backward-compatible additive surface since 0.3.0 — the adoption code
imports (`ghcrSource`, `githubReleaseSource`, `resolveAndApply`, `makeCache`,
`PatchCache`, `SourceStrategy`, `DeltaResult`, `PatchChain`, `ProgressEvent`)
are unchanged. No code changes in the adoption; only dependency bump + lockfile.

binpatch is published to npm (0.1.0 / 0.2.0 / 0.3.0 / 0.3.1) and consumed via
the devDependency (bundled into the SEA binary at build time).