### PR TITLE
fix(replays): Use `events` data source for issue replay count

### DIFF
--- a/src/lib/api/replays.ts
+++ b/src/lib/api/replays.ts
@@ -338,7 +338,7 @@ export async function listReplayIdsForIssue(
     `/organizations/${orgSlug}/replay-count/`,
     {
       params: {
-        data_source: "discover",
+        data_source: "events",
         project: "-1",
         query: `issue.id:[${normalizedIssueId}]`,
         returnIds: true,

--- a/test/lib/api/replays.test.ts
+++ b/test/lib/api/replays.test.ts
@@ -400,7 +400,7 @@ describe("listReplayIdsForIssue", () => {
     );
     expect(url.searchParams.get("returnIds")).toBe("true");
     expect(url.searchParams.get("query")).toBe("issue.id:[12345]");
-    expect(url.searchParams.get("data_source")).toBe("discover");
+    expect(url.searchParams.get("data_source")).toBe("events");
     expect(url.searchParams.get("statsPeriod")).toBe("90d");
     expect(url.searchParams.getAll("project")).toEqual(["-1"]);
     expect(replayIds).toEqual([


### PR DESCRIPTION
The `discover` dataset is deprecated. Searches by `issue.id` like this one were routed to the `events` (errors) dataset behind the scenes already; query it directly. ([Proof this is a valid option](https://github.com/getsentry/sentry/blob/5938102899e45752c97ea2081b5726d31e3fa065/src/sentry/replays/endpoints/organization_replay_count.py#L41), and that [there is no transactions equivalent for issue.id](https://github.com/getsentry/sentry/blob/5938102899e45752c97ea2081b5726d31e3fa065/src/sentry/snuba/events.py#L32-L39), so you'd route to `events` anyway 😄 ).