### PR TITLE
fix(upgrade): restrict delta patch from-version to same major.minor series

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,7 +504,11 @@ jobs:
           # of a new series (no prior tags in the same series) falls through
           # with PREV_TAG="" and the existing HAS_PREV skip handles it.
           MAJOR_MINOR=$(echo "${VERSION}" | cut -d. -f1,2)
-          SAME_SERIES_TAGS=$(printf '%s\n' "$TAGS" | grep "^nightly-${MAJOR_MINOR}\." || true)
+          # -F (fixed-string) avoids treating the dot in "0.40" as a regex
+          # metachar. In practice `oras repo tags` upstream is filtered to
+          # `^nightly-[0-9]` and MAJOR_MINOR is always digits.digits, so this
+          # can't actually mis-match — but be defensive.
+          SAME_SERIES_TAGS=$(printf '%s\n' "$TAGS" | grep -F "nightly-${MAJOR_MINOR}." || true)
           PREV_TAG=""
           for tag in $SAME_SERIES_TAGS; do
             # Current tag may not exist yet (publish-nightly hasn't run),

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,12 +488,28 @@ jobs:
 
           echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
 
-          # Find previous nightly tag
+          # Find previous nightly tag, restricted to the same major.minor series
+          # as the current build. Without this filter, `sort -V` places every
+          # 0.41 nightly after every 0.40 nightly (0.41 > 0.40), and the loop
+          # below walks past all 0.40 tags and onto the 0.41 tag — even though
+          # the current build hasn't pushed its own tag yet, so the
+          # `if [ "$tag" = "nightly-${VERSION}" ]` break never triggers.
+          # Result: PREV_TAG ends up being the 0.41 nightly, and the resulting
+          # patch is generated FROM the 0.41 binary and stamped with
+          # `from-version: 0.41.x-dev.Y` — useless to any user on the 0.40
+          # series. See commit message for the exact scenario.
           TAGS=$(oras repo tags "${REPO}" 2>/dev/null | grep '^nightly-[0-9]' | sort -V || echo "")
+          # MAJOR_MINOR is e.g. "0.40" — restricts the loop to tags that
+          # belong to the same series as the current build. The first build
+          # of a new series (no prior tags in the same series) falls through
+          # with PREV_TAG="" and the existing HAS_PREV skip handles it.
+          MAJOR_MINOR=$(echo "${VERSION}" | cut -d. -f1,2)
+          SAME_SERIES_TAGS=$(printf '%s\n' "$TAGS" | grep "^nightly-${MAJOR_MINOR}\." || true)
           PREV_TAG=""
-          for tag in $TAGS; do
+          for tag in $SAME_SERIES_TAGS; do
             # Current tag may not exist yet (publish-nightly hasn't run),
-            # but that's fine — we want the latest existing nightly tag
+            # but that's fine — we want the latest existing nightly tag in
+            # the same series as the current build.
             if [ "$tag" = "nightly-${VERSION}" ]; then
               break
             fi
@@ -501,7 +517,7 @@ jobs:
           done
 
           if [ -z "$PREV_TAG" ]; then
-            echo "No previous versioned nightly found, skipping patches"
+            echo "No previous nightly tag in ${MAJOR_MINOR}.x series, skipping patches"
             exit 0
           fi
           echo "HAS_PREV=true" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Problem

`generate-patches` was picking the wrong `PREV_TAG` for 0.40 nightly
builds, causing patches to be generated from a 0.41 source and stamped
with `from-version: 0.41.x-dev.Y` — useless for any user on the 0.40
series. Their chain resolution then fails (their version is
chronologically before 0.41) and the upgrade falls back to full-download
every time.

## Repro on the live registry

```
ghcr.io/getsentry/cli:patch-0.40.0-dev.1785524715
  from-version: 0.41.0-dev.1785504113   ← should be 0.40.0-dev.1785522378

ghcr.io/getsentry/cli:patch-0.40.0-dev.1785526951
  from-version: 0.41.0-dev.1785504113   ← should be 0.40.0-dev.1785524715
```

## Root cause

The PREV_TAG loop in `generate-patches`:

```bash
TAGS=$(oras repo tags "${REPO}" 2>/dev/null | grep '^nightly-[0-9]' | sort -V || echo "")
for tag in $TAGS; do
  if [ "$tag" = "nightly-${VERSION}" ]; then break; fi
  PREV_TAG="$tag"
done
```

`sort -V` orders `0.41.0-dev.X` after every `0.40.0-dev.Y` (because
`0.41 > 0.40` lexicographically). At the time `generate-patches` runs,
the current build's tag hasn't been pushed yet — so the
`if [ "$tag" = "nightly-${VERSION}" ]` break never triggers. The loop
walks past every 0.40 tag and onto the 0.41 tag, and PREV_TAG becomes
the 0.41 nightly.

## Fix

Filter `TAGS` to only those in the same `major.minor` series as the
current build before iterating. `MAJOR_MINOR` is parsed from VERSION
(`echo "${VERSION}" | cut -d. -f1,2` → e.g. `0.40`). For 0.40 builds
the loop only sees `nightly-0.40.0-dev.*` tags; for 0.41 builds only
`nightly-0.41.0-dev.*`. The first build of a new series (no prior tags
in the same series) falls through with `PREV_TAG=""` and the existing
HAS_PREV skip handles it cleanly.

## Retroactive remediation (follow-up)

The two mis-annotated patches above have correct bytes but wrong
annotations. Re-stamping them with the correct `from-version` will let
existing 0.40-series users chain through them to the latest. Tracked as
a separate follow-up — they're already on the registry, just need the
annotation re-pushed.

## Relationship to PR #1327

PR #1327 prevents annotation drift between `generate-patches` and
`publish-nightly` (they now agree via job outputs). This fix prevents
the initial PREV_TAG selection from being wrong in the first place.
Together they make the CI pipeline produce correct annotations
end-to-end.

## Verification

- Local simulation: `MAJOR_MINOR` filter + iteration over same-series
  tags returns `nightly-0.40.0-dev.1785522378` for VERSION=`0.40.0-dev.1785524715`
  vs. the current broken `nightly-0.41.0-dev.1785504113`.
- Workflow YAML parses cleanly.
- Will re-verify against a real build after merge (next nightly).