### PR TITLE
fix(skill): Update Explore (`/events/`) datasets

### DIFF
--- a/apps/cli-docs/src/content/docs/agent-guidance.md
+++ b/apps/cli-docs/src/content/docs/agent-guidance.md
@@ -242,7 +242,7 @@ sentry span list my-org/my-project/abc123def456...
 
 ### Dataset names for the Events API
 
-When querying the Events API (directly or via `sentry api`), valid dataset values are: `spans`, `transactions`, `logs`, `errors`, `discover`.
+When querying the Events API (directly or via `sentry api`), valid dataset values are: `spans`, `logs`, `errors`, `tracemetrics`, `profile_functions`, and `uptime_results`.
 
 ## Common Mistakes
 

--- a/apps/cli-docs/src/fragments/commands/api.md
+++ b/apps/cli-docs/src/fragments/commands/api.md
@@ -62,7 +62,7 @@ sentry api organizations/ --dry-run
 
 ### Dataset Names
 
-When querying the Events API (`/events/` endpoint), valid dataset values are: `spans`, `transactions`, `logs`, `errors`, `discover`.
+When querying the Events API (`/events/` endpoint), valid dataset values are: `spans`, `logs`, `errors`, `tracemetrics`, `profile_functions`, and `uptime_results`.
 
 ### Binary responses
 

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -252,7 +252,7 @@ sentry span list my-org/my-project/abc123def456...
 
 #### Dataset names for the Events API
 
-When querying the Events API (directly or via `sentry api`), valid dataset values are: `spans`, `transactions`, `logs`, `errors`, `discover`.
+When querying the Events API (directly or via `sentry api`), valid dataset values are: `spans`, `logs`, `errors`, `tracemetrics`, `profile_functions`, and `uptime_results`.
 
 ### Common Mistakes
 


### PR DESCRIPTION
Removed `discover` and `transactions` as they're deprecated, unadvertised, and due to be removed soon.

Added `tracemetrics`, `profile_functions`, and `uptime_results` as per [the API docs](https://docs.sentry.io/api/explore/query-explore-events-in-table-format/).

See BROWSE-682.