### PR TITLE
fix(npm): Route bare "zlib" imports through the ESM namespace shim

### DIFF
--- a/packages/cli/script/bundle.ts
+++ b/packages/cli/script/bundle.ts
@@ -170,7 +170,9 @@ const REQUIRE_ALIAS_FILTER =
   /(?:db[\\/](?:index|schema|sqlite)|list-command|telemetry)\.ts$/;
 const REQUIRE_ALIAS_RE = /\b_require\(/g;
 const IDENTIFIER_FILTER_RE = /^[A-Za-z_$][\w$]*$/;
-const NODE_ZLIB_RE = /^node:zlib$/;
+// Match both the prefixed and bare specifiers — bundled dependencies (e.g.
+// binpatch) import from "zlib", which esbuild also treats as external builtin.
+const NODE_ZLIB_RE = /^(?:node:)?zlib$/;
 const ANY_RE = /.*/;
 
 /** Transform _require() → require() so esbuild resolves lazy relative requires. */

--- a/packages/cli/test/script/package-exports.test.ts
+++ b/packages/cli/test/script/package-exports.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 import pkg from "../../package.json";
@@ -50,4 +50,20 @@ describe("package.json exports (dual ESM/CJS)", () => {
     expect(typeof mod.createSentrySDK).toBe("function");
     expect(typeof mod.default).toBe("function");
   });
+
+  // The ESM entry must be link-safe on the oldest supported runtime: named
+  // imports of version-gated builtin exports (zstd* landed in Node 22.15)
+  // fail at LINK time on older Node — before any code runs — taking the whole
+  // module down. The build shims node:zlib through a namespace import; this
+  // guards against a regression (e.g. a new dep importing from bare "zlib",
+  // which the shim must also cover).
+  test.runIf(built)(
+    "built ESM entry has no link-fatal named zlib imports",
+    () => {
+      const src = readFileSync(resolve("dist/index.mjs"), "utf-8");
+      const namedZlibImport =
+        /import\s*\{[^}]*zstd[^}]*\}\s*from\s*["'](?:node:)?zlib["']/;
+      expect(src).not.toMatch(namedZlibImport);
+    }
+  );
 });


### PR DESCRIPTION
The zlib-namespace-shim plugin only matched the "node:zlib" specifier, but bundled dependencies (binpatch) import from bare "zlib". esbuild hoisted those into top-level named imports of the version-gated zstd* family (added in Node 22.15), which fail at link time on older Node — the entire ESM entry of the npm package failed to load on Node 18/20, despite engines.node claiming >= 18.

Widen the filter to match both specifiers, and add a regression test that statically scans the built ESM bundle for link-fatal named zlib imports. (The existing dynamic import test only runs on the build Node, which already has zstd and can never catch this.)

Verified: dist/index.mjs now imports cleanly on Node 18.20.8 and 20.19.5; CJS unaffected.