### PR TITLE
fix(conversation): Parse details envelope instead of bare span array

### DIFF
--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/conversation.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/conversation.md
@@ -27,6 +27,7 @@ List recent AI conversations
 | Field | Type | Description |
 |-------|------|-------------|
 | `conversationId` | string |  |
+| `title` | string \| null |  |
 | `flow` | array |  |
 | `errors` | number |  |
 | `llmCalls` | number |  |

--- a/packages/cli/src/commands/conversation/view.ts
+++ b/packages/cli/src/commands/conversation/view.ts
@@ -103,7 +103,7 @@ export const viewCommand = buildCommand({
     }
     const org = resolved.org;
 
-    const { spans, truncated } = await withProgress(
+    const { spans, truncated, title } = await withProgress(
       {
         message: "Fetching conversation spans...",
         json: flags.json,
@@ -111,7 +111,7 @@ export const viewCommand = buildCommand({
       () => getConversationSpans(org, conversationId)
     );
 
-    const result = buildTranscriptResult(conversationId, org, spans);
+    const result = buildTranscriptResult(conversationId, org, spans, title);
     result.truncated = truncated;
     yield new CommandOutput<TranscriptResult>(result);
   },

--- a/packages/cli/src/lib/api/conversations.ts
+++ b/packages/cli/src/lib/api/conversations.ts
@@ -5,20 +5,24 @@
  * Explore AI-conversations endpoints.
  *
  * The `/organizations/{org}/ai-conversations/` endpoints are not yet in
- * `@sentry/api` (getsentry/sentry-api-schema): they are a new AI-monitoring
- * feature that has not been published to the API schema, so no generated SDK
- * function or response type exists for them. Following the same pattern as the
- * experimental endpoints in `logs.ts`/`traces.ts`, they are called directly via
- * `apiRequestToRegion` with local Zod schemas. Pagination still goes through the
- * shared `parseLinkHeader` helper, which wraps `@sentry/api`'s
- * `parseSentryLinkHeader`. Revisit once these endpoints land in `@sentry/api`.
+ * `@sentry/api` (getsentry/sentry-api-schema): they are PRIVATE AI-monitoring
+ * endpoints that have not been published to the OpenAPI schema, so no generated
+ * SDK function or response type exists for them. Following the same pattern as
+ * the experimental endpoints in `logs.ts`/`traces.ts`, they are called directly
+ * via `apiRequestToRegion` with local Zod schemas.
+ *
+ * Details responses are an envelope `{ conversationId, title, spans }`
+ * (getsentry/sentry#121143), not a bare span array. Pagination still uses the
+ * `Link` header via `parseLinkHeader` (wrapping `@sentry/api`'s
+ * `parseSentryLinkHeader`). Revisit once these endpoints land in `@sentry/api`.
  */
 
 import { z } from "zod";
 
 import {
+  type AIConversationDetails,
+  AIConversationDetailsSchema,
   type AIConversationSpan,
-  AIConversationSpanSchema,
   type ConversationListItem,
   ConversationListItemSchema,
 } from "../../types/conversation.js";
@@ -90,9 +94,12 @@ export async function getConversationSpans(
     project?: string;
     perPage?: number;
   } = {}
-): Promise<{ spans: AIConversationSpan[]; truncated: boolean }> {
+): Promise<{
+  spans: AIConversationSpan[];
+  truncated: boolean;
+  title: string | null;
+}> {
   const regionUrl = await resolveOrgRegion(orgSlug);
-  const pageSchema = z.array(AIConversationSpanSchema);
 
   const params: Record<string, string> = {
     per_page: String(options.perPage ?? 1000),
@@ -103,6 +110,7 @@ export async function getConversationSpans(
   }
 
   const spans: AIConversationSpan[] = [];
+  let title: string | null = null;
   let cursor: string | undefined;
 
   for (let page = 0; page < MAX_PAGINATION_PAGES; page++) {
@@ -110,13 +118,18 @@ export async function getConversationSpans(
       params.cursor = cursor;
     }
 
-    const { data, headers } = await apiRequestToRegion<AIConversationSpan[]>(
+    // Each page is an envelope `{ conversationId, title, spans }` (sentry#121143).
+    // Pagination cursors still live in the Link header.
+    const { data, headers } = await apiRequestToRegion<AIConversationDetails>(
       regionUrl,
       `/organizations/${orgSlug}/ai-conversations/${encodeURIComponent(conversationId)}/`,
-      { params, schema: pageSchema }
+      { params, schema: AIConversationDetailsSchema }
     );
 
-    spans.push(...data);
+    if (page === 0) {
+      title = data.title;
+    }
+    spans.push(...data.spans);
     const parsed = parseLinkHeader(headers.get("link") ?? null);
     cursor = parsed.nextCursor;
     if (!cursor) {
@@ -131,5 +144,5 @@ export async function getConversationSpans(
     );
   }
 
-  return { spans, truncated };
+  return { spans, truncated, title };
 }

--- a/packages/cli/src/lib/api/conversations.ts
+++ b/packages/cli/src/lib/api/conversations.ts
@@ -4,17 +4,12 @@
  * Functions for listing and retrieving AI conversation data from the Sentry
  * Explore AI-conversations endpoints.
  *
- * The `/organizations/{org}/ai-conversations/` endpoints are not yet in
- * `@sentry/api` (getsentry/sentry-api-schema): they are PRIVATE AI-monitoring
- * endpoints that have not been published to the OpenAPI schema, so no generated
- * SDK function or response type exists for them. Following the same pattern as
- * the experimental endpoints in `logs.ts`/`traces.ts`, they are called directly
- * via `apiRequestToRegion` with local Zod schemas.
- *
- * Details responses are an envelope `{ conversationId, title, spans }`
- * (getsentry/sentry#121143), not a bare span array. Pagination still uses the
- * `Link` header via `parseLinkHeader` (wrapping `@sentry/api`'s
- * `parseSentryLinkHeader`). Revisit once these endpoints land in `@sentry/api`.
+ * The `/organizations/{org}/ai-conversations/` endpoints are PRIVATE and not
+ * yet in `@sentry/api` (getsentry/sentry-api-schema). Call them via
+ * `apiRequestToRegion` with local Zod schemas (same pattern as `logs.ts` /
+ * `traces.ts`). Details response shape is documented on
+ * `AIConversationDetailsSchema`. Pagination uses `parseLinkHeader`. Revisit
+ * once these endpoints land in `@sentry/api`.
  */
 
 import { z } from "zod";
@@ -118,8 +113,6 @@ export async function getConversationSpans(
       params.cursor = cursor;
     }
 
-    // Each page is an envelope `{ conversationId, title, spans }` (sentry#121143).
-    // Pagination cursors still live in the Link header.
     const { data, headers } = await apiRequestToRegion<AIConversationDetails>(
       regionUrl,
       `/organizations/${orgSlug}/ai-conversations/${encodeURIComponent(conversationId)}/`,

--- a/packages/cli/src/lib/formatters/conversation.ts
+++ b/packages/cli/src/lib/formatters/conversation.ts
@@ -52,8 +52,7 @@ const ID_COLUMN: Column<ConversationListItem> = {
 
 const TITLE_COLUMN: Column<ConversationListItem> = {
   header: "Title",
-  value: (c) =>
-    c.title ? escapeMarkdownCell(truncate(c.title, 40)) : "—",
+  value: (c) => (c.title ? escapeMarkdownCell(truncate(c.title, 40)) : "—"),
   truncate: true,
 };
 

--- a/packages/cli/src/lib/formatters/conversation.ts
+++ b/packages/cli/src/lib/formatters/conversation.ts
@@ -38,15 +38,22 @@ function formatTimestamp(epochSeconds: number): string {
 }
 
 /**
- * Minimum terminal width (columns) to show the full 7-column conversation
- * table. Below this, the lower-value Tools/Errs/User columns are dropped so
- * the core ID/Started/Tokens/First Input columns don't truncate aggressively.
+ * Minimum terminal width (columns) to show the full conversation table.
+ * Below this, Tools/Errs/User are dropped so the core ID/Title/Started/
+ * Tokens/First Input columns don't truncate aggressively.
  */
 const WIDE_TABLE_MIN_TERM_WIDTH = 100;
 
 const ID_COLUMN: Column<ConversationListItem> = {
   header: "ID",
   value: (c) => escapeMarkdownCell(truncate(c.conversationId, 40)),
+  truncate: true,
+};
+
+const TITLE_COLUMN: Column<ConversationListItem> = {
+  header: "Title",
+  value: (c) =>
+    c.title ? escapeMarkdownCell(truncate(c.title, 40)) : "—",
   truncate: true,
 };
 
@@ -88,13 +95,15 @@ const FIRST_INPUT_COLUMN: Column<ConversationListItem> = {
 /**
  * Select conversation table columns for the current terminal width. Wide
  * terminals get the full set; narrow ones (piped output defaults to 80) drop
- * Tools/Errs/User to keep the remaining columns readable.
+ * Tools/Errs/User to keep the remaining columns readable. Title stays on
+ * both widths so stored conversation names remain visible.
  */
 function selectConversationColumns(): Column<ConversationListItem>[] {
   const termWidth = process.stdout.columns || 80;
   if (termWidth >= WIDE_TABLE_MIN_TERM_WIDTH) {
     return [
       ID_COLUMN,
+      TITLE_COLUMN,
       STARTED_COLUMN,
       TOKENS_COLUMN,
       TOOLS_COLUMN,
@@ -103,7 +112,13 @@ function selectConversationColumns(): Column<ConversationListItem>[] {
       FIRST_INPUT_COLUMN,
     ];
   }
-  return [ID_COLUMN, STARTED_COLUMN, TOKENS_COLUMN, FIRST_INPUT_COLUMN];
+  return [
+    ID_COLUMN,
+    TITLE_COLUMN,
+    STARTED_COLUMN,
+    TOKENS_COLUMN,
+    FIRST_INPUT_COLUMN,
+  ];
 }
 
 export function formatConversationTable(items: ConversationListItem[]): string {
@@ -416,7 +431,8 @@ function formatTurnHuman(turn: ConversationTurn): string {
 export type TranscriptResult = {
   conversationId: string;
   org: string;
-  title?: string | null;
+  /** Stored conversation title, or null when none has been titled yet. */
+  title: string | null;
   turns: ConversationTurn[];
   totalTokens: number;
   spanCount: number;
@@ -428,9 +444,15 @@ export type TranscriptResult = {
 
 export function formatTranscriptResult(result: TranscriptResult): string {
   if (result.spanCount === 0) {
-    return `No spans found for conversation ${escapeMarkdownInline(result.conversationId)} in the last 30 days.`;
+    const id = escapeMarkdownInline(result.conversationId);
+    const titled = result.title
+      ? `${id} (${escapeMarkdownInline(result.title)})`
+      : id;
+    return `No spans found for conversation ${titled} in the last 30 days.`;
   }
 
+  // Keep the conversation ID in the heading (needed to re-run `conversation
+  // view`). Surface title as a table row so it is not duplicated in the heading.
   const rows: [string, string][] = [
     ["Org", escapeMarkdownCell(result.org)],
     ["Projects", result.projects.map(escapeMarkdownCell).join(", ") || "—"],
@@ -444,12 +466,8 @@ export function formatTranscriptResult(result: TranscriptResult): string {
     rows.unshift(["Title", escapeMarkdownCell(result.title)]);
   }
 
-  const heading = result.title
-    ? `# ${escapeMarkdownInline(result.title)}`
-    : `# AI Conversation: ${escapeMarkdownInline(result.conversationId)}`;
-
   const lines: string[] = [
-    heading,
+    `# AI Conversation: ${escapeMarkdownInline(result.conversationId)}`,
     "",
     mdKvTable(rows),
     "",
@@ -470,13 +488,13 @@ export function buildTranscriptResult(
   conversationId: string,
   org: string,
   spans: AIConversationSpan[],
-  title?: string | null
+  title: string | null = null
 ): TranscriptResult {
   const turns = extractTurns(spans);
   return {
     conversationId,
     org,
-    title: title ?? null,
+    title,
     turns,
     // Sum tokens per turn (ai_client spans only). Summing every span would
     // double-count parent invoke_agent spans that aggregate child usage.

--- a/packages/cli/src/lib/formatters/conversation.ts
+++ b/packages/cli/src/lib/formatters/conversation.ts
@@ -416,6 +416,7 @@ function formatTurnHuman(turn: ConversationTurn): string {
 export type TranscriptResult = {
   conversationId: string;
   org: string;
+  title?: string | null;
   turns: ConversationTurn[];
   totalTokens: number;
   spanCount: number;
@@ -439,9 +440,16 @@ export function formatTranscriptResult(result: TranscriptResult): string {
     ["Spans", String(result.spanCount)],
     ["Tokens", String(result.totalTokens)],
   ];
+  if (result.title) {
+    rows.unshift(["Title", escapeMarkdownCell(result.title)]);
+  }
+
+  const heading = result.title
+    ? `# ${escapeMarkdownInline(result.title)}`
+    : `# AI Conversation: ${escapeMarkdownInline(result.conversationId)}`;
 
   const lines: string[] = [
-    `# AI Conversation: ${escapeMarkdownInline(result.conversationId)}`,
+    heading,
     "",
     mdKvTable(rows),
     "",
@@ -461,12 +469,14 @@ export function formatTranscriptResult(result: TranscriptResult): string {
 export function buildTranscriptResult(
   conversationId: string,
   org: string,
-  spans: AIConversationSpan[]
+  spans: AIConversationSpan[],
+  title?: string | null
 ): TranscriptResult {
   const turns = extractTurns(spans);
   return {
     conversationId,
     org,
+    title: title ?? null,
     turns,
     // Sum tokens per turn (ai_client spans only). Summing every span would
     // double-count parent invoke_agent spans that aggregate child usage.

--- a/packages/cli/src/types/conversation.ts
+++ b/packages/cli/src/types/conversation.ts
@@ -1,8 +1,8 @@
 /**
  * AI Conversation types and Zod schemas.
  *
- * Schemas for the conversation list items and the raw conversation spans
- * returned by the Sentry Explore AI-conversations endpoints.
+ * Schemas for conversation list items, the details envelope, and raw
+ * conversation spans returned by the Sentry Explore AI-conversations endpoints.
  */
 
 import { z } from "zod";

--- a/packages/cli/src/types/conversation.ts
+++ b/packages/cli/src/types/conversation.ts
@@ -92,10 +92,12 @@ export type AIConversationSpan = z.infer<typeof AIConversationSpanSchema>;
  * array. Pagination still uses the `Link` header; each page is an envelope
  * whose `spans` field holds that page's rows.
  */
-export const AIConversationDetailsSchema = z.object({
-  conversationId: z.string(),
-  title: z.string().nullable(),
-  spans: z.array(AIConversationSpanSchema),
-});
+export const AIConversationDetailsSchema = z
+  .object({
+    conversationId: z.string(),
+    title: z.string().nullable(),
+    spans: z.array(AIConversationSpanSchema),
+  })
+  .passthrough();
 
 export type AIConversationDetails = z.infer<typeof AIConversationDetailsSchema>;

--- a/packages/cli/src/types/conversation.ts
+++ b/packages/cli/src/types/conversation.ts
@@ -9,6 +9,8 @@ import { z } from "zod";
 
 export const ConversationListItemSchema = z.object({
   conversationId: z.string(),
+  /** Stored conversation title when available (added by ai-monitoring list API). */
+  title: z.string().nullable().optional(),
   flow: z.array(z.string()),
   errors: z.number(),
   llmCalls: z.number(),
@@ -80,3 +82,20 @@ export const AIConversationSpanSchema = z
   .passthrough();
 
 export type AIConversationSpan = z.infer<typeof AIConversationSpanSchema>;
+
+/**
+ * Conversation details envelope returned by
+ * `GET /organizations/{org}/ai-conversations/{conversationId}/`.
+ *
+ * As of getsentry/sentry#121143 the endpoint always returns this object
+ * (conversation-level metadata + a page of spans) instead of a bare span
+ * array. Pagination still uses the `Link` header; each page is an envelope
+ * whose `spans` field holds that page's rows.
+ */
+export const AIConversationDetailsSchema = z.object({
+  conversationId: z.string(),
+  title: z.string().nullable(),
+  spans: z.array(AIConversationSpanSchema),
+});
+
+export type AIConversationDetails = z.infer<typeof AIConversationDetailsSchema>;

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -21,10 +21,12 @@ export {
 } from "./config.js";
 // AI Conversations types
 export type {
+  AIConversationDetails,
   AIConversationSpan,
   ConversationListItem,
 } from "./conversation.js";
 export {
+  AIConversationDetailsSchema,
   AIConversationSpanSchema,
   ConversationListItemSchema,
 } from "./conversation.js";

--- a/packages/cli/test/commands/conversation/view.test.ts
+++ b/packages/cli/test/commands/conversation/view.test.ts
@@ -195,6 +195,7 @@ describe("viewCommand.func", () => {
     getConversationSpansSpy.mockResolvedValue({
       spans: sampleSpans,
       truncated: false,
+      title: null,
     });
 
     const { context, stdoutWrite } = createMockContext();
@@ -218,6 +219,7 @@ describe("viewCommand.func", () => {
     getConversationSpansSpy.mockResolvedValue({
       spans: sampleSpans,
       truncated: false,
+      title: null,
     });
 
     const { context } = createMockContext();
@@ -286,6 +288,7 @@ describe("viewCommand.func", () => {
     getConversationSpansSpy.mockResolvedValue({
       spans: sampleSpans,
       truncated: false,
+      title: null,
     });
 
     const { context, stdoutWrite } = createMockContext();
@@ -305,6 +308,7 @@ describe("viewCommand.func", () => {
     getConversationSpansSpy.mockResolvedValue({
       spans: sampleSpans,
       truncated: false,
+      title: null,
     });
 
     const { context, stdoutWrite } = createMockContext();
@@ -320,6 +324,7 @@ describe("viewCommand.func", () => {
     getConversationSpansSpy.mockResolvedValue({
       spans: sampleSpans,
       truncated: true,
+      title: null,
     });
 
     const { context, stdoutWrite } = createMockContext();
@@ -335,6 +340,7 @@ describe("viewCommand.func", () => {
     getConversationSpansSpy.mockResolvedValue({
       spans: sampleSpans,
       truncated: false,
+      title: null,
     });
 
     const { context, stdoutWrite } = createMockContext();
@@ -352,6 +358,7 @@ describe("viewCommand.func", () => {
     getConversationSpansSpy.mockResolvedValue({
       spans: sampleSpans,
       truncated: true,
+      title: null,
     });
 
     const { context, stdoutWrite } = createMockContext();
@@ -366,6 +373,7 @@ describe("viewCommand.func", () => {
     getConversationSpansSpy.mockResolvedValue({
       spans: [],
       truncated: false,
+      title: null,
     });
 
     const { context, stdoutWrite } = createMockContext();

--- a/packages/cli/test/lib/api/conversations.test.ts
+++ b/packages/cli/test/lib/api/conversations.test.ts
@@ -5,6 +5,7 @@
  * src/lib/api/conversations.ts, covering:
  * - listConversations sends correct params
  * - listConversations parses link header for pagination
+ * - getConversationSpans parses the details envelope and extracts spans
  * - getConversationSpans paginates through multiple pages
  * - getConversationSpans returns truncated=true when pagination limit reached
  * - getConversationSpans returns truncated=false when all pages fetched
@@ -260,8 +261,20 @@ describe("getConversationSpans", () => {
     };
   }
 
+  /** Details envelope returned by the conversation details endpoint. */
+  function makeEnvelope(
+    spans: ReturnType<typeof makeSpan>[],
+    title: string | null = "Test conversation"
+  ) {
+    return {
+      conversationId: CONV_ID,
+      title,
+      spans,
+    };
+  }
+
   test("hits /organizations/{org}/ai-conversations/{conversationId}/ with GET", async () => {
-    const { getCapturedUrl, getCapturedMethod } = mockOk([]);
+    const { getCapturedUrl, getCapturedMethod } = mockOk(makeEnvelope([]));
 
     await getConversationSpans(ORG, CONV_ID);
 
@@ -272,7 +285,7 @@ describe("getConversationSpans", () => {
   });
 
   test("sends default per_page=1000 and statsPeriod=30d", async () => {
-    const { getCapturedUrl } = mockOk([]);
+    const { getCapturedUrl } = mockOk(makeEnvelope([]));
 
     await getConversationSpans(ORG, CONV_ID);
 
@@ -281,25 +294,34 @@ describe("getConversationSpans", () => {
     expect(url).toContain("statsPeriod=30d");
   });
 
-  test("returns spans from a single page", async () => {
+  test("returns spans from a single page envelope", async () => {
     const spans = [makeSpan("span-1-aabb1122")];
-    mockOk(spans);
+    mockOk(makeEnvelope(spans, "Refund flow"));
 
     const result = await getConversationSpans(ORG, CONV_ID);
 
     expect(result.spans).toHaveLength(1);
     expect(result.spans[0].span_id).toBe("span-1-aabb1122");
+    expect(result.title).toBe("Refund flow");
     expect(result.truncated).toBe(false);
+  });
+
+  test("rejects a bare span array (pre-envelope response shape)", async () => {
+    mockOk([makeSpan("span-1-aabb1122")]);
+
+    await expect(getConversationSpans(ORG, CONV_ID)).rejects.toThrow(
+      /Unexpected response format/
+    );
   });
 
   test("paginates through multiple pages", async () => {
     const { getCapturedUrls } = mockSequential([
       {
-        body: [makeSpan("span-page-1-aa11")],
+        body: makeEnvelope([makeSpan("span-page-1-aa11")], "Multi-page"),
         headers: linkHeader("page-2-cursor"),
       },
       {
-        body: [makeSpan("span-page-2-bb22")],
+        body: makeEnvelope([makeSpan("span-page-2-bb22")], "Multi-page"),
         // No Link header → last page
       },
     ]);
@@ -309,6 +331,8 @@ describe("getConversationSpans", () => {
     expect(result.spans).toHaveLength(2);
     expect(result.spans[0].span_id).toBe("span-page-1-aa11");
     expect(result.spans[1].span_id).toBe("span-page-2-bb22");
+    // Title is taken from the first page
+    expect(result.title).toBe("Multi-page");
     expect(result.truncated).toBe(false);
     expect(getCapturedUrls()).toHaveLength(2);
     // Second request should include cursor
@@ -318,7 +342,7 @@ describe("getConversationSpans", () => {
   test("returns truncated=true when pagination limit reached", async () => {
     // Create responses that always have more pages
     const responses = Array.from({ length: MAX_PAGINATION_PAGES }, (_, i) => ({
-      body: [makeSpan(`span-${i}-aabb1122`)],
+      body: makeEnvelope([makeSpan(`span-${i}-aabb1122`)]),
       headers: linkHeader("always-more-cursor"),
     }));
 
@@ -331,15 +355,16 @@ describe("getConversationSpans", () => {
   });
 
   test("returns truncated=false when all pages fetched before limit", async () => {
-    mockOk([makeSpan("only-page-span1")]);
+    mockOk(makeEnvelope([makeSpan("only-page-span1")], null));
 
     const result = await getConversationSpans(ORG, CONV_ID);
 
     expect(result.truncated).toBe(false);
+    expect(result.title).toBeNull();
   });
 
   test("uses custom options when provided", async () => {
-    const { getCapturedUrl } = mockOk([]);
+    const { getCapturedUrl } = mockOk(makeEnvelope([]));
 
     await getConversationSpans(ORG, CONV_ID, {
       statsPeriod: "7d",
@@ -354,8 +379,12 @@ describe("getConversationSpans", () => {
   });
 
   test("encodes conversationId in URL", async () => {
-    const { getCapturedUrl } = mockOk([]);
     const specialId = "conv/with special";
+    const { getCapturedUrl } = mockOk({
+      conversationId: specialId,
+      title: null,
+      spans: [],
+    });
 
     await getConversationSpans(ORG, specialId);
 

--- a/packages/cli/test/lib/formatters/conversation.test.ts
+++ b/packages/cli/test/lib/formatters/conversation.test.ts
@@ -204,6 +204,16 @@ describe("buildTranscriptResult", () => {
     expect(result.endTimestamp).toBe(1_716_500_010);
   });
 
+  test("includes title when provided", () => {
+    const result = buildTranscriptResult(
+      "conv-123",
+      "my-org",
+      [makeSpan()],
+      "Refund a duplicate charge"
+    );
+    expect(result.title).toBe("Refund a duplicate charge");
+  });
+
   test("returns zero timestamps for empty spans", () => {
     const result = buildTranscriptResult("conv-123", "my-org", []);
     expect(result.startTimestamp).toBe(0);
@@ -249,6 +259,18 @@ describe("formatTranscriptResult", () => {
     expect(output).toContain("user");
     expect(output).toContain("assistant");
     expect(output).toContain("Turn 1");
+  });
+
+  test("uses title as heading when present", () => {
+    const transcript = buildTranscriptResult(
+      "conv-123",
+      "my-org",
+      [makeSpan()],
+      "Refund a duplicate charge"
+    );
+    const output = formatTranscriptResult(transcript);
+    expect(output).toContain("Refund a duplicate charge");
+    expect(output).not.toContain("AI Conversation: conv-123");
   });
 
   test("shows truncation warning", () => {

--- a/packages/cli/test/lib/formatters/conversation.test.ts
+++ b/packages/cli/test/lib/formatters/conversation.test.ts
@@ -67,17 +67,31 @@ describe("formatConversationTable", () => {
 
   test("renders the full column set on wide terminals", () => {
     setTerminalWidth(200);
-    const items = [makeListItem()];
+    const items = [makeListItem({ title: "Refund a duplicate charge" })];
     const result = formatConversationTable(items);
     // The table shrinks columns to terminal width, so long values may be
     // truncated with "…"; assert on surviving prefixes and the token count.
     expect(result).toContain("conv-");
+    expect(result).toContain("Refund");
     expect(result).toContain("test@");
     expect(result).toContain("Hello");
     expect(result).toContain("500");
     // Wide mode keeps the Tools/Errs/User columns.
     expect(result).toContain("Tools");
     expect(result).toContain("User");
+    expect(result).toContain("Title");
+  });
+
+  test("keeps Title column on narrow terminals", () => {
+    setTerminalWidth(80);
+    const items = [makeListItem({ title: "Refund a duplicate charge" })];
+    const result = formatConversationTable(items);
+    expect(result).toContain("Title");
+    expect(result).toContain("Refund");
+    expect(result).toContain("conv-");
+    // Tools/Errs/User still dropped on narrow terminals.
+    expect(result).not.toContain("Tools");
+    expect(result).not.toContain("User");
   });
 
   test("drops Tools/Errs/User columns on narrow terminals", () => {
@@ -237,6 +251,7 @@ describe("formatTranscriptResult", () => {
     const result: TranscriptResult = {
       conversationId: "conv-123",
       org: "my-org",
+      title: null,
       turns: [],
       totalTokens: 0,
       spanCount: 0,
@@ -247,6 +262,23 @@ describe("formatTranscriptResult", () => {
     const output = formatTranscriptResult(result);
     expect(output).toContain("No spans found");
     expect(output).toContain("conv-123");
+  });
+
+  test("includes title in empty-span message when present", () => {
+    const result: TranscriptResult = {
+      conversationId: "conv-123",
+      org: "my-org",
+      title: "Refund a duplicate charge",
+      turns: [],
+      totalTokens: 0,
+      spanCount: 0,
+      projects: [],
+      startTimestamp: 0,
+      endTimestamp: 0,
+    };
+    const output = formatTranscriptResult(result);
+    expect(output).toContain("conv-123");
+    expect(output).toContain("Refund a duplicate charge");
   });
 
   test("renders transcript header and turns", () => {
@@ -261,7 +293,7 @@ describe("formatTranscriptResult", () => {
     expect(output).toContain("Turn 1");
   });
 
-  test("uses title as heading when present", () => {
+  test("keeps conversation ID in heading and shows title in table", () => {
     const transcript = buildTranscriptResult(
       "conv-123",
       "my-org",
@@ -269,14 +301,15 @@ describe("formatTranscriptResult", () => {
       "Refund a duplicate charge"
     );
     const output = formatTranscriptResult(transcript);
+    expect(output).toContain("AI Conversation: conv-123");
     expect(output).toContain("Refund a duplicate charge");
-    expect(output).not.toContain("AI Conversation: conv-123");
   });
 
   test("shows truncation warning", () => {
     const result: TranscriptResult = {
       conversationId: "conv-123",
       org: "my-org",
+      title: null,
       turns: [],
       totalTokens: 0,
       spanCount: 1,


### PR DESCRIPTION
## Summary

`sentry conversation view` was failing with a Zod validation error after the conversation details API started always returning an envelope object instead of a bare span array ([getsentry/sentry#121143](https://github.com/getsentry/sentry/pull/121143)).

## Problem

```
Error: Unexpected response format from /organizations/sentry/ai-conversations/<id>/
Expected array, received object
```

Reproduction: https://sentry.sentry.io/explore/conversations/project_metadata_summary-317e47d

These endpoints are `PRIVATE` and are not published in `@sentry/api` / sentry-api-schema, so the CLI owns local Zod schemas for them.

## Changes

- Accept the `{ conversationId, title, spans }` details envelope and extract `spans` for transcript building
- Surface `title` in human/JSON transcript output when present
- Update API and formatter tests for the new shape (including a regression that rejects the old bare-array response)

## Testing

- Unit tests: `conversations` API, `conversation view` command, conversation formatters
- Manual: `pnpm run cli -- conversation view sentry/project_metadata_summary-317e47d` (no longer errors); conversation with spans renders title + transcript header


Made with [Cursor](https://cursor.com)