### PR TITLE
fix(proguard): restore leading slash in DIF assemble name

### DIFF
--- a/packages/cli/src/lib/api/proguard.ts
+++ b/packages/cli/src/lib/api/proguard.ts
@@ -162,7 +162,7 @@ export async function uploadProguardMappings(
   const assembleBody: Record<string, { name: string; chunks: string[] }> = {};
   for (const cm of chunkedMappings) {
     assembleBody[cm.overallChecksum] = {
-      name: `proguard/${cm.mapping.uuid}.txt`,
+      name: `/proguard/${cm.mapping.uuid}.txt`,
       chunks: cm.chunks.map((c: ChunkInfo) => c.sha1),
     };
   }

--- a/packages/cli/test/lib/api/proguard.test.ts
+++ b/packages/cli/test/lib/api/proguard.test.ts
@@ -5,8 +5,28 @@
  * ProGuard mappings are chunked as raw bytes (no ZIP wrapping).
  */
 
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { hashBuffer } from "../../../src/lib/api/chunk-upload.js";
+import { apiRequestToRegion } from "../../../src/lib/api/infrastructure.js";
+import { uploadProguardMappings } from "../../../src/lib/api/proguard.js";
+
+vi.mock("../../../src/lib/api/infrastructure.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../../../src/lib/api/infrastructure.js")
+    >();
+  return { ...actual, apiRequestToRegion: vi.fn() };
+});
+vi.mock("../../../src/lib/region.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/lib/region.js")>();
+  return {
+    ...actual,
+    resolveOrgRegion: vi.fn(async () => "https://us.sentry.io"),
+  };
+});
+
+const apiMock = vi.mocked(apiRequestToRegion);
 
 describe("hashBuffer", () => {
   test("single chunk for small content", () => {
@@ -72,5 +92,59 @@ describe("hashBuffer", () => {
 
     expect(chunks).toHaveLength(0);
     expect(overallChecksum).toMatch(/^[0-9a-f]{40}$/);
+  });
+});
+
+describe("uploadProguardMappings", () => {
+  const CHUNK_UPLOAD_OPTIONS = {
+    url: "https://us.sentry.io/api/0/chunk-upload/",
+    chunkSize: 8192,
+    chunksPerRequest: 64,
+    maxRequestSize: 1_048_576,
+    hashAlgorithm: "sha1",
+    concurrency: 8,
+    compression: ["gzip"],
+  };
+
+  beforeEach(() => {
+    apiMock.mockReset();
+  });
+
+  test("assemble request names each mapping with a leading-slash /proguard/ path", async () => {
+    let assembleBody: Record<string, { name: string; chunks: string[] }> = {};
+
+    apiMock.mockImplementation(
+      async (_regionUrl, endpoint, options?: { body?: unknown }) => {
+        if (endpoint.includes("chunk-upload/")) {
+          return { data: CHUNK_UPLOAD_OPTIONS } as never;
+        }
+        // DIF assemble endpoint: report every checksum as already "ok" so the
+        // upload short-circuits without needing to mock chunk uploads too.
+        assembleBody = options?.body as typeof assembleBody;
+        const response: Record<string, { state: string }> = {};
+        for (const checksum of Object.keys(assembleBody)) {
+          response[checksum] = { state: "ok" };
+        }
+        return { data: response } as never;
+      }
+    );
+
+    await uploadProguardMappings({
+      org: "test-org",
+      project: "test-project",
+      mappings: [
+        {
+          path: "mapping.txt",
+          uuid: "5db7294d-87fc-5726-a5c0-4a90679657a5",
+          content: Buffer.from("void\n"),
+        },
+      ],
+    });
+
+    const [entry] = Object.values(assembleBody);
+    // Leading slash required for the server to recognize the DIF as proguard.
+    expect(entry?.name).toBe(
+      "/proguard/5db7294d-87fc-5726-a5c0-4a90679657a5.txt"
+    );
   });
 });


### PR DESCRIPTION
Fixes #1440.

## Summary

`proguard upload` fails server-side assembly for **every** upload, on every version since the
command was added in #1074 — including `main` and the latest release (`0.42.2`). The mapping is
chunked and uploaded fine, but the DIF is never created, so nothing ever symbolicates.

```
Error: ProGuard mapping assembly failed
  Endpoint: projects/<org>/<project>/files/difs/assemble/
  Invalid debug information file: unsupported object file format
```

Every HTTP call up to that point returns `200` — the failure only appears inside the
per-checksum `detail` field of the assemble response body, which makes it easy to misdiagnose
as an auth, org/project, or mapping-file problem.

## Root cause

In `packages/cli/src/lib/api/proguard.ts:165`, `uploadProguardMappings` builds the
`files/difs/assemble/` request body with:

```ts
name: `proguard/${cm.mapping.uuid}.txt`,
```

Legacy `sentry-cli` (Rust) names the same DIF entry with a **leading slash**:

```rust
// src/utils/proguard/mapping.rs
fn name(&self) -> Cow<'_, str> {
    format!("/proguard/{}.txt", self.uuid)
}
```

The leading slash is load-bearing. ProGuard/R8 mappings are plain text with no magic bytes, so
the server identifies them purely by the `/proguard/` prefix in the request `name`
(`sentry/src/sentry/models/debugfile.py`):

```python
_proguard_file_re = re.compile(r"/proguard/(?:mapping-)?(.*?)\.txt$")
```

The full failure path:

1. `tasks/assemble.py` → `detect_single_dif_from_path(temp_file.name, name=name, debug_id=debug_id)`
2. `models/debugfile.py` → `proguard_id = _analyze_progard_filename(path) or _analyze_progard_filename(name)`
   - `name` is `proguard/<uuid>.txt`, which `_proguard_file_re.search()` does not match — no leading slash.
   - `path` is the server's own temp file, so it cannot match either.
   - `proguard_id` is `None`, and ProGuard detection is skipped entirely.
3. Control falls through to generic native-object detection: `Archive.open(path)` on a text
   file raises `SymbolicError`, which becomes
   `raise BadDif("Invalid debug information file: %s" % e)`.
4. `tasks/assemble.py` catches `BadDif` and records
   `set_assemble_status(..., ChunkFileState.ERROR, detail=e.args[0])`.
5. This CLI's `checkAssembleResponse` surfaces that `detail` as the error above.

The expected shape is documented in the server source, in the docstring of
`get_debug_id_from_dif_request` right next to the regex:

> Most DIF uploads provide an explicit `debug_id`. ProGuard mappings instead encode it in the
> request `name` such as `/proguard/mapping-<uuid>.txt`.

Since the `mapping-` prefix is optional in the regex, `/proguard/<uuid>.txt` — exactly what the
legacy CLI sends — is the correct minimal form.

## Fix

Add the leading slash back, matching the legacy protocol byte-for-byte as originally intended
by #1074. No other divergence: the UUID itself is already correct
(`uuidv5(uuidv5(NAMESPACE_DNS, "guardsquare.com"), <raw bytes>)`, verified against the legacy
fixtures).

## Test plan

- Added a regression test in `test/lib/api/proguard.test.ts` (`uploadProguardMappings >
  assemble request names each mapping with a leading-slash /proguard/ path`) that mocks the
  chunk-upload and assemble endpoints and asserts the exact DIF name sent.
- Confirmed the new test fails without the fix (`proguard/<uuid>.txt`) and passes with it
  (`/proguard/<uuid>.txt`).
- `pnpm vitest run test/lib/api/proguard.test.ts test/commands/proguard` — 18/18 passing.
- Reproduced the failure against production Sentry with `sentry proguard upload` on `0.40.0`
  and `0.41.0`. The same mappings, from the same CI pipeline, assembled successfully through
  legacy `sentry-cli` 3.6.2 before it was swapped for this CLI — the assemble `name` is the only
  relevant difference between the two.
