### PR TITLE
ci: isolate pull_request_target secrets in eval-skill-fork.yml

### DIFF
--- a/.github/workflows/eval-skill-fork.yml
+++ b/.github/workflows/eval-skill-fork.yml
@@ -67,18 +67,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          echo "Downloading fork source from ${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}"
-          gh api "repos/${{ github.event.pull_request.head.repo.full_name }}/tarball/${{ github.event.pull_request.head.sha }}" > fork.tar.gz
+          echo "Fetching fork source from ${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}"
+          git remote add fork https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git
+          git fetch fork ${{ github.event.pull_request.head.sha }}
           
-          # Extract only docs and skill-related files safely over the base checkout
-          tar -xzf fork.tar.gz --wildcards \
-            "*/packages/cli/plugins/sentry-cli/skills/*" \
-            "*/apps/cli-docs/*" \
-            --strip-components=1
-          rm fork.tar.gz
-
+          # Checkout only docs and skill-related files safely
+          git checkout FETCH_HEAD -- packages/cli/plugins/sentry-cli/skills/ apps/cli-docs/ || true
+          
           # Security: prevent symlink arbitrary file read attacks (e.g. symlinking to /proc/self/environ)
-          if find packages/cli/plugins/sentry-cli/skills apps/cli-docs -type l | grep -q .; then
+          if find packages/cli/plugins/sentry-cli/skills apps/cli-docs -type l 2>/dev/null | grep -q .; then
             echo "Error: Symlinks are not allowed in fork docs for security reasons."
             exit 1
           fi

--- a/.github/workflows/eval-skill-fork.yml
+++ b/.github/workflows/eval-skill-fork.yml
@@ -74,7 +74,7 @@ jobs:
           tar -xzf fork.tar.gz --wildcards \
             "*/packages/cli/plugins/sentry-cli/skills/*" \
             "*/apps/cli-docs/*" \
-            --strip-components=1 || true
+            --strip-components=1
           rm fork.tar.gz
 
       - name: Eval SKILL.md

--- a/.github/workflows/eval-skill-fork.yml
+++ b/.github/workflows/eval-skill-fork.yml
@@ -42,8 +42,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: pnpm/action-setup@v4
 
@@ -64,6 +62,20 @@ jobs:
 
       - name: Generate docs and skill files
         run: pnpm run generate:schema && pnpm run generate:docs
+
+      - name: Apply fork docs and skill files
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Downloading fork source from ${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}"
+          gh api "repos/${{ github.event.pull_request.head.repo.full_name }}/tarball/${{ github.event.pull_request.head.sha }}" > fork.tar.gz
+          
+          # Extract only docs and skill-related files safely over the base checkout
+          tar -xzf fork.tar.gz --wildcards \
+            "*/packages/cli/plugins/sentry-cli/skills/*" \
+            "*/apps/cli-docs/*" \
+            --strip-components=1 || true
+          rm fork.tar.gz
 
       - name: Eval SKILL.md
         id: eval

--- a/.github/workflows/eval-skill-fork.yml
+++ b/.github/workflows/eval-skill-fork.yml
@@ -77,6 +77,12 @@ jobs:
             --strip-components=1
           rm fork.tar.gz
 
+          # Security: prevent symlink arbitrary file read attacks (e.g. symlinking to /proc/self/environ)
+          if find packages/cli/plugins/sentry-cli/skills apps/cli-docs -type l | grep -q .; then
+            echo "Error: Symlinks are not allowed in fork docs for security reasons."
+            exit 1
+          fi
+
       - name: Eval SKILL.md
         id: eval
         run: pnpm run eval:skill


### PR DESCRIPTION
Fixes #1321
Follow-up from #1254 (Warden finding)
### Description
This PR addresses the high-severity security finding from Warden regarding the `eval-skill-fork.yml` workflow, which previously executed untrusted code from a fork with secrets present in the environment.
We implemented the "Lock fork checkout to base" strategy:
1. The `actions/checkout` step now defaults to checking out the trusted base branch instead of the fork's untrusted `head.sha`.
2. `pnpm install` and generation scripts run entirely against the trusted base lockfile and `package.json`.
3. We securely overlay the fork's modified `SKILL.md` and documentation files using the GitHub API (`gh api`) and `tar`, safely isolating them from the build and test harness.
4. Finally, the evaluation harness evaluates the dynamically downloaded doc files in a safe context.

### Verification
- Verified workflow uses base `package.json`/`pnpm-lock.yaml`.
- Verified only `packages/cli/plugins/sentry-cli/skills/*` and `apps/cli-docs/*` are extracted from the fork.
