### PR TITLE
fix(logs): Correct severity query examples

### DIFF
--- a/apps/cli-docs/src/fragments/commands/log.md
+++ b/apps/cli-docs/src/fragments/commands/log.md
@@ -22,7 +22,7 @@ Showing 4 logs.
 
 ```bash
 # Show only error logs
-sentry log list -q 'level:error'
+sentry log list -q 'severity:error'
 
 # Filter by message content
 sentry log list -q 'database'
@@ -41,7 +41,7 @@ sentry log list -f
 sentry log list -f 5
 
 # Stream error logs from a specific project
-sentry log list my-org/backend -f -q 'level:error'
+sentry log list my-org/backend -f -q 'severity:error'
 ```
 
 ### View a log entry

--- a/apps/cli-docs/src/fragments/commands/trace.md
+++ b/apps/cli-docs/src/fragments/commands/trace.md
@@ -57,5 +57,5 @@ sentry trace logs abc123def456abc123def456abc12345
 sentry trace logs --period 30d abc123def456abc123def456abc12345
 
 # Filter logs within a trace
-sentry trace logs -q 'level:error' abc123def456abc123def456abc12345
+sentry trace logs -q 'severity:error' abc123def456abc123def456abc12345
 ```

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/log.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/log.md
@@ -17,7 +17,7 @@ List logs from a project
 
 **Flags:**
 - `-n, --limit <value> - Number of log entries (1-1000) - (default: "100")`
-- `-q, --query <value> - Filter query (e.g., "level:error", "project:backend", "project:[a,b]")`
+- `-q, --query <value> - Filter query (e.g., "severity:error", "project:backend", "project:[a,b]")`
 - `-f, --follow <value> - Stream logs (optionally specify poll interval in seconds)`
 - `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01"`
 - `-s, --sort <value> - Sort order: "newest" (default) or "oldest" - (default: "newest")`
@@ -41,7 +41,7 @@ List logs from a project
 sentry log list
 
 # Show only error logs
-sentry log list -q 'level:error'
+sentry log list -q 'severity:error'
 
 # Filter by message content
 sentry log list -q 'database'
@@ -56,7 +56,7 @@ sentry log list -f
 sentry log list -f 5
 
 # Stream error logs from a specific project
-sentry log list my-org/backend -f -q 'level:error'
+sentry log list my-org/backend -f -q 'severity:error'
 
 sentry log list --json | jq '.data[] | select(.severity == "error")'
 ```

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/trace.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/trace.md
@@ -93,7 +93,7 @@ View logs associated with a trace
 - `-w, --web - Open trace in browser`
 - `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "14d")`
 - `-n, --limit <value> - Number of log entries (<=1000) - (default: "100")`
-- `-q, --query <value> - Filter query (e.g., "level:error", "project:backend", "project:[a,b]")`
+- `-q, --query <value> - Filter query (e.g., "severity:error", "project:backend", "project:[a,b]")`
 - `-s, --sort <value> - Sort order: "newest" (default) or "oldest" - (default: "newest")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 
@@ -107,7 +107,7 @@ sentry trace logs abc123def456abc123def456abc12345
 sentry trace logs --period 30d abc123def456abc123def456abc12345
 
 # Filter logs within a trace
-sentry trace logs -q 'level:error' abc123def456abc123def456abc12345
+sentry trace logs -q 'severity:error' abc123def456abc123def456abc12345
 ```
 
 All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/packages/cli/src/commands/log/list.ts
+++ b/packages/cli/src/commands/log/list.ts
@@ -716,7 +716,7 @@ export const listCommand = buildListCommand(
         "  sentry log list -f                 # Stream logs (2s poll interval)\n" +
         "  sentry log list -f 5               # Stream logs (5s poll interval)\n" +
         "  sentry log list --limit 50         # Show last 50 logs\n" +
-        "  sentry log list -q 'level:error'   # Filter to errors only\n" +
+        "  sentry log list -q 'severity:error' # Filter to errors only\n" +
         "  sentry log list abc123def456abc123def456abc123de  # Filter by trace\n\n" +
         "Alias: `sentry logs` → `sentry log list`",
     },
@@ -746,7 +746,7 @@ export const listCommand = buildListCommand(
           kind: "parsed",
           parse: sanitizeQuery,
           brief:
-            'Filter query (e.g., "level:error", "project:backend", "project:[a,b]")',
+            'Filter query (e.g., "severity:error", "project:backend", "project:[a,b]")',
           optional: true,
         },
         follow: {

--- a/packages/cli/src/commands/trace/logs.ts
+++ b/packages/cli/src/commands/trace/logs.ts
@@ -157,7 +157,7 @@ export const logsCommand = buildCommand({
         kind: "parsed",
         parse: sanitizeQuery,
         brief:
-          'Filter query (e.g., "level:error", "project:backend", "project:[a,b]")',
+          'Filter query (e.g., "severity:error", "project:backend", "project:[a,b]")',
         optional: true,
       },
       sort: {

--- a/packages/cli/test/commands/log/list.test.ts
+++ b/packages/cli/test/commands/log/list.test.ts
@@ -485,12 +485,12 @@ describe("listCommand.func — standard mode", () => {
     const func = await listCommand.loader();
     await func.call(
       context,
-      { json: false, limit: 50, query: "level:error", sort: "newest" },
+      { json: false, limit: 50, query: "severity:error", sort: "newest" },
       `${ORG}/${PROJECT}`
     );
 
     expect(listLogsSpy).toHaveBeenCalledWith(ORG, PROJECT, {
-      query: "level:error",
+      query: "severity:error",
       limit: 50,
       statsPeriod: "30d",
       sort: "newest",
@@ -706,12 +706,12 @@ describe("listCommand.func — trace mode", () => {
     const func = await listCommand.loader();
     await func.call(
       context,
-      { json: false, limit: 50, query: "level:error", sort: "newest" },
+      { json: false, limit: 50, query: "severity:error", sort: "newest" },
       TRACE_ID
     );
 
     expect(listTraceLogsSpy).toHaveBeenCalledWith(ORG, TRACE_ID, {
-      query: "level:error",
+      query: "severity:error",
       limit: 50,
       statsPeriod: "14d",
       sort: "newest",

--- a/packages/cli/test/commands/trace/logs.test.ts
+++ b/packages/cli/test/commands/trace/logs.test.ts
@@ -462,7 +462,7 @@ describe("logsCommand.func", () => {
           web: false,
           period: parsePeriod("7d"),
           limit: 50,
-          query: "level:error",
+          query: "severity:error",
           sort: "newest",
         },
         TRACE_ID
@@ -471,7 +471,7 @@ describe("logsCommand.func", () => {
       expect(listTraceLogsSpy).toHaveBeenCalledWith(ORG, TRACE_ID, {
         statsPeriod: "7d",
         limit: 50,
-        query: "level:error",
+        query: "severity:error",
         sort: "newest",
       });
     });


### PR DESCRIPTION
## Summary

- replace misleading `level:error` examples with `severity:error` for Logs queries
- update log and trace command help, documentation fragments, and generated skill references
- align log-specific forwarding tests with the supported field

## Why

The Logs API uses `severity` for the canonical log severity. `level` is treated as an independent custom attribute, not an alias, so the existing examples commonly return no matches.
