### PR TITLE
feat(local): inject Spotlight as a Wrangler Worker binding

### DIFF
--- a/apps/cli-docs/src/fragments/commands/local.md
+++ b/apps/cli-docs/src/fragments/commands/local.md
@@ -44,11 +44,7 @@ The `<PREFIX>` variants cover every common framework client prefix so the spotli
 
 **Server vs. client.** Server-side SDKs (`@sentry/node`, Python, and friends) read `SENTRY_SPOTLIGHT` automatically — no code changes needed.
 
-**Cloudflare Workers.** Wrangler does not expose inherited process environment variables to Worker code. When `local run` detects `wrangler dev` together with a `wrangler.json`, `wrangler.jsonc`, or `wrangler.toml`, it automatically adds:
-
-```bash
---var SENTRY_SPOTLIGHT:http://localhost:<port>/stream
-```
+**Cloudflare Workers.** Wrangler does not expose inherited process environment variables to Worker code. When `local run` detects `wrangler dev` together with a `wrangler.json`, `wrangler.jsonc`, or `wrangler.toml`, it automatically adds `--var SENTRY_SPOTLIGHT:http://localhost:<port>/stream`.
 
 This creates an ephemeral Worker binding that `@sentry/cloudflare` reads from its `env` object, so you do not need `spotlight: true` in `withSentry()` and no project file is modified. An explicit `--var SENTRY_SPOTLIGHT:...` is preserved.
 

--- a/apps/cli-docs/src/fragments/commands/local.md
+++ b/apps/cli-docs/src/fragments/commands/local.md
@@ -44,6 +44,14 @@ The `<PREFIX>` variants cover every common framework client prefix so the spotli
 
 **Server vs. client.** Server-side SDKs (`@sentry/node`, Python, and friends) read `SENTRY_SPOTLIGHT` automatically — no code changes needed.
 
+**Cloudflare Workers.** Wrangler does not expose inherited process environment variables to Worker code. When `local run` detects `wrangler dev` together with a `wrangler.json`, `wrangler.jsonc`, or `wrangler.toml`, it automatically adds:
+
+```bash
+--var SENTRY_SPOTLIGHT:http://localhost:<port>/stream
+```
+
+This creates an ephemeral Worker binding that `@sentry/cloudflare` reads from its `env` object, so you do not need `spotlight: true` in `withSentry()` and no project file is modified. An explicit `--var SENTRY_SPOTLIGHT:...` is preserved.
+
 For browser/client events, the CLI exposes the spotlight URL under every framework client prefix above. Once the [browser SDK reads these variables automatically](https://github.com/getsentry/sentry-javascript/pull/18198), client-side capture will be zero-config too. **Until then**, reference the variable matching your framework in your client config:
 
 ```ts

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/local.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/local.md
@@ -52,8 +52,6 @@ sentry local -f error -f log
 # Run quietly (suppress per-envelope tail output)
 sentry local --quiet
 
---var SENTRY_SPOTLIGHT:http://localhost:<port>/stream
-
 sentry local -f error -f log    # only errors and logs
 
 sentry local -f ai          # only AI/agent spans

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/local.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/local.md
@@ -52,6 +52,8 @@ sentry local -f error -f log
 # Run quietly (suppress per-envelope tail output)
 sentry local --quiet
 
+--var SENTRY_SPOTLIGHT:http://localhost:<port>/stream
+
 sentry local -f error -f log    # only errors and logs
 
 sentry local -f ai          # only AI/agent spans

--- a/packages/cli/src/commands/local/run.ts
+++ b/packages/cli/src/commands/local/run.ts
@@ -24,6 +24,7 @@ import { CliError, EXIT, ValidationError } from "../../lib/errors.js";
 import { bold } from "../../lib/formatters/colors.js";
 import { formatEnvelopeLines } from "../../lib/formatters/local.js";
 import { logger, printLine } from "../../lib/logger.js";
+import { injectWranglerSpotlightBinding } from "../../lib/wrangler.js";
 import {
   buildApp,
   consumeSSE,
@@ -345,14 +346,22 @@ export const runCommand = buildCommand({
     url = tail.url;
 
     const spotlightUrl = `${url}/stream`;
-    logger.info(`Starting: ${bold(args.join(" "))}`);
+    const wrangler = await injectWranglerSpotlightBinding(
+      args,
+      spotlightUrl,
+      this.cwd
+    );
+    if (wrangler.injected) {
+      logger.info("Injected SENTRY_SPOTLIGHT as a Wrangler Worker binding");
+    }
+    logger.info(`Starting: ${bold(wrangler.args.join(" "))}`);
     logger.info(`SENTRY_SPOTLIGHT=${spotlightUrl}`);
 
     const childEnv = buildChildEnv(spotlightUrl, commandSource, this.cwd);
 
     let child: ChildProcess;
     try {
-      const [cmd = "", ...cmdArgs] = args;
+      const [cmd = "", ...cmdArgs] = wrangler.args;
       child = spawn(cmd, cmdArgs, {
         cwd: this.cwd,
         env: childEnv,
@@ -361,7 +370,7 @@ export const runCommand = buildCommand({
     } catch (err) {
       await tail.cleanup();
       throw new CliError(
-        `Failed to start "${args[0]}": ${err instanceof Error ? err.message : String(err)}`,
+        `Failed to start "${wrangler.args[0]}": ${err instanceof Error ? err.message : String(err)}`,
         EXIT.GENERAL
       );
     }
@@ -483,10 +492,18 @@ async function* runWithVerify(
   });
 
   const childEnv = buildChildEnv(spotlightUrl, commandSource, cwd);
+  const wrangler = await injectWranglerSpotlightBinding(
+    args,
+    spotlightUrl,
+    cwd
+  );
+  if (wrangler.injected) {
+    logger.info("Injected SENTRY_SPOTLIGHT as a Wrangler Worker binding");
+  }
 
   let child: ChildProcess;
   try {
-    const [cmd = "", ...cmdArgs] = args;
+    const [cmd = "", ...cmdArgs] = wrangler.args;
     child = spawn(cmd, cmdArgs, {
       cwd,
       env: childEnv,
@@ -495,7 +512,7 @@ async function* runWithVerify(
   } catch (err) {
     await shutdownServer(server);
     throw new CliError(
-      `Failed to start "${args[0]}": ${err instanceof Error ? err.message : String(err)}`,
+      `Failed to start "${wrangler.args[0]}": ${err instanceof Error ? err.message : String(err)}`,
       EXIT.GENERAL
     );
   }

--- a/packages/cli/src/lib/wrangler.ts
+++ b/packages/cli/src/lib/wrangler.ts
@@ -18,14 +18,19 @@ const WRANGLER_CONFIG_FILES = [
   "wrangler.toml",
 ] as const;
 
-/** Package managers whose `run` subcommand forwards args after `--`. */
+/** Package managers that can execute project scripts. */
 const PACKAGE_MANAGERS = new Set(["npm", "pnpm", "yarn", "bun"]);
 
-/** Match `wrangler` as a shell command, optionally with a path prefix. */
-const WRANGLER_SHELL_RE = /(?:^|[\s;&|])(?:[^\s;&|]*\/)?wrangler(?:\.cmd)?\s/;
+/** Global variant used to find each candidate in a shell command. */
+const WRANGLER_DEV_SHELL_GLOBAL_RE =
+  /\bwrangler(?:\.cmd)?\s+(?:pages\s+)?dev\b/gi;
 
-/** Match Wrangler's `dev` subcommand in a shell command. */
-const WRANGLER_DEV_SHELL_RE = /\bwrangler(?:\.cmd)?\s+(?:pages\s+)?dev\b/;
+/** Match a custom Wrangler config flag inside argv or a shell command. */
+const WRANGLER_CONFIG_RE = /(?:^|\s)--config(?:=|\s+)\S+/;
+
+/** Valid tokens before Wrangler within one shell command segment. */
+const WRANGLER_COMMAND_PREFIX_RE =
+  /^(?:[A-Za-z_]\w*=\S+\s+)*(?:(?:exec|npx|bunx|pnpm\s+(?:exec|dlx|x)|yarn\s+dlx)\s+)?(?:[^\s]*[\\/])?$/i;
 
 /** Match an existing SENTRY_SPOTLIGHT Wrangler binding. */
 const SPOTLIGHT_VAR_RE = /^SENTRY_SPOTLIGHT(?::|=)/;
@@ -35,6 +40,19 @@ const SHELL_SPOTLIGHT_VAR_RE = /--var(?:=|\s+)["']?SENTRY_SPOTLIGHT(?::|=)/;
 
 /** Strip Windows' executable suffix before command comparisons. */
 const CMD_SUFFIX_RE = /\.cmd$/i;
+
+/** Package-manager commands that do not identify a project script. */
+const PACKAGE_MANAGER_NON_SCRIPT_COMMANDS = new Set([
+  "add",
+  "dlx",
+  "exec",
+  "install",
+  "publish",
+  "remove",
+  "run",
+  "uninstall",
+  "x",
+]);
 
 /** Result of attempting to augment a command for Wrangler. */
 export type WranglerCommandAugmentation = {
@@ -46,7 +64,9 @@ export type WranglerCommandAugmentation = {
 
 /** Return the executable's platform-independent basename. */
 function executableName(value: string): string {
-  return basename(value).replace(CMD_SUFFIX_RE, "").toLowerCase();
+  return basename(value.replaceAll("\\", "/"))
+    .replace(CMD_SUFFIX_RE, "")
+    .toLowerCase();
 }
 
 /** Whether args already provide an explicit SENTRY_SPOTLIGHT Wrangler var. */
@@ -124,23 +144,147 @@ function findShellCommandEnd(script: string, start: number): number {
   return script.length;
 }
 
-/** Add the binding before the next shell operator after `wrangler dev`. */
-function injectIntoShellCommand(script: string, binding: string): string {
-  const match = WRANGLER_DEV_SHELL_RE.exec(script);
-  if (!match) {
-    return script;
+/**
+ * Find the start of the shell command segment containing `position`.
+ *
+ * Returns undefined when the position is inside a quote or command
+ * substitution, which means a textual `wrangler dev` is not executable code.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: same single-pass shell lexer as findShellCommandEnd, walking in the opposite direction conceptually
+function findShellSegmentStart(
+  script: string,
+  position: number
+): number | undefined {
+  let quote: "'" | '"' | "`" | undefined;
+  let escaped = false;
+  let substitutionDepth = 0;
+  let segmentStart = 0;
+
+  for (let index = 0; index < position; index += 1) {
+    const char = script[index];
+    const next = script[index + 1];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "$" && next === "(") {
+      substitutionDepth += 1;
+      index += 1;
+      continue;
+    }
+    if (char === ")" && substitutionDepth > 0) {
+      substitutionDepth -= 1;
+      continue;
+    }
+    if (
+      substitutionDepth === 0 &&
+      (char === "\n" || char === ";" || char === "&" || char === "|")
+    ) {
+      segmentStart = index + 1;
+    }
   }
-  const commandEnd = findShellCommandEnd(script, match.index + match[0].length);
-  const before = script.slice(0, commandEnd).trimEnd();
-  const spacing = script.slice(before.length, commandEnd);
-  return `${before} --var ${binding}${spacing}${script.slice(commandEnd)}`;
+
+  return quote || substitutionDepth > 0 ? undefined : segmentStart;
+}
+
+/** Quote one argument for a POSIX shell command string. */
+function posixShellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+/** Quote one argument for a Windows cmd.exe command string. */
+function windowsShellQuote(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+/** Location of an executable `wrangler dev` within a shell script. */
+type ShellWranglerCommand = {
+  end: number;
+};
+
+/** Find an executable Wrangler command, excluding quoted text and arguments. */
+function findShellWranglerCommand(
+  script: string
+): ShellWranglerCommand | undefined {
+  for (const match of script.matchAll(WRANGLER_DEV_SHELL_GLOBAL_RE)) {
+    const matchIndex = match.index;
+    const segmentStart = findShellSegmentStart(script, matchIndex);
+    if (segmentStart === undefined) {
+      continue;
+    }
+    const prefix = script.slice(segmentStart, matchIndex);
+    if (!WRANGLER_COMMAND_PREFIX_RE.test(prefix)) {
+      continue;
+    }
+    return {
+      end: findShellCommandEnd(script, matchIndex + match[0].length),
+    };
+  }
+  return;
+}
+
+/** Add the binding to an executable Wrangler command inside a shell script. */
+function injectIntoShellCommand(
+  script: string,
+  binding: string,
+  windows = false
+): string | undefined {
+  const command = findShellWranglerCommand(script);
+  if (!command) {
+    return;
+  }
+  const before = script.slice(0, command.end).trimEnd();
+  const spacing = script.slice(before.length, command.end);
+  const quotedBinding = windows
+    ? windowsShellQuote(binding)
+    : posixShellQuote(binding);
+  return `${before} --var ${quotedBinding}${spacing}${script.slice(command.end)}`;
+}
+
+/** Find Wrangler only in supported executable/wrapper argv positions. */
+function directWranglerIndex(args: readonly string[]): number {
+  if (executableName(args[0] ?? "") === "wrangler") {
+    return 0;
+  }
+
+  const executable = executableName(args[0] ?? "");
+  if (executable === "npx" || executable === "bunx") {
+    return args.findIndex(
+      (arg, index) => index > 0 && executableName(arg) === "wrangler"
+    );
+  }
+  if (PACKAGE_MANAGERS.has(executable)) {
+    const wrapperIndex = args.findIndex((arg) =>
+      ["dlx", "exec", "x"].includes(arg)
+    );
+    if (wrapperIndex !== -1) {
+      return args.findIndex(
+        (arg, index) =>
+          index > wrapperIndex && executableName(arg) === "wrangler"
+      );
+    }
+  }
+
+  return -1;
 }
 
 /** Whether a direct/wrapped command invokes `wrangler dev`. */
 function isDirectWranglerDev(args: readonly string[]): boolean {
-  const wranglerIndex = args.findIndex(
-    (arg) => executableName(arg) === "wrangler"
-  );
+  const wranglerIndex = directWranglerIndex(args);
   if (wranglerIndex === -1) {
     return false;
   }
@@ -151,13 +295,46 @@ function isDirectWranglerDev(args: readonly string[]): boolean {
   );
 }
 
-/** Extract `package-manager run <script>` metadata when present. */
-function packageScriptName(args: readonly string[]): string | undefined {
-  if (!PACKAGE_MANAGERS.has(executableName(args[0] ?? ""))) {
+/** A package-manager script invocation and its forwarding behavior. */
+type PackageScriptInvocation = {
+  manager: string;
+  name: string;
+};
+
+/** Return the first non-option token at or after `start`. */
+function firstNonOption(
+  args: readonly string[],
+  start: number
+): string | undefined {
+  return args.slice(start).find((arg) => !arg.startsWith("-"));
+}
+
+/** Extract package-script metadata from standard and shorthand invocations. */
+function packageScriptInvocation(
+  args: readonly string[]
+): PackageScriptInvocation | undefined {
+  const manager = executableName(args[0] ?? "");
+  if (!PACKAGE_MANAGERS.has(manager)) {
     return;
   }
+
   const runIndex = args.indexOf("run");
-  return runIndex === -1 ? undefined : args[runIndex + 1];
+  if (runIndex !== -1) {
+    const name = firstNonOption(args, runIndex + 1);
+    return name ? { manager, name } : undefined;
+  }
+
+  const shorthand = firstNonOption(args, 1);
+  if (
+    shorthand &&
+    (manager === "npm" ||
+      !PACKAGE_MANAGER_NON_SCRIPT_COMMANDS.has(shorthand)) &&
+    (manager !== "npm" ||
+      ["start", "stop", "test", "restart"].includes(shorthand))
+  ) {
+    return { manager, name: shorthand };
+  }
+  return;
 }
 
 /** Read a package script without failing command startup on malformed files. */
@@ -185,7 +362,9 @@ async function hasWranglerConfig(
     args.some(
       (arg, index) => arg === "--config" && typeof args[index + 1] === "string"
     ) ||
-    args.some((arg) => arg.startsWith("--config="))
+    args.some(
+      (arg) => arg.startsWith("--config=") || WRANGLER_CONFIG_RE.test(arg)
+    )
   ) {
     return true;
   }
@@ -199,6 +378,74 @@ async function hasWranglerConfig(
     }
   }
   return false;
+}
+
+/** Try to inject into a shell string carried by `sh -c` or `cmd /c`. */
+function injectIntoShellArgs(
+  args: readonly string[],
+  binding: string
+): WranglerCommandAugmentation | undefined {
+  for (let index = 1; index < args.length; index += 1) {
+    const shellSwitch = args[index - 1]?.toLowerCase();
+    if (shellSwitch !== "-c" && shellSwitch !== "/c") {
+      continue;
+    }
+    const shellExecutable = executableName(args[index - 2] ?? "");
+    const injected = injectIntoShellCommand(
+      args[index] ?? "",
+      binding,
+      shellExecutable === "cmd" || shellExecutable === "cmd.exe"
+    );
+    if (injected) {
+      const augmented = [...args];
+      augmented[index] = injected;
+      return { args: augmented, injected: true };
+    }
+  }
+  return;
+}
+
+/** Build package-manager forwarding args without changing user script files. */
+function injectIntoPackageScript(
+  args: readonly string[],
+  binding: string,
+  invocation: PackageScriptInvocation,
+  script: string
+): WranglerCommandAugmentation {
+  const unchanged = { args: [...args], injected: false };
+  const packageWrangler = findShellWranglerCommand(script);
+  if (!packageWrangler || SHELL_SPOTLIGHT_VAR_RE.test(script)) {
+    return unchanged;
+  }
+  if (script.slice(packageWrangler.end).trim()) {
+    logger.warn(
+      `Could not inject SENTRY_SPOTLIGHT into compound package script "${invocation.name}"; run sentry local run without an explicit command to use auto-detection`
+    );
+    return unchanged;
+  }
+
+  if (invocation.manager === "npm") {
+    const separator = args.includes("--") ? [] : ["--"];
+    return {
+      args: [...args, ...separator, "--var", binding],
+      injected: true,
+    };
+  }
+
+  const separatorIndex = args.indexOf("--");
+  if (separatorIndex !== -1) {
+    return {
+      args: [
+        ...args.slice(0, separatorIndex),
+        "--var",
+        binding,
+        ...args.slice(separatorIndex),
+      ],
+      injected: true,
+    };
+  }
+
+  return { args: [...args, "--var", binding], injected: true };
 }
 
 /**
@@ -218,7 +465,13 @@ export async function injectWranglerSpotlightBinding(
   cwd: string
 ): Promise<WranglerCommandAugmentation> {
   const unchanged = { args: [...args], injected: false };
-  if (!(await hasWranglerConfig(cwd, args)) || hasSpotlightVar(args)) {
+  const packageInvocation = packageScriptInvocation(args);
+  const packageScript = packageInvocation
+    ? await readPackageScript(cwd, packageInvocation.name)
+    : undefined;
+  const configInputs = packageScript ? [...args, packageScript] : args;
+
+  if (!(await hasWranglerConfig(cwd, configInputs)) || hasSpotlightVar(args)) {
     return unchanged;
   }
 
@@ -227,34 +480,18 @@ export async function injectWranglerSpotlightBinding(
     return { args: [...args, "--var", binding], injected: true };
   }
 
-  const shellIndex = args.findIndex(
-    (arg, index) =>
-      index > 0 &&
-      ["-c", "/c"].includes(args[index - 1] ?? "") &&
-      WRANGLER_SHELL_RE.test(arg) &&
-      WRANGLER_DEV_SHELL_RE.test(arg)
+  const shellResult = injectIntoShellArgs(args, binding);
+  if (shellResult) {
+    return shellResult;
+  }
+
+  if (!(packageInvocation && packageScript)) {
+    return unchanged;
+  }
+  return injectIntoPackageScript(
+    args,
+    binding,
+    packageInvocation,
+    packageScript
   );
-  if (shellIndex !== -1) {
-    const augmented = [...args];
-    augmented[shellIndex] = injectIntoShellCommand(
-      augmented[shellIndex] ?? "",
-      binding
-    );
-    return { args: augmented, injected: true };
-  }
-
-  const scriptName = packageScriptName(args);
-  if (!scriptName) {
-    return unchanged;
-  }
-  const script = await readPackageScript(cwd, scriptName);
-  if (!(script && WRANGLER_DEV_SHELL_RE.test(script))) {
-    return unchanged;
-  }
-
-  const separator = args.includes("--") ? [] : ["--"];
-  return {
-    args: [...args, ...separator, "--var", binding],
-    injected: true,
-  };
 }

--- a/packages/cli/src/lib/wrangler.ts
+++ b/packages/cli/src/lib/wrangler.ts
@@ -1,0 +1,177 @@
+/**
+ * Wrangler-specific command augmentation for Cloudflare Workers local dev.
+ *
+ * Process environment variables inherited by `wrangler dev` are not exposed
+ * as Worker bindings. The Cloudflare Sentry SDK reads `SENTRY_SPOTLIGHT` from
+ * the Worker `env` object, so `sentry local run` must pass it through
+ * Wrangler's `--var` flag rather than relying on child-process inheritance.
+ */
+
+import { access, readFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { logger } from "./logger.js";
+
+/** Wrangler project configuration filenames, in resolution order. */
+const WRANGLER_CONFIG_FILES = [
+  "wrangler.json",
+  "wrangler.jsonc",
+  "wrangler.toml",
+] as const;
+
+/** Package managers whose `run` subcommand forwards args after `--`. */
+const PACKAGE_MANAGERS = new Set(["npm", "pnpm", "yarn", "bun"]);
+
+/** Match `wrangler` as a shell command, optionally with a path prefix. */
+const WRANGLER_SHELL_RE = /(?:^|[\s;&|])(?:[^\s;&|]*\/)?wrangler(?:\.cmd)?\s/;
+
+/** Match Wrangler's `dev` subcommand in a shell command. */
+const WRANGLER_DEV_SHELL_RE = /\bwrangler(?:\.cmd)?\s+(?:pages\s+)?dev\b/;
+
+/** Match an existing SENTRY_SPOTLIGHT Wrangler binding. */
+const SPOTLIGHT_VAR_RE = /^SENTRY_SPOTLIGHT(?::|=)/;
+
+/** Strip Windows' executable suffix before command comparisons. */
+const CMD_SUFFIX_RE = /\.cmd$/i;
+
+/** Result of attempting to augment a command for Wrangler. */
+export type WranglerCommandAugmentation = {
+  /** Spawn arguments, possibly containing an injected `--var`. */
+  args: string[];
+  /** Whether the Worker binding was injected. */
+  injected: boolean;
+};
+
+/** Return the executable's platform-independent basename. */
+function executableName(value: string): string {
+  return basename(value).replace(CMD_SUFFIX_RE, "").toLowerCase();
+}
+
+/** Whether args already provide an explicit SENTRY_SPOTLIGHT Wrangler var. */
+function hasSpotlightVar(args: readonly string[]): boolean {
+  return args.some((arg, index) => {
+    if (arg.startsWith("--var=")) {
+      return SPOTLIGHT_VAR_RE.test(arg.slice("--var=".length));
+    }
+    return args[index - 1] === "--var" && SPOTLIGHT_VAR_RE.test(arg);
+  });
+}
+
+/** Whether a direct/wrapped command invokes `wrangler dev`. */
+function isDirectWranglerDev(args: readonly string[]): boolean {
+  const wranglerIndex = args.findIndex(
+    (arg) => executableName(arg) === "wrangler"
+  );
+  if (wranglerIndex === -1) {
+    return false;
+  }
+  const following = args.slice(wranglerIndex + 1);
+  return (
+    following[0] === "dev" ||
+    (following[0] === "pages" && following[1] === "dev")
+  );
+}
+
+/** Extract `package-manager run <script>` metadata when present. */
+function packageScriptName(args: readonly string[]): string | undefined {
+  if (!PACKAGE_MANAGERS.has(executableName(args[0] ?? ""))) {
+    return;
+  }
+  const runIndex = args.indexOf("run");
+  return runIndex === -1 ? undefined : args[runIndex + 1];
+}
+
+/** Read a package script without failing command startup on malformed files. */
+async function readPackageScript(
+  cwd: string,
+  name: string
+): Promise<string | undefined> {
+  try {
+    const raw = await readFile(join(cwd, "package.json"), "utf8");
+    const pkg = JSON.parse(raw) as { scripts?: Record<string, unknown> };
+    const value = pkg.scripts?.[name];
+    return typeof value === "string" ? value : undefined;
+  } catch (error) {
+    logger.debug("Could not inspect package script for Wrangler", error);
+    return;
+  }
+}
+
+/** Whether the project has a Wrangler config or the command names one. */
+async function hasWranglerConfig(
+  cwd: string,
+  args: readonly string[]
+): Promise<boolean> {
+  if (
+    args.some(
+      (arg, index) => arg === "--config" && typeof args[index + 1] === "string"
+    ) ||
+    args.some((arg) => arg.startsWith("--config="))
+  ) {
+    return true;
+  }
+
+  for (const filename of WRANGLER_CONFIG_FILES) {
+    try {
+      await access(join(cwd, filename));
+      return true;
+    } catch {
+      // Try the next supported Wrangler filename.
+    }
+  }
+  return false;
+}
+
+/**
+ * Inject `SENTRY_SPOTLIGHT` as a Wrangler Worker binding when appropriate.
+ *
+ * Supports direct invocations (`wrangler dev`, `npx wrangler dev`),
+ * auto-detected shell scripts, and explicit package-manager scripts such as
+ * `npm run dev`. User-supplied `--var SENTRY_SPOTLIGHT:...` always wins.
+ *
+ * @param args - Child command arguments
+ * @param spotlightUrl - Local envelope endpoint
+ * @param cwd - Project root used to find Wrangler/package configuration
+ */
+export async function injectWranglerSpotlightBinding(
+  args: readonly string[],
+  spotlightUrl: string,
+  cwd: string
+): Promise<WranglerCommandAugmentation> {
+  const unchanged = { args: [...args], injected: false };
+  if (!(await hasWranglerConfig(cwd, args)) || hasSpotlightVar(args)) {
+    return unchanged;
+  }
+
+  const binding = `SENTRY_SPOTLIGHT:${spotlightUrl}`;
+  if (isDirectWranglerDev(args)) {
+    return { args: [...args, "--var", binding], injected: true };
+  }
+
+  const shellIndex = args.findIndex(
+    (arg, index) =>
+      index > 0 &&
+      ["-c", "/c"].includes(args[index - 1] ?? "") &&
+      WRANGLER_SHELL_RE.test(arg) &&
+      WRANGLER_DEV_SHELL_RE.test(arg)
+  );
+  if (shellIndex !== -1) {
+    const augmented = [...args];
+    augmented[shellIndex] = `${augmented[shellIndex]} --var ${binding}`;
+    return { args: augmented, injected: true };
+  }
+
+  const scriptName = packageScriptName(args);
+  if (!scriptName) {
+    return unchanged;
+  }
+  const script = await readPackageScript(cwd, scriptName);
+  if (!(script && WRANGLER_DEV_SHELL_RE.test(script))) {
+    return unchanged;
+  }
+
+  const separator = args.includes("--") ? [] : ["--"];
+  return {
+    args: [...args, ...separator, "--var", binding],
+    injected: true,
+  };
+}

--- a/packages/cli/src/lib/wrangler.ts
+++ b/packages/cli/src/lib/wrangler.ts
@@ -30,6 +30,9 @@ const WRANGLER_DEV_SHELL_RE = /\bwrangler(?:\.cmd)?\s+(?:pages\s+)?dev\b/;
 /** Match an existing SENTRY_SPOTLIGHT Wrangler binding. */
 const SPOTLIGHT_VAR_RE = /^SENTRY_SPOTLIGHT(?::|=)/;
 
+/** Match an existing SENTRY_SPOTLIGHT binding inside a shell command. */
+const SHELL_SPOTLIGHT_VAR_RE = /--var(?:=|\s+)["']?SENTRY_SPOTLIGHT(?::|=)/;
+
 /** Strip Windows' executable suffix before command comparisons. */
 const CMD_SUFFIX_RE = /\.cmd$/i;
 
@@ -49,11 +52,88 @@ function executableName(value: string): string {
 /** Whether args already provide an explicit SENTRY_SPOTLIGHT Wrangler var. */
 function hasSpotlightVar(args: readonly string[]): boolean {
   return args.some((arg, index) => {
+    if (SHELL_SPOTLIGHT_VAR_RE.test(arg)) {
+      return true;
+    }
     if (arg.startsWith("--var=")) {
       return SPOTLIGHT_VAR_RE.test(arg.slice("--var=".length));
     }
     return args[index - 1] === "--var" && SPOTLIGHT_VAR_RE.test(arg);
   });
+}
+
+/**
+ * Find where the Wrangler command ends inside a shell script.
+ *
+ * Shell control operators and redirections delimit the command, but operators
+ * inside quotes or command substitutions do not. The returned offset is where
+ * Wrangler's `--var` must be inserted.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: this is a single-pass shell lexer; splitting its quote/escape/substitution state would obscure the transitions
+function findShellCommandEnd(script: string, start: number): number {
+  let quote: "'" | '"' | "`" | undefined;
+  let escaped = false;
+  let substitutionDepth = 0;
+
+  for (let index = start; index < script.length; index += 1) {
+    const char = script[index];
+    const next = script[index + 1];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "$" && next === "(") {
+      substitutionDepth += 1;
+      index += 1;
+      continue;
+    }
+    if (char === ")" && substitutionDepth > 0) {
+      substitutionDepth -= 1;
+      continue;
+    }
+    if (substitutionDepth > 0) {
+      continue;
+    }
+    if (
+      char === "\n" ||
+      char === ";" ||
+      char === "&" ||
+      char === "|" ||
+      char === "<" ||
+      char === ">" ||
+      char === "#"
+    ) {
+      return index;
+    }
+  }
+  return script.length;
+}
+
+/** Add the binding before the next shell operator after `wrangler dev`. */
+function injectIntoShellCommand(script: string, binding: string): string {
+  const match = WRANGLER_DEV_SHELL_RE.exec(script);
+  if (!match) {
+    return script;
+  }
+  const commandEnd = findShellCommandEnd(script, match.index + match[0].length);
+  const before = script.slice(0, commandEnd).trimEnd();
+  const spacing = script.slice(before.length, commandEnd);
+  return `${before} --var ${binding}${spacing}${script.slice(commandEnd)}`;
 }
 
 /** Whether a direct/wrapped command invokes `wrangler dev`. */
@@ -156,7 +236,10 @@ export async function injectWranglerSpotlightBinding(
   );
   if (shellIndex !== -1) {
     const augmented = [...args];
-    augmented[shellIndex] = `${augmented[shellIndex]} --var ${binding}`;
+    augmented[shellIndex] = injectIntoShellCommand(
+      augmented[shellIndex] ?? "",
+      binding
+    );
     return { args: augmented, injected: true };
   }
 

--- a/packages/cli/test/commands/local/run.test.ts
+++ b/packages/cli/test/commands/local/run.test.ts
@@ -5,7 +5,7 @@
  * exit code propagation, auto-detection, --verify, --timeout, and error cases.
  */
 
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createSpotlightBuffer } from "@spotlightjs/spotlight/sdk";
 import { Hono } from "hono";
@@ -26,7 +26,7 @@ import { TEST_TMP_DIR } from "../../constants.js";
  * delegates to the real `spawn`, so commands like `printenv`/`true` run for
  * real and exit codes propagate normally.
  */
-const spawnCapture: { env?: NodeJS.ProcessEnv } = {};
+const spawnCapture: { args?: readonly string[]; env?: NodeJS.ProcessEnv } = {};
 
 vi.mock("node:child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:child_process")>();
@@ -37,6 +37,7 @@ vi.mock("node:child_process", async (importOriginal) => {
       args: readonly string[],
       options: Parameters<typeof actual.spawn>[2]
     ) => {
+      spawnCapture.args = args;
       spawnCapture.env = (options as { env?: NodeJS.ProcessEnv })?.env;
       return actual.spawn(cmd, args as string[], options);
     },
@@ -73,6 +74,7 @@ function makeContext(cwd?: string) {
 
 describe("sentry local run", () => {
   beforeEach(() => {
+    spawnCapture.args = undefined;
     spawnCapture.env = undefined;
   });
 
@@ -141,6 +143,29 @@ describe("sentry local run", () => {
       "echo",
       "ok"
     );
+  });
+
+  test("injects SENTRY_SPOTLIGHT as a Wrangler Worker binding", async () => {
+    await writeFile(join(tmpDir, "wrangler.jsonc"), "{}");
+    const fakeWrangler = join(tmpDir, "wrangler");
+    await writeFile(fakeWrangler, "#!/bin/sh\nexit 0\n");
+    await chmod(fakeWrangler, 0o755);
+
+    const func = (await runCommand.loader()) as unknown as RunFunc;
+    await func.call(
+      makeContext(),
+      { port: 0, host: "127.0.0.1", verify: false, timeout: 0 },
+      fakeWrangler,
+      "dev"
+    );
+
+    expect(spawnCapture.args).toEqual([
+      "dev",
+      "--var",
+      expect.stringMatching(
+        /^SENTRY_SPOTLIGHT:http:\/\/127\.0\.0\.1:\d+\/stream$/
+      ),
+    ]);
   });
 
   test("preserves existing SENTRY_TRACES_SAMPLE_RATE", async () => {

--- a/packages/cli/test/lib/wrangler.test.ts
+++ b/packages/cli/test/lib/wrangler.test.ts
@@ -151,6 +151,75 @@ describe("injectWranglerSpotlightBinding", () => {
     ]);
   });
 
+  test("injects before a chained command instead of into the last command", async () => {
+    await addWranglerConfig();
+
+    const result = await injectWranglerSpotlightBinding(
+      ["sh", "-c", "wrangler dev --port 8787 && echo done"],
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result.args).toEqual([
+      "sh",
+      "-c",
+      `wrangler dev --port 8787 --var ${BINDING} && echo done`,
+    ]);
+  });
+
+  test("ignores shell operators inside quotes and substitutions", async () => {
+    await addWranglerConfig();
+
+    const result = await injectWranglerSpotlightBinding(
+      [
+        "sh",
+        "-c",
+        'wrangler dev --define MESSAGE:"a && b" --name "$(echo x && echo y)" | tee output.log',
+      ],
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result.args).toEqual([
+      "sh",
+      "-c",
+      `wrangler dev --define MESSAGE:"a && b" --name "$(echo x && echo y)" --var ${BINDING} | tee output.log`,
+    ]);
+  });
+
+  test("injects before a shell redirection", async () => {
+    await addWranglerConfig();
+
+    const result = await injectWranglerSpotlightBinding(
+      ["sh", "-c", "wrangler dev > wrangler.log 2>&1"],
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result.args).toEqual([
+      "sh",
+      "-c",
+      `wrangler dev --var ${BINDING} > wrangler.log 2>&1`,
+    ]);
+  });
+
+  test("preserves an explicit Spotlight binding inside a shell script", async () => {
+    await addWranglerConfig();
+    const script =
+      "wrangler dev --var SENTRY_SPOTLIGHT:http://localhost:9999/stream && echo done";
+
+    const result = await injectWranglerSpotlightBinding(
+      ["sh", "-c", script],
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result).toEqual({
+      args: ["sh", "-c", script],
+      injected: false,
+    });
+  });
+
   test("respects an explicit config path when no default config exists", async () => {
     const result = await injectWranglerSpotlightBinding(
       ["wrangler", "dev", "--config", "config/worker.jsonc"],

--- a/packages/cli/test/lib/wrangler.test.ts
+++ b/packages/cli/test/lib/wrangler.test.ts
@@ -14,6 +14,7 @@ import { TEST_TMP_DIR } from "../constants.js";
 
 const SPOTLIGHT_URL = "http://localhost:8969/stream";
 const BINDING = `SENTRY_SPOTLIGHT:${SPOTLIGHT_URL}`;
+const QUOTED_BINDING = `'${BINDING}'`;
 
 let tmpDir: string;
 
@@ -75,6 +76,19 @@ describe("injectWranglerSpotlightBinding", () => {
     expect(result.injected).toBe(true);
   });
 
+  test("does not treat an argument containing wrangler dev as the executable", async () => {
+    await addWranglerConfig();
+    const args = ["echo", "wrangler", "dev"];
+
+    const result = await injectWranglerSpotlightBinding(
+      args,
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result).toEqual({ args, injected: false });
+  });
+
   test("supports wrangler pages dev", async () => {
     await addWranglerConfig();
 
@@ -110,7 +124,28 @@ describe("injectWranglerSpotlightBinding", () => {
     expect(result.args).toEqual(["npm", "run", "dev", "--", "--var", BINDING]);
   });
 
-  test("appends to an existing package-script argument separator", async () => {
+  test("preserves a Spotlight binding declared inside a package script", async () => {
+    await addWranglerConfig();
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({
+        scripts: {
+          dev: "wrangler dev --var SENTRY_SPOTLIGHT:http://localhost:9999/stream",
+        },
+      })
+    );
+    const args = ["npm", "run", "dev"];
+
+    const result = await injectWranglerSpotlightBinding(
+      args,
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result).toEqual({ args, injected: false });
+  });
+
+  test("injects before pnpm's literal package-script separator", async () => {
     await addWranglerConfig();
     await writeFile(
       join(tmpDir, "package.json"),
@@ -127,11 +162,11 @@ describe("injectWranglerSpotlightBinding", () => {
       "pnpm",
       "run",
       "dev",
+      "--var",
+      BINDING,
       "--",
       "--port",
       "8787",
-      "--var",
-      BINDING,
     ]);
   });
 
@@ -147,7 +182,7 @@ describe("injectWranglerSpotlightBinding", () => {
     expect(result.args).toEqual([
       "sh",
       "-c",
-      `NODE_ENV=development wrangler dev --var ${BINDING}`,
+      `NODE_ENV=development wrangler dev --var ${QUOTED_BINDING}`,
     ]);
   });
 
@@ -163,7 +198,37 @@ describe("injectWranglerSpotlightBinding", () => {
     expect(result.args).toEqual([
       "sh",
       "-c",
-      `wrangler dev --port 8787 --var ${BINDING} && echo done`,
+      `wrangler dev --port 8787 --var ${QUOTED_BINDING} && echo done`,
+    ]);
+  });
+
+  test("does not inject into quoted text in a shell command", async () => {
+    await addWranglerConfig();
+    const args = ["sh", "-c", 'echo "run wrangler dev"'];
+
+    const result = await injectWranglerSpotlightBinding(
+      args,
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result).toEqual({ args, injected: false });
+  });
+
+  test("quotes the binding before adding it to a shell command", async () => {
+    await addWranglerConfig();
+    const unsafeUrl = "http://localhost:8969/stream'; echo injected";
+
+    const result = await injectWranglerSpotlightBinding(
+      ["sh", "-c", "wrangler dev"],
+      unsafeUrl,
+      tmpDir
+    );
+
+    expect(result.args).toEqual([
+      "sh",
+      "-c",
+      "wrangler dev --var 'SENTRY_SPOTLIGHT:http://localhost:8969/stream'\\''; echo injected'",
     ]);
   });
 
@@ -183,7 +248,7 @@ describe("injectWranglerSpotlightBinding", () => {
     expect(result.args).toEqual([
       "sh",
       "-c",
-      `wrangler dev --define MESSAGE:"a && b" --name "$(echo x && echo y)" --var ${BINDING} | tee output.log`,
+      `wrangler dev --define MESSAGE:"a && b" --name "$(echo x && echo y)" --var ${QUOTED_BINDING} | tee output.log`,
     ]);
   });
 
@@ -199,7 +264,7 @@ describe("injectWranglerSpotlightBinding", () => {
     expect(result.args).toEqual([
       "sh",
       "-c",
-      `wrangler dev --var ${BINDING} > wrangler.log 2>&1`,
+      `wrangler dev --var ${QUOTED_BINDING} > wrangler.log 2>&1`,
     ]);
   });
 
@@ -220,6 +285,22 @@ describe("injectWranglerSpotlightBinding", () => {
     });
   });
 
+  test("supports Windows cmd and wrangler.cmd paths case-insensitively", async () => {
+    await addWranglerConfig();
+
+    const result = await injectWranglerSpotlightBinding(
+      ["cmd.exe", "/C", String.raw`C:\repo\node_modules\.bin\WRANGLER.CMD dev`],
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result.args).toEqual([
+      "cmd.exe",
+      "/C",
+      String.raw`C:\repo\node_modules\.bin\WRANGLER.CMD dev --var "SENTRY_SPOTLIGHT:http://localhost:8969/stream"`,
+    ]);
+  });
+
   test("respects an explicit config path when no default config exists", async () => {
     const result = await injectWranglerSpotlightBinding(
       ["wrangler", "dev", "--config", "config/worker.jsonc"],
@@ -236,6 +317,60 @@ describe("injectWranglerSpotlightBinding", () => {
       "--var",
       BINDING,
     ]);
+  });
+
+  test("detects a custom config path inside a package script", async () => {
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({
+        scripts: { dev: "wrangler dev --config config/worker.jsonc" },
+      })
+    );
+
+    const result = await injectWranglerSpotlightBinding(
+      ["npm", "run", "dev"],
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result.args).toEqual(["npm", "run", "dev", "--", "--var", BINDING]);
+  });
+
+  test("does not claim injection into a compound package script", async () => {
+    await addWranglerConfig();
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { dev: "wrangler dev && node after.js" } })
+    );
+    const args = ["npm", "run", "dev"];
+
+    const result = await injectWranglerSpotlightBinding(
+      args,
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result).toEqual({ args, injected: false });
+  });
+
+  test.each([
+    "pnpm",
+    "yarn",
+    "bun",
+  ])("supports %s shorthand scripts without an npm-style separator", async (manager) => {
+    await addWranglerConfig();
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { dev: "wrangler dev" } })
+    );
+
+    const result = await injectWranglerSpotlightBinding(
+      [manager, "dev"],
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result.args).toEqual([manager, "dev", "--var", BINDING]);
   });
 
   test("does not override a user-supplied Spotlight binding", async () => {

--- a/packages/cli/test/lib/wrangler.test.ts
+++ b/packages/cli/test/lib/wrangler.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for Cloudflare Wrangler command augmentation.
+ *
+ * These focus on exact command shapes because the helper sits at a process
+ * boundary: a misplaced `--` or `--var` means the binding never reaches the
+ * Worker even though the child process starts successfully.
+ */
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { injectWranglerSpotlightBinding } from "../../src/lib/wrangler.js";
+import { TEST_TMP_DIR } from "../constants.js";
+
+const SPOTLIGHT_URL = "http://localhost:8969/stream";
+const BINDING = `SENTRY_SPOTLIGHT:${SPOTLIGHT_URL}`;
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(TEST_TMP_DIR, "wrangler-binding-test-"));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+async function addWranglerConfig(
+  filename:
+    | "wrangler.json"
+    | "wrangler.jsonc"
+    | "wrangler.toml" = "wrangler.jsonc"
+): Promise<void> {
+  await writeFile(join(tmpDir, filename), "{}");
+}
+
+describe("injectWranglerSpotlightBinding", () => {
+  test.each([
+    "wrangler.json",
+    "wrangler.jsonc",
+    "wrangler.toml",
+  ] as const)("injects into direct wrangler dev with %s", async (filename) => {
+    await addWranglerConfig(filename);
+
+    const result = await injectWranglerSpotlightBinding(
+      ["wrangler", "dev"],
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result).toEqual({
+      args: ["wrangler", "dev", "--var", BINDING],
+      injected: true,
+    });
+  });
+
+  test("supports npx and a Wrangler binary path", async () => {
+    await addWranglerConfig();
+
+    const result = await injectWranglerSpotlightBinding(
+      ["npx", "./node_modules/.bin/wrangler", "dev", "--port", "8787"],
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result.args).toEqual([
+      "npx",
+      "./node_modules/.bin/wrangler",
+      "dev",
+      "--port",
+      "8787",
+      "--var",
+      BINDING,
+    ]);
+    expect(result.injected).toBe(true);
+  });
+
+  test("supports wrangler pages dev", async () => {
+    await addWranglerConfig();
+
+    const result = await injectWranglerSpotlightBinding(
+      ["wrangler", "pages", "dev", "./dist"],
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result.args).toEqual([
+      "wrangler",
+      "pages",
+      "dev",
+      "./dist",
+      "--var",
+      BINDING,
+    ]);
+  });
+
+  test("forwards the binding through an explicit npm script", async () => {
+    await addWranglerConfig();
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { dev: "wrangler dev --port 8787" } })
+    );
+
+    const result = await injectWranglerSpotlightBinding(
+      ["npm", "run", "dev"],
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result.args).toEqual(["npm", "run", "dev", "--", "--var", BINDING]);
+  });
+
+  test("appends to an existing package-script argument separator", async () => {
+    await addWranglerConfig();
+    await writeFile(
+      join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { dev: "wrangler dev" } })
+    );
+
+    const result = await injectWranglerSpotlightBinding(
+      ["pnpm", "run", "dev", "--", "--port", "8787"],
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result.args).toEqual([
+      "pnpm",
+      "run",
+      "dev",
+      "--",
+      "--port",
+      "8787",
+      "--var",
+      BINDING,
+    ]);
+  });
+
+  test("augments an auto-detected shell command", async () => {
+    await addWranglerConfig();
+
+    const result = await injectWranglerSpotlightBinding(
+      ["sh", "-c", "NODE_ENV=development wrangler dev"],
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result.args).toEqual([
+      "sh",
+      "-c",
+      `NODE_ENV=development wrangler dev --var ${BINDING}`,
+    ]);
+  });
+
+  test("respects an explicit config path when no default config exists", async () => {
+    const result = await injectWranglerSpotlightBinding(
+      ["wrangler", "dev", "--config", "config/worker.jsonc"],
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result.injected).toBe(true);
+    expect(result.args).toEqual([
+      "wrangler",
+      "dev",
+      "--config",
+      "config/worker.jsonc",
+      "--var",
+      BINDING,
+    ]);
+  });
+
+  test("does not override a user-supplied Spotlight binding", async () => {
+    await addWranglerConfig();
+    const custom = "SENTRY_SPOTLIGHT:http://localhost:9999/stream";
+    const args = ["wrangler", "dev", "--var", custom];
+
+    const result = await injectWranglerSpotlightBinding(
+      args,
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result).toEqual({ args, injected: false });
+  });
+
+  test("does not change non-Wrangler commands in a Workers project", async () => {
+    await addWranglerConfig();
+    const args = ["vite", "dev"];
+
+    const result = await injectWranglerSpotlightBinding(
+      args,
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result).toEqual({ args, injected: false });
+  });
+
+  test("does not change wrangler outside a Workers project", async () => {
+    const args = ["wrangler", "dev"];
+
+    const result = await injectWranglerSpotlightBinding(
+      args,
+      SPOTLIGHT_URL,
+      tmpDir
+    );
+
+    expect(result).toEqual({ args, injected: false });
+  });
+});


### PR DESCRIPTION
Wrangler does not expose inherited process environment variables to Worker code, so the SENTRY_SPOTLIGHT value set by local run never reached @sentry/cloudflare. Users had to hard-code spotlight: true in their SDK config.

Detect Wrangler dev commands in Workers projects and add the ephemeral --var SENTRY_SPOTLIGHT:<url> binding. This works for direct/npx commands, package-manager scripts, auto-detected shell scripts, custom config paths and verify mode; explicit user bindings remain untouched. No wrangler config or .dev.vars files are modified.