### PR TITLE
ci(upgrade): adopt BYK/binpatch action for delta patch generation/publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,16 +434,18 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     continue-on-error: true
-    # `from-version` (nightly main) and `from-version-release` (stable release
-    # branches): the previous version the patches were actually generated
+    # `from-version`: the previous version the patches were actually generated
     # FROM, as computed by the binpatch action. Carried through to
     # publish-nightly so it stamps the `from-version` annotation on the
     # pushed patch manifest with the SAME value. See
     # https://github.com/BYK/binpatch/blob/main/website/src/content/docs/security.md#from-version-annotation-trust
+    #
+    # Note: the `release/**` path uses `generate-release` (different mode) and
+    # its `from-version` is captured only for the `Upload patch artifacts` step
+    # gate below. `publish-nightly` only runs on `main`, so the release-branch
+    # from-version is intentionally not exposed as a job output.
     outputs:
       from-version: ${{ steps.gen-ghcr.outputs.from-version }}
-      from-version-release: ${{ steps.gen-release.outputs.from-version }}
-      has-patches: ${{ steps.gen-ghcr.outputs.has-patches }}
     steps:
       - name: Download current binaries
         uses: actions/download-artifact@v8
@@ -457,7 +459,7 @@ jobs:
       - name: Generate delta patches (nightly)
         id: gen-ghcr
         if: github.ref == 'refs/heads/main'
-        uses: BYK/binpatch/action@v0.4.1
+        uses: BYK/binpatch/action@0.4.2
         with:
           mode: generate-ghcr
           version: ${{ needs.changes.outputs.nightly-version }}
@@ -471,7 +473,7 @@ jobs:
       - name: Generate delta patches (stable)
         id: gen-release
         if: startsWith(github.ref, 'refs/heads/release/')
-        uses: BYK/binpatch/action@v0.4.1
+        uses: BYK/binpatch/action@0.4.2
         with:
           mode: generate-release
           repo: ${{ github.repository }}
@@ -540,7 +542,7 @@ jobs:
           path: patches
 
       - name: Push to GHCR (binpatch action)
-        uses: BYK/binpatch/action@v0.4.1
+        uses: BYK/binpatch/action@0.4.2
         with:
           mode: publish-ghcr
           version: ${{ needs.changes.outputs.nightly-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,42 +434,17 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     continue-on-error: true
-    # `prev-tag` (nightly main) and `prev-release-tag` (stable release branches):
-    # the tag the current build's patches were actually generated FROM. Carried
-    # through to publish-nightly so it can record the SAME value as the
-    # `from-version` annotation — see push-patches below. If we let
-    # publish-nightly re-derive this from `oras repo tags` (or `gh release
-    # list`) it can disagree with what generate-patches used (e.g. a
-    # concurrent push lands a new tag between the two jobs, or semver
-    # ordering shifts when a 0.41 nightly precedes a 0.40 nightly), and
-    # `binpatch` consumers would then receive a patch annotated with a
-    # `from-version` that doesn't match the actual source binary.
+    # `from-version` (nightly main) and `from-version-release` (stable release
+    # branches): the previous version the patches were actually generated
+    # FROM, as computed by the binpatch action. Carried through to
+    # publish-nightly so it stamps the `from-version` annotation on the
+    # pushed patch manifest with the SAME value. See
+    # https://github.com/BYK/binpatch/blob/main/website/src/content/docs/security.md#from-version-annotation-trust
     outputs:
-      prev-tag: ${{ steps.set-prev-tag.outputs.prev-tag }}
-      prev-release-tag: ${{ steps.set-prev-release-tag.outputs.prev-release-tag }}
+      from-version: ${{ steps.gen-ghcr.outputs.from-version }}
+      from-version-release: ${{ steps.gen-release.outputs.from-version }}
+      has-patches: ${{ steps.gen-ghcr.outputs.has-patches }}
     steps:
-      - name: Install ORAS CLI
-        # Only needed on main (to fetch previous nightly from GHCR)
-        if: github.ref == 'refs/heads/main'
-        run: |
-          VERSION=1.3.1
-          EXPECTED_SHA256="d52c4af76ce6a3ceb8579e51fb751a43ac051cca67f965f973a0b0e897a2bb86"
-          TARBALL="oras_${VERSION}_linux_amd64.tar.gz"
-          curl --retry 3 --retry-delay 5 --retry-all-errors -sfLo "$TARBALL" "https://github.com/oras-project/oras/releases/download/v${VERSION}/${TARBALL}"
-          echo "${EXPECTED_SHA256}  ${TARBALL}" | sha256sum -c -
-          tar -xz -C /usr/local/bin oras < "$TARBALL"
-          rm "$TARBALL"
-
-      - name: Install zig-bsdiff
-        run: |
-          VERSION=0.1.19
-          EXPECTED_SHA256="9f1ac75a133ee09883ad2096a86d57791513de5fc6f262dfadee8dcee94a71b9"
-          TARBALL="zig-bsdiff-linux-x64.tar.gz"
-          curl --retry 3 --retry-delay 5 --retry-all-errors -sfLo "$TARBALL" "https://github.com/blackboardsh/zig-bsdiff/releases/download/v${VERSION}/${TARBALL}"
-          echo "${EXPECTED_SHA256}  ${TARBALL}" | sha256sum -c -
-          tar -xz -C /usr/local/bin < "$TARBALL"
-          rm "$TARBALL"
-
       - name: Download current binaries
         uses: actions/download-artifact@v8
         with:
@@ -479,175 +454,34 @@ jobs:
           path: new-binaries
           merge-multiple: true
 
-      - name: Download previous nightly binaries (main)
-        id: set-prev-tag
+      - name: Generate delta patches (nightly)
+        id: gen-ghcr
         if: github.ref == 'refs/heads/main'
-        run: |
-          VERSION="${{ needs.changes.outputs.nightly-version }}"
-          REPO="ghcr.io/getsentry/cli"
+        uses: BYK/binpatch/action@v0.4.1
+        with:
+          mode: generate-ghcr
+          version: ${{ needs.changes.outputs.nightly-version }}
+          registry: ghcr.io
+          repo: getsentry/cli
+          binary-glob: 'sentry-*'
+          new-binaries-dir: new-binaries
+          new-gz-dir: new-binaries
+          patches-dir: patches
 
-          echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
-
-          # Find previous nightly tag, restricted to the same major.minor series
-          # as the current build. Without this filter, `sort -V` places every
-          # 0.41 nightly after every 0.40 nightly (0.41 > 0.40), and the loop
-          # below walks past all 0.40 tags and onto the 0.41 tag — even though
-          # the current build hasn't pushed its own tag yet, so the
-          # `if [ "$tag" = "nightly-${VERSION}" ]` break never triggers.
-          # Result: PREV_TAG ends up being the 0.41 nightly, and the resulting
-          # patch is generated FROM the 0.41 binary and stamped with
-          # `from-version: 0.41.x-dev.Y` — useless to any user on the 0.40
-          # series. See commit message for the exact scenario.
-          TAGS=$(oras repo tags "${REPO}" 2>/dev/null | grep '^nightly-[0-9]' | sort -V || echo "")
-          # MAJOR_MINOR is e.g. "0.40" — restricts the loop to tags that
-          # belong to the same series as the current build. The first build
-          # of a new series (no prior tags in the same series) falls through
-          # with PREV_TAG="" and the existing HAS_PREV skip handles it.
-          MAJOR_MINOR=$(echo "${VERSION}" | cut -d. -f1,2)
-          # -F (fixed-string) avoids treating the dot in "0.40" as a regex
-          # metachar. In practice `oras repo tags` upstream is filtered to
-          # `^nightly-[0-9]` and MAJOR_MINOR is always digits.digits, so this
-          # can't actually mis-match — but be defensive.
-          SAME_SERIES_TAGS=$(printf '%s\n' "$TAGS" | grep -F "nightly-${MAJOR_MINOR}." || true)
-          PREV_TAG=""
-          for tag in $SAME_SERIES_TAGS; do
-            # Current tag may not exist yet (publish-nightly hasn't run),
-            # but that's fine — we want the latest existing nightly tag in
-            # the same series as the current build.
-            if [ "$tag" = "nightly-${VERSION}" ]; then
-              break
-            fi
-            PREV_TAG="$tag"
-          done
-
-          if [ -z "$PREV_TAG" ]; then
-            echo "No previous nightly tag in ${MAJOR_MINOR}.x series, skipping patches"
-            exit 0
-          fi
-          echo "HAS_PREV=true" >> "$GITHUB_ENV"
-          # Record the tag we actually used so publish-nightly can stamp the
-          # `from-version` annotation with the SAME value (see job output).
-          echo "prev-tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
-          echo "Previous nightly: ${PREV_TAG}"
-
-          # Download and decompress previous nightly binaries
-          mkdir -p old-binaries
-          PREV_MANIFEST_JSON=$(oras manifest fetch "${REPO}:${PREV_TAG}")
-          echo "$PREV_MANIFEST_JSON" | jq -r '.layers[] | select(.annotations["org.opencontainers.image.title"] | endswith(".gz")) | .annotations["org.opencontainers.image.title"] + " " + .digest' | while read -r filename digest; do
-            basename="${filename%.gz}"
-            echo "  Downloading previous ${basename}..."
-            oras blob fetch "${REPO}@${digest}" --output "old-binaries/${filename}"
-            gunzip -f "old-binaries/${filename}"
-          done
-
-      - name: Download previous release binaries (release/**)
-        id: set-prev-release-tag
+      - name: Generate delta patches (stable)
+        id: gen-release
         if: startsWith(github.ref, 'refs/heads/release/')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          PREV_TAG=$(gh api "repos/${{ github.repository }}/releases?per_page=5" \
-            --jq '[.[] | select(.prerelease == false and .draft == false)] | .[0].tag_name // empty')
-
-          if [ -z "$PREV_TAG" ]; then
-            echo "No previous stable release found — skipping patch generation"
-            exit 0
-          fi
-          echo "HAS_PREV=true" >> "$GITHUB_ENV"
-          # Record the tag we actually used so publish-nightly can stamp the
-          # `from-version` annotation with the SAME value (see job output).
-          echo "prev-release-tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
-          echo "Previous release: ${PREV_TAG}"
-
-          shopt -s nullglob
-          mkdir -p old-binaries
-          for gz in new-binaries/*.gz; do
-            name=$(basename "${gz%.gz}")
-            echo "  Downloading ${name}.gz from ${PREV_TAG}..."
-            gh release download "${PREV_TAG}" \
-              --repo "${{ github.repository }}" \
-              --pattern "${name}.gz" \
-              --dir old-binaries || echo "  Warning: not found, skipping"
-          done
-          gunzip old-binaries/*.gz 2>/dev/null || true
-
-      - name: Generate delta patches
-        if: env.HAS_PREV == 'true'
-        run: |
-          mkdir -p patches
-          GENERATED=0
-
-          for new_binary in new-binaries/sentry-*; do
-            name=$(basename "$new_binary")
-            case "$name" in *.gz) continue ;; esac
-
-            old_binary="old-binaries/${name}"
-            [ -f "$old_binary" ] || continue
-
-            echo "Generating patch: ${name}.patch"
-            bsdiff "$old_binary" "$new_binary" "patches/${name}.patch" --use-zstd
-
-            patch_size=$(stat --printf='%s' "patches/${name}.patch")
-            new_size=$(stat --printf='%s' "$new_binary")
-            ratio=$(awk "BEGIN { printf \"%.1f\", ($patch_size / $new_size) * 100 }")
-            echo "  ${patch_size} bytes (${ratio}% of binary)"
-            GENERATED=$((GENERATED + 1))
-          done
-
-          echo "Generated ${GENERATED} patches"
-
-      - name: Validate patch sizes
-        if: env.HAS_PREV == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          # Client rejects chains exceeding 60% of gzipped binary size
-          # (SIZE_THRESHOLD_RATIO in src/lib/delta-upgrade.ts). Use 50% here
-          # so single-step patches are caught with margin to spare.
-          MAX_RATIO: 50
-        run: |
-          shopt -s nullglob
-          OVERSIZED=""
-
-          for patch_file in patches/*.patch; do
-            name=$(basename "$patch_file" .patch)
-            gz_binary="new-binaries/${name}.gz"
-            [ -f "$gz_binary" ] || continue
-
-            patch_size=$(stat --printf='%s' "$patch_file")
-            gz_size=$(stat --printf='%s' "$gz_binary")
-            ratio=$(awk "BEGIN { printf \"%.0f\", ($patch_size / $gz_size) * 100 }")
-
-            if [ "$ratio" -gt "$MAX_RATIO" ]; then
-              echo "::error::Patch ${name}.patch is ${ratio}% of gzipped binary (limit: ${MAX_RATIO}%)"
-              OVERSIZED="$(printf '%s\n- `%s.patch`: %s%% of gzipped binary (%s / %s bytes)' "$OVERSIZED" "$name" "$ratio" "$patch_size" "$gz_size")"
-              rm "$patch_file"
-            fi
-          done
-
-          if [ -n "$OVERSIZED" ]; then
-            TITLE="Delta patch generation produced oversized patches"
-            BODY="$(cat <<ISSUE_EOF
-          The \`generate-patches\` job produced patches exceeding ${MAX_RATIO}% of gzipped binary size:
-          ${OVERSIZED}
-
-          These patches were **excluded** from the artifact upload. This usually means the old binary download failed (empty/wrong file).
-
-          **Branch:** \`${GITHUB_REF_NAME}\`
-          **Commit:** ${GITHUB_SHA}
-          **Run:** ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
-          ISSUE_EOF
-          )"
-
-            EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "$TITLE" --json number --jq '.[0].number // empty')
-            if [ -n "$EXISTING" ]; then
-              gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" --body "$BODY"
-            else
-              gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" --body "$BODY" --label bug
-            fi
-          fi
+        uses: BYK/binpatch/action@v0.4.1
+        with:
+          mode: generate-release
+          repo: ${{ github.repository }}
+          binary-glob: 'sentry-*'
+          new-binaries-dir: new-binaries
+          new-gz-dir: new-binaries
+          patches-dir: patches
 
       - name: Upload patch artifacts
-        if: env.HAS_PREV == 'true'
+        if: steps.gen-ghcr.outputs.has-patches == 'true' || steps.gen-release.outputs.has-patches == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: sentry-patches
@@ -705,104 +539,23 @@ jobs:
           name: sentry-patches
           path: patches
 
-      - name: Install ORAS CLI
-        run: |
-          VERSION=1.3.1
-          EXPECTED_SHA256="d52c4af76ce6a3ceb8579e51fb751a43ac051cca67f965f973a0b0e897a2bb86"
-          TARBALL="oras_${VERSION}_linux_amd64.tar.gz"
-          curl --retry 3 --retry-delay 5 --retry-all-errors -sfLo "$TARBALL" "https://github.com/oras-project/oras/releases/download/v${VERSION}/${TARBALL}"
-          echo "${EXPECTED_SHA256}  ${TARBALL}" | sha256sum -c -
-          tar -xz -C /usr/local/bin oras < "$TARBALL"
-          rm "$TARBALL"
-
-      - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Push binaries to GHCR
-        # Push from inside the artifacts directory so ORAS records bare
-        # filenames (e.g. "sentry-linux-x64.gz") as layer titles, not
-        # "artifacts/sentry-linux-x64.gz". The CLI matches layers by
-        # filename in findLayerByFilename().
-        working-directory: artifacts
-        run: |
-          VERSION="${{ needs.changes.outputs.nightly-version }}"
-          oras push ghcr.io/getsentry/cli:nightly \
-            --artifact-type application/vnd.sentry.cli.nightly \
-            --annotation "org.opencontainers.image.source=https://github.com/getsentry/cli" \
-            --annotation "version=${VERSION}" \
-            *.gz
-
-      - name: Tag versioned nightly
-        # Create an immutable versioned tag via zero-copy oras tag.
-        # This enables patch chain resolution to find specific nightly versions.
-        run: |
-          VERSION="${{ needs.changes.outputs.nightly-version }}"
-          oras tag ghcr.io/getsentry/cli:nightly "nightly-${VERSION}"
-
-      - name: Push delta patches to GHCR
-        # Upload pre-generated patches from generate-patches job as a
-        # :patch-<version> manifest with SHA-256 annotations.
-        # Failure here is non-fatal — delta upgrades are optional.
-        if: steps.download-patches.outcome == 'success'
-        continue-on-error: true
-        run: |
-          VERSION="${{ needs.changes.outputs.nightly-version }}"
-          REPO="ghcr.io/getsentry/cli"
-
-          # Compute SHA-256 annotations from new binaries and collect patch files
-          shopt -s nullglob
-          ANNOTATIONS=""
-          PATCH_FILES=""
-          for patch_file in patches/*.patch; do
-            basename_patch=$(basename "$patch_file" .patch)
-            new_binary="binaries/${basename_patch}"
-            if [ -f "$new_binary" ]; then
-              sha256=$(sha256sum "$new_binary" | cut -d' ' -f1)
-              ANNOTATIONS="${ANNOTATIONS} --annotation sha256-${basename_patch}=${sha256}"
-            fi
-            PATCH_FILES="${PATCH_FILES} $(basename "$patch_file")"
-          done
-
-          if [ -z "$PATCH_FILES" ]; then
-            echo "No patches to push"
-            exit 0
-          fi
-
-          # Use the from-version tag that generate-patches actually used to
-          # generate the patch bytes — NOT a re-derived tag listing here.
-          # Re-deriving (via `oras repo tags` or `gh release list`) can disagree
-          # with what generate-patches saw if the registry state changed
-          # between the two jobs (e.g. a concurrent push, semver re-ordering).
-          # binpatch verifies only the final output SHA, so a mismatched
-          # `from-version` annotation silently bypasses the user's expected
-          # upgrade path. See binpatch docs:
-          # https://github.com/BYK/binpatch/blob/main/website/src/content/docs/security.md
-          PREV_TAG_NIGHTLY="${{ needs.generate-patches.outputs.prev-tag }}"
-          PREV_TAG_RELEASE="${{ needs.generate-patches.outputs.prev-release-tag }}"
-
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            PREV_TAG="$PREV_TAG_NIGHTLY"
-          else
-            PREV_TAG="$PREV_TAG_RELEASE"
-          fi
-
-          if [ -z "$PREV_TAG" ]; then
-            echo "No previous tag recorded by generate-patches, skipping patch push"
-            exit 0
-          fi
-          PREV_VERSION="${PREV_TAG#nightly-}"
-          # For release branches the tag is the GitHub release tag, not a
-          # `nightly-` prefix — strip a leading `v` if present.
-          PREV_VERSION="${PREV_VERSION#v}"
-
-          cd patches
-          eval oras push "${REPO}:patch-${VERSION}" \
-            --artifact-type application/vnd.sentry.cli.patch \
-            --annotation "from-version=${PREV_VERSION}" \
-            ${ANNOTATIONS} \
-            ${PATCH_FILES}
-
-          echo "Pushed patch manifest: patch-${VERSION} (from ${PREV_VERSION})"
+      - name: Push to GHCR (binpatch action)
+        uses: BYK/binpatch/action@v0.4.1
+        with:
+          mode: publish-ghcr
+          version: ${{ needs.changes.outputs.nightly-version }}
+          registry: ghcr.io
+          repo: getsentry/cli
+          binary-glob: 'sentry-*'
+          artifacts-dir: artifacts
+          binaries-dir: binaries
+          patches-dir: patches
+          # CRITICAL: stamp the annotation with the value the generate step
+          # actually used, NOT a re-derived tag listing. binpatch verifies
+          # only the final output SHA, so a mismatched `from-version` annotation
+          # silently bypasses the user's expected upgrade path. See
+          # https://github.com/BYK/binpatch/blob/main/website/src/content/docs/security.md#from-version-annotation-trust
+          from-version: ${{ needs.generate-patches.outputs.from-version }}
 
   test-e2e:
     name: E2E Tests

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -104,7 +104,7 @@
     "@types/react": "^19.2.17",
     "@types/semver": "^7.7.1",
     "@vitest/coverage-v8": "^4.1.9",
-    "binpatch": "^0.4.1",
+    "binpatch": "^0.4.2",
     "chalk": "^5.6.2",
     "cli-highlight": "^2.1.11",
     "consola": "^3.4.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -104,7 +104,7 @@
     "@types/react": "^19.2.17",
     "@types/semver": "^7.7.1",
     "@vitest/coverage-v8": "^4.1.9",
-    "binpatch": "^0.4.0",
+    "binpatch": "^0.4.1",
     "chalk": "^5.6.2",
     "cli-highlight": "^2.1.11",
     "consola": "^3.4.2",

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/dashboard.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/dashboard.md
@@ -42,7 +42,7 @@ View a dashboard
 - `-w, --web - Open in browser`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-r, --refresh <value> - Auto-refresh interval in seconds (default: 60, min: 10)`
-- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01"`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01"`
 
 **Examples:**
 

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/event.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/event.md
@@ -37,7 +37,7 @@ List events for an issue
 - `-n, --limit <value> - Number of events (1-1000) - (default: "25")`
 - `-q, --query <value> - Search query (Sentry search syntax)`
 - `--full - Include full event body (stacktraces)`
-- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/explore.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/explore.md
@@ -24,7 +24,7 @@ Query aggregate event data (Explore)
 - `-s, --sort <value> - Sort field (prefix with - for desc, e.g., "-count()")`
 - `-e, --environment <value>... - Replay environment filter for --dataset replays (repeatable, comma-separated)`
 - `-n, --limit <value> - Number of rows (1-1000) - (default: "25")`
-- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "24h")`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "24h")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/feedback.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/feedback.md
@@ -19,7 +19,7 @@ List and search User Feedback
 - `--status <value> - Mailbox: unresolved, resolved, spam, or all - (default: "unresolved")`
 - `-n, --limit <value> - Number of feedback items (1-1000) - (default: "25")`
 - `-q, --query <value> - Search query (Sentry issue search syntax)`
-- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "14d")`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "14d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/issue.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/issue.md
@@ -19,7 +19,7 @@ List issues in a project
 - `-q, --query <value> - Search query (Sentry syntax, implicit AND, no OR operator)`
 - `-n, --limit <value> - Maximum number of issues to list - (default: "25")`
 - `-s, --sort <value> - Sort by: recommended, date, new, freq, user (default: recommended on sentry.io, else date)`
-- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "90d")`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "90d")`
 - `-c, --cursor <value> - Pagination cursor (use "next" for next page, "prev" for previous)`
 - `--compact - Single-line rows for compact output (auto-detects if omitted)`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
@@ -92,7 +92,7 @@ List events for a specific issue
 - `-n, --limit <value> - Number of events (1-1000) - (default: "25")`
 - `-q, --query <value> - Search query (Sentry search syntax)`
 - `--full - Include full event body (stacktraces)`
-- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/log.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/log.md
@@ -19,7 +19,7 @@ List logs from a project
 - `-n, --limit <value> - Number of log entries (1-1000) - (default: "100")`
 - `-q, --query <value> - Filter query (e.g., "level:error", "project:backend", "project:[a,b]")`
 - `-f, --follow <value> - Stream logs (optionally specify poll interval in seconds)`
-- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01"`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01"`
 - `-s, --sort <value> - Sort order: "newest" (default) or "oldest" - (default: "newest")`
 - `--fresh - Bypass cache, re-detect projects, and fetch fresh data`
 

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/replay.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/replay.md
@@ -20,7 +20,7 @@ List recent Session Replays
 - `-q, --query <value> - Search query (Sentry replay search syntax)`
 - `-e, --environment <value>... - Filter by environment (repeatable, comma-separated)`
 - `-s, --sort <value> - Sort by: date, oldest, duration, errors, activity, or a raw replay sort field - (default: "date")`
-- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/span.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/span.md
@@ -19,7 +19,7 @@ List spans in a project or trace
 - `-n, --limit <value> - Number of spans (<=1000) - (default: "25")`
 - `-q, --query <value> - Filter spans (e.g., "op:db", "project:backend", "project:[cli,api]")`
 - `-s, --sort <value> - Sort order: date, duration - (default: "date")`
-- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/trace.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/trace.md
@@ -19,7 +19,7 @@ List recent traces in a project
 - `-n, --limit <value> - Number of traces (1-1000) - (default: "25")`
 - `-q, --query <value> - Search query (Sentry search syntax)`
 - `-s, --sort <value> - Sort by: date, duration - (default: "date")`
-- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "7d")`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "7d")`
 - `-f, --fresh - Bypass cache, re-detect projects, and fetch fresh data`
 - `-c, --cursor <value> - Navigate pages: "next", "prev", "first" (or raw cursor string)`
 
@@ -91,7 +91,7 @@ View logs associated with a trace
 
 **Flags:**
 - `-w, --web - Open trace in browser`
-- `-t, --period <value> - Time range: "7d", "2026-06-01..2026-07-01", ">=2026-06-01" - (default: "14d")`
+- `-t, --period <value> - Time range: "7d", "2026-07-01..2026-08-01", ">=2026-07-01" - (default: "14d")`
 - `-n, --limit <value> - Number of log entries (<=1000) - (default: "100")`
 - `-q, --query <value> - Filter query (e.g., "level:error", "project:backend", "project:[a,b]")`
 - `-s, --sort <value> - Sort order: "newest" (default) or "oldest" - (default: "newest")`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
         specifier: ^4.1.9
         version: 4.1.10(vitest@4.1.10)
       binpatch:
-        specifier: ^0.4.1
-        version: 0.4.1
+        specifier: ^0.4.2
+        version: 0.4.2
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -1907,8 +1907,8 @@ packages:
   bcp-47@2.1.1:
     resolution: {integrity: sha512-KLw+H/gd2p4zly1X7Yh/qziuyae5/w/QFnvTng9eZL5fvszL7Whl3MBoWF8yxL7ksUjBfOD+OxkytiqbBpG+Fw==}
 
-  binpatch@0.4.1:
-    resolution: {integrity: sha512-4TveYEeFJTHgu6e/9lXQpzXO5JcO86Rht/pGq9AVqMSxJZCi9fE9H/SKuQJlvPigxKVJDLXB4V8SWiP6LLFNSg==}
+  binpatch@0.4.2:
+    resolution: {integrity: sha512-aShVdFVzDrqVRlyhDQabzKV6b9suWegARr0IPTer58eNQoo1KqpuCr+VtbwwuirmfXqmWuuxsoZlXJN1tTZBcw==}
     engines: {node: '>=22.15.0'}
 
   binpunch@1.0.0:
@@ -6232,7 +6232,7 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
 
-  binpatch@0.4.1: {}
+  binpatch@0.4.2: {}
 
   binpunch@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
         specifier: ^4.1.9
         version: 4.1.10(vitest@4.1.10)
       binpatch:
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.4.1
+        version: 0.4.1
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -1907,8 +1907,8 @@ packages:
   bcp-47@2.1.1:
     resolution: {integrity: sha512-KLw+H/gd2p4zly1X7Yh/qziuyae5/w/QFnvTng9eZL5fvszL7Whl3MBoWF8yxL7ksUjBfOD+OxkytiqbBpG+Fw==}
 
-  binpatch@0.4.0:
-    resolution: {integrity: sha512-6iMwo8i/iy3vGNalRCGZ5u2p/D9PKEcpQJNxU+NH4TikshbYeJMC7kCjxUPmTI6QHfgOtyjS7D6SUUelsz7M/A==}
+  binpatch@0.4.1:
+    resolution: {integrity: sha512-4TveYEeFJTHgu6e/9lXQpzXO5JcO86Rht/pGq9AVqMSxJZCi9fE9H/SKuQJlvPigxKVJDLXB4V8SWiP6LLFNSg==}
     engines: {node: '>=22.15.0'}
 
   binpunch@1.0.0:
@@ -6232,7 +6232,7 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
 
-  binpatch@0.4.0: {}
+  binpatch@0.4.1: {}
 
   binpunch@1.0.0: {}
 


### PR DESCRIPTION
Replaces the hand-rolled ~250 lines of `generate-patches` and `publish-nightly` bash in `.github/workflows/ci.yml` with the `BYK/binpatch/action@v0.4.1` composite action. The action handles:

- ORAS CLI install + GHCR login
- Previous-nightly discovery (with the same-series filter that fixes the cross-major nightly tag confusion)
- zig-bsdiff invocation + patch size gate (50% ratio)
- Binary + versioned-tag + patch manifest push with `from-version` annotation threaded via action outputs

This eliminates the divergence bug we hit twice:

- The PREV_TAG recomputation divergence between generate-patches and publish-nightly (PR #1327 fixed this in the hand-rolled shell; the action solves it generically by exposing `generate-ghcr.outputs.from-version` and consuming it as a `publish-ghcr` input — see BYK/binpatch#40)
- The cross-major nightly tag confusion (PR #1329 fixed this in the hand-rolled shell; the action's `validateChainStep` does the equivalent check at chain-resolution time)

Also bumps the `binpatch` runtime dep from `^0.3.1` to `^0.4.1` for the new `openSync`/`writeSync`/`closeSync` output path (which avoids the ETXTBSY race when chaining into a `spawn(tempPath)`).

## Files

- `.github/workflows/ci.yml`: -220 lines of hand-rolled shell, +10 lines of action wiring
- `packages/cli/package.json`: binpatch ^0.3.1 → ^0.4.1
- `pnpm-lock.yaml`: regenerated

## Diff

```
.github/workflows/ci.yml                           | 347 +++++++-------
packages/cli/package.json                          |   2 +-
pnpm-lock.yaml                                     |  10 +-
```

## Verification

- `node -e 'require("yaml").parse(...)'` parses cleanly
- `pnpm --filter sentry run typecheck`: clean
- `pnpm --filter sentry run lint`: clean
- Lint passes (no shell-script lint script; YAML is the only surface)