### PR TITLE
feat(init): resolve projects and improve existing setups

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -246,17 +246,14 @@ async function resolveTarget(targetArg: string | undefined): Promise<{
       // the name for a new project to create.
       const { projects, orgs } = await findProjectsBySlug(parsed.projectSlug);
 
-      // Multiple matches — disambiguation error
+      // Multiple cross-org matches are not concrete until an organization is
+      // known. Preserve the requested name and let preflight resolve the org;
+      // within that org an exact match wins, otherwise this is a new project.
       if (projects.length > 1) {
-        const first = projects[0];
-        const orgList = projects
-          .map((p) => `  ${p.orgSlug}/${p.slug}`)
-          .join("\n");
-        throw new ValidationError(
-          `Project "${parsed.projectSlug}" exists in multiple organizations.\n\n` +
-            `Specify the organization:\n${orgList}\n\n` +
-            `Example: sentry init ${first?.orgSlug ?? "<org>"}/${parsed.projectSlug}`
+        log.info(
+          `Project "${parsed.projectSlug}" exists in multiple organizations — the selected organization will determine whether to use it or create it.`
         );
+        return { org: undefined, project: parsed.projectSlug };
       }
 
       // Exactly one match — use it (wizard handles existing-project flow)
@@ -301,6 +298,13 @@ export const initCommand = buildCommand<
       "Supports org/project syntax and a directory positional. Path-like\n" +
       "arguments (starting with . / ~) are treated as the directory;\n" +
       "everything else is treated as the target.\n\n" +
+      "Without an explicit project, an exact DSN, repository, or directory\n" +
+      "match is reused automatically. Otherwise creating a new project is the\n" +
+      "default; selecting from existing projects is a separate choice.\n\n" +
+      "For project creation, interactive runs let you create a new team or use\n" +
+      "a team where you are Team Admin. Non-interactive runs use one eligible\n" +
+      "team automatically; multiple eligible teams require --team. With no\n" +
+      "eligible team, Sentry creates one when your organization allows it.\n\n" +
       "Examples:\n" +
       "  sentry init\n" +
       "  sentry init acme/\n" +

--- a/packages/cli/src/commands/project/create.ts
+++ b/packages/cli/src/commands/project/create.ts
@@ -9,8 +9,9 @@
  * 1. Parse one or more name:platform pairs and extract any org prefix
  * 2. Resolve org → positional prefix > env vars > config defaults > DSN auto-detection
  *    (all names must share one org)
- * 3. For each name: resolve team + create project (fetch DSN, build URL)
- * 4. Display results (one block per project)
+ * 3. Resolve one team for the batch
+ * 4. Create each project under that team (fetch DSN, build URL)
+ * 5. Display results (one block per project)
  *
  * Every project is a `name:platform` pair (e.g. `sentry project create
  * web:javascript api:python-django`). The platform must always be attached
@@ -20,9 +21,6 @@
 
 import type { SentryContext } from "../../context.js";
 import {
-  type CreatedProjectDetails,
-  createProjectWithAutoTeam,
-  createProjectWithDsn,
   listTeams,
   MEMBER_PROJECT_CREATION_DISABLED_DETAIL,
 } from "../../lib/api-client.js";
@@ -42,6 +40,7 @@ import {
   type ProjectCreateOutput,
 } from "../../lib/formatters/human.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
+import { interactivePromptsAllowed } from "../../lib/interactive-prompts.js";
 import { logger } from "../../lib/logger.js";
 import { DRY_RUN_ALIASES, DRY_RUN_FLAG } from "../../lib/mutate-command.js";
 import { renderPlatformGrid } from "../../lib/platform-grid.js";
@@ -50,16 +49,70 @@ import {
   isValidPlatform,
   suggestPlatform,
 } from "../../lib/platforms.js";
+import {
+  createProjectWithTeamFallback,
+  ProjectCreationApiError,
+} from "../../lib/project-creation.js";
 import { resolveOrg } from "../../lib/resolve-target.js";
 import {
   buildOrgNotFoundError,
+  type ChooseProjectTeam,
   type ResolvedConcreteTeam,
   resolveOrCreateTeam,
 } from "../../lib/resolve-team.js";
+import { chooseProjectTeam } from "../../lib/team-choice.js";
 import { slugify } from "../../lib/utils.js";
 
 const log = logger.withTag("project.create");
 const WHITESPACE_RE = /\s/;
+
+class ProjectTeamChoiceCancelledError extends Error {
+  constructor() {
+    super("Project team selection cancelled.");
+    this.name = "ProjectTeamChoiceCancelledError";
+  }
+}
+
+/** Whether this command invocation can safely display a terminal prompt. */
+function canPromptForTeam(context: SentryContext): boolean {
+  return (
+    interactivePromptsAllowed() &&
+    context.stdin.isTTY === true &&
+    context.process.stdout.isTTY === true
+  );
+}
+
+/** Adapt the shared team-choice flow to consola's plain terminal prompts. */
+function createTeamChooser(
+  context: SentryContext
+): ChooseProjectTeam | undefined {
+  if (!canPromptForTeam(context)) {
+    return;
+  }
+
+  return async (teams) =>
+    await chooseProjectTeam(teams, async (options) => {
+      const response = await log.prompt(options.message, {
+        type: "select",
+        options: options.options,
+        initial: options.initialValue,
+        cancel: "null",
+      });
+      if (response === null) {
+        throw new ProjectTeamChoiceCancelledError();
+      }
+      if (typeof response !== "string") {
+        throw new CliError("Team selection returned an invalid response.");
+      }
+      const selected = options.options.find(
+        (option) => option.value === response
+      );
+      if (!selected) {
+        throw new CliError(`Unknown team selection '${response}'.`);
+      }
+      return selected.value;
+    });
+}
 
 /** Full usage hint shown in errors and help text. */
 const USAGE_HINT = "sentry project create [<org>/]<name>:<platform>...";
@@ -204,9 +257,8 @@ async function handleCreateProject404(opts: {
 /**
  * Resolve the team to show in a --dry-run preview.
  *
- * Mirrors the non-dry-run fallback: if resolveOrCreateTeam 403s (member lacks
- * team:read), the real run would use POST /organizations/{org}/projects/ which
- * auto-creates a personal team. Show a placeholder instead of failing.
+ * Mirrors the real resolver without mutating. When the real run would use the
+ * org-scoped endpoint, show a personal-team placeholder.
  */
 async function resolveDryRunTeam(
   orgSlug: string,
@@ -214,27 +266,18 @@ async function resolveDryRunTeam(
     team?: string;
     detectedFrom?: string;
     autoCreateSlug: string;
+    chooseTeam?: ChooseProjectTeam;
   }
 ): Promise<ResolvedConcreteTeam> {
-  try {
-    return await resolveOrCreateTeam(orgSlug, {
-      team: opts.team,
-      detectedFrom: opts.detectedFrom,
-      usageHint: USAGE_HINT,
-      autoCreateSlug: opts.autoCreateSlug,
-      dryRun: true,
-    });
-  } catch (error) {
-    // 403 from listTeams: member lacks team:read. The real run falls back to the
-    // org-scoped endpoint which auto-creates a personal team. Preview that outcome.
-    if (!(error instanceof ApiError && error.status === 403) || opts.team) {
-      throw error;
-    }
-    log.debug(
-      "403 on listTeams in dry-run — previewing org-scoped fallback outcome"
-    );
-    return { slug: "team-<username>", source: "auto-created" };
-  }
+  const team = await resolveOrCreateTeam(orgSlug, {
+    team: opts.team,
+    detectedFrom: opts.detectedFrom,
+    usageHint: USAGE_HINT,
+    autoCreateSlug: opts.autoCreateSlug,
+    dryRun: true,
+    chooseTeam: opts.chooseTeam,
+  });
+  return team ?? { slug: "team-<username>", source: "auto-created" };
 }
 
 /** Inputs shared by both project-creation endpoints. */
@@ -246,63 +289,6 @@ type CreateProjectBaseOpts = {
   /** Validated Sentry platform identifier. */
   platform: string;
 };
-
-/** Inputs required by the team-scoped project-creation endpoint. */
-type CreateProjectOpts = CreateProjectBaseOpts & {
-  /** Team slug that will own the project. */
-  teamSlug: string;
-  /** Source used to resolve the organization, when auto-detected. */
-  detectedFrom?: string;
-};
-
-/**
- * Fallback project creation via POST /organizations/{org}/projects/.
- *
- * Used when the team-scoped flow 403s (member lacks project:write or can't
- * create teams). Returns the created project details plus the team slug the
- * server auto-created. Surfaces a clear policy error if the org has disabled
- * member project creation entirely.
- */
-async function createProjectWithAutoTeamFallback(
-  opts: CreateProjectBaseOpts
-): Promise<
-  CreatedProjectDetails & {
-    teamSlug: string;
-    teamSource: ResolvedConcreteTeam["source"];
-  }
-> {
-  const { orgSlug, name, platform } = opts;
-  let result: Awaited<ReturnType<typeof createProjectWithAutoTeam>>;
-  try {
-    result = await createProjectWithAutoTeam(orgSlug, { name, platform });
-  } catch (error) {
-    if (!(error instanceof ApiError)) {
-      throw error;
-    }
-    if (
-      error.status === 403 &&
-      error.detail?.includes(MEMBER_PROJECT_CREATION_DISABLED_DETAIL)
-    ) {
-      throw new ApiError(
-        `Failed to create project '${name}' in ${orgSlug} (HTTP 403).\n\n` +
-          "Your organization has disabled project creation for members.\n" +
-          "Ask an org owner or manager to enable it in Organization Settings → Member Roles,\n" +
-          "or ask them to create the project and add you to it.",
-        403,
-        error.detail,
-        error.endpoint
-      );
-    }
-    return handleCreateApiError(error, opts);
-  }
-  return {
-    project: result.project,
-    dsn: result.dsn,
-    url: result.url,
-    teamSlug: result.team_slug,
-    teamSource: "auto-created",
-  };
-}
 
 /**
  * A project with this name already exists in the org (HTTP 409). Shared by the
@@ -326,6 +312,20 @@ function handleCreateApiError(
   opts: CreateProjectBaseOpts
 ): never {
   const { orgSlug, name, platform } = opts;
+  if (
+    error.status === 403 &&
+    error.detail?.includes(MEMBER_PROJECT_CREATION_DISABLED_DETAIL)
+  ) {
+    throw new ApiError(
+      `Failed to create project '${name}' in ${orgSlug} (HTTP 403).\n\n` +
+        "Your organization has disabled project creation for members.\n" +
+        "Ask an org owner or manager to enable it in Organization Settings → Member Roles,\n" +
+        "or ask them to create the project and add you to it.",
+      403,
+      error.detail,
+      error.endpoint
+    );
+  }
   if (error.status === 409) {
     throw projectExistsError(orgSlug, name);
   }
@@ -342,27 +342,6 @@ function handleCreateApiError(
     error.detail,
     error.endpoint
   );
-}
-
-/**
- * Create a project (with DSN + URL) with user-friendly error handling.
- * Wraps API errors with actionable messages instead of raw HTTP status codes.
- */
-async function createProjectWithErrors(
-  opts: CreateProjectOpts
-): Promise<CreatedProjectDetails> {
-  const { orgSlug, teamSlug, name, platform } = opts;
-  try {
-    return await createProjectWithDsn(orgSlug, teamSlug, { name, platform });
-  } catch (error) {
-    if (!(error instanceof ApiError)) {
-      throw error;
-    }
-    if (error.status === 404) {
-      return await handleCreateProject404(opts);
-    }
-    return handleCreateApiError(error, opts);
-  }
 }
 
 /** A validated project specification parsed from the command positionals. */
@@ -520,17 +499,24 @@ async function createOneProject(opts: {
    * one team the first project creates — rather than each resolving its own.
    */
   teamAutoCreateSlug?: string;
+  /** Team already fixed by an earlier project in the same batch. */
+  team?: ResolvedConcreteTeam;
+  /** Interactive choice capability, omitted for JSON and non-TTY runs. */
+  chooseTeam?: ChooseProjectTeam;
 }): Promise<ProjectCreatedResult> {
   const { orgSlug, name, platform, flags, detectedFrom } = opts;
   const expectedSlug = slugify(name);
   const autoCreateSlug = opts.teamAutoCreateSlug ?? expectedSlug;
 
   if (flags["dry-run"]) {
-    const team = await resolveDryRunTeam(orgSlug, {
-      team: flags.team,
-      detectedFrom,
-      autoCreateSlug,
-    });
+    const team =
+      opts.team ??
+      (await resolveDryRunTeam(orgSlug, {
+        team: flags.team,
+        detectedFrom,
+        autoCreateSlug,
+        chooseTeam: opts.chooseTeam,
+      }));
     return {
       project: { id: "", slug: expectedSlug, name, platform },
       orgSlug,
@@ -545,51 +531,46 @@ async function createOneProject(opts: {
     };
   }
 
-  let teamSlug: string;
-  let teamSource: ResolvedConcreteTeam["source"];
-  let projectDetails: CreatedProjectDetails;
-
-  try {
-    const team: ResolvedConcreteTeam = await resolveOrCreateTeam(orgSlug, {
+  const team =
+    opts.team ??
+    (await resolveOrCreateTeam(orgSlug, {
       team: flags.team,
       detectedFrom,
       usageHint: USAGE_HINT,
       autoCreateSlug,
-    });
-    teamSlug = team.slug;
-    teamSource = team.source;
-    projectDetails = await createProjectWithErrors({
+      chooseTeam: opts.chooseTeam,
+    }));
+
+  let projectDetails: Awaited<ReturnType<typeof createProjectWithTeamFallback>>;
+  try {
+    projectDetails = await createProjectWithTeamFallback({
       orgSlug,
-      teamSlug,
       name,
       platform,
-      detectedFrom,
+      team,
     });
   } catch (error) {
-    // 403 means the user lacks permission to create or access teams, or to
-    // create projects on the resolved team. Fall back to the org-scoped endpoint
-    // which requires only project:read and auto-creates a personal team.
-    // Skip the fallback when --team was explicit: the 403 is meaningful there.
-    if (!(error instanceof ApiError && error.status === 403) || flags.team) {
+    if (!(error instanceof ApiError)) {
       throw error;
     }
-    // Policy 403: org has disabled member project creation. The org-scoped
-    // endpoint enforces the same flag — re-throw to avoid a wasted round-trip.
-    if (error.detail?.includes(MEMBER_PROJECT_CREATION_DISABLED_DETAIL)) {
-      throw error;
+    if (
+      error instanceof ProjectCreationApiError &&
+      error.status === 404 &&
+      error.route === "team" &&
+      team
+    ) {
+      return await handleCreateProject404({
+        orgSlug,
+        teamSlug: team.slug,
+        name,
+        platform,
+        detectedFrom,
+      });
     }
-    log.debug("403 on team-based flow — falling back to org-scoped endpoint");
-    const fallback = await createProjectWithAutoTeamFallback({
-      orgSlug,
-      name,
-      platform,
-    });
-    teamSlug = fallback.teamSlug;
-    teamSource = fallback.teamSource;
-    projectDetails = fallback;
+    return handleCreateApiError(error, { orgSlug, name, platform });
   }
 
-  const { project, dsn, url } = projectDetails;
+  const { project, dsn, url, teamSlug, teamSource } = projectDetails;
   return {
     project,
     orgSlug,
@@ -614,8 +595,9 @@ export const createCommand = buildCommand({
       "cannot contain whitespace.\n\n" +
       "Every project is a name:platform pair. Create several projects at once\n" +
       "by passing multiple pairs as separate arguments. All projects share one org.\n\n" +
-      "Projects are created under a team. If the org has one team, it is used\n" +
-      "automatically. If no teams exist, one is created. Otherwise, specify --team.\n\n" +
+      "Projects are created under a team. In an interactive terminal, choose to\n" +
+      "create a new team or use a team where you are Team Admin. In non-interactive\n" +
+      "runs, one eligible team is used automatically; multiple teams require --team.\n\n" +
       "Examples:\n" +
       "  sentry project create my-app:node\n" +
       "  sentry project create acme-corp/my-app:javascript-nextjs\n" +
@@ -676,24 +658,35 @@ export const createCommand = buildCommand({
     const teamAutoCreateSlug = parsed
       .map((p) => slugify(p.name))
       .find((slug) => slug !== "");
+    const chooseTeam = flags.json ? undefined : createTeamChooser(this);
 
     // Create sequentially to respect rate limits. Results are emitted as one
     // value so --json stays parseable, including partial success before an error.
     const results: ProjectCreatedResult[] = [];
+    let batchTeam: ResolvedConcreteTeam | undefined;
     try {
       for (const { name, platform } of parsed) {
-        results.push(
-          await createOneProject({
-            orgSlug,
-            name,
-            platform,
-            flags,
-            detectedFrom: resolved.detectedFrom,
-            teamAutoCreateSlug,
-          })
-        );
+        const result = await createOneProject({
+          orgSlug,
+          name,
+          platform,
+          flags,
+          detectedFrom: resolved.detectedFrom,
+          teamAutoCreateSlug,
+          team: batchTeam,
+          chooseTeam,
+        });
+        results.push(result);
+        batchTeam = {
+          slug: result.teamSlug,
+          source: result.teamSource,
+        };
       }
     } catch (error) {
+      if (error instanceof ProjectTeamChoiceCancelledError) {
+        log.info("Cancelled.");
+        return;
+      }
       if (results.length > 0) {
         yield new CommandOutput(
           buildProjectCreateOutput(results, parsed.length)

--- a/packages/cli/src/lib/api/projects.ts
+++ b/packages/cli/src/lib/api/projects.ts
@@ -27,7 +27,7 @@ import {
   setCachedProjectByDsnKey,
 } from "../db/project-cache.js";
 import { getCachedOrganizations } from "../db/regions.js";
-import { type AuthGuardSuccess, withAuthGuard } from "../errors.js";
+import { type AuthGuardSuccess, CliError, withAuthGuard } from "../errors.js";
 import { getApiBaseUrl } from "../sentry-client.js";
 import { buildProjectUrl } from "../sentry-urls.js";
 import { isAllDigits } from "../utils.js";
@@ -307,6 +307,11 @@ export async function createProjectWithAutoTeam(
     result,
     "Failed to create project"
   );
+  if (typeof data.team_slug !== "string" || data.team_slug.trim() === "") {
+    throw new CliError(
+      `Sentry created project '${data.slug}' but did not return its owning team.`
+    );
+  }
   const dsn = await tryGetPrimaryDsn(orgSlug, data.slug);
   const url = buildProjectUrl(orgSlug, data.slug);
 

--- a/packages/cli/src/lib/api/teams.ts
+++ b/packages/cli/src/lib/api/teams.ts
@@ -10,15 +10,14 @@ import {
   listOrganizationTeams,
   listProjectTeams as sdkListProjectTeams,
 } from "@sentry/api";
-// biome-ignore lint/performance/noNamespaceImport: Sentry SDK recommends namespace import
-import * as Sentry from "@sentry/node-core/light";
 
 import type { SentryTeam } from "../../types/index.js";
 
-import { logger } from "../logger.js";
-
 import {
+  API_MAX_PER_PAGE,
+  autoPaginate,
   getOrgSdkConfig,
+  MAX_PAGINATION_PAGES,
   type PaginatedResponse,
   unwrapPaginatedResult,
   unwrapResult,
@@ -26,17 +25,25 @@ import {
 
 /**
  * List teams in an organization.
+ * Automatically paginates through all API pages to return the complete list.
  * Uses region-aware routing for multi-region support.
  */
 export async function listTeams(orgSlug: string): Promise<SentryTeam[]> {
   const config = await getOrgSdkConfig(orgSlug);
 
-  const result = await listOrganizationTeams({
-    ...config,
-    path: { organization_id_or_slug: orgSlug },
-  });
+  const { data: allResults } = await autoPaginate(async (cursor) => {
+    const result = await listOrganizationTeams({
+      ...config,
+      path: { organization_id_or_slug: orgSlug },
+      query: { cursor, per_page: API_MAX_PER_PAGE } as {
+        cursor?: string;
+        per_page?: number;
+      },
+    });
+    return unwrapPaginatedResult<SentryTeam[]>(result, "Failed to list teams");
+  }, MAX_PAGINATION_PAGES * API_MAX_PER_PAGE);
 
-  return unwrapResult<SentryTeam[]>(result, "Failed to list teams");
+  return allResults;
 }
 
 /**
@@ -91,12 +98,8 @@ export async function listProjectTeams(
 }
 
 /**
- * Create a new team in an organization and add the current user as a member.
- *
- * The Sentry API does not automatically add the creator to a new team,
- * so we follow up with an `addMemberToTeam("me")` call. The member-add
- * is best-effort — if it fails (e.g., permissions), the team is still
- * returned successfully.
+ * Create a new team in an organization. The Sentry backend adds the creator's
+ * membership as part of this request.
  *
  * @param orgSlug - The organization slug
  * @param slug - Team slug (also used as display name)
@@ -112,21 +115,7 @@ export async function createTeam(
     path: { organization_id_or_slug: orgSlug },
     body: { slug },
   });
-  const team = unwrapResult<SentryTeam>(result, "Failed to create team");
-
-  // Best-effort: add the current user to the team
-  try {
-    await addMemberToTeam(orgSlug, team.slug, "me");
-  } catch (error) {
-    Sentry.captureException(error, {
-      extra: { orgSlug, teamSlug: team.slug, context: "auto-add member" },
-    });
-    logger.warn(
-      `Team '${team.slug}' was created but you could not be added as a member.`
-    );
-  }
-
-  return team;
+  return unwrapResult<SentryTeam>(result, "Failed to create team");
 }
 
 /**

--- a/packages/cli/src/lib/dsn/code-scanner.ts
+++ b/packages/cli/src/lib/dsn/code-scanner.ts
@@ -45,6 +45,8 @@ const log = logger.withTag("dsn-scan");
  */
 export type CodeScanResult = {
   dsns: DetectedDsn[];
+  /** Every source occurrence, including the same DSN in different files. */
+  occurrences?: DetectedDsn[];
   /**
    * Map of source file paths (POSIX, relative to cwd) → mtime.
    * Only files containing at least one validated DSN. The cache
@@ -266,6 +268,7 @@ function scanDirectory(cwd: string): Promise<CodeScanResult> {
       const sourceMtimes: Record<string, number> = {};
       const dirMtimes: Record<string, number> = {};
       const seen = new Map<string, DetectedDsn>();
+      const occurrences: DetectedDsn[] = [];
       // Dedup set for mtime recording. `grepFiles` emits one match
       // per line, so a file with 3 DSN-containing lines would trigger
       // 3 redundant writes to `sourceMtimes` without this gate.
@@ -291,7 +294,12 @@ function scanDirectory(cwd: string): Promise<CodeScanResult> {
         });
 
         for (const match of matches) {
-          processMatch(match, { seen, sourceMtimes, filesSeenForMtime });
+          processMatch(match, {
+            seen,
+            occurrences,
+            sourceMtimes,
+            filesSeenForMtime,
+          });
         }
 
         span.setAttribute("dsn.files_collected", stats.filesRead);
@@ -300,7 +308,12 @@ function scanDirectory(cwd: string): Promise<CodeScanResult> {
           "dsn.dsns_found": seen.size,
         });
 
-        return { dsns: [...seen.values()], sourceMtimes, dirMtimes };
+        return {
+          dsns: [...seen.values()],
+          occurrences,
+          sourceMtimes,
+          dirMtimes,
+        };
       } catch (error) {
         if (error instanceof ConfigError) {
           throw error;
@@ -322,6 +335,7 @@ function scanDirectory(cwd: string): Promise<CodeScanResult> {
 
 type MatchProcessingContext = {
   seen: Map<string, DetectedDsn>;
+  occurrences: DetectedDsn[];
   sourceMtimes: Record<string, number>;
   filesSeenForMtime: Set<string>;
 };
@@ -355,6 +369,7 @@ function processMatch(
       continue;
     }
     fileHadValidDsn = true;
+    ctx.occurrences.push(detected);
     if (!ctx.seen.has(raw)) {
       ctx.seen.set(raw, detected);
     }

--- a/packages/cli/src/lib/dsn/detector.ts
+++ b/packages/cli/src/lib/dsn/detector.ts
@@ -233,6 +233,26 @@ export async function detectAllDsns(cwd: string): Promise<DsnDetectionResult> {
 }
 
 /**
+ * Detect every DSN source location without collapsing identical URLs.
+ * Init uses these occurrences to map each instrumented workspace package.
+ */
+export async function detectAllDsnOccurrences(
+  cwd: string
+): Promise<DetectedDsn[]> {
+  const { projectRoot } = await findProjectRoot(cwd);
+  const [codeResult, envResult] = await Promise.all([
+    scanCodeForDsns(projectRoot),
+    detectFromAllEnvFiles(projectRoot),
+  ]);
+  const envDsn = detectFromEnv();
+  return [
+    ...(codeResult.occurrences ?? codeResult.dsns),
+    ...envResult.dsns,
+    ...(envDsn ? [envDsn] : []),
+  ];
+}
+
+/**
  * Check if a higher-priority code DSN exists.
  * Used to invalidate low-priority cached DSNs when code is added.
  */

--- a/packages/cli/src/lib/dsn/index.ts
+++ b/packages/cli/src/lib/dsn/index.ts
@@ -31,6 +31,7 @@ export type { CodeScanResult } from "./code-scanner.js";
 export { scanCodeForDsns, scanCodeForFirstDsn } from "./code-scanner.js";
 // Main Detection API
 export {
+  detectAllDsnOccurrences,
   detectAllDsns,
   detectDsn,
   getDsnSourceDescription,

--- a/packages/cli/src/lib/formatters/human.ts
+++ b/packages/cli/src/lib/formatters/human.ts
@@ -1949,7 +1949,7 @@ export type ProjectCreatedResult = {
   /** Team slug the project was assigned to */
   teamSlug: string;
   /** How the team was resolved */
-  teamSource: "explicit" | "auto-selected" | "auto-created";
+  teamSource: "explicit" | "selected" | "auto-selected" | "auto-created";
   /** The platform the user requested via CLI argument (used as fallback display) */
   requestedPlatform: string;
   /** Primary DSN, if fetched successfully */
@@ -1999,8 +1999,8 @@ export function formatProjectCreated(result: ProjectCreatedResult): string {
   if (result.teamSource === "auto-created") {
     lines.push(
       dry
-        ? `> **Note:** Would create team '${escapeMarkdownInline(result.teamSlug)}' (org has no teams).`
-        : `> **Note:** Created team '${escapeMarkdownInline(result.teamSlug)}' (org had no teams).`
+        ? `> **Note:** Would create team '${escapeMarkdownInline(result.teamSlug)}' for this project.`
+        : `> **Note:** Created team '${escapeMarkdownInline(result.teamSlug)}' for this project.`
     );
     lines.push("");
   } else if (result.teamSource === "auto-selected") {

--- a/packages/cli/src/lib/git.ts
+++ b/packages/cli/src/lib/git.ts
@@ -14,6 +14,7 @@
 import { execFileSync } from "node:child_process";
 
 import { ValidationError, validationError } from "./errors.js";
+import { logger } from "./logger.js";
 
 /** `execFileSync` failure shape when git exits non-zero. */
 type ExecFileSyncError = Error & {
@@ -420,6 +421,18 @@ export function inferRepositoryName(
     }
   }
   return;
+}
+
+/**
+ * Return the absolute root of the current git worktree.
+ */
+export function inferRepositoryRoot(cwd?: string): string | undefined {
+  try {
+    return git(["rev-parse", "--show-toplevel"], cwd) || undefined;
+  } catch (error) {
+    logger.debug("Could not infer git repository root", error);
+    return;
+  }
 }
 
 /**

--- a/packages/cli/src/lib/init/existing-project.ts
+++ b/packages/cli/src/lib/init/existing-project.ts
@@ -1,4 +1,8 @@
-import { getProject, tryGetPrimaryDsn } from "../api-client.js";
+import {
+  getProject,
+  resolveOrgDisplayName,
+  tryGetPrimaryDsn,
+} from "../api-client.js";
 import { ApiError } from "../errors.js";
 import { buildProjectUrl } from "../sentry-urls.js";
 import type { ExistingProjectData } from "./types.js";
@@ -16,13 +20,23 @@ export async function tryGetExistingProjectData(
 ): Promise<ExistingProjectData | null> {
   try {
     const project = await getProject(orgSlug, projectSlug);
-    const dsn = await tryGetPrimaryDsn(orgSlug, project.slug);
+    // The shared DSN resolver intentionally keeps cold SaaS lookups fast by
+    // returning numeric IDs. Once init fetches the concrete project, switch to
+    // the canonical organization slug returned by Sentry for display, URLs,
+    // and every subsequent API call.
+    const canonicalOrgSlug = project.organization?.slug ?? orgSlug;
+    const dsn = await tryGetPrimaryDsn(canonicalOrgSlug, project.slug);
     return {
-      orgSlug,
+      orgSlug: canonicalOrgSlug,
+      orgDisplay: resolveOrgDisplayName(
+        canonicalOrgSlug,
+        project.organization?.name
+      ),
       projectSlug: project.slug,
+      projectDisplay: project.name,
       projectId: project.id,
-      dsn: dsn ?? "",
-      url: buildProjectUrl(orgSlug, project.slug),
+      url: buildProjectUrl(canonicalOrgSlug, project.slug),
+      ...(dsn ? { dsn } : {}),
       ...(project.platform ? { platform: project.platform } : {}),
     };
   } catch (error) {

--- a/packages/cli/src/lib/init/interactive.ts
+++ b/packages/cli/src/lib/init/interactive.ts
@@ -19,6 +19,7 @@ import {
 } from "./clack-utils.js";
 import { REQUIRED_FEATURE } from "./constants.js";
 import type {
+  AppEntry,
   ConfirmPayload,
   InteractiveContext,
   InteractivePayload,
@@ -26,6 +27,10 @@ import type {
   SelectPayload,
 } from "./types.js";
 import type { PromptDetail, WizardUI } from "./ui/types.js";
+
+type InteractiveUiOptions = {
+  holdPresentationOnSelect?: boolean;
+};
 
 function prependRequiredFeature(features: string[]): string[] {
   if (features.includes(REQUIRED_FEATURE)) {
@@ -94,11 +99,12 @@ function buildFeatureReviewDetails(features: string[]): PromptDetail[] {
 export async function handleInteractive(
   payload: InteractivePayload,
   options: InteractiveContext,
-  ui: WizardUI
+  ui: WizardUI,
+  uiOptions: InteractiveUiOptions = {}
 ): Promise<Record<string, unknown>> {
   switch (payload.kind) {
     case "select":
-      return await handleSelect(payload, options, ui);
+      return await handleSelect(payload, options, ui, uiOptions);
     case "multi-select":
       return await handleMultiSelect(payload, options, ui);
     case "confirm":
@@ -111,28 +117,88 @@ export async function handleInteractive(
   }
 }
 
-type AppEntry = { name: string; path: string; framework?: string };
+const APP_ROLE_LABELS: Record<NonNullable<AppEntry["role"]>, string> = {
+  application: "Application",
+  documentation: "Documentation website",
+  example: "Reference application",
+  runtime: "Runtime package",
+};
+
+function canAutoSelectSentrySetup(app: AppEntry): boolean {
+  return app.sentrySetup === "auto-select";
+}
+
+function autoSelectTarget(
+  items: string[],
+  apps: AppEntry[],
+  yes: boolean
+): Record<string, unknown> | undefined {
+  if (!yes) {
+    return;
+  }
+  if (items.length === 1) {
+    const onlyApp = apps.find((app) => app.name === items[0]);
+    if (
+      onlyApp?.sentrySetup === "detected" &&
+      !canAutoSelectSentrySetup(onlyApp)
+    ) {
+      return;
+    }
+    return { selectedApp: items[0] };
+  }
+  const detectedTargets = apps.filter(canAutoSelectSentrySetup);
+  if (detectedTargets.length !== 1) {
+    return;
+  }
+  const selectedApp = detectedTargets[0]?.name;
+  if (!selectedApp) {
+    return;
+  }
+  return { selectedApp };
+}
 
 function formatAppList(apps: AppEntry[], items: string[]): string[] {
   // Name-based lookup keeps this correct even when payload.options and
   // payload.apps arrive with different lengths.
-  const nameWidth = Math.max(1, ...items.map((n) => n.length));
+  const labels = items.map(
+    (name) => apps.find((app) => app.name === name)?.label ?? name
+  );
+  const nameWidth = Math.max(1, ...labels.map((label) => label.length));
   return items.map((name) => {
     const meta = apps.find((a) => a.name === name);
-    const fw = meta?.framework ? ` (${meta.framework})` : "";
+    const label = meta?.label ?? name;
+    const hint = meta ? appHint(meta) : "";
+    const formattedHint = hint ? ` (${hint})` : "";
     const path = meta?.path ? `  ${meta.path}` : "";
-    return `  ${name.padEnd(nameWidth)}${fw}${path}`;
+    return `  ${label.padEnd(nameWidth)}${formattedHint}${path}`;
   });
+}
+
+function appHint(app: AppEntry): string {
+  const parts: string[] = [];
+  if (app.role) {
+    parts.push(APP_ROLE_LABELS[app.role]);
+  }
+  if (app.framework) {
+    parts.push(app.framework);
+  }
+  if (
+    app.sentrySetup &&
+    !parts.some((part) => part.toLowerCase().includes("sentry detected"))
+  ) {
+    parts.push("Sentry detected");
+  }
+  return parts.join(" · ");
 }
 
 function buildMultiAppMessage(apps: AppEntry[], items: string[]): string {
   const exampleApp = items[0] ?? "<app>";
   return [
-    `This monorepo has ${items.length} apps. Use --app to specify which one to initialize:`,
+    `This monorepo has ${items.length} targets. Use --app to specify which one to initialize:`,
     "",
     `  sentry init --yes --features <features> --app ${exampleApp}`,
     "",
-    "Available apps:",
+    "Available targets:",
     ...formatAppList(apps, items),
     "",
     "Or run without --yes to pick interactively:",
@@ -149,7 +215,7 @@ function buildAppNotFoundMessage(
   return [
     `App "${requested}" not found in this monorepo.`,
     "",
-    "Available apps:",
+    "Available targets:",
     ...formatAppList(apps, items),
     "",
     "Re-run with --app <name>, for example:",
@@ -160,7 +226,8 @@ function buildAppNotFoundMessage(
 async function handleSelect(
   payload: SelectPayload,
   options: InteractiveContext,
-  ui: WizardUI
+  ui: WizardUI,
+  uiOptions: InteractiveUiOptions
 ): Promise<Record<string, unknown>> {
   const apps = payload.apps ?? [];
   const items = payload.options ?? apps.map((a) => a.name);
@@ -172,21 +239,21 @@ async function handleSelect(
   }
 
   if (options.app && payload.apps && payload.apps.length > 0) {
-    const match = items.find(
-      (item) => item.toLowerCase() === options.app?.toLowerCase()
+    const match = apps.find(
+      (app) => app.name.toLowerCase() === options.app?.toLowerCase()
     );
     if (!match) {
       const message = buildAppNotFoundMessage(options.app, apps, items);
       ui.log.error(message);
       throw new WizardError(message, { rendered: true });
     }
-    ui.log.info(`Using app: ${match}`);
-    return { selectedApp: match };
+    ui.log.info(`Using app: ${match.label ?? match.name}`);
+    return { selectedApp: match.name };
   }
 
-  if (options.yes && items.length === 1) {
-    ui.log.info(`Auto-selected: ${items[0]}`);
-    return { selectedApp: items[0] };
+  const autoSelected = autoSelectTarget(items, apps, options.yes);
+  if (autoSelected) {
+    return autoSelected;
   }
 
   if (options.yes && payload.apps && payload.apps.length > 0) {
@@ -201,10 +268,13 @@ async function handleSelect(
       const app = apps.find((a) => a.name === item);
       return {
         value: item,
-        label: item,
-        ...(app?.framework ? { hint: app.framework } : {}),
+        label: app?.label ?? item,
+        ...(app && appHint(app) ? { hint: appHint(app) } : {}),
       };
     }),
+    ...(uiOptions.holdPresentationOnSelect
+      ? { holdPresentationOnResolve: true }
+      : {}),
   });
 
   return { selectedApp: abortIfCancelled(selected) };
@@ -220,18 +290,28 @@ async function handleMultiSelect(
       (feature) => !UNSUPPORTED_INIT_FEATURES.has(feature)
     )
   );
+  const detectedExisting = (payload.initialFeatures ?? []).filter((feature) =>
+    available.includes(feature)
+  );
 
   if (options.yes) {
-    ui.log.info(
-      `Auto-selected all features: ${available.map(featureLabel).join(", ")}`
+    const defaults = normalizeFeatureSelection(
+      available.filter(
+        (feature) =>
+          DEFAULT_FEATURES.has(feature) || detectedExisting.includes(feature)
+      )
     );
-    return { features: available };
+    ui.log.info(
+      `Auto-selected default features: ${defaults.map(featureLabel).join(", ")}`
+    );
+    return { features: defaults };
   }
 
   const sorted = sortFeatureOptions(available);
   setTag("wizard.features.offered", available.join(","));
-  let initialValues: string[] = sorted.filter((feature) =>
-    DEFAULT_FEATURES.has(feature)
+  let initialValues: string[] = sorted.filter(
+    (feature) =>
+      DEFAULT_FEATURES.has(feature) || detectedExisting.includes(feature)
   );
 
   while (true) {

--- a/packages/cli/src/lib/init/preflight.ts
+++ b/packages/cli/src/lib/init/preflight.ts
@@ -1,18 +1,20 @@
-import type { SentryTeam } from "../../types/index.js";
-import {
-  getOrganization,
-  listOrganizations,
-  listTeams,
-} from "../api-client.js";
+import type { SentryProject } from "../../types/index.js";
+import { listOrganizations, listProjects } from "../api-client.js";
 import { getAuthToken } from "../db/auth.js";
+import { parseDsn } from "../dsn/index.js";
 import { ApiError, AuthError, HostScopeError, WizardError } from "../errors.js";
-import { buildOrgNotFoundError, resolveOrCreateTeam } from "../resolve-team.js";
+import { logger } from "../logger.js";
+import { resolveAllTargets } from "../resolve-target.js";
 import { captureOAuthScopeRecoveryGate } from "../scope-recovery.js";
+import { getSentryBaseUrl, isSentrySaasUrl } from "../sentry-urls.js";
 import { slugify } from "../utils.js";
 import { WizardCancelledError } from "./clack-utils.js";
 import { tryGetExistingProjectData } from "./existing-project.js";
 import { resolveOrgPrefetched } from "./org-prefetch.js";
-import { formatMemberProjectCreationDisabledError } from "./project-creation-errors.js";
+import {
+  detectSentrySetup,
+  type ExistingSentryDetection,
+} from "./tools/detect-sentry.js";
 import type {
   ExistingProjectData,
   ResolvedInitContext,
@@ -21,51 +23,60 @@ import type {
 import { isCancelled, type WizardUI } from "./ui/types.js";
 
 const NUMERIC_ORG_ID_RE = /^\d+$/;
+const log = logger.withTag("init-preflight");
 
-type ExistingProjectChoice = {
-  project?: string;
-  existingProject?: ExistingProjectData;
-  shouldAbort?: boolean;
-};
-
-type InitContextSeed = {
-  org?: string;
-  project?: string;
-  existingProject?: ExistingProjectData;
+type CanonicalProjectCandidate = {
+  org: string;
+  project: string;
+  detectedDsn?: string;
 };
 
 type ProjectSelection = Pick<
   ResolvedInitContext,
-  "project" | "existingProject"
->;
+  "project" | "existingProject" | "setupIntent"
+> & {
+  /** Canonical slug discovered while resolving a numeric DSN target. */
+  org?: string;
+};
+
+function markExistingSetupForImprovement(
+  selection: ProjectSelection,
+  setup: ExistingSentryDetection
+): ProjectSelection {
+  return setup.status === "none"
+    ? selection
+    : { ...selection, setupIntent: "improve-existing" };
+}
 
 /**
- * Resolve org, project, team, and auth state before the init workflow starts.
+ * Resolve organization and authentication before the remote workflow starts.
+ * Project resolution is deliberately deferred until the workflow has selected
+ * the concrete app in a monorepo.
  */
 export async function resolveInitContext(
   initial: WizardOptions,
   ui: WizardUI
 ): Promise<ResolvedInitContext | null> {
   return await withPreflightHandling(ui, async () => {
-    const seed = await resolveInitContextSeed(initial, ui);
-    if (!seed) {
-      return null;
-    }
+    const codebaseCandidates = initial.org
+      ? []
+      : await resolveCanonicalProjects(initial.directory);
+    const candidateOrgs = [
+      ...new Set(codebaseCandidates.map((candidate) => candidate.org)),
+    ];
+    const inferredOrg =
+      candidateOrgs.length === 1 ? candidateOrgs[0] : undefined;
+    const preferredOrg =
+      initial.org ??
+      inferredOrg ??
+      (await resolvePreferredOrg(initial.directory));
+    const org = await ensureOrg(preferredOrg, initial, ui);
 
-    const org = await ensureOrg(seed.org, initial, ui);
-    const projectSelection = await resolveProjectSelection(
-      org,
-      initial,
-      seed,
-      ui
-    );
-    if (!projectSelection) {
-      return null;
-    }
+    const team = initial.team
+      ? ({ slug: initial.team, source: "explicit" } as const)
+      : undefined;
 
-    const team = await resolveTeam(org, initial, ui);
-
-    return buildResolvedInitContext(initial, org, team, projectSelection);
+    return buildResolvedInitContext(initial, org, team);
   });
 }
 
@@ -103,8 +114,7 @@ async function withPreflightHandling(
 function buildResolvedInitContext(
   initial: WizardOptions,
   org: string,
-  team: string | undefined,
-  selection: ProjectSelection
+  team: ResolvedInitContext["team"]
 ): ResolvedInitContext {
   return {
     directory: initial.directory,
@@ -113,28 +123,18 @@ function buildResolvedInitContext(
     features: initial.features,
     org,
     team,
-    isExplicitTeam: Boolean(initial.team),
-    project: selection.project,
+    project: initial.project,
     app: initial.app,
     authToken: getAuthToken(),
-    existingProject: selection.existingProject,
   };
 }
 
-async function resolveInitContextSeed(
-  initial: WizardOptions,
-  ui: WizardUI
-): Promise<InitContextSeed | null> {
-  const detected = await resolveDetectedProject(initial, ui);
-  if (detected?.shouldAbort) {
-    return null;
-  }
-
-  return {
-    org: detected?.org ?? initial.org,
-    project: detected?.project ?? initial.project,
-    existingProject: detected?.existingProject,
-  };
+/** Resolve organization-only context before project inference. */
+async function resolvePreferredOrg(cwd: string): Promise<string | undefined> {
+  const resolved = await resolveOrgPrefetched(cwd);
+  return resolved && !NUMERIC_ORG_ID_RE.test(resolved.org)
+    ? resolved.org
+    : undefined;
 }
 
 async function ensureOrg(
@@ -154,342 +154,454 @@ async function ensureOrg(
   throw new WizardError(orgResult.error ?? "Failed to resolve organization.");
 }
 
-async function resolveProjectSelection(
-  org: string,
-  initial: WizardOptions,
-  seed: InitContextSeed,
-  ui: WizardUI
-): Promise<ProjectSelection | null> {
-  if (!seed.project) {
-    return {
-      project: seed.project,
-      existingProject: seed.existingProject,
-    };
+/**
+ * Resolve the Sentry project only after the workflow has selected its concrete
+ * project directory. This lets monorepos use app-local DSNs, package files,
+ * repository signals, and cwd inference instead of the workspace root.
+ */
+export async function resolveInitProjectContext(
+  context: ResolvedInitContext,
+  cwd: string,
+  ui: WizardUI,
+  options: {
+    setup?: ExistingSentryDetection;
+    suggestedProjectName?: string;
+    supportsExistingSetupImprovement?: boolean;
+  } = {}
+): Promise<ProjectSelection> {
+  const setup = options.setup ?? (await detectSentrySetup(cwd));
+
+  if (context.project) {
+    return await resolveExplicitProjectSelection(context, cwd, setup, options);
   }
 
-  const resolved = await resolveExistingProjectChoice({
-    org,
-    project: seed.project,
-    existingProject: seed.existingProject,
-    yes: initial.yes,
-    promptOnExisting: Boolean(initial.project && !initial.org),
+  const canonicalSelection = await resolveCanonicalProjectSelection({
+    context,
+    cwd,
+    options,
+    setup,
     ui,
   });
-  if (resolved.shouldAbort) {
-    return null;
+  if (canonicalSelection) {
+    return canonicalSelection;
   }
 
-  return mergeProjectSelection(seed, resolved);
+  return await resolveImplicitProjectSelection(context.org, context.yes, ui);
 }
 
-function mergeProjectSelection(
-  seed: InitContextSeed,
-  resolved: ExistingProjectChoice
-): ProjectSelection {
-  const project = "project" in resolved ? resolved.project : seed.project;
-  const clearedProject =
-    "project" in resolved && resolved.project === undefined;
-
-  return {
-    project,
-    existingProject: clearedProject
-      ? undefined
-      : (resolved.existingProject ?? seed.existingProject),
-  };
-}
-
-async function resolveDetectedProject(
-  initial: WizardOptions,
-  ui: WizardUI
-): Promise<{
-  org?: string;
-  project?: string;
-  existingProject?: ExistingProjectData;
-  shouldAbort?: boolean;
-} | null> {
-  if (initial.org || initial.project) {
-    return null;
-  }
-
-  let detectedProject: { orgSlug: string; projectSlug: string } | null = null;
-  // biome-ignore lint/plugin: grandfathered silent catch — see #1531; drain by adding log.debug()/log.warn() or re-throwing.
-  try {
-    detectedProject = await detectExistingProject(initial.directory);
-  } catch {
-    return null;
-  }
-  if (!detectedProject) {
-    return null;
-  }
-
-  const existingProject = await tryGetExistingProjectData(
-    detectedProject.orgSlug,
-    detectedProject.projectSlug
-  ).catch(() => null);
-
-  if (initial.yes) {
-    return {
-      org: detectedProject.orgSlug,
-      project: detectedProject.projectSlug,
-      ...(existingProject ? { existingProject } : {}),
-    };
-  }
-
-  const choice = await ui.select<"existing" | "create">({
-    message: "Found an existing Sentry project in this codebase.",
-    options: [
-      {
-        value: "existing",
-        label: `Use existing project (${detectedProject.orgSlug}/${detectedProject.projectSlug})`,
-        hint: "Sentry is already configured here",
-      },
-      {
-        value: "create",
-        label: "Create a new Sentry project",
-      },
-    ],
+async function resolveExplicitProjectSelection(
+  context: ResolvedInitContext,
+  cwd: string,
+  setup: ExistingSentryDetection,
+  options: { supportsExistingSetupImprovement?: boolean }
+): Promise<ProjectSelection> {
+  const explicit = await resolveExistingProjectChoice({
+    org: context.org,
+    project: context.project ?? "",
+    detectedDsn: setup.dsn,
   });
-  if (isCancelled(choice)) {
-    throw new WizardCancelledError();
+  if (!explicit.existingProject || setup.status === "none") {
+    return explicit;
   }
-  if (choice === "existing") {
-    return {
-      org: detectedProject.orgSlug,
-      project: detectedProject.projectSlug,
-      ...(existingProject ? { existingProject } : {}),
-    };
+  const matchesDetectedSetup = setup.dsn
+    ? detectedSetupMatchesProject(setup, explicit.existingProject)
+    : await canonicalProjectMatches(
+        cwd,
+        explicit.existingProject.orgSlug,
+        explicit.existingProject.projectSlug
+      );
+  if (!matchesDetectedSetup) {
+    return explicit;
+  }
+  assertImprovementSupported(setup, options);
+  return markExistingSetupForImprovement(explicit, setup);
+}
+
+async function resolveCanonicalProjectSelection({
+  context,
+  cwd,
+  options,
+  setup,
+  ui,
+}: {
+  context: ResolvedInitContext;
+  cwd: string;
+  options: {
+    suggestedProjectName?: string;
+    supportsExistingSetupImprovement?: boolean;
+  };
+  setup: ExistingSentryDetection;
+  ui: WizardUI;
+}): Promise<ProjectSelection | undefined> {
+  const candidates = await resolveCanonicalProjects(cwd, context.org);
+  const candidate = candidates.length === 1 ? candidates[0] : undefined;
+  if (!candidate) {
+    return;
+  }
+  const detected = await resolveExistingProjectChoice(candidate);
+  if (!detected.existingProject) {
+    return;
+  }
+  if (
+    setup.status !== "none" &&
+    setup.dsn &&
+    !detectedSetupMatchesProject(setup, detected.existingProject)
+  ) {
+    return await resolveImplicitProjectSelection(context.org, context.yes, ui, {
+      avoidProjectSlug: detected.existingProject.projectSlug,
+      suggestedProjectName: options.suggestedProjectName,
+    });
+  }
+  if (setup.status !== "none" && !(context.yes || context.dryRun)) {
+    return await resolveDetectedSetupChoice(
+      {
+        context,
+        detected,
+        setup,
+        suggestedProjectName: options.suggestedProjectName,
+        supportsExistingSetupImprovement:
+          options.supportsExistingSetupImprovement,
+      },
+      ui
+    );
+  }
+  assertImprovementSupported(setup, options);
+  return markExistingSetupForImprovement(detected, setup);
+}
+
+function detectedSetupMatchesProject(
+  setup: ExistingSentryDetection,
+  project: ExistingProjectData
+): boolean {
+  if (setup.status === "none" || !setup.dsn) {
+    return false;
+  }
+  const parsed = parseDsn(setup.dsn);
+  if (!parsed || parsed.projectId !== project.projectId) {
+    return false;
+  }
+  const configuredOrigin = getSentryBaseUrl();
+  if (isSentrySaasUrl(configuredOrigin)) {
+    return parsed.orgId !== undefined;
+  }
+  return parsed.host === new URL(configuredOrigin).host;
+}
+
+async function canonicalProjectMatches(
+  cwd: string,
+  org: string,
+  project: string
+): Promise<boolean> {
+  const candidates = await resolveCanonicalProjects(cwd, org);
+  return (
+    candidates.length === 1 &&
+    candidates[0]?.org === org &&
+    candidates[0]?.project === project
+  );
+}
+
+function assertImprovementSupported(
+  setup: ExistingSentryDetection,
+  options: { supportsExistingSetupImprovement?: boolean }
+): void {
+  if (
+    setup.status !== "none" &&
+    options.supportsExistingSetupImprovement !== true
+  ) {
+    throw new WizardError(
+      "This setup service version cannot safely improve an existing Sentry setup. Deploy or update the setup service before using this CLI version.",
+      { rendered: false }
+    );
+  }
+}
+
+async function resolveCanonicalProjects(
+  cwd: string,
+  organizationFilter?: string
+): Promise<CanonicalProjectCandidate[]> {
+  // Auto-resolution is best-effort: only exact local evidence is safe enough to
+  // reuse implicitly, and self-hosted targets belong to a different API origin.
+  let resolved: Awaited<ReturnType<typeof resolveAllTargets>>;
+  try {
+    resolved = await resolveAllTargets({
+      cwd,
+      resolutionMode: "codebase",
+      ...(organizationFilter ? { organizationFilter } : {}),
+    });
+  } catch (error) {
+    log.debug("Could not auto-resolve an init project", error);
+    return [];
   }
 
-  return {};
+  if (resolved.skippedSelfHosted) {
+    return [];
+  }
+
+  return resolved.targets
+    .filter((target) => target.matchStrength !== "fuzzy")
+    .map((target) => ({
+      org: target.org,
+      project: target.project,
+      ...(target.detectedDsn ? { detectedDsn: target.detectedDsn.raw } : {}),
+    }));
 }
 
 async function resolveExistingProjectChoice(opts: {
   org: string;
   project: string;
-  existingProject?: ExistingProjectData;
-  yes: boolean;
-  promptOnExisting: boolean;
-  ui: WizardUI;
-}): Promise<ExistingProjectChoice> {
+  detectedDsn?: string;
+}): Promise<ProjectSelection> {
   const slug = slugify(opts.project);
   if (!slug) {
     return { project: opts.project };
   }
 
-  const existingProject =
-    opts.existingProject &&
-    opts.existingProject.orgSlug === opts.org &&
-    opts.existingProject.projectSlug === slug
-      ? opts.existingProject
-      : await tryGetExistingProjectData(opts.org, slug).catch(() => null);
+  const existingProject = await tryGetExistingProjectData(opts.org, slug);
   if (!existingProject) {
     return { project: opts.project };
   }
 
-  if (!opts.promptOnExisting || opts.yes) {
-    return {
-      project: existingProject.projectSlug,
-      existingProject,
-    };
-  }
+  const matchingDetectedDsn =
+    opts.detectedDsn &&
+    parseDsn(opts.detectedDsn)?.projectId === existingProject.projectId
+      ? opts.detectedDsn
+      : undefined;
+  const resolvedDsn = existingProject.dsn ?? matchingDetectedDsn;
 
-  const choice = await opts.ui.select<"existing" | "create">({
-    message: `Found existing project '${slug}' in ${opts.org}.`,
+  return {
+    org: existingProject.orgSlug,
+    project: existingProject.projectSlug,
+    existingProject: {
+      ...existingProject,
+      ...(resolvedDsn ? { dsn: resolvedDsn } : {}),
+    },
+  };
+}
+
+async function resolveDetectedSetupChoice(
+  options: {
+    context: ResolvedInitContext;
+    detected: ProjectSelection;
+    setup: ExistingSentryDetection;
+    suggestedProjectName?: string;
+    supportsExistingSetupImprovement?: boolean;
+  },
+  ui: WizardUI
+): Promise<ProjectSelection> {
+  const {
+    context,
+    detected,
+    setup,
+    suggestedProjectName,
+    supportsExistingSetupImprovement,
+  } = options;
+  if (supportsExistingSetupImprovement === false) {
+    ui.log.warn(
+      "The current setup service cannot safely improve this existing Sentry setup. Choose another project or create a new one."
+    );
+    return await resolveImplicitProjectSelection(context.org, false, ui, {
+      avoidProjectSlug:
+        detected.existingProject?.projectSlug ?? detected.project,
+      suggestedProjectName,
+    });
+  }
+  const project = detected.existingProject;
+  const setupContext = project
+    ? `Sentry detected for project ${project.projectDisplay ?? project.projectSlug} in organization ${project.orgDisplay ?? project.orgSlug}. What would you like to do?`
+    : "What would you like to do with this Sentry setup?";
+  const intent = await ui.select<"improve" | "other">({
+    message: setupContext,
     options: [
       {
-        value: "existing",
-        label: `Use existing (${opts.org}/${slug})`,
-        hint: "Already configured",
+        value: "improve",
+        label: "Improve your Sentry setup",
+        description: "Upgrade your current setup and add more Sentry features.",
       },
       {
+        value: "other",
+        label: "Use or create another Sentry project",
+        description: "Use another project or create a new one.",
+      },
+    ],
+    initialValue: "improve",
+  });
+  if (isCancelled(intent)) {
+    throw new WizardCancelledError();
+  }
+  if (intent === "improve") {
+    assertImprovementSupported(setup, { supportsExistingSetupImprovement });
+    return { ...detected, setupIntent: "improve-existing" };
+  }
+  return await resolveImplicitProjectSelection(context.org, false, ui, {
+    avoidProjectSlug: detected.existingProject?.projectSlug ?? detected.project,
+    suggestedProjectName,
+  });
+}
+
+/**
+ * Resolve new-project creation versus an existing project after the shared
+ * resolver found no unique target. Creation is the default and selecting an
+ * existing project is a separate, deliberate action.
+ */
+async function resolveImplicitProjectSelection(
+  org: string,
+  yes: boolean,
+  ui: WizardUI,
+  options: {
+    avoidProjectSlug?: string;
+    suggestedProjectName?: string;
+  } = {}
+): Promise<ProjectSelection> {
+  if (yes) {
+    return options.avoidProjectSlug
+      ? await resolveAlternativeProjectSelection(
+          org,
+          options.avoidProjectSlug,
+          options.suggestedProjectName
+        )
+      : { project: undefined, existingProject: undefined };
+  }
+
+  const intent = await ui.select<"create" | "existing">({
+    message: "How should Sentry be configured for this codebase?",
+    options: [
+      {
         value: "create",
-        label: "Create a new project",
-        hint: "Wizard will detect the project name from your codebase",
+        label: "+ Create a new Sentry project",
+      },
+      {
+        value: "existing",
+        label: "Use an existing Sentry project",
       },
     ],
   });
-  if (isCancelled(choice)) {
+  if (isCancelled(intent)) {
     throw new WizardCancelledError();
   }
-  if (choice === "create") {
-    return { project: undefined };
+  if (intent === "create") {
+    if (options.avoidProjectSlug) {
+      const selection = await resolveAlternativeProjectSelection(
+        org,
+        options.avoidProjectSlug,
+        options.suggestedProjectName
+      );
+      const { project } = selection;
+      ui.log.info(`New project ${project} in organization ${org}`);
+      return selection;
+    }
+    return { project: undefined, existingProject: undefined };
   }
 
+  return await resolveExistingProjectSelection(
+    org,
+    ui,
+    options.avoidProjectSlug
+  );
+}
+
+async function resolveExistingProjectSelection(
+  org: string,
+  ui: WizardUI,
+  avoidProjectSlug?: string
+): Promise<ProjectSelection> {
+  let projects: SentryProject[];
+  try {
+    projects = await listProjects(org);
+  } catch (error) {
+    const reason = error instanceof ApiError ? error.format() : String(error);
+    throw new WizardError(
+      `Could not list existing projects in '${org}'.\n\n${reason}`
+    );
+  }
+  if (avoidProjectSlug) {
+    const avoided = slugify(avoidProjectSlug);
+    projects = projects.filter((project) => project.slug !== avoided);
+  }
+  if (projects.length === 0) {
+    throw new WizardError(
+      `There are no${avoidProjectSlug ? " other" : ""} existing projects in '${org}'. Choose "+ Create a new Sentry project" instead.`
+    );
+  }
+
+  const projectSlug = await ui.select<string>({
+    message: "Which existing Sentry project should be used?",
+    options: projects.map((project) => ({
+      value: project.slug,
+      label: project.name,
+      ...(project.name !== project.slug ? { hint: project.slug } : {}),
+    })),
+  });
+  if (isCancelled(projectSlug)) {
+    throw new WizardCancelledError();
+  }
+
+  const existingProject = await loadExistingProject(
+    org,
+    projectSlug,
+    "your project selection"
+  );
+  if (!existingProject) {
+    throw new WizardError(
+      `Project '${org}/${projectSlug}' is no longer available. Run sentry init again to refresh the project list.`
+    );
+  }
   return {
+    org: existingProject.orgSlug,
     project: existingProject.projectSlug,
     existingProject,
   };
 }
 
-/**
- * Normalize a team-resolution failure into a WizardError, preserving an
- * ApiError's enriched detail (e.g. 401 `member-disabled-over-limit`) via
- * format() instead of collapsing to its bare message + status line.
- */
-function toPreflightWizardError(error: unknown): WizardError {
-  if (error instanceof AuthError || error instanceof HostScopeError) {
-    throw error;
-  }
-  if (error instanceof WizardError) {
-    return error;
-  }
-  if (error instanceof ApiError) {
-    return new WizardError(error.format());
-  }
-  return new WizardError(
-    error instanceof Error ? error.message : String(error)
-  );
-}
-
-async function resolveTeam(
+async function resolveAlternativeProjectSelection(
   org: string,
-  initial: WizardOptions,
-  ui: WizardUI
-): Promise<string | undefined> {
-  if (!initial.team) {
-    return await resolveImplicitTeam(org, initial, ui);
-  }
-
-  const scopeRecovery = captureOAuthScopeRecoveryGate();
-  try {
-    const result = await resolveOrCreateTeam(org, {
-      team: initial.team,
-      usageHint: "sentry init",
-      dryRun: initial.dryRun,
-      deferAutoCreateOnEmptyOrg: true,
-    });
-    return result.source === "deferred" ? undefined : result.slug;
-  } catch (error) {
-    if (error instanceof WizardCancelledError) {
-      throw error;
-    }
-    if (
-      error instanceof ApiError &&
-      (error.status === 401 || error.status === 403) &&
-      (await scopeRecovery.shouldDelegate(error, {
-        unattended: initial.yes || initial.dryRun,
-      }))
-    ) {
-      throw error;
-    }
-    if (error instanceof ApiError && error.status === 403) {
-      return;
-    }
-    throw toPreflightWizardError(error);
-  }
-}
-
-function canCreateProjectInTeam(team: SentryTeam): boolean {
-  return Array.isArray(team.access) && team.access.includes("team:admin");
-}
-
-/**
- * Whether the user's access scopes indicate they can create projects
- * regardless of the org's `allowMemberProjectCreation` flag.
- *
- * Sentry's role hierarchy (from server.py SENTRY_ROLES):
- * - member:  project:read only — blocked when flag is disabled
- * - admin:   project:write, project:admin, team:admin — CAN create projects
- * - manager: org:write, project:admin, is_global — CAN create projects
- * - owner:   org:write, org:admin, is_global — CAN create projects
- *
- * The previous check only looked for `org:write`, which excluded org admins
- * who have `project:write` / `project:admin` but not `org:write`.
- */
-function canBypassMemberCreationRestriction(access: unknown): boolean {
-  if (!Array.isArray(access)) {
-    return false;
-  }
-  return (
-    access.includes("org:write") ||
-    access.includes("project:admin") ||
-    access.includes("project:write")
-  );
-}
-
-async function assertOrgScopedCreationCanProceed(org: string): Promise<void> {
-  let organization: Awaited<ReturnType<typeof getOrganization>>;
-  // biome-ignore lint/plugin: grandfathered silent catch — see #1531; drain by adding log.debug()/log.warn() or re-throwing.
-  try {
-    organization = await getOrganization(org);
-  } catch {
-    // If org details cannot be fetched, let the actual create endpoint surface
-    // the precise API error during the project-creation step.
-    return;
-  }
-
-  if (
-    organization.allowMemberProjectCreation === false &&
-    !canBypassMemberCreationRestriction(organization.access)
-  ) {
-    throw new WizardError(formatMemberProjectCreationDisabledError(org));
-  }
-}
-
-async function listTeamsForImplicitInit(
-  org: string,
-  unattended: boolean
-): Promise<SentryTeam[] | undefined> {
-  const scopeRecovery = captureOAuthScopeRecoveryGate();
-  try {
-    return await listTeams(org);
-  } catch (error) {
-    // 403 from listTeams means the user cannot inspect team access. Continue
-    // without a team so init mirrors onboarding's org-scoped auto-team path.
-    if (
-      error instanceof ApiError &&
-      (error.status === 401 || error.status === 403) &&
-      (await scopeRecovery.shouldDelegate(error, { unattended }))
-    ) {
-      throw error;
-    }
-    if (error instanceof ApiError && error.status === 403) {
-      await assertOrgScopedCreationCanProceed(org);
-      return;
-    }
-    if (error instanceof ApiError && error.status === 404) {
-      return await buildOrgNotFoundError(org, "sentry init");
-    }
-    throw toPreflightWizardError(error);
-  }
-}
-
-async function resolveImplicitTeam(
-  org: string,
-  initial: WizardOptions,
-  ui: WizardUI
-): Promise<string | undefined> {
-  const teams = await listTeamsForImplicitInit(
+  avoidProjectSlug: string,
+  suggestedProjectName?: string
+): Promise<ProjectSelection> {
+  const project = await findAvailableProjectSlug(
     org,
-    initial.yes || initial.dryRun
+    suggestedProjectName ?? avoidProjectSlug,
+    avoidProjectSlug
   );
-  if (!teams) {
-    return;
+  return { project, existingProject: undefined };
+}
+
+async function findAvailableProjectSlug(
+  org: string,
+  suggestedProjectName: string,
+  avoidedProjectSlug: string
+): Promise<string> {
+  const base = slugify(suggestedProjectName) || "sentry-project";
+  const avoided = slugify(avoidedProjectSlug);
+
+  if (base !== avoided && !(await tryGetExistingProjectData(org, base))) {
+    return base;
   }
 
-  const candidateTeams = teams
-    .filter(canCreateProjectInTeam)
-    .sort((left, right) => left.slug.localeCompare(right.slug));
-  if (candidateTeams.length === 0) {
-    await assertOrgScopedCreationCanProceed(org);
-    return;
-  }
-  if (candidateTeams.length === 1 || initial.yes) {
-    return (candidateTeams[0] as SentryTeam).slug;
+  for (let suffix = 2; suffix <= 100; suffix += 1) {
+    const candidate = `${base}-${suffix}`;
+    if (!(await tryGetExistingProjectData(org, candidate))) {
+      return candidate;
+    }
   }
 
-  const selected = await ui.select<string>({
-    message: "Which team should own this project?",
-    options: candidateTeams.map((team) => ({
-      value: team.slug,
-      label: team.slug,
-      ...(team.name !== team.slug ? { hint: team.name } : {}),
-    })),
-  });
-  if (isCancelled(selected)) {
-    throw new WizardCancelledError();
+  throw new WizardError(
+    `Could not find an available project slug based on '${base}'. Choose an existing Sentry project instead.`
+  );
+}
+
+async function loadExistingProject(
+  org: string,
+  project: string,
+  detectedFrom: string
+): Promise<ExistingProjectData | null> {
+  try {
+    return await tryGetExistingProjectData(org, project);
+  } catch (error) {
+    const reason = error instanceof ApiError ? error.format() : String(error);
+    throw new WizardError(
+      `Found existing project '${org}/${project}' from ${detectedFrom}, but could not load its DSN.\n\n${reason}`
+    );
   }
-  return selected;
 }
 
 /**
@@ -571,7 +683,7 @@ async function resolveOrgSlug(
   }
 
   const selected = await ui.select<string>({
-    message: "Which organization should the project be created in?",
+    message: "Which organization should Sentry use?",
     options: orgs.map((org) => ({
       value: org.slug,
       label: org.name,
@@ -582,29 +694,4 @@ async function resolveOrgSlug(
     throw new WizardCancelledError();
   }
   return selected;
-}
-
-async function detectExistingProject(
-  cwd: string
-): Promise<{ orgSlug: string; projectSlug: string } | null> {
-  const { detectDsn } = await import("../dsn/index.js");
-  const dsn = await detectDsn(cwd);
-  if (!dsn?.publicKey) {
-    return null;
-  }
-
-  // biome-ignore lint/plugin: grandfathered silent catch — see #1531; drain by adding log.debug()/log.warn() or re-throwing.
-  try {
-    const { resolveDsnByPublicKey } = await import("../resolve-target.js");
-    const resolved = await resolveDsnByPublicKey(dsn);
-    if (!resolved) {
-      return null;
-    }
-    return {
-      orgSlug: resolved.org,
-      projectSlug: resolved.project,
-    };
-  } catch {
-    return null;
-  }
 }

--- a/packages/cli/src/lib/init/readiness.ts
+++ b/packages/cli/src/lib/init/readiness.ts
@@ -14,16 +14,29 @@ import type { WizardUI } from "./ui/types.js";
 /** Timeout for the health check fetch (5 seconds). */
 const HEALTH_CHECK_TIMEOUT_MS = 5000;
 
+/** Setup-service behavior negotiated before the remote workflow starts. */
+export type InitServiceCapabilities = {
+  /** The API preserves and upgrades an already-installed Sentry setup. */
+  improveExistingSetup: boolean;
+};
+
+type ReadinessResult = {
+  apiOk: boolean;
+  capabilities: InitServiceCapabilities;
+};
+
 /**
  * Check whether the setup service is reachable before starting the workflow.
  * Authentication is resolved before the wizard UI is created so recoverable
  * OAuth failures can use the CLI's global auto-auth flow.
  */
-export async function checkReadiness(ui: WizardUI): Promise<void> {
+export async function checkReadiness(
+  ui: WizardUI
+): Promise<InitServiceCapabilities> {
   const spin = ui.spinner();
   spin.start("Checking prerequisites...");
 
-  const apiOk = await checkMastraApi();
+  const { apiOk, capabilities } = await checkMastraApi();
 
   if (apiOk) {
     spin.stop("");
@@ -33,9 +46,10 @@ export async function checkReadiness(ui: WizardUI): Promise<void> {
       "Setup service may be slow or unreachable. The wizard will retry if needed."
     );
   }
+  return capabilities;
 }
 
-async function checkMastraApi(): Promise<boolean> {
+async function checkMastraApi(): Promise<ReadinessResult> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), HEALTH_CHECK_TIMEOUT_MS);
   try {
@@ -43,10 +57,30 @@ async function checkMastraApi(): Promise<boolean> {
       signal: controller.signal,
       method: "GET",
     });
-    return resp.ok;
+    if (!resp.ok) {
+      return {
+        apiOk: false,
+        capabilities: { improveExistingSetup: false },
+      };
+    }
+    const body = (await resp.json().catch(() => null)) as {
+      capabilities?: unknown;
+    } | null;
+    const advertised = Array.isArray(body?.capabilities)
+      ? body.capabilities
+      : [];
+    return {
+      apiOk: true,
+      capabilities: {
+        improveExistingSetup: advertised.includes("improve-existing-setup"),
+      },
+    };
   } catch (error) {
     logger.withTag("readiness").debug("Mastra API health check failed", error);
-    return false;
+    return {
+      apiOk: false,
+      capabilities: { improveExistingSetup: false },
+    };
   } finally {
     clearTimeout(timer);
   }

--- a/packages/cli/src/lib/init/tools/create-sentry-project.ts
+++ b/packages/cli/src/lib/init/tools/create-sentry-project.ts
@@ -2,22 +2,24 @@
  * Sentry project creation tool for the init wizard.
  *
  * Implements the `create-sentry-project` and `ensure-sentry-project` wizard
- * operations. Uses the team-scoped endpoint for explicit or Team Admin teams;
- * otherwise uses POST /organizations/{org}/projects/, the onboarding endpoint
- * that auto-creates a personal team for eligible members.
+ * operations. Resolves team capabilities only after the final project slug is
+ * known, using the same policy as `sentry project create`.
  */
 
 import { captureException } from "@sentry/node-core/light";
-import {
-  createProjectWithAutoTeam,
-  createProjectWithDsn,
-  MEMBER_PROJECT_CREATION_DISABLED_DETAIL,
-} from "../../api-client.js";
+import { MEMBER_PROJECT_CREATION_DISABLED_DETAIL } from "../../api-client.js";
 import { ApiError } from "../../errors.js";
-import { resolveOrCreateTeam } from "../../resolve-team.js";
+import {
+  createProjectWithTeamFallback,
+  ProjectCreationApiError,
+} from "../../project-creation.js";
+import {
+  type ResolvedConcreteTeam,
+  resolveOrCreateTeam,
+} from "../../resolve-team.js";
 import { captureOAuthScopeRecoveryGate } from "../../scope-recovery.js";
 import { slugify } from "../../utils.js";
-import { tryGetExistingProjectData } from "../existing-project.js";
+import { WizardCancelledError } from "../clack-utils.js";
 import { formatMemberProjectCreationDisabledError } from "../project-creation-errors.js";
 import type {
   CreateSentryProjectPayload,
@@ -25,7 +27,10 @@ import type {
   ToolResult,
 } from "../types.js";
 import { formatToolError } from "./shared.js";
-import type { InitToolDefinition, ToolContext } from "./types.js";
+import type {
+  InitToolDefinition,
+  ProjectCreationToolContext,
+} from "./types.js";
 
 type ProjectData = {
   projectSlug: string;
@@ -33,6 +38,27 @@ type ProjectData = {
   dsn: string;
   url: string;
 };
+
+function existingProjectResult(
+  context: Pick<ProjectCreationToolContext, "existingProject" | "setupIntent">
+): ToolResult | undefined {
+  if (!context.existingProject) {
+    return;
+  }
+  if (
+    !context.existingProject.dsn &&
+    context.setupIntent !== "improve-existing"
+  ) {
+    return {
+      ok: false,
+      error: `Could not obtain a DSN for existing project '${context.existingProject.orgSlug}/${context.existingProject.projectSlug}'. Check project-key access or choose a project whose keys you can read.`,
+    };
+  }
+  return {
+    ok: true,
+    data: { ...context.existingProject, ensuredVia: "existing" },
+  };
+}
 
 type ProjectCreationResponse = {
   project: {
@@ -52,163 +78,87 @@ function toProjectData(response: ProjectCreationResponse): ProjectData {
   };
 }
 
-/**
- * Resolve project creation using the frontend onboarding policy.
- *
- * @param opts.org - Organization slug
- * @param opts.name - Project display name
- * @param opts.platform - Platform identifier (null/undefined → omitted from request)
- * @param opts.team - Pre-resolved team slug (explicit or auto-selected by preflight).
- *   When undefined, use the org-scoped onboarding endpoint directly.
- * @param opts.suppressFallback - When true, a 403 from the team-scoped flow is
- *   surfaced directly rather than triggering the org-scoped fallback. Set only
- *   when the team was explicitly named via `--team` — a 403 there is meaningful
- *   user feedback, not a permission gap.
- * @returns Resolved project identifiers and DSN
- */
-async function resolveProjectCreation(opts: {
-  org: string;
-  name: string;
-  platform: string | null | undefined;
-  team: string | undefined;
-  suppressFallback: boolean;
-}): Promise<ProjectData> {
-  const { org, name, team, suppressFallback } = opts;
-  // Coerce null → undefined: CreateProjectBody.platform is string | undefined.
-  const platform = opts.platform ?? undefined;
-
-  const withPlatformFallback = async (
-    fn: (p: string | undefined) => Promise<ProjectData>
-  ): Promise<ProjectData> => {
-    try {
-      return await fn(platform);
-    } catch (err) {
-      // The registry may include SDK keys whose derived platform slug (e.g.
-      // "javascript-hono") is not yet in the Sentry API's allowed platform
-      // list. Retry without a platform so the project is still created, and
-      // capture to track which slugs need to be added to the API allowlist.
-      if (
-        err instanceof ApiError &&
-        err.status === 400 &&
-        platform &&
-        err.detail?.includes("Invalid platform")
-      ) {
-        captureException(err, {
-          extra: {
-            attemptedPlatform: platform,
-            projectName: name,
-            apiResponseDetail: err.detail,
-            apiStatus: err.status,
-          },
-        });
-        return await fn(undefined);
-      }
-      throw err;
-    }
-  };
-
-  if (!team) {
-    return await withPlatformFallback(async (p) => {
-      const result = await createProjectWithAutoTeam(org, {
-        name,
-        platform: p,
-      });
-      return toProjectData(result);
-    });
-  }
-
-  try {
-    return await withPlatformFallback(async (p) => {
-      const result = await createProjectWithDsn(org, team, {
-        name,
-        platform: p,
-      });
-      return toProjectData(result);
-    });
-  } catch (innerError) {
-    // Fall back to org-scoped endpoint on 403, unless the fallback is suppressed
-    // (explicit --team means the 403 is meaningful feedback, not a permission gap).
-    // Note: a 403 can originate from either the initial createProjectWithDsn call
-    // or from the platform-less retry inside withPlatformFallback — both mean the
-    // caller lacks team:write, so the org-scoped fallback is correct in either case.
-    if (
-      !(innerError instanceof ApiError && innerError.status === 403) ||
-      suppressFallback
-    ) {
-      throw innerError;
-    }
-    // Policy 403: org has disabled member project creation. The org-scoped
-    // endpoint enforces the same flag — re-throw immediately so the outer
-    // catch surfaces the friendly disabled-policy message without a wasted round-trip.
-    if (innerError.detail?.includes(MEMBER_PROJECT_CREATION_DISABLED_DETAIL)) {
-      throw innerError;
-    }
-    return await withPlatformFallback(async (p) => {
-      const result = await createProjectWithAutoTeam(org, {
-        name,
-        platform: p,
-      });
-      return toProjectData(result);
-    });
+/** Preserve user cancellation across the tool-result error boundary. */
+function rethrowWizardCancellation(error: unknown): void {
+  if (error instanceof WizardCancelledError) {
+    throw error;
   }
 }
 
 /**
- * Validate explicit team access for a dry-run, mirroring preflight.ts:resolveTeam.
- *
- * When `team` is undefined, preflight intentionally chose the org-scoped
- * onboarding endpoint, so there is no local team path to validate.
- *
- * @throws Non-403 errors from resolveOrCreateTeam (org not found, network, etc.)
+ * Retry a registry platform unknown to the projects API on the same concrete
+ * route that rejected it. This avoids restarting team-to-organization routing.
  */
-async function validateTeamForDryRun(
-  org: string,
-  team: string | undefined,
-  autoCreateSlug: string
-): Promise<void> {
-  if (!team) {
-    return;
-  }
+async function createProjectWithPlatformFallback(opts: {
+  org: string;
+  name: string;
+  platform: string | null | undefined;
+  team: ResolvedConcreteTeam | undefined;
+}): Promise<ProjectData> {
+  const { name, org, team } = opts;
+  const platform = opts.platform ?? undefined;
+  const create = async (
+    selectedPlatform: string | undefined,
+    selectedTeam: ResolvedConcreteTeam | undefined
+  ) =>
+    toProjectData(
+      await createProjectWithTeamFallback({
+        orgSlug: org,
+        name,
+        platform: selectedPlatform,
+        team: selectedTeam,
+      })
+    );
 
   try {
-    await resolveOrCreateTeam(org, {
-      team,
-      autoCreateSlug,
-      usageHint: "sentry init",
-      dryRun: true,
-      deferAutoCreateOnEmptyOrg: true,
-    });
-  } catch (teamErr) {
-    if (!(teamErr instanceof ApiError && teamErr.status === 403)) {
-      throw teamErr;
+    return await create(platform, team);
+  } catch (error) {
+    if (
+      !(error instanceof ProjectCreationApiError) ||
+      error.status !== 400 ||
+      !platform ||
+      !error.detail?.includes("Invalid platform")
+    ) {
+      throw error;
     }
+
+    captureException(error.cause, {
+      extra: {
+        attemptedPlatform: platform,
+        projectName: name,
+        apiResponseDetail: error.detail,
+        apiStatus: error.status,
+      },
+    });
+    return await create(undefined, error.route === "team" ? team : undefined);
   }
 }
 
 /**
  * Create a new Sentry project using the org that preflight already resolved.
- * When preflight does not resolve a Team Admin team, creation uses the same
- * org-scoped auto-team endpoint as Sentry onboarding.
+ * Team resolution happens here rather than in preflight so existing projects
+ * never trigger a team prompt or API call, and a new team's slug can be based
+ * on the final project name selected by the workflow.
  *
  * New Sentry orgs have member project creation disabled by default
  * (Organization.flags.disable_member_project_creation = true). When the org
  * restricts project creation for members, we surface a clear error with an
  * escape hatch: the user can pass `sentry init <org>/<project-slug>` once an
  * admin creates the project, which resolves to an existing project and skips
- * creation entirely (preflight.ts:261).
+ * creation entirely (`resolveInitProjectContext` in preflight).
  */
 export async function createSentryProject(
   payload: CreateSentryProjectPayload | EnsureSentryProjectPayload,
   context: Pick<
-    ToolContext,
+    ProjectCreationToolContext,
     | "dryRun"
     | "existingProject"
-    | "isExplicitTeam"
     | "org"
     | "team"
     | "project"
-    | "yes"
-  >
+    | "setupIntent"
+    | "chooseTeam"
+  > & { yes?: boolean }
 ): Promise<ToolResult> {
   const name = context.project ?? payload.params.name;
   const slug = slugify(name);
@@ -219,29 +169,22 @@ export async function createSentryProject(
     };
   }
 
-  if (context.existingProject) {
-    return {
-      ok: true,
-      message: `Using existing project "${context.existingProject.projectSlug}" in ${context.existingProject.orgSlug}`,
-      data: context.existingProject,
-    };
+  const existing = existingProjectResult(context);
+  if (existing) {
+    return existing;
   }
 
   const scopeRecovery = captureOAuthScopeRecoveryGate();
   try {
-    const existingProject = await tryGetExistingProjectData(context.org, slug);
-    if (existingProject) {
-      return {
-        ok: true,
-        message: `Using existing project "${existingProject.projectSlug}" in ${existingProject.orgSlug}`,
-        data: existingProject,
-      };
-    }
+    const team = await resolveOrCreateTeam(context.org, {
+      team: context.team?.slug,
+      autoCreateSlug: slug,
+      usageHint: "sentry init",
+      dryRun: context.dryRun,
+      chooseTeam: context.chooseTeam,
+    });
 
     if (context.dryRun) {
-      // Validate team access in dry-run — mirrors preflight.ts:resolveTeam.
-      // Not needed in real runs: resolveProjectCreation handles its own resolution.
-      await validateTeamForDryRun(context.org, context.team, slug);
       return {
         ok: true,
         data: {
@@ -254,15 +197,11 @@ export async function createSentryProject(
       };
     }
 
-    // Use the Team Admin path when preflight found one; otherwise use the
-    // org-scoped onboarding path, which auto-creates a personal team for
-    // eligible members.
-    const projectData = await resolveProjectCreation({
+    const projectData = await createProjectWithPlatformFallback({
       org: context.org,
       name,
       platform: payload.params.platform,
-      team: context.team,
-      suppressFallback: Boolean(context.isExplicitTeam),
+      team,
     });
 
     return {
@@ -273,9 +212,11 @@ export async function createSentryProject(
         projectId: projectData.projectId,
         dsn: projectData.dsn,
         url: projectData.url,
+        ensuredVia: "created",
       },
     };
   } catch (error) {
+    rethrowWizardCancellation(error);
     // Org-level policy: member project creation is disabled on this org.
     // Surface a clear message with the escape hatch.
     if (
@@ -290,7 +231,7 @@ export async function createSentryProject(
     }
     if (
       await scopeRecovery.shouldDelegate(error, {
-        unattended: context.yes || context.dryRun,
+        unattended: context.yes === true || context.dryRun,
       })
     ) {
       throw error;

--- a/packages/cli/src/lib/init/tools/detect-sentry.ts
+++ b/packages/cli/src/lib/init/tools/detect-sentry.ts
@@ -1,25 +1,341 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import {
+  collectGlob,
+  collectGrep,
+  DEFAULT_SKIP_DIRS,
+  DSN_ADDITIONAL_SKIP_DIRS,
+} from "../../scan/index.js";
 import type { DetectSentryPayload, ToolResult } from "../types.js";
 import type { InitToolDefinition } from "./types.js";
 
-/**
- * Detect existing Sentry signals in the local project directory.
- */
-export async function detectSentry(cwd: string): Promise<ToolResult> {
-  const { detectDsn } = await import("../../dsn/index.js");
-  const dsn = await detectDsn(cwd);
+const INITIALIZATION_PATTERN = [
+  String.raw`\bSentry(?:Sdk|Flutter|SDK|Android)?\.(?:init\s*(?:\(|\bdo\b)|start\s*(?:\(|\{))`,
+  String.raw`\bsentry_sdk\.init\s*\(`,
+  String.raw`\bsentry\.Init\s*\(`,
+  String.raw`\bsentry::init\s*\(`,
+  String.raw`\bsentry_init\s*\(`,
+  String.raw`\\Sentry\\init\s*\(`,
+  String.raw`\[SentrySDK\s+startWithConfigureOptions`,
+  String.raw`\bconfig\s+:sentry\b`,
+].join("|");
 
-  if (!dsn) {
-    return { ok: true, data: { status: "none", signals: [] } };
+const SDK_REFERENCE_PATTERN = [
+  String.raw`@sentry/(?:angular|astro|aws-serverless|browser|bun|capacitor|cloudflare|core|deno|electron|expo|gatsby|google-cloud-serverless|nestjs|nextjs|node|nuxt|opentelemetry|react|react-native|react-router|remix|solidstart|svelte|sveltekit|tanstackstart-react|vue|wasm)(?:["'/\s]|$)`,
+  String.raw`\bsentry[-_.]?sdk\b`,
+  String.raw`\bio\.sentry\b`,
+  String.raw`\bsentry_flutter\b`,
+  String.raw`\bsentry-ruby\b`,
+  String.raw`\bsentry-go\b`,
+  String.raw`\bsentry/sentry\b`,
+  String.raw`\{:sentry\s*,`,
+  String.raw`PackageReference[^>]+Include=["']Sentry(?:\.|["'])`,
+  "getsentry/sentry-cocoa",
+].join("|");
+
+const CONFIGURED_FEATURE_MARKERS = [
+  {
+    feature: "performanceMonitoring",
+    markers: [
+      "tracesSampleRate",
+      "tracesSampler",
+      "traces_sample_rate",
+      "traces_sampler",
+      "browserTracingIntegration",
+    ],
+  },
+  {
+    feature: "sessionReplay",
+    markers: [
+      "replaysSessionSampleRate",
+      "replaysOnErrorSampleRate",
+      "replayIntegration",
+      "new Sentry.Replay",
+    ],
+  },
+  {
+    feature: "profiling",
+    markers: [
+      "profilesSampleRate",
+      "profilesSampler",
+      "profileSessionSampleRate",
+      "profileLifecycle",
+      "profiles_sample_rate",
+      "profiles_sampler",
+      "profile_session_sample_rate",
+      "profile_lifecycle",
+      "nodeProfilingIntegration",
+      "browserProfilingIntegration",
+      "@sentry/profiling-node",
+    ],
+  },
+  { feature: "logs", markers: ["enableLogs", "enable_logs"] },
+  {
+    feature: "aiMonitoring",
+    markers: [
+      "openAIIntegration",
+      "vercelAIIntegration",
+      "anthropicAIIntegration",
+    ],
+  },
+  {
+    feature: "mcpObservability",
+    markers: ["wrapMcpServerWithSentry", "MCPIntegration"],
+  },
+  {
+    feature: "userFeedback",
+    markers: ["showReportDialog", "feedbackIntegration"],
+  },
+  {
+    feature: "reactFeatures",
+    markers: [
+      "Sentry.ErrorBoundary",
+      "withErrorBoundary",
+      "reactErrorHandler",
+      "captureReactException",
+    ],
+  },
+] as const;
+
+const FEATURE_SIGNAL_PATTERN = CONFIGURED_FEATURE_MARKERS.flatMap(
+  ({ markers }) => markers
+)
+  .map((marker) => marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+  .join("|");
+
+const SDK_CONFIG_PATTERNS = [
+  "**/sentry.*.config.*",
+  "**/sentry.config.*",
+  "**/config/sentry.php",
+] as const;
+
+const AUXILIARY_CONFIG_PATTERNS = [
+  "**/sentry.properties",
+  "**/sentry.yml",
+  "**/sentry.yaml",
+] as const;
+
+const DETECTION_EXCLUDES = [
+  "**/{test,tests,__tests__,spec,specs,fixture,fixtures,__fixtures__}/**",
+  "**/*.{test,spec}.*",
+] as const;
+
+const SDK_CONFIG_FILE_RE = /(?:^|\/)sentry(?:\.[^./]+)?\.config\./;
+const LARAVEL_CONFIG_FILE_RE = /(?:^|\/)config\/sentry\.php$/;
+const COMMENT_ONLY_LINE_RE = /^\s*(?:\/\/|#|\/\*|\*|<!--|--)/;
+
+const SOURCE_AND_MANIFEST_PATTERNS = [
+  "*.{ts,tsx,js,jsx,mjs,cjs,astro,vue,svelte,py,go,rb,erb,php,java,kt,kts,scala,groovy,cs,fs,vb,rs,swift,m,mm,dart,ex,exs,erl,lua,c,cc,cpp,cxx,h,hpp}",
+  "package.json",
+  "pyproject.toml",
+  "requirements*.txt",
+  "Pipfile",
+  "go.mod",
+  "Cargo.toml",
+  "Gemfile",
+  "*.gemspec",
+  "composer.json",
+  "pom.xml",
+  "build.gradle*",
+  "Package.swift",
+  "pubspec.yaml",
+  "*.csproj",
+  "packages.config",
+  "mix.exs",
+] as const;
+
+export type ExistingSentryStatus = "installed" | "partial" | "none";
+
+export type ExistingSentryEvidence =
+  | { kind: "initialization"; path: string }
+  | { kind: "config"; path: string; sdkConfig: boolean }
+  | { kind: "sdk"; path: string }
+  | { kind: "dsn"; path?: string; source: string };
+
+/** Deterministic local evidence used by the workflow and project resolver. */
+export type ExistingSentryDetection = {
+  status: ExistingSentryStatus;
+  signals: string[];
+  evidence?: ExistingSentryEvidence[];
+  features?: string[];
+  dsn?: string;
+  evidenceTruncated?: boolean;
+};
+
+function configuredFeatures(lines: readonly string[]): string[] {
+  const normalizedLines = lines.map((line) => line.toLowerCase());
+  return CONFIGURED_FEATURE_MARKERS.flatMap(({ feature, markers }) =>
+    markers.some((marker) =>
+      normalizedLines.some((line) => line.includes(marker.toLowerCase()))
+    )
+      ? [feature]
+      : []
+  );
+}
+
+async function findConfigFiles(
+  cwd: string
+): Promise<{ files: string[]; truncated: boolean }> {
+  const result = await collectGlob({
+    cwd,
+    patterns: [...SDK_CONFIG_PATTERNS, ...AUXILIARY_CONFIG_PATTERNS],
+    exclude: DETECTION_EXCLUDES,
+    maxResults: 50,
+  });
+  const files = new Set(result.files);
+  if (existsSync(path.join(cwd, ".sentryclirc"))) {
+    files.add(".sentryclirc");
+  }
+  return { files: [...files].sort(), truncated: result.truncated };
+}
+
+/**
+ * Detect an existing Sentry setup without requiring a literal DSN.
+ * Runtime initialization, an SDK config convention, or a DSN means installed.
+ * An SDK reference or auxiliary CLI/build config by itself means partial so
+ * the improvement flow can repair the application setup.
+ */
+export async function detectSentrySetup(
+  cwd: string
+): Promise<ExistingSentryDetection> {
+  const { detectAllDsnOccurrences } = await import("../../dsn/index.js");
+  const [
+    dsnOccurrences,
+    initialization,
+    sdkReferences,
+    featureSignals,
+    configResult,
+  ] = await Promise.all([
+    detectAllDsnOccurrences(cwd),
+    collectGrep({
+      cwd,
+      pattern: INITIALIZATION_PATTERN,
+      include: SOURCE_AND_MANIFEST_PATTERNS,
+      exclude: DETECTION_EXCLUDES,
+      alwaysSkipDirs: [...DEFAULT_SKIP_DIRS, ...DSN_ADDITIONAL_SKIP_DIRS],
+      maxMatchesPerFile: 1,
+      maxResults: 100,
+    }),
+    collectGrep({
+      cwd,
+      pattern: SDK_REFERENCE_PATTERN,
+      caseSensitive: false,
+      include: SOURCE_AND_MANIFEST_PATTERNS,
+      exclude: DETECTION_EXCLUDES,
+      alwaysSkipDirs: [...DEFAULT_SKIP_DIRS, ...DSN_ADDITIONAL_SKIP_DIRS],
+      maxResults: 20,
+    }),
+    collectGrep({
+      cwd,
+      pattern: FEATURE_SIGNAL_PATTERN,
+      caseSensitive: false,
+      include: SOURCE_AND_MANIFEST_PATTERNS,
+      exclude: DETECTION_EXCLUDES,
+      alwaysSkipDirs: [...DEFAULT_SKIP_DIRS, ...DSN_ADDITIONAL_SKIP_DIRS],
+      maxMatchesPerFile: 20,
+      maxResults: 200,
+    }),
+    findConfigFiles(cwd),
+  ]);
+
+  const dsn = dsnOccurrences[0];
+  const configFiles = configResult.files;
+
+  const runtimeInitialization = initialization.matches.filter(
+    (match) => !COMMENT_ONLY_LINE_RE.test(match.line)
+  );
+  const rawEvidence: ExistingSentryEvidence[] = [
+    ...runtimeInitialization.map(
+      (match): ExistingSentryEvidence => ({
+        kind: "initialization",
+        path: match.path,
+      })
+    ),
+    ...configFiles.map(
+      (file): ExistingSentryEvidence => ({
+        kind: "config",
+        path: file,
+        sdkConfig:
+          SDK_CONFIG_FILE_RE.test(file) || LARAVEL_CONFIG_FILE_RE.test(file),
+      })
+    ),
+    ...sdkReferences.matches.map(
+      (match): ExistingSentryEvidence => ({ kind: "sdk", path: match.path })
+    ),
+    ...dsnOccurrences.map(
+      (detectedDsn): ExistingSentryEvidence => ({
+        kind: "dsn",
+        source: detectedDsn.source,
+        ...(detectedDsn.sourcePath ? { path: detectedDsn.sourcePath } : {}),
+      })
+    ),
+  ];
+  const evidenceBySignal = new Map(
+    rawEvidence.map((item) => [formatEvidence(item), item])
+  );
+  const uniqueSignals = [...evidenceBySignal.keys()];
+  const evidence = [...evidenceBySignal.values()];
+  const hasSdkConfig = evidence.some(
+    (item) => item.kind === "config" && item.sdkConfig
+  );
+  const installed =
+    runtimeInitialization.length > 0 || hasSdkConfig || Boolean(dsn);
+  let status: ExistingSentryStatus = "none";
+  if (installed) {
+    status = "installed";
+  } else if (uniqueSignals.length > 0) {
+    status = "partial";
+  }
+  const features = configuredFeatures(
+    featureSignals.matches
+      .filter((match) => !COMMENT_ONLY_LINE_RE.test(match.line))
+      .map((match) => match.line)
+  );
+  if (installed) {
+    features.unshift("errorMonitoring");
   }
 
-  const signals = [
-    `dsn: ${dsn.source}${dsn.sourcePath ? ` (${dsn.sourcePath})` : ""}`,
-  ];
-
   return {
-    ok: true,
-    data: { status: "installed", signals, dsn: dsn.raw },
+    status,
+    signals: uniqueSignals,
+    evidence,
+    ...(features.length > 0 ? { features } : {}),
+    ...(dsn ? { dsn: dsn.raw } : {}),
+    ...((initialization.stats.truncated || configResult.truncated) && {
+      evidenceTruncated: true,
+    }),
   };
+}
+
+/**
+ * Derive the backward-compatible display signal from structured evidence.
+ * Target discovery consumes `evidence` directly and must not parse this text.
+ */
+function formatEvidence(evidence: ExistingSentryEvidence): string {
+  switch (evidence.kind) {
+    case "initialization":
+      return `init: ${evidence.path}`;
+    case "config":
+      return `config: ${evidence.path}`;
+    case "sdk":
+      return `sdk: ${evidence.path}`;
+    case "dsn":
+      return `dsn: ${evidence.source}${evidence.path ? ` (${evidence.path})` : ""}`;
+    default:
+      throw new Error("Unsupported Sentry evidence kind");
+  }
+}
+
+/** Detect existing Sentry signals in the local project directory. */
+export async function detectSentry(cwd: string): Promise<ToolResult> {
+  try {
+    return { ok: true, data: await detectSentrySetup(cwd) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 /**

--- a/packages/cli/src/lib/init/tools/registry.ts
+++ b/packages/cli/src/lib/init/tools/registry.ts
@@ -1,4 +1,5 @@
 import { ApiError } from "../../errors.js";
+import { WizardCancelledError } from "../clack-utils.js";
 import type { ToolOperation, ToolPayload, ToolResult } from "../types.js";
 import { agentCheckpointTool } from "./agent-checkpoint.js";
 import { applyPatchsetTool } from "./apply-patchset.js";
@@ -14,7 +15,16 @@ import { listDirTool } from "./list-dir.js";
 import { readFilesTool } from "./read-files.js";
 import { runCommandsTool } from "./run-commands.js";
 import { formatToolError, validateToolSandbox } from "./shared.js";
-import type { AnyInitToolDefinition, ToolContext } from "./types.js";
+import type {
+  AnyInitToolDefinition,
+  ToolCapabilities,
+  ToolContext,
+} from "./types.js";
+
+const PROJECT_CREATION_OPERATIONS = new Set<ToolOperation>([
+  "create-sentry-project",
+  "ensure-sentry-project",
+]);
 
 const toolDefinitions = [
   agentCheckpointTool,
@@ -54,7 +64,8 @@ export function describeTool(payload: ToolPayload): string {
  */
 export async function executeTool(
   payload: ToolPayload,
-  context: ToolContext
+  context: ToolContext,
+  capabilities: ToolCapabilities = {}
 ): Promise<ToolResult> {
   const tool = toolRegistry.get(payload.operation);
   if (!tool) {
@@ -74,8 +85,17 @@ export async function executeTool(
   }
 
   try {
-    return await tool.execute(sandboxedPayload as never, context);
+    const executionContext = PROJECT_CREATION_OPERATIONS.has(payload.operation)
+      ? { ...context, chooseTeam: capabilities.chooseTeam }
+      : context;
+    return await tool.execute(
+      sandboxedPayload as never,
+      executionContext as never
+    );
   } catch (error) {
+    if (error instanceof WizardCancelledError) {
+      throw error;
+    }
     if (
       error instanceof ApiError &&
       (error.status === 401 || error.status === 403)

--- a/packages/cli/src/lib/init/tools/run-commands.ts
+++ b/packages/cli/src/lib/init/tools/run-commands.ts
@@ -11,6 +11,7 @@ import {
 import type { InitToolDefinition, ToolContext } from "./types.js";
 
 const WINDOWS_BATCH_SHIM_RE = /\.(?:cmd|bat)$/iu;
+const PNPM_MANAGE_VERSION_ARG = "--config.manage-package-manager-versions=true";
 
 type SpawnCommand = {
   executable: string;
@@ -129,22 +130,44 @@ async function runSingleCommand(
   stderr: string;
 }> {
   const executable = whichSync(command.executable) ?? command.executable;
+  const executableName = command.executable
+    .replaceAll("\\", "/")
+    .split("/")
+    .at(-1)
+    ?.replace(WINDOWS_BATCH_SHIM_RE, "")
+    .toLowerCase();
+  const args =
+    executableName === "pnpm" && !command.args.includes(PNPM_MANAGE_VERSION_ARG)
+      ? [PNPM_MANAGE_VERSION_ARG, ...command.args]
+      : command.args;
+  const spawnEnv =
+    executableName === "pnpm"
+      ? (() => {
+          const env = { ...process.env };
+          // `sentry init` is often launched through pnpm itself. Its inherited
+          // config must not override the target repository's packageManager.
+          for (const key of Object.keys(env)) {
+            if (
+              key.toLowerCase() === "npm_config_manage_package_manager_versions"
+            ) {
+              delete env[key];
+            }
+          }
+          return env;
+        })()
+      : undefined;
   const spawnCommand: SpawnCommand = isWindowsBatchShim(executable)
     ? {
         executable: process.env.ComSpec ?? "cmd.exe",
-        args: [
-          "/d",
-          "/s",
-          "/c",
-          buildWindowsBatchCommand(executable, command.args),
-        ],
+        args: ["/d", "/s", "/c", buildWindowsBatchCommand(executable, args)],
         windowsVerbatimArguments: true,
       }
-    : { executable, args: command.args };
+    : { executable, args };
 
   try {
     const child = spawn(spawnCommand.executable, spawnCommand.args, {
       cwd,
+      ...(spawnEnv ? { env: spawnEnv } : {}),
       shell: false,
       stdio: ["ignore", "pipe", "pipe"],
       ...(spawnCommand.windowsVerbatimArguments

--- a/packages/cli/src/lib/init/tools/types.ts
+++ b/packages/cli/src/lib/init/tools/types.ts
@@ -1,3 +1,4 @@
+import type { ChooseProjectTeam } from "../../resolve-team.js";
 import type {
   ResolvedInitContext,
   ToolOperation,
@@ -5,10 +6,25 @@ import type {
   ToolResult,
 } from "../types.js";
 
-/**
- * Client-side context available to init tools while the workflow is suspended.
- */
+/** Client-side context shared by every init tool. */
 export type ToolContext = ResolvedInitContext;
+
+/** Narrow interactive capabilities supplied by the local wizard runner. */
+export type ToolCapabilities = {
+  chooseTeam?: ChooseProjectTeam;
+};
+
+export type ProjectCreationToolOperation =
+  | "create-sentry-project"
+  | "ensure-sentry-project";
+
+/** Extra local capabilities visible only to project-creation tools. */
+export type ProjectCreationToolContext = ToolContext & ToolCapabilities;
+
+type ToolContextFor<TOperation extends ToolOperation> =
+  TOperation extends ProjectCreationToolOperation
+    ? ProjectCreationToolContext
+    : ToolContext;
 
 /**
  * A single init tool implementation plus its user-facing spinner copy.
@@ -23,7 +39,7 @@ export type InitToolDefinition<TOperation extends ToolOperation> = {
   /** Execute the tool and return a resumable payload result. */
   execute: (
     payload: Extract<ToolPayload, { operation: TOperation }>,
-    context: ToolContext
+    context: ToolContextFor<TOperation>
   ) => Promise<ToolResult>;
 };
 

--- a/packages/cli/src/lib/init/types.ts
+++ b/packages/cli/src/lib/init/types.ts
@@ -1,3 +1,5 @@
+import type { ResolvedConcreteTeam } from "../resolve-team.js";
+
 export type DirEntry = {
   name: string;
   path: string;
@@ -9,9 +11,11 @@ export type DirEntry = {
 
 export type ExistingProjectData = {
   orgSlug: string;
+  orgDisplay?: string;
   projectSlug: string;
+  projectDisplay?: string;
   projectId: string;
-  dsn: string;
+  dsn?: string;
   url: string;
   platform?: string;
 };
@@ -46,22 +50,18 @@ export type ResolvedInitContext = {
   features?: string[];
   org: string;
   /**
-   * Resolved team slug for init operations.
-   * Omitted when init defers empty-org auto-creation until project creation.
+   * Explicit team requested with `--team`.
+   * Implicit team resolution is deferred until project creation so existing
+   * projects never require a team choice.
    */
-  team?: string;
-  /**
-   * True only when `team` was supplied via the `--team` CLI flag.
-   * False/absent when the team was auto-selected by preflight.
-   * Used by project creation tools to decide whether to suppress the
-   * org-scoped fallback on 403 (only suppress for explicitly named teams).
-   */
-  isExplicitTeam?: boolean;
+  team?: Omit<ResolvedConcreteTeam, "source"> & { source: "explicit" };
   project?: string;
   /** Pre-selected app name for monorepo runs. Passed through from `--app`. */
   app?: string;
   authToken?: string;
   existingProject?: ExistingProjectData;
+  /** Existing setup should be preserved, reviewed, and brought up to date. */
+  setupIntent?: "improve-existing";
 };
 
 export type InteractiveContext = Pick<
@@ -329,12 +329,28 @@ export type InteractivePayload =
   | MultiSelectPayload
   | ConfirmPayload;
 
+/** One stable target identity plus optional human-facing selector metadata. */
+export type AppEntry = {
+  /** Presentation-only target name; selection and `--app` use `name`. */
+  label?: string;
+  /** Stable identifier returned through workflow suspend/resume. */
+  name: string;
+  /** Absolute filesystem path to the target root. */
+  path: string;
+  /** Framework proven or inferred for the target, when available. */
+  framework?: string;
+  /** Product role used to explain the target in the selector. */
+  role?: "application" | "documentation" | "example" | "runtime";
+  /** Deterministic existing-setup status and unattended-selection safety. */
+  sentrySetup?: "detected" | "auto-select";
+};
+
 export type SelectPayload = {
   type: "interactive";
   kind: "select";
   prompt: string;
   options?: string[];
-  apps?: Array<{ name: string; path: string; framework?: string }>;
+  apps?: AppEntry[];
 };
 
 export type MultiSelectPayload = {
@@ -342,6 +358,7 @@ export type MultiSelectPayload = {
   kind: "multi-select";
   prompt: string;
   availableFeatures?: string[];
+  initialFeatures?: string[];
   options?: string[];
 };
 
@@ -358,6 +375,7 @@ export type WorkflowRunResult = {
   status: "suspended" | "success" | "failed";
   suspended?: string[][];
   activeStepsPath?: Record<string, unknown>;
+  suspendedPaths?: Record<string, unknown>;
   steps?: Record<
     string,
     {

--- a/packages/cli/src/lib/init/ui/file-tree.ts
+++ b/packages/cli/src/lib/init/ui/file-tree.ts
@@ -200,9 +200,8 @@ function rowFor(
  * {@link buildFileTree} but tags leaves with `status` instead of
  * `action`.
  *
- * Insertion order is preserved (no sort) so newly-read files always
- * land at the bottom of their parent directory — gives the Ink
- * `FilesPanel`'s tail-window viewport a stable "tail -f" feel.
+ * Insertion order is preserved (no sort) so the Files panel presents the read
+ * chronology from the first analyzed path onward.
  */
 export function buildReadTree(files: ReadFile[]): FileTreeNode {
   const root: FileTreeNode = { name: "", children: [] };
@@ -233,7 +232,6 @@ export function buildReadTree(files: ReadFile[]): FileTreeNode {
     }
   }
 
-  // Deliberately no `sortRecursive(root)` — keep insertion order so
-  // sticky-bottom scrollbox tracking feels right.
+  // Deliberately no `sortRecursive(root)` — keep read chronology intact.
   return root;
 }

--- a/packages/cli/src/lib/init/ui/ink-app.tsx
+++ b/packages/cli/src/lib/init/ui/ink-app.tsx
@@ -189,11 +189,23 @@ export function App({ store }: AppProps): React.ReactNode {
 }
 
 function AppBody({ store }: AppProps): React.ReactNode {
-  const snapshot = useSyncExternalStore(
+  const liveSnapshot = useSyncExternalStore(
     store.subscribe,
     store.getSnapshot,
     store.getSnapshot
   );
+  const lastVisibleSnapshot = useRef(liveSnapshot);
+  const snapshot = liveSnapshot.presentationHold
+    ? lastVisibleSnapshot.current
+    : liveSnapshot;
+  const visibleOverlay = liveSnapshot.presentationHold
+    ? liveSnapshot.overlay
+    : snapshot.overlay;
+  useEffect(() => {
+    if (!liveSnapshot.presentationHold) {
+      lastVisibleSnapshot.current = liveSnapshot;
+    }
+  }, [liveSnapshot]);
   const { columns, rows } = useInkFrameSize();
   const [activeTab, setActiveTab] = useState(0);
 
@@ -217,7 +229,7 @@ function AppBody({ store }: AppProps): React.ReactNode {
         priority: 0,
         showInFooter: false,
         match: (input, key) => key.ctrl && input === "c",
-        run: () => snapshot.requestCancel?.(),
+        run: () => liveSnapshot.requestCancel?.(),
       },
       {
         key: "\u2190\u2192",
@@ -235,12 +247,29 @@ function AppBody({ store }: AppProps): React.ReactNode {
       },
     ];
     return bindings;
-  }, [snapshot.requestCancel, tabs.length]);
+  }, [liveSnapshot.requestCancel, tabs.length]);
   useInkShortcuts("init-app", appShortcuts, {
     isActive:
+      !liveSnapshot.presentationHold &&
       snapshot.layout === "workflow" &&
       snapshot.prompt === null &&
       snapshot.outroState === null,
+  });
+  const heldPresentationShortcuts = useMemo<ShortcutBinding[]>(
+    () => [
+      {
+        key: "ctrl+c",
+        action: "cancel",
+        priority: 0,
+        showInFooter: false,
+        match: (input, key) => key.ctrl && input === "c",
+        run: () => liveSnapshot.requestCancel?.(),
+      },
+    ],
+    [liveSnapshot.requestCancel]
+  );
+  useInkShortcuts("held-presentation", heldPresentationShortcuts, {
+    isActive: liveSnapshot.presentationHold,
   });
 
   if (snapshot.outroState?.kind === "success") {
@@ -277,12 +306,14 @@ function AppBody({ store }: AppProps): React.ReactNode {
         >
           <IntroScreen
             bannerRows={snapshot.bannerRows}
+            interactionDisabled={liveSnapshot.presentationHold}
             logs={snapshot.logs}
             prompt={snapshot.prompt}
             spinner={snapshot.spinner}
             width={width}
           />
         </Box>
+        {visibleOverlay ? <OverlayPanel overlay={visibleOverlay} /> : null}
         <FeedbackBanner cliVersion={snapshot.cliVersion} width={width} />
       </Box>
     );
@@ -310,6 +341,7 @@ function AppBody({ store }: AppProps): React.ReactNode {
             <Box flexDirection="column" flexGrow={1} overflow="hidden">
               {activeTab === 0 ? (
                 <ActivityPane
+                  interactionDisabled={liveSnapshot.presentationHold}
                   logs={snapshot.logs}
                   prompt={snapshot.prompt}
                   spinner={snapshot.spinner}
@@ -334,9 +366,7 @@ function AppBody({ store }: AppProps): React.ReactNode {
             ) : null}
           </Box>
 
-          {snapshot.overlay ? (
-            <OverlayPanel overlay={snapshot.overlay} />
-          ) : null}
+          {visibleOverlay ? <OverlayPanel overlay={visibleOverlay} /> : null}
 
           <TabFooter
             activeColor={ACCENT}
@@ -391,12 +421,14 @@ function Sidebar({
 // ─────────────────────────── Activity Pane ────────────────────────────
 
 function ActivityPane({
+  interactionDisabled,
   logs,
   spinner,
   prompt,
   summary,
   terminalRows,
 }: {
+  interactionDisabled: boolean;
   logs: LogEntry[];
   spinner: SpinnerState;
   prompt: ActivePrompt | null;
@@ -441,6 +473,7 @@ function ActivityPane({
       {summary ? <SummaryPanel summary={summary} /> : null}
       {prompt ? (
         <PromptArea
+          interactionDisabled={interactionDisabled}
           occupiedRows={visibleLogs.length + (spinner.active ? 2 : 0)}
           prompt={prompt}
         />
@@ -1051,12 +1084,14 @@ function CompletionMenu({
 
 function IntroScreen({
   bannerRows,
+  interactionDisabled,
   logs,
   prompt,
   spinner,
   width,
 }: {
   bannerRows: BannerLine[];
+  interactionDisabled: boolean;
   logs: LogEntry[];
   prompt: ActivePrompt | null;
   spinner: SpinnerState;
@@ -1105,7 +1140,12 @@ function IntroScreen({
         </>
       ) : null}
       {welcomePrompt ? null : (
-        <IntroPreflightContent logs={logs} prompt={prompt} spinner={spinner} />
+        <IntroPreflightContent
+          interactionDisabled={interactionDisabled}
+          logs={logs}
+          prompt={prompt}
+          spinner={spinner}
+        />
       )}
     </Box>
   );
@@ -1148,10 +1188,12 @@ function WelcomeActions({
 }
 
 function IntroPreflightContent({
+  interactionDisabled,
   logs,
   prompt,
   spinner,
 }: {
+  interactionDisabled: boolean;
   logs: LogEntry[];
   prompt: ActivePrompt | null;
   spinner: SpinnerState;
@@ -1168,6 +1210,7 @@ function IntroPreflightContent({
     <Box alignItems="center" width="100%">
       <PromptArea
         alignment="center"
+        interactionDisabled={interactionDisabled}
         occupiedRows={spinner.active ? 2 : 0}
         prompt={prompt}
       />
@@ -1424,7 +1467,6 @@ function FilesPanel({
   maxRows: number;
   hasActivePrompt: boolean;
 }): React.ReactNode {
-  const [pinnedToBottom, setPinnedToBottom] = useState(true);
   const [offset, setOffset] = useState(0);
 
   const tree = buildReadTree(filesRead);
@@ -1435,26 +1477,14 @@ function FilesPanel({
   const canScroll = totalRows > viewport;
 
   const maxOffset = Math.max(0, totalRows - viewport);
-  const effectiveOffset = pinnedToBottom ? 0 : Math.min(offset, maxOffset);
-
-  const sliceEnd = totalRows - effectiveOffset;
-  const sliceStart = Math.max(0, sliceEnd - viewport);
+  const effectiveOffset = Math.min(offset, maxOffset);
+  const sliceStart = effectiveOffset;
+  const sliceEnd = Math.min(totalRows, sliceStart + viewport);
   const visible = rows.slice(sliceStart, sliceEnd);
 
-  const prevTotalRef = useRef(totalRows);
   useEffect(() => {
-    const prev = prevTotalRef.current;
-    prevTotalRef.current = totalRows;
-    if (pinnedToBottom) {
-      return;
-    }
-    const newMax = Math.max(0, totalRows - viewport);
-    if (totalRows > prev) {
-      setOffset((current) => Math.min(newMax, current + (totalRows - prev)));
-    } else if (totalRows < prev) {
-      setOffset((current) => Math.min(current, newMax));
-    }
-  }, [totalRows, viewport, pinnedToBottom]);
+    setOffset((current) => Math.min(current, maxOffset));
+  }, [maxOffset]);
 
   const fileShortcuts = useMemo<ShortcutBinding[]>(() => {
     if (!canScroll) {
@@ -1468,17 +1498,10 @@ function FilesPanel({
         match: (_input, key) => key.upArrow || key.downArrow,
         run: (_input, key) => {
           if (key.upArrow) {
-            setPinnedToBottom(false);
-            setOffset((current) => Math.min(maxOffset, current + 1));
+            setOffset((current) => Math.max(0, current - 1));
             return;
           }
-          setOffset((current) => {
-            const next = Math.max(0, current - 1);
-            if (next === 0) {
-              setPinnedToBottom(true);
-            }
-            return next;
-          });
+          setOffset((current) => Math.min(maxOffset, current + 1));
         },
       },
       {
@@ -1489,17 +1512,10 @@ function FilesPanel({
         match: (_input, key) => key.pageUp || key.pageDown,
         run: (_input, key) => {
           if (key.pageUp) {
-            setPinnedToBottom(false);
-            setOffset((current) => Math.min(maxOffset, current + viewport));
+            setOffset((current) => Math.max(0, current - viewport));
             return;
           }
-          setOffset((current) => {
-            const next = Math.max(0, current - viewport);
-            if (next === 0) {
-              setPinnedToBottom(true);
-            }
-            return next;
-          });
+          setOffset((current) => Math.min(maxOffset, current + viewport));
         },
       },
       {
@@ -1510,12 +1526,10 @@ function FilesPanel({
         match: (_input, key) => key.home || key.end,
         run: (_input, key) => {
           if (key.home) {
-            setPinnedToBottom(false);
-            setOffset(maxOffset);
+            setOffset(0);
             return;
           }
-          setPinnedToBottom(true);
-          setOffset(0);
+          setOffset(maxOffset);
         },
       },
     ];
@@ -1540,7 +1554,7 @@ function FilesPanel({
           Files analyzed
         </Text>
         <Text color={MUTED_DIM}>
-          {pinnedToBottom ? "" : "\u2191 "}
+          {effectiveOffset === 0 ? "" : "\u2191 "}
           {analyzedCount}/{filesRead.length}
         </Text>
       </Box>
@@ -1580,7 +1594,7 @@ function Scrollbar({
   const maxOff = Math.max(1, totalRows - viewport);
   const thumbSize = Math.max(1, Math.floor((viewport * viewport) / totalRows));
   const trackSpan = Math.max(1, viewport - thumbSize);
-  const thumbStart = Math.round(((maxOff - offset) / maxOff) * trackSpan);
+  const thumbStart = Math.round((offset / maxOff) * trackSpan);
   const cells = Array.from({ length: viewport }, (_v, i) => {
     const inThumb = i >= thumbStart && i < thumbStart + thumbSize;
     return inThumb ? "\u2588" : ICONS.verticalLine;
@@ -1763,9 +1777,16 @@ function getCenteredSelectLayout(
     0,
     ...options.map((option) => stringWidth(option.hint ?? ""))
   );
+  const descriptionWidth = Math.max(
+    0,
+    ...options.map((option) => stringWidth(option.description ?? ""))
+  );
   return {
     labelWidth,
-    width: 2 + labelWidth + (hintWidth > 0 ? hintWidth + 1 : 0),
+    width: Math.max(
+      2 + labelWidth + (hintWidth > 0 ? hintWidth + 1 : 0),
+      2 + descriptionWidth
+    ),
   };
 }
 
@@ -2275,10 +2296,12 @@ function SelectPromptHeader({
 
 function SelectPromptArea({
   alignment,
+  interactionDisabled,
   occupiedRows,
   prompt,
 }: {
   alignment: PromptAlignment;
+  interactionDisabled: boolean;
   occupiedRows: number;
   prompt: Extract<ActivePrompt, { kind: "select" }>;
 }): React.ReactNode {
@@ -2301,6 +2324,7 @@ function SelectPromptArea({
         alignment={alignment}
         compact={layout.compact}
         detailWidth={layout.detailWidth}
+        interactionDisabled={interactionDisabled}
         maxVisibleDetailRows={layout.maxVisibleDetailRows}
         maxVisibleOptions={layout.maxVisibleOptions}
         prompt={prompt}
@@ -2341,6 +2365,7 @@ function SelectPromptArea({
       alignment={alignment}
       compact={optionLimit < minimumVisibleOptions}
       detailWidth={getPromptDetailWidth(columns, alignment)}
+      interactionDisabled={interactionDisabled}
       maxVisibleDetailRows={maxVisibleDetailRows}
       maxVisibleOptions={Math.max(minimumVisibleOptions, optionLimit)}
       prompt={prompt}
@@ -2393,12 +2418,22 @@ function MultiSelectPromptArea({
   );
 }
 
+function getWrappedTextRows(text: string, width: number): number {
+  return wrapAnsi(text, Math.max(1, width), {
+    hard: true,
+    trim: false,
+    wordWrap: true,
+  }).split("\n").length;
+}
+
 function PromptArea({
   alignment = "start",
+  interactionDisabled = false,
   occupiedRows = 0,
   prompt,
 }: {
   alignment?: PromptAlignment;
+  interactionDisabled?: boolean;
   occupiedRows?: number;
   prompt: ActivePrompt;
 }): React.ReactNode {
@@ -2406,6 +2441,7 @@ function PromptArea({
     return (
       <SelectPromptArea
         alignment={alignment}
+        interactionDisabled={interactionDisabled}
         occupiedRows={occupiedRows}
         prompt={prompt}
       />
@@ -2430,6 +2466,7 @@ function SelectPrompt({
   alignment,
   compact,
   detailWidth,
+  interactionDisabled,
   maxVisibleDetailRows,
   maxVisibleOptions,
   prompt,
@@ -2437,6 +2474,7 @@ function SelectPrompt({
   alignment: PromptAlignment;
   compact: boolean;
   detailWidth: number;
+  interactionDisabled: boolean;
   maxVisibleDetailRows: number;
   maxVisibleOptions: number;
   prompt: Extract<ActivePrompt, { kind: "select" }>;
@@ -2459,17 +2497,25 @@ function SelectPrompt({
   const centeredLayout = isCentered
     ? getCenteredSelectLayout(prompt.options)
     : null;
-  const centeredOptionsWidth = centeredLayout
-    ? Math.min(centeredLayout.width, getPromptContentWidth(columns, alignment))
-    : undefined;
+  const contentWidth = getPromptContentWidth(columns, alignment);
+  const optionsWidth = centeredLayout
+    ? Math.min(centeredLayout.width, contentWidth)
+    : contentWidth;
+  const descriptionWidth = Math.max(1, optionsWidth - (isCentered ? 2 : 3));
   const totalCount = prompt.options.length;
+  const optionRowHeights = prompt.options.map((option) =>
+    option.description
+      ? 1 + getWrappedTextRows(option.description, descriptionWidth)
+      : 1
+  );
+  const maximumOptionRowHeight = Math.max(1, ...optionRowHeights);
   const [highlighted, setHighlighted] = useState<number>(() =>
     Math.min(Math.max(prompt.initialIndex, 0), Math.max(0, totalCount - 1))
   );
   const [windowStart, windowEnd] = getOptionWindow(
     totalCount,
     highlighted,
-    maxVisibleOptions
+    Math.max(1, Math.floor(maxVisibleOptions / maximumOptionRowHeight))
   );
   const visibleOptions = prompt.options.slice(windowStart, windowEnd);
   const isWindowed = visibleOptions.length < totalCount;
@@ -2512,7 +2558,9 @@ function SelectPrompt({
     ],
     [detailShortcut, highlighted, prompt, totalCount]
   );
-  useInkShortcuts("select-prompt", shortcuts);
+  useInkShortcuts("select-prompt", shortcuts, {
+    isActive: !interactionDisabled,
+  });
 
   return (
     <Box
@@ -2536,7 +2584,7 @@ function SelectPrompt({
         justifyContent={isCentered ? "center" : "flex-start"}
         width={promptWidth}
       >
-        <Box flexDirection="column" width={centeredOptionsWidth}>
+        <Box flexDirection="column" width={optionsWidth}>
           {visibleOptions.map((option, visibleIndex) => {
             const idx = windowStart + visibleIndex;
             const isCursor = idx === highlighted;
@@ -2544,9 +2592,11 @@ function SelectPrompt({
               <SelectPromptOptionRow
                 centered={isCentered}
                 centeredLabelWidth={centeredLayout?.labelWidth}
+                interactionDisabled={interactionDisabled}
                 isCursor={isCursor}
                 key={option.value}
                 option={option}
+                rowHeight={optionRowHeights[idx] ?? 1}
               />
             );
           })}
@@ -2559,40 +2609,97 @@ function SelectPrompt({
 function SelectPromptOptionRow({
   centered,
   centeredLabelWidth,
+  interactionDisabled,
   isCursor,
   option,
+  rowHeight,
 }: {
   centered: boolean;
   centeredLabelWidth?: number;
+  interactionDisabled: boolean;
   isCursor: boolean;
   option: SelectPromptOptionData;
+  rowHeight: number;
 }): React.ReactNode {
+  const description = option.description;
   if (centered) {
     return (
-      <Box flexDirection="row" height={1} overflow="hidden" width="100%">
-        <Box flexShrink={0} width={2}>
-          <Text color={ACCENT}>{isCursor ? ICONS.triangleRight : " "}</Text>
+      <Box
+        flexDirection="column"
+        height={rowHeight}
+        overflow="hidden"
+        width="100%"
+      >
+        <Box flexDirection="row" height={1} overflow="hidden" width="100%">
+          <Box flexShrink={0} width={2}>
+            <SelectOptionCursor
+              active={isCursor}
+              loading={interactionDisabled}
+            />
+          </Box>
+          <Box flexShrink={0} width={centeredLabelWidth}>
+            <Text bold={isCursor}>{option.label}</Text>
+          </Box>
+          {option.hint !== undefined && option.hint !== "" ? (
+            <Text color={MUTED}> {option.hint}</Text>
+          ) : null}
         </Box>
-        <Box flexShrink={0} width={centeredLabelWidth}>
-          <Text bold={isCursor}>{option.label}</Text>
-        </Box>
-        {option.hint !== undefined && option.hint !== "" ? (
-          <Text color={MUTED}> {option.hint}</Text>
+        {description ? (
+          <Box
+            flexDirection="row"
+            height={rowHeight - 1}
+            overflow="hidden"
+            width="100%"
+          >
+            <Box flexShrink={0} width={2} />
+            <Text color={MUTED} wrap="wrap">
+              {description}
+            </Text>
+          </Box>
         ) : null}
       </Box>
     );
   }
   return (
-    <Box flexDirection="row" height={1} overflow="hidden">
-      <Box flexShrink={0} width={3}>
-        <Text color={ACCENT}>{isCursor ? ICONS.triangleRight : " "}</Text>
+    <Box flexDirection="column" height={rowHeight} overflow="hidden">
+      <Box flexDirection="row" height={1} overflow="hidden">
+        <Box flexShrink={0} width={3}>
+          <SelectOptionCursor active={isCursor} loading={interactionDisabled} />
+        </Box>
+        <Text bold={isCursor}>{option.label}</Text>
+        {option.hint !== undefined && option.hint !== "" ? (
+          <Text color={MUTED}> {option.hint}</Text>
+        ) : null}
       </Box>
-      <Text bold={isCursor}>{option.label}</Text>
-      {option.hint !== undefined && option.hint !== "" ? (
-        <Text color={MUTED}> {option.hint}</Text>
+      {description ? (
+        <Box
+          flexDirection="row"
+          height={rowHeight - 1}
+          overflow="hidden"
+          width="100%"
+        >
+          <Box flexShrink={0} width={3} />
+          <Text color={MUTED} wrap="wrap">
+            {description}
+          </Text>
+        </Box>
       ) : null}
     </Box>
   );
+}
+
+function SelectOptionCursor({
+  active,
+  loading,
+}: {
+  active: boolean;
+  loading: boolean;
+}): React.ReactNode {
+  let content: React.ReactNode = " ";
+  if (active) {
+    content = loading ? <Spinner type="dots" /> : ICONS.triangleSmallRight;
+  }
+  return <Text color={ACCENT}>{content}</Text>;
 }
 
 function ConfirmPrompt({

--- a/packages/cli/src/lib/init/ui/ink-ui.ts
+++ b/packages/cli/src/lib/init/ui/ink-ui.ts
@@ -410,6 +410,7 @@ type InkInstance = {
  * re-renders.
  */
 export class InkUI implements WizardUI {
+  readonly supportsInteractivePrompts = true;
   private readonly instance: InkInstance;
   private readonly store: WizardStore;
   /**
@@ -748,6 +749,9 @@ export class InkUI implements WizardUI {
           value: option.value,
           label: option.label,
           ...(option.hint ? { hint: option.hint } : {}),
+          ...(option.description
+            ? { description: stripAnsi(option.description) }
+            : {}),
         })),
         initialIndex,
         resolve: (value) => {
@@ -755,6 +759,13 @@ export class InkUI implements WizardUI {
             return;
           }
           settled = true;
+          if (value !== null && opts.holdPresentationOnResolve) {
+            this.activePromptCancel = undefined;
+            this.completedPrompt = prompt;
+            this.store.holdPresentation();
+            resolve(value as T);
+            return;
+          }
           this.completePrompt(
             prompt,
             value === null ? CANCELLED : (value as T),

--- a/packages/cli/src/lib/init/ui/types.ts
+++ b/packages/cli/src/lib/init/ui/types.ts
@@ -96,6 +96,8 @@ export type SelectOption<T extends string> = {
   label: string;
   /** Optional secondary copy rendered beside the label; omitted by default. */
   hint?: string;
+  /** Supporting copy rendered as muted lines below the option label. */
+  description?: string;
 };
 
 /** Option in a multiselect prompt, optionally carrying supporting copy or a fixed selection. */
@@ -126,6 +128,8 @@ export type SelectOptions<T extends string> = {
   options: SelectOption<T>[];
   /** Initially highlighted value. Defaults to the first option. */
   initialValue?: T;
+  /** Keep the current frame visible until the next prompt is mounted. */
+  holdPresentationOnResolve?: boolean;
 };
 
 /** Args for `multiselect`. */
@@ -254,6 +258,9 @@ export type CompletionActions = {
  * the main screen buffer, and release any held TTY resources.
  */
 export type WizardUI = AsyncDisposable & {
+  /** Whether this implementation can render and resolve interactive prompts. */
+  readonly supportsInteractivePrompts?: boolean;
+
   // ── Lifecycle messages ────────────────────────────────────────────
 
   /**

--- a/packages/cli/src/lib/init/ui/wizard-store.ts
+++ b/packages/cli/src/lib/init/ui/wizard-store.ts
@@ -196,6 +196,8 @@ export type WizardLayout = "intro" | "workflow";
 export type WizardSnapshot = {
   /** Top-level layout: centered intro/preflight or full workflow shell. */
   layout: WizardLayout;
+  /** Freeze the last rendered snapshot while the next prompt is prepared. */
+  presentationHold: boolean;
   /** CLI version displayed in the persistent Ink footer banner. */
   cliVersion: string | null;
   bannerRows: { content: string; color: string }[];
@@ -290,6 +292,7 @@ function baseSnapshot(): WizardSnapshot {
     overlay: null,
     outroState: null,
     postExitActions: [],
+    presentationHold: false,
     learnState: { blockIndex: 0, lineIndex: 0, complete: false },
   };
 }
@@ -326,10 +329,15 @@ export class WizardStore {
   }
 
   setLayout(layout: WizardLayout): void {
-    if (this.snapshot.layout === layout) {
+    const releasePresentation =
+      layout === "workflow" && this.snapshot.presentationHold;
+    if (this.snapshot.layout === layout && !releasePresentation) {
       return;
     }
-    this.update({ layout });
+    this.update({
+      layout,
+      ...(releasePresentation ? { presentationHold: false } : {}),
+    });
   }
 
   appendLog(severity: LogSeverity, text: string): LogEntry {
@@ -385,7 +393,20 @@ export class WizardStore {
   }
 
   setPrompt(prompt: ActivePrompt | null): void {
-    this.update({ prompt });
+    this.update({
+      prompt,
+      ...(prompt && this.snapshot.presentationHold
+        ? { presentationHold: false }
+        : {}),
+    });
+  }
+
+  /** Freeze the visible frame until another prompt replaces this one. */
+  holdPresentation(): void {
+    if (this.snapshot.presentationHold) {
+      return;
+    }
+    this.update({ presentationHold: true });
   }
 
   setTipIndex(index: number): void {
@@ -522,7 +543,7 @@ export class WizardStore {
   }
 
   setOutro(state: OutroState): void {
-    this.update({ outroState: state });
+    this.update({ outroState: state, presentationHold: false });
   }
 
   /** Queue a shell command to run after the alternate screen tears down. */

--- a/packages/cli/src/lib/init/wizard-runner.ts
+++ b/packages/cli/src/lib/init/wizard-runner.ts
@@ -12,6 +12,7 @@
  */
 
 import { randomBytes } from "node:crypto";
+import nodePath from "node:path";
 
 import { MastraClient } from "@mastra/client-js";
 import {
@@ -20,6 +21,7 @@ import {
   getTraceData,
   setTag,
 } from "@sentry/node-core/light";
+import { extractRequiredScopes } from "../api-scope.js";
 import { formatBanner } from "../banner.js";
 import { CLI_VERSION } from "../constants.js";
 import { customFetch } from "../custom-ca.js";
@@ -30,6 +32,7 @@ import {
   stripColorTags,
 } from "../formatters/markdown.js";
 import { logger } from "../logger.js";
+import { chooseProjectTeam } from "../team-choice.js";
 import {
   abortIfCancelled,
   PROGRESS_ROTATE_INTERVAL_MS,
@@ -58,10 +61,11 @@ import {
   withInitServiceAuthClassification,
 } from "./init-service-auth.js";
 import { handleInteractive } from "./interactive.js";
-import { resolveInitContext } from "./preflight.js";
+import { resolveInitContext, resolveInitProjectContext } from "./preflight.js";
 import { checkReadiness } from "./readiness.js";
 
 import { describeTool, executeTool } from "./tools/registry.js";
+import { validateToolSandbox } from "./tools/shared.js";
 import type {
   InteractivePayload,
   ResolvedInitContext,
@@ -78,15 +82,18 @@ import type { SpinnerHandle, WelcomeOptions, WizardUI } from "./ui/types.js";
 import { type VerifyResult, verifySetup } from "./verify-setup.js";
 import {
   precomputeDirListing,
-  precomputeSentryDetection,
+  precomputeSentrySetupTargets,
+  precomputeWorkspaceTargetInventory,
   preReadCommonFiles,
 } from "./workflow-inputs.js";
 
 type SpinState = { running: boolean };
 
 const INIT_SERVICE_AUTH_FAILED_LABEL = "Authentication failed";
+const INIT_SCOPE_UPDATE_REQUIRED_LABEL = "Authorization update required";
 
 const APPLY_CODEMODS_STEP = "apply-codemods";
+const SELECT_TARGET_APP_STEP = "select-target-app";
 
 type CompactPhaseHistoryEntry = {
   ok: boolean;
@@ -112,9 +119,55 @@ type StepContext = {
   spin: SpinnerHandle;
   spinState: SpinState;
   context: ResolvedInitContext;
+  supportsExistingSetupImprovement: boolean;
+  projectContextState: ProjectContextState;
   ui: WizardUI;
   sentryProject: SentryProjectRef;
 };
+
+type ProjectContextState = {
+  cwd?: string;
+  selection?: Pick<
+    ResolvedInitContext,
+    "project" | "existingProject" | "setupIntent"
+  > &
+    Partial<Pick<ResolvedInitContext, "org">>;
+};
+
+function supportsInteractiveTeamChoice(ui: WizardUI): boolean {
+  return ui.supportsInteractivePrompts === true;
+}
+
+function isProjectCreationOperation(
+  payload: ToolPayload
+): payload is Extract<
+  ToolPayload,
+  { operation: "create-sentry-project" | "ensure-sentry-project" }
+> {
+  return (
+    payload.operation === "create-sentry-project" ||
+    payload.operation === "ensure-sentry-project"
+  );
+}
+
+/** Validate untrusted tool output before using it to resolve local project context. */
+function isExistingSentryDetection(value: unknown): value is {
+  status: "installed" | "partial" | "none";
+  signals: string[];
+  dsn?: string;
+} {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const candidate = value as { status?: unknown; signals?: unknown };
+  return (
+    (candidate.status === "installed" ||
+      candidate.status === "partial" ||
+      candidate.status === "none") &&
+    Array.isArray(candidate.signals) &&
+    candidate.signals.every((signal) => typeof signal === "string")
+  );
+}
 
 /** Tool operations that create/resolve the Sentry project and return its identity. */
 const SENTRY_PROJECT_OPERATIONS = new Set<ToolPayload["operation"]>([
@@ -201,6 +254,20 @@ function hasActiveStepsPath(value: Record<string, unknown>): value is Record<
     typeof value.activeStepsPath === "object" &&
     value.activeStepsPath !== null &&
     !Array.isArray(value.activeStepsPath)
+  );
+}
+
+/** Accept both current and legacy Mastra run snapshots during resume recovery. */
+function hasSuspendedPaths(value: Record<string, unknown>): value is Record<
+  string,
+  unknown
+> & {
+  suspendedPaths: Record<string, unknown>;
+} {
+  return (
+    typeof value.suspendedPaths === "object" &&
+    value.suspendedPaths !== null &&
+    !Array.isArray(value.suspendedPaths)
   );
 }
 
@@ -382,7 +449,17 @@ async function handleSuspendedStep(
   stepPhases: Map<string, number>,
   stepHistory: Map<string, CompactPhaseHistoryEntry[]>
 ): Promise<Record<string, unknown>> {
-  const { payload, stepId, spin, spinState, context, ui, sentryProject } = ctx;
+  const {
+    payload,
+    stepId,
+    spin,
+    spinState,
+    context,
+    supportsExistingSetupImprovement,
+    projectContextState,
+    ui,
+    sentryProject,
+  } = ctx;
 
   if (payload.type === "tool") {
     const message =
@@ -407,13 +484,109 @@ async function handleSuspendedStep(
       ui.recordFilesReading?.(payload.params.paths);
     }
 
-    const toolResult = await executeTool(payload, context);
+    const sandbox = validateToolSandbox(payload, context.directory);
+    const sandboxedPayload =
+      "ok" in sandbox
+        ? payload
+        : ({ ...payload, cwd: sandbox.cwd } as ToolPayload);
+    let executionContext = context;
+    let toolResult: ToolResult | undefined =
+      "ok" in sandbox ? sandbox : undefined;
+
+    // Once the concrete target directory is resolved, execute detection
+    // through the registry first (which enforces the cwd sandbox), then
+    // resolve the Sentry project from that exact directory.
+    // Keep the choice locally so the later ensure step does not prompt twice.
+    if (!toolResult && sandboxedPayload.operation === "detect-sentry") {
+      toolResult = await executeTool(sandboxedPayload, context);
+      if (toolResult.ok && isExistingSentryDetection(toolResult.data)) {
+        spin.stop("");
+        spinState.running = false;
+        const selection = await resolveInitProjectContext(
+          context,
+          sandboxedPayload.cwd,
+          ui,
+          {
+            setup: toolResult.data,
+            suggestedProjectName: nodePath.basename(sandboxedPayload.cwd),
+            supportsExistingSetupImprovement,
+          }
+        );
+        projectContextState.cwd = sandboxedPayload.cwd;
+        projectContextState.selection = selection;
+        toolResult = {
+          ...toolResult,
+          data: {
+            ...toolResult.data,
+            ...(selection.existingProject?.platform
+              ? { knownPlatform: selection.existingProject.platform }
+              : {}),
+            ...(selection.setupIntent
+              ? { setupIntent: selection.setupIntent }
+              : {}),
+          },
+        };
+        spin.start("Preparing project setup...");
+        spinState.running = true;
+      }
+    }
+
+    if (!toolResult && isProjectCreationOperation(sandboxedPayload)) {
+      let projectContext =
+        projectContextState.cwd === sandboxedPayload.cwd
+          ? projectContextState.selection
+          : undefined;
+      if (!projectContext) {
+        spin.stop("");
+        spinState.running = false;
+        projectContext = await resolveInitProjectContext(
+          context,
+          sandboxedPayload.cwd,
+          ui,
+          {
+            suggestedProjectName: sandboxedPayload.params.name,
+            supportsExistingSetupImprovement,
+          }
+        );
+        projectContextState.cwd = sandboxedPayload.cwd;
+        projectContextState.selection = projectContext;
+      }
+      executionContext = { ...context, ...projectContext };
+      if (!spinState.running) {
+        spin.start(
+          projectContext.existingProject
+            ? "Preparing existing Sentry project..."
+            : "Preparing Sentry project..."
+        );
+        spinState.running = true;
+      }
+    }
+
+    const canChooseTeam =
+      isProjectCreationOperation(sandboxedPayload) &&
+      !context.yes &&
+      !context.dryRun &&
+      supportsInteractiveTeamChoice(ui);
+    toolResult ??= canChooseTeam
+      ? await executeTool(sandboxedPayload, executionContext, {
+          chooseTeam: async (teams) => {
+            spin.stop("Found available teams");
+            spinState.running = false;
+            const choice = await chooseProjectTeam(teams, async (options) =>
+              abortIfCancelled(await ui.select(options))
+            );
+            spin.start("Creating Sentry project...");
+            spinState.running = true;
+            return choice;
+          },
+        })
+      : await executeTool(sandboxedPayload, executionContext);
 
     // The CLI creates the Sentry project itself — retain the identity it just
     // resolved so the completion screen can build the Issues link locally,
     // without the server having to echo org/project/projectId back.
     if (
-      SENTRY_PROJECT_OPERATIONS.has(payload.operation) &&
+      SENTRY_PROJECT_OPERATIONS.has(sandboxedPayload.operation) &&
       toolResult.ok !== false
     ) {
       const identity = extractSentryProjectIdentity(toolResult.data);
@@ -482,7 +655,11 @@ async function handleSuspendedStep(
     spin.stop("");
     spinState.running = false;
 
-    const interactiveResult = await handleInteractive(payload, context, ui);
+    const interactiveResult = await handleInteractive(payload, context, ui, {
+      ...(stepId === SELECT_TARGET_APP_STEP && !(context.yes || context.dryRun)
+        ? { holdPresentationOnSelect: true }
+        : {}),
+    });
 
     // Safety net: { cancelled: true } would send malformed resume data to the
     // server and produce a cryptic HTTP 500. All interactive handlers should
@@ -547,6 +724,12 @@ function assertWorkflowResult(raw: unknown): WorkflowRunResult {
     if (activeStepIds.length > 0) {
       obj.suspended = activeStepIds.map((id) => [id]);
     }
+  }
+  if (
+    (!Array.isArray(obj.suspended) || obj.suspended.length === 0) &&
+    hasSuspendedPaths(obj)
+  ) {
+    obj.suspended = Object.keys(obj.suspendedPaths).map((id) => [id]);
   }
   return obj as WorkflowRunResult;
 }
@@ -845,6 +1028,7 @@ async function tryRecoverCurrentRunState(
             "suspended",
             "steps",
             "activeStepsPath",
+            "suspendedPaths",
             "suspendPayload",
             "result",
             "error",
@@ -1008,7 +1192,7 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     return;
   }
 
-  await checkReadiness(ui);
+  const serviceCapabilities = await checkReadiness(ui);
 
   const effectiveOptions = dryRun
     ? { ...initialOptions, yes: true }
@@ -1081,19 +1265,33 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
   let run: Awaited<ReturnType<typeof workflow.createRun>>;
   let result: WorkflowRunResult;
   try {
-    const [dirListing, existingSentry] = await Promise.all([
+    const [dirListing, sentrySetupTargets] = await Promise.all([
       precomputeDirListing(directory),
-      precomputeSentryDetection(directory).catch(() => null),
+      precomputeSentrySetupTargets(directory).catch((error) => {
+        logger.debug("Failed to precompute Sentry setup targets", error);
+        return [];
+      }),
     ]);
-    const fileCache = await preReadCommonFiles(directory, dirListing);
+    const [fileCache, workspaceInventory] = await Promise.all([
+      preReadCommonFiles(directory, dirListing),
+      precomputeWorkspaceTargetInventory(
+        directory,
+        dirListing,
+        sentrySetupTargets
+      ).catch((error) => {
+        logger.debug("Failed to precompute workspace targets", error);
+        return { complete: false, targets: [] };
+      }),
+    ]);
     ui.setIntroMode?.(false);
     spin.message("Connecting to wizard...");
     run = await withInitServiceAuthClassification(
       () => workflow.createRun(),
       WORKFLOW_CREATE_RUN_ENDPOINT
     );
-    // Large shared context (dirListing, fileCache, existingSentry)
-    // travels via Mastra's workflow `initialState` instead of `inputData`.
+    // Large shared context (dirListing and fileCache), deterministic workspace
+    // inventory, and existing-setup evidence travel via Mastra's workflow
+    // `initialState` instead of `inputData`.
     // Keeping it on state means the server stores it exactly once per run
     // rather than duplicating it across every step's output in the D1
     // snapshot — which used to overflow the per-row size limit on big
@@ -1117,7 +1315,9 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
               initialState: {
                 dirListing,
                 fileCache,
-                existingSentry: existingSentry?.data,
+                sentrySetupTargets,
+                workspaceTargets: workspaceInventory.targets,
+                workspaceTargetsComplete: workspaceInventory.complete,
                 knownPlatform: context.existingProject?.platform,
               },
               tracingOptions,
@@ -1144,6 +1344,7 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
 
   const stepPhases = new Map<string, number>();
   const stepHistory = new Map<string, CompactPhaseHistoryEntry[]>();
+  const projectContextState: ProjectContextState = {};
   // Populated when the create/ensure-sentry-project tool runs; read at the end
   // to build the completion screen's Issues link from local data.
   const sentryProjectRef: SentryProjectRef = {};
@@ -1183,13 +1384,7 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
       }
       activeStepId = extracted.stepId;
       ui.setStep?.(extracted.stepId, "in_progress");
-      let activeLabel = STEP_ACTIVE_LABELS[extracted.stepId];
-      if (
-        extracted.stepId === "detect-platform" &&
-        context.existingProject?.platform
-      ) {
-        activeLabel = `Analyzing project (existing Sentry platform: ${context.existingProject.platform})...`;
-      }
+      const activeLabel = STEP_ACTIVE_LABELS[extracted.stepId];
       if (activeLabel && spinState.running) {
         spin.message(activeLabel);
       }
@@ -1201,6 +1396,9 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
           spin,
           spinState,
           context,
+          supportsExistingSetupImprovement:
+            serviceCapabilities.improveExistingSetup,
+          projectContextState,
           ui,
           sentryProject: sentryProjectRef,
         },
@@ -1232,8 +1430,9 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     }
   } catch (err) {
     const isAuthFailure = err instanceof ApiError && err.status === 401;
-    const isPermissionFailure =
-      err instanceof ApiError && (err.status === 401 || err.status === 403);
+    const isPermissionFailure = err instanceof ApiError && err.status === 403;
+    const isScopeFailure =
+      isPermissionFailure && extractRequiredScopes(err.detail).length > 0;
     // A running spinner owns a live interval, so stop it before any early
     // return or rethrow to avoid leaving the event loop artificially busy.
     if (spinState.running) {
@@ -1244,6 +1443,8 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
         code = 0;
       } else if (isAuthFailure) {
         label = INIT_SERVICE_AUTH_FAILED_LABEL;
+      } else if (isScopeFailure) {
+        label = INIT_SCOPE_UPDATE_REQUIRED_LABEL;
       } else if (isPermissionFailure) {
         label = "Sentry API request denied";
       }
@@ -1263,8 +1464,13 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
     if (activeStepId) {
       ui.setStep?.(activeStepId, "failed");
     }
-    if (isAuthFailure) {
-      showFailedFeedback(ui, INIT_SERVICE_AUTH_FAILED_LABEL);
+    if (isAuthFailure || isScopeFailure) {
+      showFailedFeedback(
+        ui,
+        isAuthFailure
+          ? INIT_SERVICE_AUTH_FAILED_LABEL
+          : INIT_SCOPE_UPDATE_REQUIRED_LABEL
+      );
       setTag("wizard.outcome", "errored");
       throw err;
     }
@@ -1274,7 +1480,7 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
       throw err;
     }
     if (err instanceof WizardError) {
-      showFailedFeedback(ui);
+      showFailedFeedback(ui, err.rendered ? "Setup failed" : err.message);
       setTag("wizard.outcome", "errored");
       throw err;
     }

--- a/packages/cli/src/lib/init/workflow-inputs.ts
+++ b/packages/cli/src/lib/init/workflow-inputs.ts
@@ -1,5 +1,17 @@
+/**
+ * Builds the deterministic, project-scoped filesystem snapshot sent to the
+ * remote workflow. Files are opened through the project-file boundary and
+ * revalidated before their contents are trusted, so later AI discovery can
+ * narrow this inventory but cannot expand access beyond the selected project.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { logger } from "../logger.js";
 import { MAX_FILE_BYTES } from "./constants.js";
-import { detectSentry } from "./tools/detect-sentry.js";
+import {
+  detectSentrySetup,
+  type ExistingSentryEvidence,
+} from "./tools/detect-sentry.js";
 import { listDir } from "./tools/list-dir.js";
 import {
   closeProjectFile,
@@ -84,6 +96,120 @@ const COMMON_CONFIG_FILES = [
 ] as const;
 
 const MAX_PREREAD_TOTAL_BYTES = 512 * 1024;
+const INITIAL_DIR_MAX_ENTRIES = 500;
+
+const PROJECT_MANIFESTS = new Set([
+  "package.json",
+  "pyproject.toml",
+  "setup.py",
+  "setup.cfg",
+  "requirements.txt",
+  "requirements-dev.txt",
+  "Pipfile",
+  "deno.json",
+  "deno.jsonc",
+  "deps.ts",
+  "Cargo.toml",
+  "go.mod",
+  "Gemfile",
+  "composer.json",
+  "mix.exs",
+  "rebar.config",
+  "pubspec.yaml",
+  "Package.swift",
+  "Podfile",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+  "settings.gradle",
+  "settings.gradle.kts",
+  "packages.config",
+  "CMakeLists.txt",
+  "Makefile",
+  "meson.build",
+]);
+const PROJECT_MANIFEST_RE =
+  /^(?:requirements.*\.txt)$|\.(?:csproj|fsproj|vbproj|sln|gemspec|rockspec)$/i;
+
+const SDK_CONFIG_PATH_RE =
+  /(?:^|\/)sentry(?:\.[^/]+)?\.config\.[^/]+$|(?:^|\/)config\/sentry\.php$/;
+
+/** Deterministic project root containing strong local Sentry evidence. */
+export type SentrySetupTarget = {
+  /** Whether complete, untruncated evidence makes unattended selection safe. */
+  autoSelect: boolean;
+  /** Stable, non-empty repository-relative identifier. */
+  name: string;
+  /** Absolute filesystem path to the detected project root. */
+  path: string;
+};
+
+/** Deterministic workspace surface shown in the monorepo target selector. */
+export type WorkspaceTarget = {
+  /** Framework proven by target-local config or scripts, when available. */
+  framework?: string;
+  /** Human-facing name enriched with repository context. */
+  label: string;
+  /** Stable CLI identifier used by `--app` and suspend/resume. */
+  name: string;
+  /** Absolute filesystem path to the workspace surface. */
+  path: string;
+  /** Product role inferred from workspace position, manifest, and local docs. */
+  role: "application" | "documentation" | "example" | "runtime";
+};
+
+/** Deterministic workspace inventory plus whether it covers every project root. */
+export type WorkspaceTargetInventory = {
+  /** True only when every conventional workspace project can be classified. */
+  complete: boolean;
+  /** Targets proven locally and safe to use as the authoritative target set. */
+  targets: WorkspaceTarget[];
+};
+
+type PackageManifest = {
+  dependencies?: Record<string, unknown>;
+  devDependencies?: Record<string, unknown>;
+  exports?: unknown;
+  name?: unknown;
+  private?: unknown;
+  publishConfig?: unknown;
+  scripts?: Record<string, unknown>;
+  workspaces?: unknown;
+};
+
+const WORKSPACE_PACKAGE_RE =
+  /^(?:apps|packages|services|sites|websites)\/[^/]+\/package\.json$/;
+const DIRECT_DEPLOYMENT_ROOT_RE = /^(?:apps|services|sites|websites)\//;
+const EXAMPLE_NAME_RE =
+  /(?:^|[-_.])(demo|example|playground|sandbox)(?:$|[-_.])/i;
+const DOCS_NAME_RE = /(?:^|[-_.])(docs?|documentation|website)(?:$|[-_.])/i;
+const REFERENCE_APP_RE =
+  /\b(?:canonical\s+consumer|demo|example|reference)\s+(?:application|app)|\btest bed\b/i;
+const DEVELOPMENT_PACKAGE_RE =
+  /(?:^|[-_.])(evals?|fixtures?|tests?|testing)(?:$|[-_.])/i;
+const SUPPORTED_WORKSPACE_GLOB_RE =
+  /^(?:apps|packages|services|sites|websites)\/\*$/;
+const YAML_LIST_ITEM_RE = /^\s+-\s+["']?([^"'#\s]+)["']?\s*(?:#.*)?$/;
+const LEADING_WHITESPACE_RE = /^\s/;
+const REPO_SUFFIX_RE = /[-_.](?:monorepo|repo|workspace)$/i;
+const NAME_SEPARATOR_RE = /[-_.]+/;
+
+const FRAMEWORK_CONFIGS = [
+  ["astro.config.", "Astro"],
+  ["nitro.config.", "Nitro"],
+  ["next.config.", "Next.js"],
+  ["nuxt.config.", "Nuxt"],
+  ["svelte.config.", "SvelteKit"],
+  ["remix.config.", "Remix"],
+] as const;
+const FRAMEWORK_SCRIPTS = [
+  [/\bastro\s+(?:build|dev|preview)\b/i, "Astro"],
+  [/\bnitro\s+(?:build|dev|preview)\b/i, "Nitro"],
+  [/\bnext\s+(?:build|dev|start)\b/i, "Next.js"],
+  [/\bnuxt\s+(?:build|dev|generate|preview)\b/i, "Nuxt"],
+  [/\bsvelte-kit\s+(?:build|dev|preview)\b/i, "SvelteKit"],
+  [/\bremix\s+(?:build|dev)\b/i, "Remix"],
+] as const;
 
 /**
  * Pre-compute the initial directory listing before the first workflow call.
@@ -95,7 +221,12 @@ export async function precomputeDirListing(
     type: "tool",
     operation: "list-dir",
     cwd: directory,
-    params: { path: ".", recursive: true, maxDepth: 3, maxEntries: 500 },
+    params: {
+      path: ".",
+      recursive: true,
+      maxDepth: 3,
+      maxEntries: INITIAL_DIR_MAX_ENTRIES,
+    },
   });
   return (result.data as { entries?: DirEntry[] } | undefined)?.entries ?? [];
 }
@@ -191,8 +322,563 @@ async function readCommonConfigFile(
 }
 
 /**
- * Pre-compute local Sentry detection so the workflow can start with that context.
+ * Locate concrete project/workspace roots that already contain a strong
+ * Sentry setup signal. These are discovery hints only: the selected target is
+ * scanned again later, so root evidence can never become another app's status.
  */
-export async function precomputeSentryDetection(directory: string) {
-  return await detectSentry(directory);
+export async function precomputeSentrySetupTargets(
+  directory: string
+): Promise<SentrySetupTarget[]> {
+  const root = path.resolve(directory);
+  const detection = await detectSentrySetup(directory);
+  if (detection.status !== "installed") {
+    return [];
+  }
+
+  const roots = new Set<string>();
+  for (const evidence of detection.evidence ?? []) {
+    const signalPath = strongEvidencePath(evidence);
+    if (!signalPath) {
+      continue;
+    }
+    const projectRoot = await findNearestProjectRoot(directory, signalPath);
+    if (projectRoot) {
+      roots.add(projectRoot);
+    }
+  }
+
+  return await Promise.all(
+    [...roots].sort().map((projectRoot) => ({
+      autoSelect: detection.evidenceTruncated !== true,
+      name: workspaceTargetId(root, projectRoot),
+      path: projectRoot,
+    }))
+  );
+}
+
+/**
+ * Inventory concrete JavaScript workspace targets before AI analysis so model
+ * output can enrich, but never omit, applications and relevant packages.
+ */
+export async function precomputeWorkspaceTargetInventory(
+  directory: string,
+  dirListing: DirEntry[],
+  sentrySetupTargets: SentrySetupTarget[]
+): Promise<WorkspaceTargetInventory> {
+  const root = path.resolve(directory);
+  const listingPaths = new Set(
+    dirListing
+      .filter((entry) => entry.type === "file")
+      .map((entry) => entry.path)
+  );
+  const candidateRoots = workspaceCandidateRoots(
+    root,
+    listingPaths,
+    sentrySetupTargets
+  );
+  const rootManifest = await readPackageManifest(root, root);
+  const repoName = cleanRepoName(
+    packageName(rootManifest) ?? path.basename(root)
+  );
+  const setupPaths = new Set(
+    sentrySetupTargets.map((target) => path.resolve(target.path))
+  );
+  const targets: WorkspaceTarget[] = [];
+  let complete =
+    dirListing.length < INITIAL_DIR_MAX_ENTRIES &&
+    (await hasSupportedWorkspaceDeclaration(
+      root,
+      rootManifest,
+      listingPaths
+    )) &&
+    hasCompleteWorkspaceCoverage(root, listingPaths, candidateRoots);
+
+  for (const projectRoot of [...candidateRoots].sort()) {
+    const inspection = await inspectWorkspaceCandidate({
+      listingPaths,
+      projectRoot,
+      repoName,
+      root,
+      setupPaths,
+    });
+    complete = complete && inspection.classified;
+    if (inspection.target) {
+      targets.push(inspection.target);
+    }
+  }
+
+  return { complete, targets };
+}
+
+async function hasSupportedWorkspaceDeclaration(
+  root: string,
+  rootManifest: PackageManifest | undefined,
+  listingPaths: Set<string>
+): Promise<boolean> {
+  if (listingPaths.has("pnpm-workspace.yaml")) {
+    const workspacePath = path.join(root, "pnpm-workspace.yaml");
+    if (!(await isSafeRegularFile(root, workspacePath))) {
+      return false;
+    }
+    try {
+      const contents = await fs.promises.readFile(workspacePath, "utf-8");
+      return areSupportedWorkspacePatterns(pnpmWorkspacePatterns(contents));
+    } catch (error) {
+      logger.debug(
+        `Failed to read workspace declaration: ${workspacePath}`,
+        error
+      );
+      return false;
+    }
+  }
+  return areSupportedWorkspacePatterns(
+    manifestWorkspacePatterns(rootManifest?.workspaces)
+  );
+}
+
+function pnpmWorkspacePatterns(contents: string): string[] {
+  const patterns: string[] = [];
+  let readingPackages = false;
+  for (const line of contents.split("\n")) {
+    if (line.trim() === "packages:") {
+      readingPackages = true;
+      continue;
+    }
+    if (
+      readingPackages &&
+      line.length > 0 &&
+      !LEADING_WHITESPACE_RE.test(line)
+    ) {
+      break;
+    }
+    const pattern = readingPackages
+      ? YAML_LIST_ITEM_RE.exec(line)?.[1]
+      : undefined;
+    if (pattern) {
+      patterns.push(pattern);
+    }
+  }
+  return patterns;
+}
+
+function manifestWorkspacePatterns(workspaces: unknown): string[] {
+  if (Array.isArray(workspaces)) {
+    return workspaces.filter(
+      (value): value is string => typeof value === "string"
+    );
+  }
+  if (typeof workspaces !== "object" || workspaces === null) {
+    return [];
+  }
+  const packages = (workspaces as { packages?: unknown }).packages;
+  return Array.isArray(packages)
+    ? packages.filter((value): value is string => typeof value === "string")
+    : [];
+}
+
+function areSupportedWorkspacePatterns(patterns: string[]): boolean {
+  return (
+    patterns.length > 0 &&
+    patterns.every((pattern) => SUPPORTED_WORKSPACE_GLOB_RE.test(pattern))
+  );
+}
+
+function workspaceCandidateRoots(
+  root: string,
+  listingPaths: Set<string>,
+  sentrySetupTargets: SentrySetupTarget[]
+): Set<string> {
+  const roots = new Set(
+    [...listingPaths]
+      .filter((filePath) => WORKSPACE_PACKAGE_RE.test(filePath))
+      .map((filePath) => path.resolve(root, path.dirname(filePath)))
+  );
+  for (const target of sentrySetupTargets) {
+    roots.add(path.resolve(target.path));
+  }
+  return roots;
+}
+
+function hasCompleteWorkspaceCoverage(
+  root: string,
+  listingPaths: Set<string>,
+  candidateRoots: Set<string>
+): boolean {
+  return [...listingPaths].every((filePath) => {
+    if (!isProjectManifestName(path.basename(filePath))) {
+      return true;
+    }
+    const relativeProjectRoot = path.dirname(filePath);
+    if (relativeProjectRoot === ".") {
+      return true;
+    }
+    return candidateRoots.has(path.resolve(root, relativeProjectRoot));
+  });
+}
+
+async function inspectWorkspaceCandidate({
+  listingPaths,
+  projectRoot,
+  repoName,
+  root,
+  setupPaths,
+}: {
+  listingPaths: Set<string>;
+  projectRoot: string;
+  repoName: string;
+  root: string;
+  setupPaths: Set<string>;
+}): Promise<{ classified: boolean; target?: WorkspaceTarget }> {
+  const manifest = await readPackageManifest(root, projectRoot);
+  if (!manifest) {
+    return { classified: false };
+  }
+  const relativeRoot = path.relative(root, projectRoot).replaceAll("\\", "/");
+  if (relativeRoot.startsWith("../") || path.isAbsolute(relativeRoot)) {
+    return { classified: false };
+  }
+
+  const framework = detectWorkspaceFramework(
+    relativeRoot,
+    manifest,
+    listingPaths
+  );
+  const hasSentrySetup = setupPaths.has(projectRoot);
+  if (
+    !isWorkspaceTarget({
+      framework,
+      hasSentrySetup,
+      listingPaths,
+      manifest,
+      relativeRoot,
+    })
+  ) {
+    return {
+      classified: isKnownWorkspacePackage(relativeRoot, manifest),
+    };
+  }
+
+  const rawName = packageName(manifest) ?? path.basename(projectRoot);
+  const role = classifyWorkspaceRole({
+    hasSentrySetup,
+    manifest,
+    rawName,
+    readme: await readProjectReadme(root, projectRoot),
+    relativeRoot,
+  });
+  return {
+    classified: true,
+    target: {
+      ...(framework ? { framework } : {}),
+      label: workspaceLabel(rawName, repoName, role),
+      name: workspaceTargetId(root, projectRoot),
+      path: projectRoot,
+      role,
+    },
+  };
+}
+
+function isWorkspaceTarget({
+  framework,
+  hasSentrySetup,
+  listingPaths,
+  manifest,
+  relativeRoot,
+}: {
+  framework: string | undefined;
+  hasSentrySetup: boolean;
+  listingPaths: Set<string>;
+  manifest: PackageManifest;
+  relativeRoot: string;
+}): boolean {
+  const hasDeployment =
+    Boolean(framework) ||
+    hasDeploymentIndicator(relativeRoot, manifest, listingPaths);
+  return (
+    DIRECT_DEPLOYMENT_ROOT_RE.test(relativeRoot) ||
+    hasSentrySetup ||
+    (hasDeployment && manifest.exports === undefined)
+  );
+}
+
+function isKnownWorkspacePackage(
+  relativeRoot: string,
+  manifest: PackageManifest
+): boolean {
+  return (
+    manifest.exports !== undefined ||
+    manifest.private === false ||
+    manifest.publishConfig !== undefined ||
+    DEVELOPMENT_PACKAGE_RE.test(
+      `${packageName(manifest) ?? ""} ${relativeRoot}`
+    )
+  );
+}
+
+function isProjectManifestName(name: string): boolean {
+  return PROJECT_MANIFESTS.has(name) || PROJECT_MANIFEST_RE.test(name);
+}
+
+function hasDeploymentIndicator(
+  relativeRoot: string,
+  manifest: PackageManifest,
+  listingPaths: Set<string>
+): boolean {
+  const prefix = relativeRoot ? `${relativeRoot}/` : "";
+  if (
+    ["Dockerfile", "vercel.json", "wrangler.toml", "wrangler.jsonc"].some(
+      (fileName) => listingPaths.has(`${prefix}${fileName}`)
+    )
+  ) {
+    return true;
+  }
+  return ["deploy", "start"].some(
+    (script) => typeof manifest.scripts?.[script] === "string"
+  );
+}
+
+function classifyWorkspaceRole({
+  hasSentrySetup,
+  manifest,
+  rawName,
+  readme,
+  relativeRoot,
+}: {
+  hasSentrySetup: boolean;
+  manifest: PackageManifest;
+  rawName: string;
+  readme: string;
+  relativeRoot: string;
+}): WorkspaceTarget["role"] {
+  const identity = `${rawName} ${relativeRoot}`;
+  if (EXAMPLE_NAME_RE.test(identity) || REFERENCE_APP_RE.test(readme)) {
+    return "example";
+  }
+  if (
+    DOCS_NAME_RE.test(identity) ||
+    hasDependency(manifest, "@astrojs/starlight")
+  ) {
+    return "documentation";
+  }
+  if (hasSentrySetup && manifest.exports) {
+    return "runtime";
+  }
+  return "application";
+}
+
+function detectWorkspaceFramework(
+  relativeRoot: string,
+  manifest: PackageManifest,
+  listingPaths: Set<string>
+): string | undefined {
+  const prefix = relativeRoot ? `${relativeRoot}/` : "";
+  for (const [configPrefix, framework] of FRAMEWORK_CONFIGS) {
+    if (
+      [...listingPaths].some(
+        (filePath) =>
+          filePath.startsWith(`${prefix}${configPrefix}`) &&
+          !filePath.slice(prefix.length + configPrefix.length).includes("/")
+      )
+    ) {
+      return framework;
+    }
+  }
+  const scripts = Object.values(manifest.scripts ?? {})
+    .filter((script): script is string => typeof script === "string")
+    .join("\n");
+  for (const [pattern, framework] of FRAMEWORK_SCRIPTS) {
+    if (pattern.test(scripts)) {
+      return framework;
+    }
+  }
+  return;
+}
+
+function hasDependency(manifest: PackageManifest, name: string): boolean {
+  return Boolean(
+    manifest.dependencies?.[name] ?? manifest.devDependencies?.[name]
+  );
+}
+
+function packageName(
+  manifest: PackageManifest | undefined
+): string | undefined {
+  return typeof manifest?.name === "string" && manifest.name.trim()
+    ? manifest.name.trim()
+    : undefined;
+}
+
+function cleanRepoName(name: string): string {
+  return packageTail(name).replace(REPO_SUFFIX_RE, "");
+}
+
+function packageTail(name: string): string {
+  return name.split("/").at(-1) ?? name;
+}
+
+function titleCase(name: string): string {
+  return packageTail(name)
+    .split(NAME_SEPARATOR_RE)
+    .filter(Boolean)
+    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+    .join(" ");
+}
+
+function workspaceLabel(
+  packageNameValue: string,
+  repoName: string,
+  role: WorkspaceTarget["role"]
+): string {
+  const packageLabel = titleCase(packageNameValue);
+  const repoLabel = titleCase(repoName);
+  if (
+    role !== "runtime" &&
+    !packageLabel.toLowerCase().includes(repoLabel.toLowerCase())
+  ) {
+    return `${repoLabel} ${packageLabel}`;
+  }
+  return packageLabel;
+}
+
+async function readPackageManifest(
+  root: string,
+  projectRoot: string
+): Promise<PackageManifest | undefined> {
+  const packagePath = path.join(projectRoot, "package.json");
+  if (!(await isSafeRegularFile(root, packagePath))) {
+    return;
+  }
+  try {
+    return JSON.parse(
+      await fs.promises.readFile(packagePath, "utf-8")
+    ) as PackageManifest;
+  } catch (error) {
+    logger.debug(`Failed to read workspace manifest: ${packagePath}`, error);
+    return;
+  }
+}
+
+async function readProjectReadme(
+  root: string,
+  projectRoot: string
+): Promise<string> {
+  for (const name of ["README.md", "README.mdx", "README.txt"]) {
+    const readmePath = path.join(projectRoot, name);
+    if (!(await isSafeRegularFile(root, readmePath))) {
+      continue;
+    }
+    try {
+      return (await fs.promises.readFile(readmePath, "utf-8")).slice(0, 16_384);
+    } catch (error) {
+      logger.debug(`Failed to read workspace README: ${readmePath}`, error);
+      return "";
+    }
+  }
+  return "";
+}
+
+async function isSafeRegularFile(
+  root: string,
+  candidate: string
+): Promise<boolean> {
+  try {
+    const stat = await fs.promises.lstat(candidate);
+    if (!stat.isFile()) {
+      return false;
+    }
+    const [realRoot, realCandidate] = await Promise.all([
+      fs.promises.realpath(root),
+      fs.promises.realpath(candidate),
+    ]);
+    return isPathWithin(realRoot, realCandidate);
+  } catch (error) {
+    logger.debug(`Workspace file is unavailable: ${candidate}`, error);
+    return false;
+  }
+}
+
+function strongEvidencePath(
+  evidence: ExistingSentryEvidence
+): string | undefined {
+  if (evidence.kind === "initialization" || evidence.kind === "dsn") {
+    return evidence.path;
+  }
+  if (evidence.kind === "config" && SDK_CONFIG_PATH_RE.test(evidence.path)) {
+    return evidence.path;
+  }
+  return;
+}
+
+async function findNearestProjectRoot(
+  directory: string,
+  signalPath: string
+): Promise<string | undefined> {
+  const root = path.resolve(directory);
+  const absoluteSignal = path.resolve(root, signalPath);
+  if (
+    absoluteSignal !== root &&
+    !absoluteSignal.startsWith(`${root}${path.sep}`)
+  ) {
+    return;
+  }
+
+  const [realRoot, realSignal] = await Promise.all([
+    tryRealpath(root),
+    tryRealpath(absoluteSignal),
+  ]);
+  if (!(realRoot && realSignal && isPathWithin(realRoot, realSignal))) {
+    return;
+  }
+
+  let current = path.dirname(absoluteSignal);
+  while (current === root || current.startsWith(`${root}${path.sep}`)) {
+    const realCurrent = await tryRealpath(current);
+    if (
+      realCurrent &&
+      isPathWithin(realRoot, realCurrent) &&
+      (await hasProjectManifest(current))
+    ) {
+      return current;
+    }
+    if (current === root) {
+      break;
+    }
+    current = path.dirname(current);
+  }
+  return;
+}
+
+function isPathWithin(root: string, candidate: string): boolean {
+  return candidate === root || candidate.startsWith(`${root}${path.sep}`);
+}
+
+function workspaceTargetId(root: string, projectRoot: string): string {
+  const relative = path.relative(root, projectRoot).replaceAll("\\", "/");
+  return relative || ".";
+}
+
+async function tryRealpath(candidate: string): Promise<string | undefined> {
+  try {
+    return await fs.promises.realpath(candidate);
+  } catch (error) {
+    logger.debug(`Failed to resolve workspace path: ${candidate}`, error);
+    return;
+  }
+}
+
+async function hasProjectManifest(directory: string): Promise<boolean> {
+  try {
+    const entries = await fs.promises.readdir(directory, {
+      withFileTypes: true,
+    });
+    return entries.some(
+      (entry) =>
+        entry.isFile() &&
+        (PROJECT_MANIFESTS.has(entry.name) ||
+          PROJECT_MANIFEST_RE.test(entry.name))
+    );
+  } catch (error) {
+    logger.debug(`Failed to inspect project manifests: ${directory}`, error);
+    return false;
+  }
 }

--- a/packages/cli/src/lib/project-creation.ts
+++ b/packages/cli/src/lib/project-creation.ts
@@ -1,0 +1,188 @@
+/**
+ * Shared project-creation routing for CLI commands.
+ *
+ * A resolved team uses the team-scoped endpoint. When an implicitly resolved
+ * team rejects creation, the org-scoped onboarding endpoint can create a
+ * personal team instead. Explicit or interactively selected teams and org
+ * policy failures never fall back, preserving the user's choice and the
+ * organization's restriction.
+ */
+
+import {
+  type CreatedProjectDetails,
+  createProjectWithAutoTeam,
+  createProjectWithDsn,
+  MEMBER_PROJECT_CREATION_DISABLED_DETAIL,
+} from "./api-client.js";
+import { ApiError } from "./errors.js";
+import {
+  buildTeamAdminAuthorizationError,
+  type ResolvedConcreteTeam,
+} from "./resolve-team.js";
+
+/** Project details plus the owning team selected by the creation route. */
+export type ProjectCreationResult = CreatedProjectDetails & {
+  /** Slug of the existing or newly created team that owns the project. */
+  teamSlug: string;
+  /** How the owning team was selected. */
+  teamSource: ResolvedConcreteTeam["source"];
+};
+
+/** Inputs for shared project-creation endpoint selection. */
+export type ProjectCreationOptions = {
+  /** Project display name. */
+  name: string;
+  /** Organization that will own the project. */
+  orgSlug: string;
+  /** Optional Sentry platform identifier. */
+  platform?: string;
+  /** Resolved team, or undefined to use org-scoped onboarding creation. */
+  team?: ResolvedConcreteTeam;
+};
+
+/** API route selected by the shared project-creation resolver. */
+export type ProjectCreationRoute = "organization" | "team";
+
+/** ApiError annotated with the concrete project-creation route that failed. */
+export class ProjectCreationApiError extends ApiError {
+  /** Original API error before route annotation. */
+  override readonly cause: ApiError;
+  /** Concrete endpoint family that produced the error. */
+  readonly route: ProjectCreationRoute;
+
+  /**
+   * @param cause - Original API error
+   * @param route - Project-creation route that failed
+   */
+  constructor(cause: ApiError, route: ProjectCreationRoute) {
+    super(
+      cause.message,
+      cause.status,
+      cause.detail,
+      cause.endpoint,
+      cause.enriched403
+    );
+    this.name = "ProjectCreationApiError";
+    this.cause = cause;
+    this.route = route;
+  }
+}
+
+/**
+ * Execute one concrete creation route and retain that provenance on API errors.
+ * The caller can use the route tag without inferring it from mutable resolver state.
+ */
+async function createOnRoute(
+  requestedPlatform: string | undefined,
+  route: ProjectCreationRoute,
+  create: (
+    selectedPlatform: string | undefined
+  ) => Promise<ProjectCreationResult>
+): Promise<ProjectCreationResult> {
+  try {
+    return await create(requestedPlatform);
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw new ProjectCreationApiError(error, route);
+    }
+    throw error;
+  }
+}
+
+/** Match the policy detail shared by both project-creation endpoints. */
+function isMemberCreationDisabled403(
+  error: unknown
+): error is ProjectCreationApiError {
+  return (
+    error instanceof ProjectCreationApiError &&
+    error.status === 403 &&
+    error.detail?.includes(MEMBER_PROJECT_CREATION_DISABLED_DETAIL) === true
+  );
+}
+
+/** Whether team choice must be preserved instead of using a personal team. */
+function isUserSelectedTeam(team: ResolvedConcreteTeam): boolean {
+  return team.source === "explicit" || team.source === "selected";
+}
+
+/**
+ * Create a project through the same endpoint-selection policy used by the UI.
+ */
+export async function createProjectWithTeamFallback(
+  options: ProjectCreationOptions
+): Promise<ProjectCreationResult> {
+  const { name, orgSlug, platform, team } = options;
+
+  if (!team) {
+    return await createOnRoute(
+      platform,
+      "organization",
+      async (selectedPlatform) => {
+        const result = await createProjectWithAutoTeam(orgSlug, {
+          name,
+          platform: selectedPlatform,
+        });
+        return {
+          project: result.project,
+          dsn: result.dsn,
+          url: result.url,
+          teamSlug: result.team_slug,
+          teamSource: "auto-created",
+        };
+      }
+    );
+  }
+
+  try {
+    return await createOnRoute(platform, "team", async (selectedPlatform) => {
+      const result = await createProjectWithDsn(orgSlug, team.slug, {
+        name,
+        platform: selectedPlatform,
+      });
+      return {
+        ...result,
+        teamSlug: team.slug,
+        teamSource: team.source,
+      };
+    });
+  } catch (error) {
+    if (!(error instanceof ProjectCreationApiError && error.status === 403)) {
+      throw error;
+    }
+
+    // TeamProjectsEndpoint uses the member-creation-disabled detail when its
+    // `has_team_scope(team, "team:admin")` check fails. Since this team was
+    // selected from serialized Team Admin access, that response means the
+    // token's OAuth upper bound is stale, not that another route can work.
+    if (team.source !== "explicit" && isMemberCreationDisabled403(error)) {
+      throw buildTeamAdminAuthorizationError(orgSlug, team.slug);
+    }
+
+    // A user-selected team is authoritative just like --team: never replace
+    // it with a personal team through the organization route.
+    if (isUserSelectedTeam(team)) {
+      throw error;
+    }
+
+    // Unlike TeamProjectsEndpoint, the organization-scoped endpoint's policy
+    // detail is authoritative. Preserve its route and detail so callers show
+    // the policy recovery, not a useless OAuth team:admin refresh.
+    return await createOnRoute(
+      platform,
+      "organization",
+      async (selectedPlatform) => {
+        const result = await createProjectWithAutoTeam(orgSlug, {
+          name,
+          platform: selectedPlatform,
+        });
+        return {
+          project: result.project,
+          dsn: result.dsn,
+          url: result.url,
+          teamSlug: result.team_slug,
+          teamSource: "auto-created",
+        };
+      }
+    );
+  }
+}

--- a/packages/cli/src/lib/resolve-target.ts
+++ b/packages/cli/src/lib/resolve-target.ts
@@ -11,10 +11,10 @@
  * 3. `.sentryclirc` config file (walked up from CWD, merged with global)
  * 4. Config defaults (SQLite)
  * 5. DSN auto-detection (source code, .env files, environment variables)
- * 6. Directory name inference (matches project slugs with word boundaries)
+ * 6. Codebase-name inference (specific project root/cwd, git remote, fuzzy root fallback)
  */
 
-import { basename } from "node:path";
+import { basename, resolve as resolvePath } from "node:path";
 import { isatty } from "node:tty";
 import pLimit from "p-limit";
 import type { SentryOrganization, SentryProject } from "../types/index.js";
@@ -66,12 +66,17 @@ import {
   withAuthGuard,
 } from "./errors.js";
 import { fuzzyMatch } from "./fuzzy.js";
+import { inferRepositoryName, inferRepositoryRoot } from "./git.js";
 import { interactivePromptsAllowed } from "./interactive-prompts.js";
 import { logger } from "./logger.js";
 import { resolveEffectiveOrg } from "./region.js";
-import { CONFIG_FILENAME, loadSentryCliRc } from "./sentryclirc.js";
+import {
+  CONFIG_FILENAME,
+  getGlobalPaths,
+  loadSentryCliRc,
+} from "./sentryclirc.js";
 import { setOrgProjectContext, withTracingSpan } from "./telemetry.js";
-import { isAllDigits } from "./utils.js";
+import { isAllDigits, slugify } from "./utils.js";
 
 const log = logger.withTag("resolve-target");
 
@@ -123,6 +128,10 @@ export type ResolvedTarget = {
   packagePath?: string;
   /** Full project data when already fetched (avoids redundant getProject re-fetch) */
   projectData?: SentryProject;
+  /** Exact detected DSN that produced this target, when DSN-resolved. */
+  detectedDsn?: DetectedDsn;
+  /** Whether a name-based signal matched the project slug exactly or fuzzily. */
+  matchStrength?: "exact" | "fuzzy";
 };
 
 /**
@@ -168,7 +177,28 @@ export type ResolveOptions = {
    * invocations never block on a prompt).
    */
   interactive?: boolean;
+  /**
+   * Resolution policy. `codebase` ignores account-wide defaults and accepts
+   * `.sentryclirc` only when its project came from a file in the cwd ancestry.
+   * Use it for create-first workflows that must not reuse an unrelated global
+   * default when the checked-out code has no concrete project signal.
+   */
+  resolutionMode?: "standard" | "codebase";
+  /**
+   * Restrict auto-detected targets to one organization while still allowing
+   * lower-priority signals to run when a higher-priority signal points at a
+   * different organization. Explicit `org` + `project` inputs still win.
+   */
+  organizationFilter?: string;
 };
+
+/** Whether a resolved `.sentryclirc` project came from the cwd ancestry. */
+function hasLocalRcProject(
+  config: Awaited<ReturnType<typeof loadSentryCliRc>>
+) {
+  const source = config.sources.project;
+  return source !== undefined && !getGlobalPaths().has(source);
+}
 
 /**
  * Options for resolving org only.
@@ -209,6 +239,7 @@ export async function resolveFromDsn(
       orgDisplay: dsn.resolved.orgName,
       projectDisplay: dsn.resolved.projectName,
       detectedFrom,
+      detectedDsn: dsn,
     };
   }
 
@@ -222,6 +253,7 @@ export async function resolveFromDsn(
       orgDisplay: cached.orgName,
       projectDisplay: cached.projectName,
       detectedFrom,
+      detectedDsn: dsn,
     };
   }
 
@@ -229,7 +261,7 @@ export async function resolveFromDsn(
   // discovery call (and its auth round-trip). Enrich the org slug from the
   // local regions cache when available, otherwise fall back to the numeric IDs
   // — the API accepts both as {org,project}_id_or_slug path params.
-  return dsnTargetFromNumericIds(dsn.orgId, dsn.projectId, detectedFrom);
+  return dsnTargetFromNumericIds(dsn.orgId, dsn.projectId, detectedFrom, dsn);
 }
 
 /**
@@ -241,7 +273,7 @@ function dsnTargetFromNumericIds(
   orgId: string,
   projectId: string,
   detectedFrom: string,
-  packagePath?: string
+  detectedDsn: DetectedDsn
 ): ResolvedTarget {
   const org = getOrgByNumericId(orgId)?.slug ?? orgId;
   return {
@@ -251,7 +283,8 @@ function dsnTargetFromNumericIds(
     orgDisplay: org,
     projectDisplay: projectId,
     detectedFrom,
-    packagePath,
+    packagePath: detectedDsn.packagePath,
+    detectedDsn,
   };
 }
 
@@ -355,6 +388,7 @@ export async function resolveDsnByPublicKey(
       projectDisplay: cached.projectName,
       detectedFrom,
       packagePath: dsn.packagePath,
+      detectedDsn: dsn,
     };
   }
 
@@ -387,6 +421,7 @@ export async function resolveDsnByPublicKey(
         projectDisplay: projectInfo.name,
         detectedFrom,
         packagePath: dsn.packagePath,
+        detectedDsn: dsn,
       };
     }
 
@@ -431,6 +466,7 @@ async function resolveDsnToTarget(
       projectDisplay: dsn.resolved.projectName,
       detectedFrom,
       packagePath,
+      detectedDsn: dsn,
     };
   }
 
@@ -445,17 +481,13 @@ async function resolveDsnToTarget(
       projectDisplay: cached.projectName,
       detectedFrom,
       packagePath,
+      detectedDsn: dsn,
     };
   }
 
   // The DSN already encodes org+project identity, so skip the getProject
   // discovery call (and its auth round-trip) and build the target directly.
-  return dsnTargetFromNumericIds(
-    orgId,
-    dsnProjectId,
-    detectedFrom,
-    packagePath
-  );
+  return dsnTargetFromNumericIds(orgId, dsnProjectId, detectedFrom, dsn);
 }
 
 /** Minimum directory name length for inference (avoids matching too broadly) */
@@ -478,18 +510,27 @@ export function isValidDirNameForInference(dirName: string): boolean {
   return true;
 }
 
+/** Classify a directory signal against one concrete project slug. */
+function projectNameMatchStrength(
+  projectSlug: string,
+  directoryName: string
+): "exact" | "fuzzy" {
+  return projectSlug === slugify(directoryName) ? "exact" : "fuzzy";
+}
+
 /**
- * Infer project(s) from directory name when DSN detection fails.
+ * Infer project(s) from the discovered project-root name.
  * Uses word-boundary matching (`\b`) against all accessible projects.
  *
  * Caches results in dsn_cache with source: "inferred" for performance.
  * Cache is invalidated when directory mtime changes or after 24h TTL.
  *
- * @param cwd - Current working directory
+ * @param projectRoot - Project root selected by local project discovery
  * @returns Resolved targets, or empty if no matches found
  */
-async function inferFromDirectoryName(cwd: string): Promise<ResolvedTargets> {
-  const { projectRoot } = await findProjectRoot(cwd);
+async function inferFromProjectRootName(
+  projectRoot: string
+): Promise<ResolvedTargets> {
   const dirName = basename(projectRoot);
 
   // Skip inference for invalid directory names
@@ -504,12 +545,13 @@ async function inferFromDirectoryName(cwd: string): Promise<ResolvedTargets> {
 
     // Return all cached targets if available
     if (cached.allResolved && cached.allResolved.length > 0) {
-      const targets = cached.allResolved.map((r) => ({
+      const targets: ResolvedTarget[] = cached.allResolved.map((r) => ({
         org: r.orgSlug,
         project: r.projectSlug,
         orgDisplay: r.orgName,
         projectDisplay: r.projectName,
         detectedFrom,
+        matchStrength: projectNameMatchStrength(r.projectSlug, dirName),
       }));
       return {
         targets,
@@ -530,6 +572,10 @@ async function inferFromDirectoryName(cwd: string): Promise<ResolvedTargets> {
             orgDisplay: cached.resolved.orgName,
             projectDisplay: cached.resolved.projectName,
             detectedFrom,
+            matchStrength: projectNameMatchStrength(
+              cached.resolved.projectSlug,
+              dirName
+            ),
           },
         ],
       };
@@ -577,6 +623,7 @@ async function inferFromDirectoryName(cwd: string): Promise<ResolvedTargets> {
     orgDisplay: m.organization?.name ?? m.orgSlug,
     projectDisplay: m.name,
     detectedFrom,
+    matchStrength: projectNameMatchStrength(m.slug, dirName),
   }));
 
   return {
@@ -585,6 +632,262 @@ async function inferFromDirectoryName(cwd: string): Promise<ResolvedTargets> {
       matches.length > 1
         ? `Found ${matches.length} projects matching directory "${dirName}"`
         : undefined,
+  };
+}
+
+/**
+ * Resolve all accessible projects for an exact slug signal.
+ */
+async function inferFromExactProjectSlug(options: {
+  projectSlug: string;
+  detectedFrom: string;
+  matchDescription: string;
+  logDescription: string;
+}): Promise<ResolvedTargets> {
+  try {
+    const { projects } = await findProjectsBySlug(options.projectSlug);
+    const targets: ResolvedTarget[] = projects.map((project) => ({
+      org: project.orgSlug,
+      project: project.slug,
+      projectId: toNumericId(project.id),
+      orgDisplay: project.organization?.name ?? project.orgSlug,
+      projectDisplay: project.name,
+      projectData: project,
+      detectedFrom: options.detectedFrom,
+      matchStrength: "exact",
+    }));
+    return {
+      targets,
+      footer:
+        targets.length > 1
+          ? `Found ${targets.length} projects matching ${options.matchDescription}`
+          : undefined,
+    };
+  } catch (error) {
+    log.debug(`${options.logDescription} project inference failed`, error);
+    return { targets: [] };
+  }
+}
+
+/**
+ * Infer projects from the exact leaf name of the local git remote.
+ *
+ * Unlike directory inference this does not use fuzzy matching: a repository
+ * named `owner/junior` only resolves projects whose slug is exactly `junior`.
+ * Multiple cross-organization matches are preserved so callers can decide
+ * whether the result is concrete enough for their workflow.
+ */
+async function inferFromRepositoryName(cwd: string): Promise<ResolvedTargets> {
+  const repository = inferRepositoryName(cwd);
+  const repositoryName = repository?.name.split("/").at(-1);
+  const projectSlug = repositoryName ? slugify(repositoryName) : "";
+  if (!(repository && projectSlug)) {
+    return { targets: [] };
+  }
+
+  return await inferFromExactProjectSlug({
+    projectSlug,
+    detectedFrom: `git ${repository.remote} remote "${repository.name}"`,
+    matchDescription: `git repository "${repository.name}"`,
+    logDescription: "Git repository",
+  });
+}
+
+/**
+ * Infer projects from the exact current working-directory name.
+ *
+ * This is intentionally exact because nested directory names such as `src`
+ * are common and must not trigger broad fuzzy matches. Project-root inference
+ * remains the final word-boundary fallback.
+ */
+async function inferFromWorkingDirectoryName(
+  cwd: string
+): Promise<ResolvedTargets> {
+  const directoryName = basename(cwd);
+  if (!isValidDirNameForInference(directoryName)) {
+    return { targets: [] };
+  }
+
+  const projectSlug = slugify(directoryName);
+  if (!projectSlug) {
+    return { targets: [] };
+  }
+  return await inferFromExactProjectSlug({
+    projectSlug,
+    detectedFrom: `working directory name "${directoryName}"`,
+    matchDescription: `working directory "${directoryName}"`,
+    logDescription: "Working-directory",
+  });
+}
+
+/** Resolve an exact project slug from the root selected by project discovery. */
+async function inferFromExactProjectRoot(
+  projectRoot: string
+): Promise<ResolvedTargets> {
+  const directoryName = basename(projectRoot);
+  if (!isValidDirNameForInference(directoryName)) {
+    return { targets: [] };
+  }
+  const projectSlug = slugify(directoryName);
+  if (!projectSlug) {
+    return { targets: [] };
+  }
+  return await inferFromExactProjectSlug({
+    projectSlug,
+    detectedFrom: `project root name "${directoryName}"`,
+    matchDescription: `project root "${directoryName}"`,
+    logDescription: "Project-root",
+  });
+}
+
+/**
+ * Resolve name-based codebase signals without letting a repository-root name
+ * override a more specific monorepo app, or an arbitrary checkout directory
+ * override the canonical remote name.
+ */
+async function inferFromCodebaseNames(
+  cwd: string,
+  organizationFilter?: string
+): Promise<ResolvedTargets> {
+  const projectRootInfo = await findProjectRoot(cwd);
+  const repositoryRoot = inferRepositoryRoot(cwd);
+  const resolvedCwd = resolvePath(cwd);
+  const resolvedProjectRoot = resolvePath(projectRootInfo.projectRoot);
+  const resolvedRepositoryRoot = repositoryRoot
+    ? resolvePath(repositoryRoot)
+    : undefined;
+
+  const workingDirectoryResult = filterTargetsByOrganization(
+    await inferFromWorkingDirectoryName(resolvedCwd),
+    organizationFilter
+  );
+  const projectRootResult =
+    resolvedProjectRoot === resolvedCwd
+      ? workingDirectoryResult
+      : filterTargetsByOrganization(
+          await inferFromExactProjectRoot(resolvedProjectRoot),
+          organizationFilter
+        );
+
+  const projectRootIsSpecific =
+    resolvedRepositoryRoot !== undefined &&
+    resolvedProjectRoot !== resolvedRepositoryRoot;
+  if (projectRootIsSpecific && projectRootResult.targets.length > 0) {
+    return projectRootResult;
+  }
+
+  if (projectRootIsSpecific && workingDirectoryResult.targets.length > 0) {
+    return workingDirectoryResult;
+  }
+
+  const repositoryResult = filterTargetsByOrganization(
+    await inferFromRepositoryName(cwd),
+    organizationFilter
+  );
+  if (repositoryResult.targets.length > 0) {
+    return repositoryResult;
+  }
+  if (projectRootResult.targets.length > 0) {
+    return projectRootResult;
+  }
+  if (workingDirectoryResult.targets.length > 0) {
+    return workingDirectoryResult;
+  }
+
+  return filterTargetsByOrganization(
+    await inferFromProjectRootName(resolvedProjectRoot),
+    organizationFilter
+  );
+}
+
+/** Keep auto-detected targets inside an already resolved organization. */
+function filterTargetsByOrganization(
+  result: ResolvedTargets,
+  organizationFilter?: string
+): ResolvedTargets {
+  if (!organizationFilter) {
+    return result;
+  }
+  const targets = result.targets.filter(
+    (target) => target.org === organizationFilter
+  );
+  if (targets.length === result.targets.length) {
+    return result;
+  }
+  return {
+    ...result,
+    targets,
+    footer:
+      targets.length > 1 ? formatMultipleProjectsFooter(targets) : undefined,
+  };
+}
+
+/**
+ * Filter DSN-derived targets by organization without discarding a cold SaaS
+ * DSN whose organization is still represented by its numeric ID.
+ *
+ * The DSN itself cannot prove that a caller-provided slug names the encoded
+ * organization. In that one case, validate the exact numeric project against
+ * the selected organization. This is a concrete project lookup, not the
+ * account-wide DSN discovery that SaaS DSNs intentionally avoid.
+ */
+async function filterDsnTargetsByOrganization(
+  result: ResolvedTargets,
+  organizationFilter?: string
+): Promise<ResolvedTargets> {
+  if (!organizationFilter) {
+    return result;
+  }
+
+  const targets = (
+    await Promise.all(
+      result.targets.map(async (target): Promise<ResolvedTarget | null> => {
+        if (target.org === organizationFilter) {
+          return target;
+        }
+        if (
+          !(
+            target.detectedDsn &&
+            isAllDigits(target.org) &&
+            isAllDigits(target.project)
+          )
+        ) {
+          return null;
+        }
+
+        try {
+          const projectData = await getProject(
+            organizationFilter,
+            target.project
+          );
+          return {
+            ...target,
+            org: organizationFilter,
+            project: projectData.slug,
+            projectId: toNumericId(projectData.id) ?? target.projectId,
+            orgDisplay: resolveOrgDisplayName(
+              organizationFilter,
+              projectData.organization?.name
+            ),
+            projectDisplay: projectData.name,
+            projectData,
+          };
+        } catch (error) {
+          log.debug(
+            `Numeric DSN project ${target.project} does not match organization '${organizationFilter}'`,
+            error
+          );
+          return null;
+        }
+      })
+    )
+  ).filter((target): target is ResolvedTarget => target !== null);
+
+  return {
+    ...result,
+    targets,
+    footer:
+      targets.length > 1 ? formatMultipleProjectsFooter(targets) : undefined,
   };
 }
 
@@ -1065,7 +1368,7 @@ async function resolveDsnsWithTimeout(
  * 3. `.sentryclirc` config file - returns single target
  * 4. Config defaults - returns single target
  * 5. DSN auto-detection - may return multiple targets
- * 6. Directory name inference - matches project slugs with word boundaries
+ * 6. Codebase-name inference (specific project root/cwd, git remote, fuzzy root fallback)
  *
  * @param options - Resolution options with org, project, and cwd
  * @returns All resolved targets and optional footer message
@@ -1079,7 +1382,8 @@ export async function resolveAllTargets(
     "resolve",
     // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Priority-based resolution cascade requires sequential checks.
     async (span) => {
-      const { org, project, cwd } = options;
+      const { org, project, cwd, organizationFilter } = options;
+      const codebaseMode = options.resolutionMode === "codebase";
 
       // 1. CLI flags take priority (both must be provided together)
       if (org && project) {
@@ -1110,7 +1414,10 @@ export async function resolveAllTargets(
 
       // 2. SENTRY_ORG / SENTRY_PROJECT environment variables
       const envVars = resolveFromEnvVars();
-      if (envVars?.project) {
+      if (
+        envVars?.project &&
+        (!organizationFilter || envVars.org === organizationFilter)
+      ) {
         span.setAttribute("resolve.method", "env_vars");
         setOrgProjectContext([envVars.org], [envVars.project]);
         return {
@@ -1132,7 +1439,12 @@ export async function resolveAllTargets(
 
       // 3. .sentryclirc config file (walked up from cwd, merged with global)
       const rcConfig = await loadSentryCliRc(cwd);
-      if (rcConfig.org && rcConfig.project) {
+      if (
+        rcConfig.org &&
+        rcConfig.project &&
+        (!organizationFilter || rcConfig.org === organizationFilter) &&
+        (!codebaseMode || hasLocalRcProject(rcConfig))
+      ) {
         span.setAttribute("resolve.method", "sentryclirc");
         setOrgProjectContext([rcConfig.org], [rcConfig.project]);
         return {
@@ -1148,24 +1460,34 @@ export async function resolveAllTargets(
         };
       }
 
-      log.debug(`No ${CONFIG_FILENAME} org/project, trying config defaults`);
+      log.debug(
+        codebaseMode
+          ? `No local ${CONFIG_FILENAME} org/project, skipping account defaults`
+          : `No ${CONFIG_FILENAME} org/project, trying config defaults`
+      );
 
       // 4. Config defaults
-      const defaultOrg = getDefaultOrganization();
-      const defaultProject = getDefaultProject();
-      if (defaultOrg && defaultProject) {
-        span.setAttribute("resolve.method", "defaults");
-        setOrgProjectContext([defaultOrg], [defaultProject]);
-        return {
-          targets: [
-            {
-              org: defaultOrg,
-              project: defaultProject,
-              orgDisplay: defaultOrg,
-              projectDisplay: defaultProject,
-            },
-          ],
-        };
+      if (!codebaseMode) {
+        const defaultOrg = getDefaultOrganization();
+        const defaultProject = getDefaultProject();
+        if (
+          defaultOrg &&
+          defaultProject &&
+          (!organizationFilter || defaultOrg === organizationFilter)
+        ) {
+          span.setAttribute("resolve.method", "defaults");
+          setOrgProjectContext([defaultOrg], [defaultProject]);
+          return {
+            targets: [
+              {
+                org: defaultOrg,
+                project: defaultProject,
+                orgDisplay: defaultOrg,
+                projectDisplay: defaultProject,
+              },
+            ],
+          };
+        }
       }
 
       log.debug("No config defaults set, trying DSN auto-detection");
@@ -1173,30 +1495,38 @@ export async function resolveAllTargets(
       // 5. DSN auto-detection (may find multiple in monorepos)
       const detection = await detectAllDsns(cwd);
 
-      if (detection.all.length === 0) {
-        log.debug(
-          "No DSNs found in source code or env files, trying directory name inference"
+      if (detection.all.length > 0) {
+        const dsnResult = await filterDsnTargetsByOrganization(
+          await resolveDetectedDsns(detection),
+          organizationFilter
         );
-        // 6. Fallback: infer from directory name
-        const result = await inferFromDirectoryName(cwd);
-        if (result.targets.length === 0) {
-          span.setAttribute("resolve.method", "none");
-          log.debug(
-            "Directory name inference found no matching projects — auto-detection failed"
-          );
-        } else {
-          span.setAttribute("resolve.method", "inference");
-          const uniqueOrgs = [...new Set(result.targets.map((t) => t.org))];
-          const uniqueProjects = [
-            ...new Set(result.targets.map((t) => t.project)),
-          ];
-          setOrgProjectContext(uniqueOrgs, uniqueProjects);
+        if (dsnResult.targets.length > 0 || dsnResult.skippedSelfHosted) {
+          span.setAttribute("resolve.method", "dsn");
+          return dsnResult;
         }
-        return result;
+        log.debug(
+          organizationFilter
+            ? `Detected DSNs did not match organization '${organizationFilter}', trying codebase name inference`
+            : "Detected DSNs could not be resolved, trying codebase name inference"
+        );
       }
 
-      span.setAttribute("resolve.method", "dsn");
-      return resolveDetectedDsns(detection);
+      log.debug("No matching DSNs found, trying codebase name inference");
+      const result = await inferFromCodebaseNames(cwd, organizationFilter);
+      if (result.targets.length === 0) {
+        span.setAttribute("resolve.method", "none");
+        log.debug(
+          "Codebase name inference found no matching projects — auto-detection failed"
+        );
+      } else {
+        span.setAttribute("resolve.method", "codebase-name");
+        const uniqueOrgs = [...new Set(result.targets.map((t) => t.org))];
+        const uniqueProjects = [
+          ...new Set(result.targets.map((t) => t.project)),
+        ];
+        setOrgProjectContext(uniqueOrgs, uniqueProjects);
+      }
+      return result;
     },
     { "resolve.mode": "multi" }
   );
@@ -1289,7 +1619,7 @@ async function resolveDetectedDsns(
  * 3. `.sentryclirc` config file
  * 4. Config defaults
  * 5. DSN auto-detection
- * 6. Directory name inference - matches project slugs with word boundaries
+ * 6. Codebase-name inference (specific project root/cwd, git remote, fuzzy root fallback)
  *
  * @param options - Resolution options with org, project, and cwd
  * @returns Resolved target, or null if resolution failed
@@ -1303,7 +1633,8 @@ export async function resolveOrgAndProject(
     "resolve",
     // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Priority-based resolution cascade requires sequential checks.
     async (span) => {
-      const { org, project, cwd } = options;
+      const { org, project, cwd, organizationFilter } = options;
+      const codebaseMode = options.resolutionMode === "codebase";
 
       // 1. CLI flags take priority (both must be provided together)
       if (org && project) {
@@ -1327,7 +1658,10 @@ export async function resolveOrgAndProject(
 
       // 2. SENTRY_ORG / SENTRY_PROJECT environment variables
       const envVars = resolveFromEnvVars();
-      if (envVars?.project) {
+      if (
+        envVars?.project &&
+        (!organizationFilter || envVars.org === organizationFilter)
+      ) {
         span.setAttribute("resolve.method", "env_vars");
         return withTelemetryContext({
           org: envVars.org,
@@ -1340,7 +1674,12 @@ export async function resolveOrgAndProject(
 
       // 3. .sentryclirc config file
       const rcConfig = await loadSentryCliRc(cwd);
-      if (rcConfig.org && rcConfig.project) {
+      if (
+        rcConfig.org &&
+        rcConfig.project &&
+        (!organizationFilter || rcConfig.org === organizationFilter) &&
+        (!codebaseMode || hasLocalRcProject(rcConfig))
+      ) {
         span.setAttribute("resolve.method", "sentryclirc");
         return withTelemetryContext({
           org: rcConfig.org,
@@ -1352,22 +1691,36 @@ export async function resolveOrgAndProject(
       }
 
       // 4. Config defaults
-      const defaultOrg = getDefaultOrganization();
-      const defaultProject = getDefaultProject();
-      if (defaultOrg && defaultProject) {
-        span.setAttribute("resolve.method", "defaults");
-        return withTelemetryContext({
-          org: defaultOrg,
-          project: defaultProject,
-          orgDisplay: defaultOrg,
-          projectDisplay: defaultProject,
-        });
+      if (!codebaseMode) {
+        const defaultOrg = getDefaultOrganization();
+        const defaultProject = getDefaultProject();
+        if (
+          defaultOrg &&
+          defaultProject &&
+          (!organizationFilter || defaultOrg === organizationFilter)
+        ) {
+          span.setAttribute("resolve.method", "defaults");
+          return withTelemetryContext({
+            org: defaultOrg,
+            project: defaultProject,
+            orgDisplay: defaultOrg,
+            projectDisplay: defaultProject,
+          });
+        }
       }
 
       // 5. DSN auto-detection
       // biome-ignore lint/plugin: grandfathered silent catch — see #1531; drain by adding log.debug()/log.warn() or re-throwing.
       try {
-        const dsnResult = await resolveFromDsn(cwd);
+        const detectedTarget = await resolveFromDsn(cwd);
+        const [dsnResult] = detectedTarget
+          ? (
+              await filterDsnTargetsByOrganization(
+                { targets: [detectedTarget] },
+                organizationFilter
+              )
+            ).targets
+          : [];
         if (dsnResult) {
           span.setAttribute("resolve.method", "dsn");
           return withTelemetryContext(dsnResult);
@@ -1376,35 +1729,37 @@ export async function resolveOrgAndProject(
         // Fall through to directory inference
       }
 
-      // 6. Fallback: infer from directory name
-      const inferred = await inferFromDirectoryName(cwd);
+      // 6-8. Resolve cwd, project-root, and git-remote names as one policy.
+      const inferred = await inferFromCodebaseNames(cwd, organizationFilter);
       const [first] = inferred.targets;
+      if (inferred.targets.length > 1) {
+        span.setAttribute("resolve.method", "codebase-name-ambiguous");
+        return null;
+      }
       if (!first) {
-        // 7. Authenticated last resort: if the account has exactly one
+        // 9. Authenticated last resort: if the account has exactly one
         //    accessible org with exactly one project, that pair is the only
         //    possible target — use it instead of failing. This removes the
         //    "Could not auto-detect organization and project" dead-end for
         //    single-org/single-project accounts (CLI-3B). Callers that rely on
         //    a null return (e.g. event view's cross-org search) are unaffected:
         //    this only ever turns a null into a uniquely-determined target.
-        const sole = await resolveSoleAccountTarget();
-        if (sole) {
-          span.setAttribute("resolve.method", "account_sole");
-          return withTelemetryContext(sole);
+        if (!codebaseMode) {
+          const sole = await resolveSoleAccountTarget();
+          if (
+            sole &&
+            (!organizationFilter || sole.org === organizationFilter)
+          ) {
+            span.setAttribute("resolve.method", "account_sole");
+            return withTelemetryContext(sole);
+          }
         }
         span.setAttribute("resolve.method", "none");
         return null;
       }
 
-      span.setAttribute("resolve.method", "inference");
-      // If multiple matches, note it in detectedFrom
-      return withTelemetryContext({
-        ...first,
-        detectedFrom:
-          inferred.targets.length > 1
-            ? `${first.detectedFrom} (1 of ${inferred.targets.length} matches)`
-            : first.detectedFrom,
-      });
+      span.setAttribute("resolve.method", "codebase-name");
+      return withTelemetryContext(first);
     },
     { "resolve.mode": "single" }
   );

--- a/packages/cli/src/lib/resolve-team.ts
+++ b/packages/cli/src/lib/resolve-team.ts
@@ -1,8 +1,8 @@
 /**
  * Team Resolution
  *
- * Resolves which team to use for operations that require one (e.g., project creation).
- * Shared across create commands that need a team in the API path.
+ * Resolves which team to use for project creation.
+ * Shared by `sentry project create` and `sentry init`.
  *
  * ## Resolution flow
  *
@@ -10,19 +10,31 @@
  * 2. Fetch org teams via `listTeams`
  *    - On 404: org doesn't exist → resolve effective org via cache, show org list
  *    - On other errors: surface status + generic hint
- * 3. If zero teams → auto-create a team named after the project (slug-based),
- *    or defer init-specific creation until the final slug is known
- * 4. If exactly one team → auto-select it
- * 5. Filter to teams the user belongs to (`isMember === true`)
- *    - If exactly one member team → auto-select it
- * 6. Multiple candidate teams → error with team list and `--team` hint
+ * 3. Filter to teams on which the caller has effective `team:admin` access.
+ *    - One eligible team is the non-interactive default.
+ *    - Interactive callers offer create-new first, then existing-team choice.
+ *    - Multiple eligible teams require an interactive choice or `--team`.
+ * 4. If the user chooses create-new or no eligible team exists, inspect the
+ *    organization policy. When member project creation is allowed or the
+ *    caller has `org:write`, return no team so the org-scoped onboarding
+ *    endpoint can atomically create the project and its personal Team Admin
+ *    team.
+ * 5. For a restricted organization, create a new project-owning team only when
+ *    the caller has both `project:admin` and `team:admin`. The latter is needed
+ *    to administer the team after creating it and create its project.
  *
- * The auto-created team (step 3) mirrors the Sentry UI behavior where new
- * organizations always have at least one team.
+ * The resolver owns capability and fallback policy. Callers own presentation
+ * through the narrow `chooseTeam` callback so Ink and plain CLI prompts can
+ * share the same decision flow without leaking UI dependencies here.
  */
 
 import type { SentryTeam } from "../types/index.js";
-import { createTeam, listOrganizations, listTeams } from "./api-client.js";
+import {
+  createTeam,
+  getOrganization,
+  listOrganizations,
+  listTeams,
+} from "./api-client.js";
 import {
   ApiError,
   AuthError,
@@ -30,8 +42,9 @@ import {
   ContextError,
   ResolutionError,
 } from "./errors.js";
+import { logger } from "./logger.js";
 import { resolveEffectiveOrg } from "./region.js";
-import { getSentryBaseUrl } from "./sentry-urls.js";
+import type { ProjectTeamChoice, ProjectTeamOption } from "./team-choice.js";
 
 /**
  * Best-effort fetch the user's organizations and format as a hint string.
@@ -55,6 +68,10 @@ async function fetchOrgListHint(fallbackHint: string): Promise<string> {
 }
 
 /** Options for resolving a team within an organization */
+export type ChooseProjectTeam = (
+  teams: readonly ProjectTeamOption[]
+) => Promise<ProjectTeamChoice>;
+
 export type ResolveTeamOptions = {
   /** Explicit team slug from --team flag */
   team?: string;
@@ -62,11 +79,7 @@ export type ResolveTeamOptions = {
   detectedFrom?: string;
   /** Usage hint shown in errors (e.g., "sentry project create <org>/<name>:<platform>") */
   usageHint: string;
-  /**
-   * Slug to use when auto-creating a team in an empty org.
-   * If not provided and the org has zero teams, an error is thrown instead
-   * unless empty-org auto-creation is being deferred.
-   */
+  /** Slug to use when auto-creating a team for a project admin. */
   autoCreateSlug?: string;
   /**
    * When true, skip the actual team creation API call and return what
@@ -74,16 +87,8 @@ export type ResolveTeamOptions = {
    * with the autoCreateSlug value.
    */
   dryRun?: boolean;
-  /**
-   * When true, an empty org returns a deferred result instead of auto-creating
-   * a team immediately. This lets callers wait until they know the final slug.
-   */
-  deferAutoCreateOnEmptyOrg?: boolean;
-  /**
-   * Called when multiple candidate teams remain after membership filtering.
-   * Return the selected team slug. If not provided, a ContextError is thrown.
-   */
-  onAmbiguous?: (candidates: SentryTeam[]) => Promise<string>;
+  /** Ask an interactive user whether to create or select an eligible team. */
+  chooseTeam?: ChooseProjectTeam;
 };
 
 /** Result of team resolution that produced a concrete team slug. */
@@ -91,35 +96,37 @@ export type ResolvedConcreteTeam = {
   /** The resolved team slug */
   slug: string;
   /** How the team was determined */
-  source: "explicit" | "auto-selected" | "auto-created";
+  source: "explicit" | "selected" | "auto-selected" | "auto-created";
 };
-
-/** Result of init-specific deferred team resolution for empty organizations. */
-export type DeferredResolvedTeam = {
-  /** Indicates that team creation should happen later once the final slug is known. */
-  source: "deferred";
-};
-
-/** Result of team resolution, including deferred empty-org handling for init. */
-export type ResolvedTeam = ResolvedConcreteTeam | DeferredResolvedTeam;
 
 /**
- * Resolve which team to use for an operation.
- *
- * @param orgSlug - Organization to list teams from
- * @param options - Resolution options (team flag, usage hint, detection source)
- * @returns Resolved team slug with source info
- * @throws {ContextError} When team cannot be resolved
- * @throws {ResolutionError} When org slug returns 404
+ * Build the actionable authorization error used when account permissions and
+ * token scopes disagree. This commonly happens to OAuth sessions issued before
+ * `team:admin` became part of the CLI's standard scope set. Keeping the scope
+ * name in an `ApiError` detail lets the global scope-recovery middleware offer
+ * a one-time OAuth refresh and retry the command for those existing grants.
  */
+export function buildTeamAdminAuthorizationError(
+  orgSlug: string,
+  teamSlug?: string
+): ApiError {
+  const target = teamSlug ? `team '${teamSlug}'` : "a new project-owning team";
+  return new ApiError(
+    `Cannot create the project through ${target} in '${orgSlug}' without the 'team:admin' authorization scope.`,
+    403,
+    [
+      "This operation requires the 'team:admin' authorization scope.",
+      "Your Sentry role may already grant Team Admin access, but the current CLI authorization may predate that standard scope.",
+      "Re-authorize the CLI, or use an auth token with team:admin.",
+    ].join("\n")
+  );
+}
 
 /**
  * Handle errors from `listTeams` during team resolution.
  *
  * - 404 → org not found (builds a rich error with org list)
- * - 403 → member lacks team:read; re-thrown as `ApiError` so callers that
- *   implement a member-accessible fallback can detect it and use
- *   POST /organizations/{org}/projects/ instead.
+ * - 403 is handled by the caller as an org-scoped creation fallback.
  * - 401 → re-thrown as `ApiError` so the enriched detail (expired session,
  *   member-disabled-over-limit, etc.) survives instead of being flattened.
  * - other → generic ResolutionError (5xx, network, etc.)
@@ -153,123 +160,205 @@ async function handleListTeamsError(
   throw error;
 }
 
-export async function resolveOrCreateTeam(
-  orgSlug: string,
-  options: ResolveTeamOptions & {
-    deferAutoCreateOnEmptyOrg?: false | undefined;
-  }
-): Promise<ResolvedConcreteTeam>;
-export async function resolveOrCreateTeam(
-  orgSlug: string,
-  options: ResolveTeamOptions & { deferAutoCreateOnEmptyOrg: true }
-): Promise<ResolvedTeam>;
-export async function resolveOrCreateTeam(
+/**
+ * List visible teams. A 403 is not fatal: the organization-scoped onboarding
+ * route may still be available without permission to enumerate teams.
+ */
+async function listTeamsForResolution(
   orgSlug: string,
   options: ResolveTeamOptions
-): Promise<ResolvedTeam> {
-  if (options.team) {
-    return { slug: options.team, source: "explicit" };
-  }
-
-  let teams: SentryTeam[];
+): Promise<SentryTeam[] | undefined> {
   try {
-    teams = await listTeams(orgSlug);
+    return await listTeams(orgSlug);
   } catch (error) {
+    if (error instanceof ApiError && error.status === 403) {
+      return;
+    }
     return await handleListTeamsError(error, orgSlug, options);
   }
+}
 
-  // No teams — auto-create one if a slug was provided
-  if (teams.length === 0) {
-    return resolveEmptyTeams(orgSlug, options);
+type EligibleTeamDecision =
+  | { kind: "create" }
+  | { kind: "team"; team: ResolvedConcreteTeam };
+
+/** Resolve the existing-team side of the policy without creating anything. */
+async function resolveEligibleTeam(
+  orgSlug: string,
+  teams: readonly SentryTeam[],
+  options: ResolveTeamOptions
+): Promise<EligibleTeamDecision> {
+  const eligibleTeams = teams.filter(
+    (team) => Array.isArray(team.access) && team.access.includes("team:admin")
+  );
+
+  if (eligibleTeams.length === 0) {
+    return { kind: "create" };
   }
 
-  // Single team — auto-select
-  if (teams.length === 1) {
-    return { slug: (teams[0] as SentryTeam).slug, source: "auto-selected" };
-  }
-
-  // Multiple teams — prefer teams the user belongs to
-  const memberTeams = teams.filter((t) => t.isMember === true);
-  const candidates = memberTeams.length > 0 ? memberTeams : teams;
-
-  if (candidates.length === 1) {
+  if (options.chooseTeam) {
+    const eligibleBySlug = new Map(
+      eligibleTeams.map((team) => [team.slug, team] as const)
+    );
+    const choice = await options.chooseTeam(
+      eligibleTeams.map(({ slug, name }) => ({ slug, name }))
+    );
+    if (choice.kind === "create") {
+      return choice;
+    }
+    const selected = eligibleBySlug.get(choice.slug);
+    if (!selected) {
+      throw new CliError(
+        `Selected team '${choice.slug}' is not an eligible Team Admin team in '${orgSlug}'.`
+      );
+    }
     return {
-      slug: (candidates[0] as SentryTeam).slug,
-      source: "auto-selected",
+      kind: "team",
+      team: { slug: selected.slug, source: "selected" },
     };
   }
 
-  // Multiple candidates — let caller choose or throw
-  if (options.onAmbiguous) {
-    const slug = await options.onAmbiguous(candidates);
-    return { slug, source: "auto-selected" };
+  const [onlyTeam] = eligibleTeams;
+  if (eligibleTeams.length === 1 && onlyTeam) {
+    return {
+      kind: "team",
+      team: { slug: onlyTeam.slug, source: "auto-selected" },
+    };
   }
 
-  const label =
-    memberTeams.length > 0
-      ? `You belong to ${candidates.length} teams in ${orgSlug}`
-      : `Multiple teams found in ${orgSlug}`;
-  throw new ContextError(
-    "Team",
-    `${options.usageHint} --team ${(candidates[0] as SentryTeam).slug}`,
-    [
-      `${label}. Specify one with --team`,
-      ...candidates.map((t) => `Available: ${t.slug}`),
-    ]
-  );
+  const shown = eligibleTeams.slice(0, 10);
+  const remaining = eligibleTeams.length - shown.length;
+  throw new ContextError("Team", `${options.usageHint} --team <team-slug>`, [
+    `You are a Team Admin of ${eligibleTeams.length} teams in '${orgSlug}'. Choose one explicitly with --team.`,
+    ...shown.map((team) => `Available: ${team.slug}`),
+    ...(remaining > 0 ? [`...and ${remaining} more`] : []),
+  ]);
 }
 
-/**
- * Handle the case when an org has zero teams.
- * Either defers init-specific creation, auto-creates a team, returns a dry-run
- * preview, or throws.
- */
-function resolveEmptyTeams(
+/** Resolve the create-new path after existing-team selection is exhausted. */
+async function resolveNewTeam(
   orgSlug: string,
   options: ResolveTeamOptions
-): Promise<ResolvedTeam> | ResolvedTeam {
-  if (options.deferAutoCreateOnEmptyOrg) {
-    return { source: "deferred" };
-  }
+): Promise<ResolvedConcreteTeam | undefined> {
   if (!options.autoCreateSlug) {
-    const teamsUrl = `${getSentryBaseUrl()}/settings/${orgSlug}/teams/`;
-    throw new ContextError("Team", `${options.usageHint} --team <team-slug>`, [
-      `No teams found in org '${orgSlug}'`,
-      `Create a team at ${teamsUrl}`,
-    ]);
+    return;
+  }
+
+  let organization: Awaited<ReturnType<typeof getOrganization>>;
+  try {
+    organization = await getOrganization(orgSlug);
+  } catch (error) {
+    // Team listing already proved the org exists. If its detail endpoint is
+    // unavailable, let the org-scoped project endpoint produce the precise
+    // creation error instead of turning a best-effort capability check into a
+    // blocker.
+    logger.debug(
+      "Could not inspect organization project-creation policy",
+      error
+    );
+    return;
+  }
+
+  const access = Array.isArray(organization.access) ? organization.access : [];
+  if (
+    organization.allowMemberProjectCreation !== false ||
+    access.includes("org:write")
+  ) {
+    return;
+  }
+  if (!access.includes("project:admin")) {
+    return;
+  }
+  if (!access.includes("team:admin")) {
+    throw buildTeamAdminAuthorizationError(orgSlug);
   }
   if (options.dryRun) {
     return { slug: options.autoCreateSlug, source: "auto-created" };
   }
-  return autoCreateTeam(orgSlug, options.autoCreateSlug);
+  return await autoCreateTeam(orgSlug, options.autoCreateSlug);
 }
 
 /**
- * Auto-create a team in an org that has no teams.
- * Uses the provided slug as the team name.
+ * Resolve which team to use for project creation.
+ *
+ * @param orgSlug - Organization to list teams from
+ * @param options - Resolution options (team flag, usage hint, detection source)
+ * @returns Resolved team slug with source info, or undefined for the
+ *   org-scoped onboarding route
+ * @throws {ResolutionError} When org slug returns 404
+ */
+export async function resolveOrCreateTeam(
+  orgSlug: string,
+  options: ResolveTeamOptions
+): Promise<ResolvedConcreteTeam | undefined> {
+  if (options.team) {
+    return { slug: options.team, source: "explicit" };
+  }
+
+  const teams = await listTeamsForResolution(orgSlug, options);
+  if (!teams) {
+    return;
+  }
+
+  const decision = await resolveEligibleTeam(orgSlug, teams, options);
+  if (decision.kind === "team") {
+    return decision.team;
+  }
+  return await resolveNewTeam(orgSlug, options);
+}
+
+/**
+ * Auto-create a project-owning team, retrying deterministic suffixes when a
+ * non-admin team already owns the preferred slug.
  */
 async function autoCreateTeam(
   orgSlug: string,
   slug: string
-): Promise<ResolvedTeam> {
+): Promise<ResolvedConcreteTeam> {
+  const candidates = [
+    slug,
+    `${slug}-team`,
+    ...[2, 3, 4].map((n) => `${slug}-team-${n}`),
+  ];
+
+  for (const candidate of candidates) {
+    const result = await tryCreateTeamCandidate(orgSlug, candidate, slug);
+    if (result === "conflict") {
+      continue;
+    }
+    return result;
+  }
+
+  throw new CliError(
+    `Could not create a unique team for project '${slug}' in '${orgSlug}'.`
+  );
+}
+
+/**
+ * Attempt one candidate slug. A conflict asks the outer bounded retry loop for
+ * another slug; a permission failure reports the stale authorization without
+ * mutating further.
+ */
+async function tryCreateTeamCandidate(
+  orgSlug: string,
+  candidate: string,
+  projectSlug: string
+): Promise<ResolvedConcreteTeam | "conflict"> {
   try {
-    const team = await createTeam(orgSlug, slug);
+    const team = await createTeam(orgSlug, candidate);
     return { slug: team.slug, source: "auto-created" };
   } catch (error) {
-    // Let auth errors propagate so the central handler can trigger auto-login
     if (error instanceof AuthError) {
       throw error;
     }
-    // 403 means the user lacks permission to create teams (e.g., org member role).
-    // Re-throw as ApiError so callers can fall back to the org-scoped endpoint
-    // (POST /organizations/{org}/projects/) instead of showing a dead-end error.
     if (error instanceof ApiError && error.status === 403) {
-      throw error;
+      throw buildTeamAdminAuthorizationError(orgSlug, candidate);
     }
-    // Other failures (permissions, network, etc.) — surface with manual fallback
+    if (error instanceof ApiError && error.status === 409) {
+      return "conflict";
+    }
     throw new CliError(
-      `No teams found in org '${orgSlug}' and automatic team creation failed.\n\n` +
-        `Create a team manually at ${getSentryBaseUrl()}/settings/${orgSlug}/teams/` +
+      `Could not create a team for project '${projectSlug}' in '${orgSlug}'.` +
         (error instanceof ApiError
           ? `\n\nAPI error (${error.status}): ${error.detail ?? error.message}`
           : "")

--- a/packages/cli/src/lib/team-choice.ts
+++ b/packages/cli/src/lib/team-choice.ts
@@ -1,0 +1,78 @@
+/**
+ * Interactive project-team choice shared by `sentry init` and
+ * `sentry project create`.
+ *
+ * Creating a team is a top-level action, never an item appended to the team
+ * selector. This keeps the action visible even when the organization has a
+ * long team list.
+ */
+
+export type ProjectTeamChoice =
+  | { kind: "create" }
+  | { kind: "existing"; slug: string };
+
+/** Team fields needed by the project-creation prompt. */
+export type ProjectTeamOption = Readonly<{
+  slug: string;
+  name: string;
+}>;
+
+export type ProjectTeamSelectOptions<T extends string> = {
+  message: string;
+  options: { value: T; label: string; hint?: string }[];
+  initialValue?: T;
+};
+
+/** Narrow prompt capability required by the shared team-choice flow. */
+export type ProjectTeamSelect = <T extends string>(
+  options: ProjectTeamSelectOptions<T>
+) => Promise<T>;
+
+/**
+ * Ask whether to create a team or use an existing Team Admin team.
+ *
+ * With one eligible team, that team is shown directly in the top-level
+ * decision. With several, choosing the existing-team action opens a second
+ * prompt containing only teams.
+ */
+export async function chooseProjectTeam(
+  teams: readonly ProjectTeamOption[],
+  select: ProjectTeamSelect
+): Promise<ProjectTeamChoice> {
+  const onlyTeam = teams.length === 1 ? teams[0] : undefined;
+  const existingLabel = onlyTeam
+    ? `Use #${onlyTeam.slug}`
+    : "Select an existing team";
+
+  const intent = await select<"create" | "existing">({
+    message: "Choose a team for the new project",
+    options: [
+      {
+        value: "create",
+        label: "+ Create a new team",
+      },
+      {
+        value: "existing",
+        label: existingLabel,
+      },
+    ],
+    ...(onlyTeam ? { initialValue: "existing" } : {}),
+  });
+
+  if (intent === "create") {
+    return { kind: "create" };
+  }
+  if (onlyTeam) {
+    return { kind: "existing", slug: onlyTeam.slug };
+  }
+
+  const slug = await select({
+    message: "Select an existing team",
+    options: teams.map((team) => ({
+      value: team.slug,
+      label: `#${team.slug}`,
+      ...(team.name !== team.slug ? { hint: team.name } : {}),
+    })),
+  });
+  return { kind: "existing", slug };
+}

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -449,7 +449,7 @@ describe("init command func", () => {
       expect(capturedArgs?.project).toBeUndefined();
     });
 
-    test("bare slug in multiple orgs → throws ValidationError", async () => {
+    test("bare slug in multiple orgs → defers the decision until org resolution", async () => {
       findProjectsSpy.mockImplementation(async (slug: string) => ({
         projects: [mockProject(slug, "org-a"), mockProject(slug, "org-b")],
         orgs: [
@@ -458,9 +458,10 @@ describe("init command func", () => {
         ],
       }));
       const ctx = makeContext();
-      await expect(func.call(ctx, DEFAULT_FLAGS, "my-app")).rejects.toThrow(
-        ValidationError
-      );
+      await func.call(ctx, DEFAULT_FLAGS, "my-app");
+
+      expect(capturedArgs?.org).toBeUndefined();
+      expect(capturedArgs?.project).toBe("my-app");
     });
   });
 

--- a/packages/cli/test/commands/project/create-team-choice.test.ts
+++ b/packages/cli/test/commands/project/create-team-choice.test.ts
@@ -1,0 +1,146 @@
+/** Interactive team-choice adapter coverage for `sentry project create`. */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const { fakeLog, mockPrompt } = vi.hoisted(() => {
+  const prompt = vi.fn<() => Promise<string | null>>();
+  const noop = vi.fn();
+  const log = {
+    prompt,
+    info: noop,
+    warn: noop,
+    error: noop,
+    debug: noop,
+    success: noop,
+    withTag: () => log,
+  };
+  return { fakeLog: log, mockPrompt: prompt };
+});
+
+vi.mock("../../../src/lib/logger.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../src/lib/logger.js")>()),
+  logger: fakeLog,
+}));
+vi.mock("../../../src/lib/api/projects.js");
+vi.mock("../../../src/lib/api/teams.js");
+vi.mock("../../../src/lib/api/organizations.js");
+vi.mock("../../../src/lib/resolve-target.js");
+
+import { createCommand } from "../../../src/commands/project/create.js";
+import type { SentryContext } from "../../../src/context.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for vi.spyOn mocking
+import * as projectsApi from "../../../src/lib/api/projects.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for vi.spyOn mocking
+import * as teamsApi from "../../../src/lib/api/teams.js";
+import { CliError } from "../../../src/lib/errors.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for vi.spyOn mocking
+import * as resolveTarget from "../../../src/lib/resolve-target.js";
+
+function createInteractiveContext(): SentryContext {
+  return {
+    process: { stdout: { isTTY: true } },
+    env: {},
+    stdout: { write: vi.fn(() => true) },
+    stderr: { write: vi.fn(() => true) },
+    stdin: { isTTY: true },
+    cwd: "/tmp",
+    homeDir: "/tmp",
+    configDir: "/tmp",
+  } as unknown as SentryContext;
+}
+
+describe("project create interactive team choice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(resolveTarget.resolveOrg).mockResolvedValue({ org: "acme" });
+    vi.mocked(teamsApi.listTeams).mockResolvedValue([
+      {
+        id: "1",
+        slug: "platform",
+        name: "Platform",
+        access: ["team:admin"],
+      },
+      {
+        id: "2",
+        slug: "mobile",
+        name: "Mobile",
+        access: ["team:admin"],
+      },
+    ]);
+    vi.mocked(projectsApi.createProjectWithDsn).mockResolvedValue({
+      project: {
+        id: "42",
+        slug: "my-app",
+        name: "my-app",
+        platform: "node",
+      },
+      dsn: "https://key@example.com/42",
+      url: "https://acme.sentry.io/projects/my-app/",
+    });
+    mockPrompt
+      .mockResolvedValueOnce("existing")
+      .mockResolvedValueOnce("mobile");
+  });
+
+  test("keeps create first, outside the team selector, and prompts once per batch", async () => {
+    const context = createInteractiveContext();
+    const func = await createCommand.loader();
+
+    await func.call(context, { json: false }, "my-app:node", "worker:node");
+
+    expect(mockPrompt).toHaveBeenCalledTimes(2);
+    const firstOptions = mockPrompt.mock.calls[0]?.[1]?.options;
+    expect(firstOptions).toEqual([
+      {
+        value: "create",
+        label: "+ Create a new team",
+      },
+      { value: "existing", label: "Select an existing team" },
+    ]);
+    const secondOptions = mockPrompt.mock.calls[1]?.[1]?.options;
+    expect(secondOptions).toEqual([
+      expect.objectContaining({ value: "platform", label: "#platform" }),
+      expect.objectContaining({ value: "mobile", label: "#mobile" }),
+    ]);
+    expect(
+      secondOptions?.some(
+        (option: { value: string }) => option.value === "create"
+      )
+    ).toBe(false);
+    expect(projectsApi.createProjectWithDsn).toHaveBeenCalledWith(
+      "acme",
+      "mobile",
+      { name: "my-app", platform: "node" }
+    );
+    expect(projectsApi.createProjectWithDsn).toHaveBeenCalledWith(
+      "acme",
+      "mobile",
+      { name: "worker", platform: "node" }
+    );
+  });
+
+  test("cancels cleanly before creating a project", async () => {
+    mockPrompt.mockReset().mockResolvedValueOnce(null);
+    const context = createInteractiveContext();
+    const func = await createCommand.loader();
+
+    await func.call(context, { json: false }, "my-app:node");
+
+    expect(projectsApi.createProjectWithDsn).not.toHaveBeenCalled();
+    expect(projectsApi.createProjectWithAutoTeam).not.toHaveBeenCalled();
+    expect(fakeLog.info).toHaveBeenCalledWith("Cancelled.");
+  });
+
+  test("surfaces an invalid prompt result instead of treating it as cancellation", async () => {
+    mockPrompt.mockReset().mockResolvedValueOnce("not-an-option");
+    const context = createInteractiveContext();
+    const func = await createCommand.loader();
+
+    await expect(
+      func.call(context, { json: false }, "my-app:node")
+    ).rejects.toBeInstanceOf(CliError);
+
+    expect(projectsApi.createProjectWithDsn).not.toHaveBeenCalled();
+    expect(fakeLog.info).not.toHaveBeenCalledWith("Cancelled.");
+  });
+});

--- a/packages/cli/test/commands/project/create.test.ts
+++ b/packages/cli/test/commands/project/create.test.ts
@@ -11,7 +11,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { app } from "../../../src/app.js";
 import { createCommand } from "../../../src/commands/project/create.js";
 import type { SentryContext } from "../../../src/context.js";
-import type { CreatedProjectDetails } from "../../../src/lib/api-client.js";
+import {
+  type CreatedProjectDetails,
+  MEMBER_PROJECT_CREATION_DISABLED_DETAIL,
+} from "../../../src/lib/api-client.js";
 
 // Auto-mock at the definition site so internal calls (e.g. createProjectWithDsn
 // calling createProject within projects.js) are intercepted. All exports become
@@ -50,6 +53,8 @@ const sampleTeam: SentryTeam = {
   name: "Engineering",
   memberCount: 5,
   isMember: true,
+  teamRole: "admin",
+  access: ["team:admin"],
 };
 
 const sampleTeam2: SentryTeam = {
@@ -58,6 +63,8 @@ const sampleTeam2: SentryTeam = {
   name: "Mobile Team",
   memberCount: 3,
   isMember: true,
+  teamRole: "admin",
+  access: ["team:admin"],
 };
 
 const sampleProject: SentryProject = {
@@ -114,6 +121,7 @@ describe("project create", () => {
   const createTeamSpy = vi.mocked(teamsApi.createTeam);
   const tryGetPrimaryDsnSpy = vi.mocked(projectsApi.tryGetPrimaryDsn);
   const listOrgsSpy = vi.mocked(orgsApi.listOrganizations);
+  const getOrganizationSpy = vi.mocked(orgsApi.getOrganization);
   const resolveOrgSpy = vi.mocked(resolveTarget.resolveOrg);
 
   beforeEach(() => {
@@ -147,6 +155,13 @@ describe("project create", () => {
       { slug: "acme-corp", name: "Acme Corp" },
       { slug: "other-org", name: "Other Org" },
     ]);
+    getOrganizationSpy.mockResolvedValue({
+      id: "1",
+      slug: "acme-corp",
+      name: "Acme Corp",
+      access: ["project:admin", "team:admin"],
+      allowMemberProjectCreation: false,
+    });
   });
 
   afterEach(() => {
@@ -156,6 +171,7 @@ describe("project create", () => {
     createTeamSpy.mockReset();
     tryGetPrimaryDsnSpy.mockReset();
     listOrgsSpy.mockReset();
+    getOrganizationSpy.mockReset();
     resolveOrgSpy.mockReset();
   });
 
@@ -293,14 +309,19 @@ describe("project create", () => {
   });
 
   test("auto-selects team when user is member of exactly one among many", async () => {
-    const nonMemberTeam = { ...sampleTeam2, isMember: false };
+    const nonMemberTeam = {
+      ...sampleTeam2,
+      isMember: false,
+      teamRole: null,
+      access: ["team:read"],
+    };
     listTeamsSpy.mockResolvedValue([nonMemberTeam, sampleTeam]);
 
     const { context } = createMockContext();
     const func = await createCommand.loader();
     await func.call(context, { json: false }, "my-app:node");
 
-    // Should auto-select the one team the user is a member of
+    // Only teams with effective Team Admin access are eligible.
     expect(createProjectWithDsnSpy).toHaveBeenCalledWith(
       "acme-corp",
       "engineering",
@@ -311,60 +332,63 @@ describe("project create", () => {
     );
   });
 
-  test("errors when user is member of multiple teams without --team", async () => {
+  test("requires --team when several Team Admin teams are ambiguous non-interactively", async () => {
     listTeamsSpy.mockResolvedValue([sampleTeam, sampleTeam2]);
 
     const { context } = createMockContext();
     const func = await createCommand.loader();
-
-    const err = await func
+    const error = await func
       .call(context, { json: false }, "my-app:node")
-      .catch((e: Error) => e);
-    expect(err).toBeInstanceOf(ContextError);
-    expect(err.message).toContain("You belong to 2 teams");
-    expect(err.message).toContain("engineering");
-    expect(err.message).toContain("mobile");
+      .catch((cause) => cause);
 
+    expect(error).toBeInstanceOf(ContextError);
+    expect(error.message).toContain("Choose one explicitly with --team");
     expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
   });
 
-  test("shows only member teams in error, not all org teams", async () => {
+  test("ignores teams without Team Admin access", async () => {
     const nonMemberTeam = {
       id: "3",
       slug: "infra",
       name: "Infrastructure",
       isMember: false,
+      access: ["team:read"],
     };
-    listTeamsSpy.mockResolvedValue([sampleTeam, sampleTeam2, nonMemberTeam]);
+    listTeamsSpy.mockResolvedValue([nonMemberTeam, sampleTeam2]);
 
     const { context } = createMockContext();
     const func = await createCommand.loader();
+    await func.call(context, { json: false }, "my-app:node");
 
-    const err = await func
-      .call(context, { json: false }, "my-app:node")
-      .catch((e: Error) => e);
-    expect(err).toBeInstanceOf(ContextError);
-    expect(err.message).toContain("engineering");
-    expect(err.message).toContain("mobile");
-    // Non-member team should NOT appear
-    expect(err.message).not.toContain("infra");
+    expect(createProjectWithDsnSpy).toHaveBeenCalledWith(
+      "acme-corp",
+      "mobile",
+      expect.objectContaining({ name: "my-app" })
+    );
   });
 
-  test("falls back to all teams when isMember is not available", async () => {
+  test("uses org-scoped creation for a member with no eligible team", async () => {
     const teamNoMembership1 = { id: "1", slug: "alpha", name: "Alpha" };
     const teamNoMembership2 = { id: "2", slug: "beta", name: "Beta" };
     listTeamsSpy.mockResolvedValue([teamNoMembership1, teamNoMembership2]);
+    getOrganizationSpy.mockResolvedValue({
+      id: "1",
+      slug: "acme-corp",
+      name: "Acme Corp",
+      access: ["project:read"],
+      allowMemberProjectCreation: true,
+    });
+    createProjectWithAutoTeamSpy.mockResolvedValue({
+      ...createdProjectDetails("my-app"),
+      team_slug: "team-user",
+    });
 
     const { context } = createMockContext();
     const func = await createCommand.loader();
+    await func.call(context, { json: false }, "my-app:node");
 
-    const err = await func
-      .call(context, { json: false }, "my-app:node")
-      .catch((e: Error) => e);
-    expect(err).toBeInstanceOf(ContextError);
-    expect(err.message).toContain("Multiple teams found");
-    expect(err.message).toContain("alpha");
-    expect(err.message).toContain("beta");
+    expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
+    expect(createProjectWithAutoTeamSpy).toHaveBeenCalled();
   });
 
   test("auto-creates team when org has no teams", async () => {
@@ -391,7 +415,8 @@ describe("project create", () => {
 
     const output = stdoutWrite.mock.calls.map((c) => c[0]).join("");
     expect(output).toContain("Created team 'my-app'");
-    expect(output).toContain("org had no teams");
+    expect(output).toContain("for this project");
+    expect(output).not.toContain("org had no teams");
   });
 
   test("errors when org cannot be resolved", async () => {
@@ -466,6 +491,24 @@ describe("project create", () => {
     expect(err.message).toContain("permission");
     // Must NOT say "not found" — the team clearly exists
     expect(err.message).not.toContain("not found");
+  });
+
+  test("does not diagnose an org-scoped fallback 404 as a team failure", async () => {
+    createProjectWithDsnSpy.mockRejectedValueOnce(
+      new ApiError("Forbidden", 403, "No project:write access")
+    );
+    createProjectWithAutoTeamSpy.mockRejectedValueOnce(
+      new ApiError("Not found", 404, "Endpoint unavailable")
+    );
+
+    const { context } = createMockContext();
+    const func = await createCommand.loader();
+    const error = await func
+      .call(context, { json: false }, "my-app:node")
+      .catch((cause) => cause);
+
+    expect(error.message).toContain("Failed to create project");
+    expect(error.message).not.toContain("Team 'engineering'");
   });
 
   test("handles 404 from createProject with bad org — shows user's orgs", async () => {
@@ -546,6 +589,7 @@ describe("project create", () => {
     expect(err).toBeInstanceOf(CliError);
     expect(err.message).toContain("Invalid platform 'node'");
     expect(err.message).toContain("Common platforms:");
+    expect(createProjectWithDsnSpy).toHaveBeenCalledOnce();
   });
 
   test("wraps other API errors with context, preserving ApiError type", async () => {
@@ -655,11 +699,14 @@ describe("project create", () => {
     expect(err).toBeInstanceOf(CliError);
     expect(err.message).toContain("Invalid platform 'node'");
     expect(err.message).toContain("Common platforms:");
+    expect(createProjectWithDsnSpy).toHaveBeenCalledOnce();
+    expect(createProjectWithAutoTeamSpy).toHaveBeenCalledOnce();
   });
 
-  test("surfaces policy error when org has disabled member project creation", async () => {
-    // Both paths 403: team-based creation fails, and the fallback returns
-    // the org-level policy error ("disabled this feature").
+  test("reports the organization policy when the org fallback is restricted", async () => {
+    // The team route did not expose a precise reason. The organization route
+    // is authoritative for its own policy and must not be rewritten as a
+    // team:admin scope failure.
     createProjectWithDsnSpy.mockRejectedValue(
       new ApiError("Forbidden", 403, "You do not have permission")
     );
@@ -668,12 +715,18 @@ describe("project create", () => {
     const { context } = createMockContext();
     const func = await createCommand.loader();
 
-    const err = (await func
+    const err = await func
       .call(context, { json: false }, "my-app:node")
-      .catch((e: Error) => e)) as ApiError;
+      .catch((e: Error) => e);
     expect(err).toBeInstanceOf(ApiError);
-    expect(err.status).toBe(403);
-    expect(err.message).toContain("disabled project creation for members");
+    expect(err).toMatchObject({ status: 403 });
+    expect((err as ApiError).detail).toContain(
+      MEMBER_PROJECT_CREATION_DISABLED_DETAIL
+    );
+    expect(err.message).toContain(
+      "Your organization has disabled project creation for members"
+    );
+    expect((err as ApiError).detail).not.toContain("team:admin");
   });
 
   test("outputs JSON when --json flag is set", async () => {
@@ -686,6 +739,27 @@ describe("project create", () => {
     expect(parsed.project.slug).toBe("my-app");
     expect(parsed.dsn).toBe("https://abc@o123.ingest.us.sentry.io/999");
     expect(parsed.teamSlug).toBe("engineering");
+  });
+
+  test("never offers an interactive team picker for JSON output", async () => {
+    listTeamsSpy.mockResolvedValue([sampleTeam, sampleTeam2]);
+    const { context: baseContext } = createMockContext();
+    const ttyProcess = Object.create(process) as NodeJS.Process;
+    Object.defineProperty(ttyProcess, "stdout", {
+      value: { isTTY: true },
+    });
+    const ttyStdin = Object.create(process.stdin) as SentryContext["stdin"];
+    Object.defineProperty(ttyStdin, "isTTY", { value: true });
+    const context = {
+      ...baseContext,
+      process: ttyProcess,
+      stdin: ttyStdin,
+    } satisfies SentryContext;
+    const func = await createCommand.loader();
+
+    await expect(
+      func.call(context, { json: true }, "my-app:node")
+    ).rejects.toThrow("Choose one explicitly with --team");
   });
 
   test("handles DSN fetch failure gracefully", async () => {
@@ -940,6 +1014,7 @@ describe("project create", () => {
     );
 
     expect(createProjectWithDsnSpy).toHaveBeenCalledTimes(3);
+    expect(listTeamsSpy).toHaveBeenCalledOnce();
     for (const [name, platform] of [
       ["web", "javascript"],
       ["api", "python-django"],

--- a/packages/cli/test/lib/api-client.coverage.test.ts
+++ b/packages/cli/test/lib/api-client.coverage.test.ts
@@ -46,6 +46,7 @@ import {
 import { setAuthToken } from "../../src/lib/db/auth.js";
 import { setOrgRegion } from "../../src/lib/db/regions.js";
 import { ApiError, AuthError } from "../../src/lib/errors.js";
+import { resolveOrCreateTeam } from "../../src/lib/resolve-team.js";
 import { mockFetch, useTestConfigDir } from "../helpers.js";
 
 // --- Shared test setup ---
@@ -508,6 +509,57 @@ describe("teams.ts", () => {
       const result = await listTeams("test-org");
       expect(result).toHaveLength(2);
     });
+
+    test("lets team resolution select a Team Admin from a later page", async () => {
+      let requestCount = 0;
+      globalThis.fetch = mockFetch(async (input, init) => {
+        const req = new Request(input!, init);
+        requestCount += 1;
+        if (requestCount === 1) {
+          expect(new URL(req.url).searchParams.get("cursor")).toBeNull();
+          return new Response(
+            JSON.stringify([
+              mockTeam({
+                id: "1",
+                slug: "contributors",
+                access: ["team:read"],
+              }),
+            ]),
+            {
+              status: 200,
+              headers: {
+                "Content-Type": "application/json",
+                Link: linkHeader("next-teams-page", true),
+              },
+            }
+          );
+        }
+
+        expect(new URL(req.url).searchParams.get("cursor")).toBe(
+          "next-teams-page"
+        );
+        return new Response(
+          JSON.stringify([
+            mockTeam({
+              id: "2",
+              slug: "platform",
+              access: ["team:read", "team:admin"],
+            }),
+          ]),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        );
+      });
+
+      const result = await resolveOrCreateTeam("test-org", {
+        usageHint: "sentry init",
+        autoCreateSlug: "my-app",
+      });
+      expect(result).toEqual({ slug: "platform", source: "auto-selected" });
+      expect(requestCount).toBe(2);
+    });
   });
 
   describe("listProjectTeams", () => {
@@ -530,7 +582,7 @@ describe("teams.ts", () => {
   });
 
   describe("createTeam", () => {
-    test("creates team and adds current user as member", async () => {
+    test("creates a team in one request", async () => {
       const team = mockTeam({ slug: "new-team" });
       const requestUrls: string[] = [];
 
@@ -547,45 +599,12 @@ describe("teams.ts", () => {
             headers: { "Content-Type": "application/json" },
           });
         }
-        if (req.url.includes("/member")) {
-          return new Response(JSON.stringify({}), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
         return new Response("Not found", { status: 404 });
       });
 
       const result = await createTeam("test-org", "new-team");
       expect(result.slug).toBe("new-team");
-      // Should have made at least 2 calls (create + add member)
-      expect(requestUrls.length).toBeGreaterThanOrEqual(2);
-    });
-
-    test("returns team even when member-add fails", async () => {
-      const team = mockTeam({ slug: "new-team" });
-
-      globalThis.fetch = mockFetch(async (input, init) => {
-        const req = new Request(input!, init);
-
-        if (
-          req.method === "POST" &&
-          req.url.includes("/organizations/test-org/teams/")
-        ) {
-          return new Response(JSON.stringify(team), {
-            status: 201,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-        // addMemberToTeam fails
-        return new Response(JSON.stringify({ detail: "Permission denied" }), {
-          status: 403,
-          headers: { "Content-Type": "application/json" },
-        });
-      });
-
-      const result = await createTeam("test-org", "new-team");
-      expect(result.slug).toBe("new-team");
+      expect(requestUrls).toHaveLength(1);
     });
   });
 
@@ -769,6 +788,21 @@ describe("projects.ts", () => {
       await expect(
         createProjectWithAutoTeam("test-org", { name: "Blocked" })
       ).rejects.toMatchObject({ status: 403 });
+    });
+
+    test("rejects a successful response without an owning team slug", async () => {
+      const { team_slug: _missing, ...projectWithoutTeam } = autoTeamProject;
+      globalThis.fetch = mockFetch(
+        async () =>
+          new Response(JSON.stringify(projectWithoutTeam), {
+            status: 201,
+            headers: { "Content-Type": "application/json" },
+          })
+      );
+
+      await expect(
+        createProjectWithAutoTeam("test-org", { name: "Auto Project" })
+      ).rejects.toThrow("did not return its owning team");
     });
 
     test("returns dsn:null when DSN fetch fails", async () => {

--- a/packages/cli/test/lib/init/interactive.test.ts
+++ b/packages/cli/test/lib/init/interactive.test.ts
@@ -13,7 +13,10 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { WizardError } from "../../../src/lib/errors.js";
 import { handleInteractive } from "../../../src/lib/init/interactive.js";
 import type { InteractiveContext } from "../../../src/lib/init/types.js";
-import { CANCELLED } from "../../../src/lib/init/ui/types.js";
+import {
+  CANCELLED,
+  type SelectOptions,
+} from "../../../src/lib/init/ui/types.js";
 import { createMockUI } from "./ui/mock-ui.js";
 
 function makeOptions(
@@ -58,9 +61,7 @@ describe("handleSelect", () => {
     );
 
     expect(result).toEqual({ selectedApp: "my-app" });
-    expect(
-      calls.some((c) => c.kind === "log.info" && c.message.includes("my-app"))
-    ).toBe(true);
+    expect(calls.filter((call) => call.kind.startsWith("log."))).toEqual([]);
   });
 
   test("throws WizardError with app list when --yes and multiple apps", async () => {
@@ -81,6 +82,80 @@ describe("handleSelect", () => {
       )
     ).rejects.toBeInstanceOf(WizardError);
     expect(calls.some((c) => c.kind === "log.error")).toBe(true);
+  });
+
+  test("auto-selects the single existing Sentry target with --yes", async () => {
+    const { ui, calls } = createMockUI();
+
+    const result = await handleInteractive(
+      {
+        type: "interactive",
+        prompt: "Choose target",
+        kind: "select",
+        apps: [
+          {
+            name: "junior",
+            path: "/repo/packages/junior",
+            framework: "Sentry detected",
+            sentrySetup: "auto-select",
+          },
+          { name: "docs", path: "/repo/packages/docs", framework: "Astro" },
+          { name: "example", path: "/repo/apps/example", framework: "Nitro" },
+        ],
+      },
+      makeOptions({ yes: true }),
+      ui
+    );
+
+    expect(result).toEqual({ selectedApp: "junior" });
+    expect(calls.filter((call) => call.kind.startsWith("log."))).toEqual([]);
+  });
+
+  test("does not trust an AI framework label as deterministic setup evidence", async () => {
+    const { ui } = createMockUI();
+
+    await expect(
+      handleInteractive(
+        {
+          type: "interactive",
+          prompt: "Choose target",
+          kind: "select",
+          apps: [
+            {
+              name: "hallucinated",
+              path: "/repo/apps/hallucinated",
+              framework: "Sentry detected by framework analysis",
+            },
+            { name: "docs", path: "/repo/apps/docs", framework: "Astro" },
+          ],
+        },
+        makeOptions({ yes: true }),
+        ui
+      )
+    ).rejects.toBeInstanceOf(WizardError);
+  });
+
+  test("does not auto-select a sole setup target when discovery was truncated", async () => {
+    const { ui } = createMockUI();
+
+    await expect(
+      handleInteractive(
+        {
+          type: "interactive",
+          prompt: "Choose target",
+          kind: "select",
+          apps: [
+            {
+              name: "api",
+              path: "/repo/apps/api",
+              sentrySetup: "detected",
+            },
+          ],
+        },
+        makeOptions({ yes: true }),
+        ui
+      )
+    ).rejects.toBeInstanceOf(WizardError);
   });
 
   test("falls through to ui.select when --yes and non-monorepo select", async () => {
@@ -150,6 +225,73 @@ describe("handleSelect", () => {
 
     expect(result).toEqual({ selectedApp: "vue" });
     expect(calls.some((c) => c.kind === "select")).toBe(true);
+  });
+
+  test("presents workspace labels, roles, frameworks, and Sentry status", async () => {
+    const { ui, respond } = createMockUI();
+    respond.select("docs");
+    let selection: SelectOptions<string> | undefined;
+    const select = ui.select.bind(ui);
+    ui.select = (options) => {
+      selection = options;
+      return select(options);
+    };
+
+    await handleInteractive(
+      {
+        type: "interactive",
+        prompt: "Select the target application or package:",
+        kind: "select",
+        apps: [
+          {
+            label: "Junior",
+            name: "junior",
+            path: "/repo/packages/junior",
+            role: "runtime",
+            sentrySetup: "auto-select",
+          },
+          {
+            framework: "Astro",
+            label: "Junior Docs",
+            name: "docs",
+            path: "/repo/packages/docs",
+            role: "documentation",
+          },
+          {
+            framework: "Nitro",
+            label: "Junior Example",
+            name: "example",
+            path: "/repo/apps/example",
+            role: "example",
+          },
+        ],
+      },
+      makeOptions(),
+      ui,
+      { holdPresentationOnSelect: true }
+    );
+
+    expect(selection).toEqual({
+      message: "Select the target application or package:",
+      holdPresentationOnResolve: true,
+      options: [
+        {
+          hint: "Runtime package · Sentry detected",
+          label: "Junior",
+          value: "junior",
+        },
+        {
+          hint: "Documentation website · Astro",
+          label: "Junior Docs",
+          value: "docs",
+        },
+        {
+          hint: "Reference application · Nitro",
+          label: "Junior Example",
+          value: "example",
+        },
+      ],
+    });
   });
 
   test("throws WizardCancelledError on user cancellation", async () => {
@@ -308,8 +450,8 @@ describe("handleMultiSelect", () => {
     );
   });
 
-  test("auto-selects all features with --yes", async () => {
-    const { ui } = createMockUI();
+  test("auto-selects only the safe defaults with --yes", async () => {
+    const { ui, calls } = createMockUI();
     const result = await handleInteractive(
       {
         type: "interactive",
@@ -319,6 +461,8 @@ describe("handleMultiSelect", () => {
           "errorMonitoring",
           "performanceMonitoring",
           "sessionReplay",
+          "logs",
+          "profiling",
           "userFeedback",
         ],
       },
@@ -328,9 +472,94 @@ describe("handleMultiSelect", () => {
 
     expect(result.features).toEqual([
       "errorMonitoring",
-      "performanceMonitoring",
+      "logs",
       "sessionReplay",
+      "performanceMonitoring",
     ]);
+    expect(result.features).not.toContain("profiling");
+    expect(calls.find((call) => call.kind === "log.info")?.message).toBe(
+      "Auto-selected default features: Error Monitoring, Logs, Session Replay, Tracing"
+    );
+  });
+
+  test("keeps profiling optional for the Junior runtime defaults", async () => {
+    const { ui } = createMockUI();
+    const result = await handleInteractive(
+      {
+        type: "interactive",
+        prompt: "Select features",
+        kind: "multi-select",
+        availableFeatures: [
+          "errorMonitoring",
+          "performanceMonitoring",
+          "profiling",
+          "logs",
+        ],
+      },
+      makeOptions({ yes: true }),
+      ui
+    );
+
+    expect(result.features).toEqual([
+      "errorMonitoring",
+      "logs",
+      "performanceMonitoring",
+    ]);
+  });
+
+  test("keeps detected existing features selected with --yes", async () => {
+    const { ui } = createMockUI();
+    const result = await handleInteractive(
+      {
+        availableFeatures: [
+          "errorMonitoring",
+          "performanceMonitoring",
+          "profiling",
+          "logs",
+        ],
+        initialFeatures: ["profiling"],
+        kind: "multi-select",
+        prompt: "Select features",
+        type: "interactive",
+      },
+      makeOptions({ yes: true }),
+      ui
+    );
+
+    expect(result.features).toContain("profiling");
+  });
+
+  test("preselects detected existing features in the interactive checklist", async () => {
+    const { calls, respond, ui } = createMockUI();
+    respond.multiselect(["profiling"]);
+    respond.select("continue");
+
+    await handleInteractive(
+      {
+        availableFeatures: [
+          "errorMonitoring",
+          "performanceMonitoring",
+          "profiling",
+          "logs",
+        ],
+        initialFeatures: ["profiling"],
+        kind: "multi-select",
+        prompt: "Select features",
+        type: "interactive",
+      },
+      makeOptions(),
+      ui
+    );
+
+    const prompt = calls.find((call) => call.kind === "multiselect");
+    expect(prompt?.initialValues).toEqual(
+      expect.arrayContaining([
+        "errorMonitoring",
+        "performanceMonitoring",
+        "logs",
+        "profiling",
+      ])
+    );
   });
 
   test("returns error monitoring when no features are provided", async () => {

--- a/packages/cli/test/lib/init/preflight.test.ts
+++ b/packages/cli/test/lib/init/preflight.test.ts
@@ -1,6 +1,5 @@
 /**
- * Tests for `resolveInitContext`. Stubs API and DSN-detection layers
- * with `spyOn` and uses `MockUI` to drive prompts deterministically.
+ * Tests for init organization preflight and app-scoped project resolution.
  */
 
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -9,9 +8,55 @@ vi.mock("../../../src/lib/api-client.js", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../../../src/lib/api-client.js")>();
   return Object.fromEntries(
-    Object.entries(actual).map(([k, v]) => [
-      k,
-      typeof v === "function" ? vi.fn(v) : v,
+    Object.entries(actual).map(([key, value]) => [
+      key,
+      typeof value === "function" ? vi.fn(value) : value,
+    ])
+  );
+});
+
+vi.mock("../../../src/lib/db/auth.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/lib/db/auth.js")>();
+  return Object.fromEntries(
+    Object.entries(actual).map(([key, value]) => [
+      key,
+      typeof value === "function" ? vi.fn(value) : value,
+    ])
+  );
+});
+
+vi.mock("../../../src/lib/init/org-prefetch.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../../../src/lib/init/org-prefetch.js")
+    >();
+  return Object.fromEntries(
+    Object.entries(actual).map(([key, value]) => [
+      key,
+      typeof value === "function" ? vi.fn(value) : value,
+    ])
+  );
+});
+
+vi.mock(
+  "../../../src/lib/init/tools/detect-sentry.js",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../../src/lib/init/tools/detect-sentry.js")
+      >();
+    return { ...actual, detectSentrySetup: vi.fn(actual.detectSentrySetup) };
+  }
+);
+
+vi.mock("../../../src/lib/resolve-target.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/lib/resolve-target.js")>();
+  return Object.fromEntries(
+    Object.entries(actual).map(([key, value]) => [
+      key,
+      typeof value === "function" ? vi.fn(value) : value,
     ])
   );
 });
@@ -22,540 +67,198 @@ vi.mock("../../../src/lib/scope-recovery.js", () => ({
 
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as apiClient from "../../../src/lib/api-client.js";
-
-vi.mock("../../../src/lib/db/auth.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../../../src/lib/db/auth.js")>();
-  return Object.fromEntries(
-    Object.entries(actual).map(([k, v]) => [
-      k,
-      typeof v === "function" ? vi.fn(v) : v,
-    ])
-  );
-});
-
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as auth from "../../../src/lib/db/auth.js";
-
-vi.mock("../../../src/lib/dsn/index.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../../../src/lib/dsn/index.js")>();
-  return Object.fromEntries(
-    Object.entries(actual).map(([k, v]) => [
-      k,
-      typeof v === "function" ? vi.fn(v) : v,
-    ])
-  );
-});
-
-// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
-import * as dsnIndex from "../../../src/lib/dsn/index.js";
-import {
-  ApiError,
-  AuthError,
-  HostScopeError,
-  WizardError,
-} from "../../../src/lib/errors.js";
-
-vi.mock("../../../src/lib/init/org-prefetch.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<
-      typeof import("../../../src/lib/init/org-prefetch.js")
-    >();
-  return Object.fromEntries(
-    Object.entries(actual).map(([k, v]) => [
-      k,
-      typeof v === "function" ? vi.fn(v) : v,
-    ])
-  );
-});
-
+import { ApiError } from "../../../src/lib/errors.js";
+import { WizardCancelledError } from "../../../src/lib/init/clack-utils.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as prefetch from "../../../src/lib/init/org-prefetch.js";
-import { resolveInitContext } from "../../../src/lib/init/preflight.js";
-import type { WizardOptions } from "../../../src/lib/init/types.js";
-import { CANCELLED } from "../../../src/lib/init/ui/types.js";
-// biome-ignore lint/performance/noNamespaceImport: scope decision is mocked at the module boundary
-import * as scopeRecovery from "../../../src/lib/scope-recovery.js";
-
-vi.mock("../../../src/lib/resolve-target.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../../../src/lib/resolve-target.js")>();
-  return Object.fromEntries(
-    Object.entries(actual).map(([k, v]) => [
-      k,
-      typeof v === "function" ? vi.fn(v) : v,
-    ])
-  );
-});
-
+import {
+  resolveInitContext,
+  resolveInitProjectContext,
+} from "../../../src/lib/init/preflight.js";
+// biome-ignore lint/performance/noNamespaceImport: mocked at the module boundary
+import * as detector from "../../../src/lib/init/tools/detect-sentry.js";
+import type {
+  ResolvedInitContext,
+  WizardOptions,
+} from "../../../src/lib/init/types.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as resolveTarget from "../../../src/lib/resolve-target.js";
-
-vi.mock("../../../src/lib/resolve-team.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../../../src/lib/resolve-team.js")>();
-  return Object.fromEntries(
-    Object.entries(actual).map(([k, v]) => [
-      k,
-      typeof v === "function" ? vi.fn(v) : v,
-    ])
-  );
-});
-
-// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
-import * as resolveTeam from "../../../src/lib/resolve-team.js";
-import { createMockUI, type MockCall } from "./ui/mock-ui.js";
+// biome-ignore lint/performance/noNamespaceImport: mocked at the module boundary
+import * as scopeRecovery from "../../../src/lib/scope-recovery.js";
+import { createMockUI } from "./ui/mock-ui.js";
 
 function makeOptions(overrides?: Partial<WizardOptions>): WizardOptions {
   return {
-    directory: "/tmp/test",
+    directory: "/work/checkout",
     yes: true,
     dryRun: false,
     ...overrides,
   };
 }
 
-function feedbackOutcomes(calls: MockCall[]): string[] {
-  return calls
-    .filter(
-      (c): c is Extract<MockCall, { kind: "feedback" }> => c.kind === "feedback"
-    )
-    .map((c) => c.outcome);
+function makeContext(
+  overrides?: Partial<ResolvedInitContext>
+): ResolvedInitContext {
+  return {
+    directory: "/work/checkout",
+    yes: false,
+    dryRun: false,
+    org: "acme",
+    ...overrides,
+  };
 }
 
-let resolveOrgPrefetchedSpy: ReturnType<typeof spyOn>;
-let listOrganizationsSpy: ReturnType<typeof spyOn>;
-let listTeamsSpy: ReturnType<typeof spyOn>;
-let getOrganizationSpy: ReturnType<typeof spyOn>;
-let getProjectSpy: ReturnType<typeof spyOn>;
-let tryGetPrimaryDsnSpy: ReturnType<typeof spyOn>;
-let getAuthTokenSpy: ReturnType<typeof spyOn>;
-let resolveOrCreateTeamSpy: ReturnType<typeof spyOn>;
-let detectDsnSpy: ReturnType<typeof spyOn>;
-let resolveDsnByPublicKeySpy: ReturnType<typeof spyOn>;
+function makeProject(slug: string, name = slug) {
+  return {
+    id: `id-${slug}`,
+    slug,
+    name,
+    platform: "javascript-react",
+    dateCreated: "2026-04-16T00:00:00Z",
+  } as any;
+}
+
+let resolveOrgPrefetchedSpy: ReturnType<typeof vi.spyOn>;
+let listOrganizationsSpy: ReturnType<typeof vi.spyOn>;
+let listProjectsSpy: ReturnType<typeof vi.spyOn>;
+let getProjectSpy: ReturnType<typeof vi.spyOn>;
+let tryGetPrimaryDsnSpy: ReturnType<typeof vi.spyOn>;
+let getAuthTokenSpy: ReturnType<typeof vi.spyOn>;
+let resolveAllTargetsSpy: ReturnType<typeof vi.spyOn>;
+let detectSentrySetupSpy: ReturnType<typeof vi.spyOn>;
 let shouldDelegateScopeRecovery: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
-  shouldDelegateScopeRecovery = vi.fn().mockResolvedValue(false);
-  vi.mocked(scopeRecovery.captureOAuthScopeRecoveryGate).mockReturnValue({
-    shouldDelegate: shouldDelegateScopeRecovery,
-  });
   resolveOrgPrefetchedSpy = vi
     .spyOn(prefetch, "resolveOrgPrefetched")
     .mockResolvedValue({ org: "acme" });
   listOrganizationsSpy = vi
     .spyOn(apiClient, "listOrganizations")
     .mockResolvedValue([{ id: "1", slug: "acme", name: "Acme" }]);
-  listTeamsSpy = vi.spyOn(apiClient, "listTeams").mockResolvedValue([
-    {
-      id: "1",
-      slug: "platform",
-      name: "Platform",
-      access: ["team:admin"],
-      isMember: true,
-    } as any,
-  ]);
-  getOrganizationSpy = vi
-    .spyOn(apiClient, "getOrganization")
-    .mockResolvedValue({
-      id: "1",
-      slug: "acme",
-      name: "Acme",
-      access: ["project:read"],
-      allowMemberProjectCreation: true,
-    } as any);
-  getProjectSpy = vi.spyOn(apiClient, "getProject").mockResolvedValue({
-    id: "42",
-    slug: "my-app",
-    name: "my-app",
-    platform: "javascript-react",
-    dateCreated: "2026-04-16T00:00:00Z",
-  } as any);
+  listProjectsSpy = vi.spyOn(apiClient, "listProjects").mockResolvedValue([]);
+  getProjectSpy = vi
+    .spyOn(apiClient, "getProject")
+    .mockImplementation(async (_org, slug) => {
+      if (slug === "junior" || slug === "frontend") {
+        return makeProject(slug);
+      }
+      throw new ApiError("not found", 404);
+    });
   tryGetPrimaryDsnSpy = vi
     .spyOn(apiClient, "tryGetPrimaryDsn")
     .mockResolvedValue("https://abc@o1.ingest.sentry.io/42");
   getAuthTokenSpy = vi
     .spyOn(auth, "getAuthToken")
     .mockReturnValue("sntrys_test");
-  resolveOrCreateTeamSpy = vi
-    .spyOn(resolveTeam, "resolveOrCreateTeam")
-    .mockResolvedValue({
-      slug: "platform",
-      source: "auto-selected",
-    });
-  detectDsnSpy = vi.spyOn(dsnIndex, "detectDsn").mockResolvedValue(null);
-  resolveDsnByPublicKeySpy = vi
-    .spyOn(resolveTarget, "resolveDsnByPublicKey")
-    .mockResolvedValue(null);
+  resolveAllTargetsSpy = vi
+    .spyOn(resolveTarget, "resolveAllTargets")
+    .mockResolvedValue({ targets: [] });
+  detectSentrySetupSpy = vi
+    .spyOn(detector, "detectSentrySetup")
+    .mockResolvedValue({ status: "none", signals: [] });
+  shouldDelegateScopeRecovery = vi.fn().mockResolvedValue(false);
+  vi.mocked(scopeRecovery.captureOAuthScopeRecoveryGate).mockReturnValue({
+    shouldDelegate: shouldDelegateScopeRecovery,
+  });
 });
 
 afterEach(() => {
   resolveOrgPrefetchedSpy.mockRestore();
   listOrganizationsSpy.mockRestore();
-  listTeamsSpy.mockRestore();
-  getOrganizationSpy.mockRestore();
+  listProjectsSpy.mockRestore();
   getProjectSpy.mockRestore();
   tryGetPrimaryDsnSpy.mockRestore();
   getAuthTokenSpy.mockRestore();
-  resolveOrCreateTeamSpy.mockRestore();
-  detectDsnSpy.mockRestore();
-  resolveDsnByPublicKeySpy.mockRestore();
+  resolveAllTargetsSpy.mockRestore();
+  detectSentrySetupSpy.mockRestore();
   vi.mocked(scopeRecovery.captureOAuthScopeRecoveryGate).mockReset();
   process.exitCode = 0;
 });
 
 describe("resolveInitContext", () => {
-  test("uses an existing detected project in --yes mode", async () => {
-    detectDsnSpy.mockResolvedValue({
-      publicKey: "abc",
-      protocol: "https",
-      host: "o1.ingest.sentry.io",
-      projectId: "42",
-      raw: "https://abc@o1.ingest.sentry.io/42",
-      source: "env_file" as const,
-    });
-    resolveDsnByPublicKeySpy.mockResolvedValue({
-      org: "acme",
-      project: "my-app",
-    });
-
+  test("uses codebase resolution for the org but defers the project until app selection", async () => {
     const { ui } = createMockUI();
-    const context = await resolveInitContext(makeOptions(), ui);
+
+    const context = await resolveInitContext(makeOptions({ yes: false }), ui);
 
     expect(context).toEqual(
       expect.objectContaining({
         org: "acme",
-        project: "my-app",
-        team: "platform",
-        authToken: "sntrys_test",
-        existingProject: expect.objectContaining({
-          orgSlug: "acme",
-          projectSlug: "my-app",
-        }),
-      })
-    );
-    expect(getProjectSpy).toHaveBeenCalledTimes(1);
-    expect(tryGetPrimaryDsnSpy).toHaveBeenCalledTimes(1);
-  });
-
-  test("keeps a detected DSN project even when project enrichment fails", async () => {
-    detectDsnSpy.mockResolvedValue({
-      publicKey: "abc",
-      protocol: "https",
-      host: "o1.ingest.sentry.io",
-      projectId: "42",
-      raw: "https://abc@o1.ingest.sentry.io/42",
-      source: "env_file" as const,
-    });
-    resolveDsnByPublicKeySpy.mockResolvedValue({
-      org: "acme",
-      project: "my-app",
-    });
-    getProjectSpy.mockRejectedValue(new ApiError("temporary failure", 503));
-
-    const { ui } = createMockUI();
-    const context = await resolveInitContext(makeOptions(), ui);
-
-    expect(context).toEqual(
-      expect.objectContaining({
-        org: "acme",
-        project: "my-app",
-        team: "platform",
+        project: undefined,
       })
     );
     expect(context?.existingProject).toBeUndefined();
+    expect(resolveAllTargetsSpy).toHaveBeenCalledWith({
+      cwd: "/work/checkout",
+      resolutionMode: "codebase",
+    });
+    expect(listProjectsSpy).not.toHaveBeenCalled();
   });
 
-  test("retries detected project enrichment during project selection when the first lookup yields no metadata", async () => {
-    detectDsnSpy.mockResolvedValue({
-      publicKey: "abc",
-      protocol: "https",
-      host: "o1.ingest.sentry.io",
-      projectId: "42",
-      raw: "https://abc@o1.ingest.sentry.io/42",
-      source: "env_file" as const,
-    });
-    resolveDsnByPublicKeySpy.mockResolvedValue({
-      org: "acme",
-      project: "my-app",
-    });
-    getProjectSpy
-      .mockRejectedValueOnce(new ApiError("not found", 404))
-      .mockResolvedValue({
-        id: "42",
-        slug: "my-app",
-        name: "my-app",
-        platform: "javascript-react",
-        dateCreated: "2026-04-16T00:00:00Z",
-      } as any);
-
-    const { ui } = createMockUI();
-    const context = await resolveInitContext(makeOptions(), ui);
-
-    expect(context?.existingProject).toEqual(
-      expect.objectContaining({
-        orgSlug: "acme",
-        projectSlug: "my-app",
-      })
-    );
-    expect(getProjectSpy).toHaveBeenCalledTimes(2);
-    expect(tryGetPrimaryDsnSpy).toHaveBeenCalledTimes(1);
-  });
-
-  test("falls back to listing organizations when prefetch misses", async () => {
+  test("avoids the organization prompt when the repository maps to one org", async () => {
     resolveOrgPrefetchedSpy.mockResolvedValue(null);
-    listOrganizationsSpy.mockResolvedValue([
-      { id: "1", slug: "solo-org", name: "Solo Org" },
-    ]);
-
-    const { ui } = createMockUI();
-    const context = await resolveInitContext(makeOptions({ yes: false }), ui);
-
-    expect(context?.org).toBe("solo-org");
-  });
-
-  test("lets the user choose an existing bare-slug project", async () => {
-    const { ui, respond } = createMockUI();
-    respond.select("existing");
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "sentry",
+          project: "junior",
+          matchStrength: "exact",
+        },
+      ],
+    });
+    const { ui, calls } = createMockUI();
 
     const context = await resolveInitContext(
-      makeOptions({ yes: false, project: "my-app" }),
+      makeOptions({ directory: "/work/junior", yes: false }),
       ui
     );
 
-    expect(context?.project).toBe("my-app");
-    expect(context?.existingProject?.projectSlug).toBe("my-app");
-  });
-
-  test("keeps the bare slug when the existence lookup fails", async () => {
-    getProjectSpy.mockRejectedValue(new ApiError("temporary failure", 503));
-
-    const { ui } = createMockUI();
-    const context = await resolveInitContext(
-      makeOptions({ yes: false, project: "my-app" }),
-      ui
-    );
-
-    expect(context?.project).toBe("my-app");
-    expect(context?.existingProject).toBeUndefined();
-  });
-
-  test("uses org-scoped creation when no Team Admin team is available", async () => {
-    listTeamsSpy.mockResolvedValueOnce([
-      {
-        id: "1",
-        slug: "frontend",
-        name: "Frontend",
-        access: ["team:read"],
-        isMember: true,
-      } as any,
-    ]);
-
-    const { ui } = createMockUI();
-    const context = await resolveInitContext(makeOptions(), ui);
-
-    expect(context?.team).toBeUndefined();
-    expect(getOrganizationSpy).toHaveBeenCalledWith("acme");
-    expect(resolveOrCreateTeamSpy).not.toHaveBeenCalled();
-  });
-
-  test("clears the project when the user chooses to create new", async () => {
-    const { ui, respond } = createMockUI();
-    respond.select("create");
-
-    const context = await resolveInitContext(
-      makeOptions({ yes: false, project: "my-app" }),
-      ui
-    );
-
+    expect(context?.org).toBe("sentry");
     expect(context?.project).toBeUndefined();
-    expect(context?.existingProject).toBeUndefined();
+    expect(calls.filter((call) => call.kind === "select")).toHaveLength(0);
+    expect(listOrganizationsSpy).not.toHaveBeenCalled();
   });
 
-  test("resolves an explicit team during preflight", async () => {
-    resolveOrCreateTeamSpy.mockImplementation(async (_org, options) => ({
-      slug: options.team ?? "platform",
-      source: options.team ? "explicit" : "auto-selected",
-    }));
-
+  test("preserves explicit project and team inputs without resolving them early", async () => {
     const { ui } = createMockUI();
+
     const context = await resolveInitContext(
-      makeOptions({ team: "backend", yes: false }),
+      makeOptions({ project: "junior", team: "backend" }),
       ui
     );
 
-    expect(context?.team).toBe("backend");
-    expect(resolveOrCreateTeamSpy).toHaveBeenCalledWith(
-      "acme",
-      expect.objectContaining({
-        team: "backend",
-        deferAutoCreateOnEmptyOrg: true,
-      })
-    );
+    expect(context?.project).toBe("junior");
+    expect(context?.team).toEqual({ slug: "backend", source: "explicit" });
+    expect(getProjectSpy).not.toHaveBeenCalled();
   });
 
-  test("selects a Team Admin team over non-admin member teams", async () => {
-    listTeamsSpy.mockResolvedValueOnce([
-      {
-        id: "1",
-        slug: "frontend",
-        name: "Frontend",
-        access: ["team:read"],
-        isMember: true,
-      } as any,
-      {
-        id: "2",
-        slug: "platform",
-        name: "Platform",
-        access: ["team:admin"],
-        isMember: true,
-      } as any,
-    ]);
-
-    const { ui } = createMockUI();
-    const context = await resolveInitContext(makeOptions(), ui);
-
-    expect(context?.team).toBe("platform");
-    expect(resolveOrCreateTeamSpy).not.toHaveBeenCalled();
-  });
-
-  test("prompts when multiple Team Admin teams are available", async () => {
-    const { ui, calls, respond } = createMockUI();
-    respond.select("mobile");
-    listTeamsSpy.mockResolvedValueOnce([
-      {
-        id: "1",
-        slug: "platform",
-        name: "Platform",
-        access: ["team:admin"],
-        isMember: true,
-      } as any,
-      {
-        id: "2",
-        slug: "mobile",
-        name: "Mobile",
-        access: ["team:admin"],
-        isMember: true,
-      } as any,
-    ]);
-
-    const context = await resolveInitContext(makeOptions({ yes: false }), ui);
-
-    expect(context?.team).toBe("mobile");
-    const selectCall = calls.find((call) => call.kind === "select");
-    expect(selectCall?.options).toEqual(["mobile", "platform"]);
-  });
-
-  test("selects the first alphabetical Team Admin team in --yes mode", async () => {
-    listTeamsSpy.mockResolvedValueOnce([
-      {
-        id: "1",
-        slug: "platform",
-        name: "Platform",
-        access: ["team:admin"],
-        isMember: true,
-      } as any,
-      {
-        id: "2",
-        slug: "mobile",
-        name: "Mobile",
-        access: ["team:admin"],
-        isMember: true,
-      } as any,
-    ]);
-
-    const { ui } = createMockUI();
-    const context = await resolveInitContext(makeOptions({ yes: true }), ui);
-
-    expect(context?.team).toBe("mobile");
-  });
-
-  test("sorts organization options alphabetically by name", async () => {
+  test("sorts organization options before prompting", async () => {
     resolveOrgPrefetchedSpy.mockResolvedValue(null);
     listOrganizationsSpy.mockResolvedValue([
       { id: "1", slug: "z-org", name: "Alpha" },
       { id: "2", slug: "beta", name: "Beta" },
       { id: "3", slug: "a-org", name: "Alpha" },
     ]);
-
     const { ui, calls, respond } = createMockUI();
     respond.select("a-org");
 
     const context = await resolveInitContext(makeOptions({ yes: false }), ui);
 
     expect(context?.org).toBe("a-org");
-    const selectCall = calls.find((call) => call.kind === "select");
-    expect(selectCall?.options).toEqual(["a-org", "z-org", "beta"]);
+    expect(calls.find((call) => call.kind === "select")).toEqual({
+      kind: "select",
+      message: "Which organization should Sentry use?",
+      options: ["a-org", "z-org", "beta"],
+    });
   });
 
-  test("sorts organizations in the --yes error", async () => {
-    resolveOrgPrefetchedSpy.mockResolvedValue(null);
-    listOrganizationsSpy.mockResolvedValue([
-      { id: "1", slug: "z-org", name: "Zulu" },
-      { id: "2", slug: "a-org", name: "Alpha" },
-    ]);
-
-    const { ui } = createMockUI();
-
-    await expect(
-      resolveInitContext(makeOptions({ yes: true }), ui)
-    ).rejects.toThrow("Multiple organizations found (a-org, z-org).");
-  });
-
-  test("returns null when the user cancels an org selection", async () => {
-    resolveOrgPrefetchedSpy.mockResolvedValue(null);
-    listOrganizationsSpy.mockResolvedValue([
-      { id: "1", slug: "acme", name: "Acme" },
-      { id: "2", slug: "beta", name: "Beta" },
-    ]);
-
-    const { ui, calls, respond } = createMockUI();
-    respond.select(CANCELLED);
-
-    const context = await resolveInitContext(makeOptions({ yes: false }), ui);
-
-    expect(context).toBeNull();
-    const cancelCall = calls.find((c) => c.kind === "cancel");
-    expect(cancelCall?.kind === "cancel" && cancelCall.message).toBe(
-      "Setup cancelled."
-    );
-    expect(feedbackOutcomes(calls)).toEqual(["cancelled"]);
-  });
-
-  test("surfaces 403 guidance when listOrganizations is forbidden", async () => {
-    resolveOrgPrefetchedSpy.mockResolvedValue(null);
-    listOrganizationsSpy.mockRejectedValueOnce(
-      new ApiError(
-        "Failed to list organizations",
-        403,
-        "You do not have permission."
-      )
-    );
-
-    const { ui, calls } = createMockUI();
-    await expect(
-      resolveInitContext(makeOptions({ yes: true }), ui)
-    ).rejects.toThrow("403 Forbidden");
-
-    const errorCall = calls.find(
-      (c): c is Extract<MockCall, { kind: "log.error" }> =>
-        c.kind === "log.error"
-    );
-    expect(errorCall?.message).toContain("403 Forbidden");
-    expect(errorCall?.message).toContain("sentry init <org-slug>/");
-  });
-
-  test("preserves an organization-list 403 when OAuth recovery can run", async () => {
-    const error = new ApiError(
-      "Failed to list organizations",
-      403,
-      "Missing org:read"
-    );
+  test("preserves an organization 403 when OAuth recovery can run", async () => {
+    const error = new ApiError("Forbidden", 403, "Missing org:read");
     resolveOrgPrefetchedSpy.mockResolvedValue(null);
     listOrganizationsSpy.mockRejectedValueOnce(error);
     shouldDelegateScopeRecovery.mockResolvedValueOnce(true);
-
     const { ui } = createMockUI();
 
     await expect(
@@ -563,355 +266,712 @@ describe("resolveInitContext", () => {
     ).rejects.toBe(error);
   });
 
-  test("surfaces 401 guidance when listOrganizations is unauthorized", async () => {
+  test("renders organization guidance when OAuth recovery cannot run", async () => {
     resolveOrgPrefetchedSpy.mockResolvedValue(null);
     listOrganizationsSpy.mockRejectedValueOnce(
-      new ApiError("Failed to list organizations", 401, "Token expired")
+      new ApiError("Forbidden", 403, "Missing org:read")
     );
-
     const { ui, calls } = createMockUI();
-    await expect(
-      resolveInitContext(makeOptions({ yes: true }), ui)
-    ).rejects.toThrow("401 Unauthorized");
 
-    const errorCall = calls.find(
-      (c): c is Extract<MockCall, { kind: "log.error" }> =>
-        c.kind === "log.error"
+    await expect(resolveInitContext(makeOptions(), ui)).rejects.toThrow(
+      "403 Forbidden"
     );
-    expect(errorCall?.message).toContain("401 Unauthorized");
-    expect(errorCall?.message).toContain("Token expired");
+    expect(calls.find((call) => call.kind === "log.error")).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining("sentry init <org-slug>/"),
+      })
+    );
   });
 
   test("includes the auth token in the resolved context", async () => {
     const { ui } = createMockUI();
+
     const context = await resolveInitContext(makeOptions(), ui);
 
     expect(context?.authToken).toBe("sntrys_test");
   });
+});
 
-  test("sets isExplicitTeam:true when --team flag is provided", async () => {
-    resolveOrCreateTeamSpy.mockResolvedValue({
-      slug: "backend",
-      source: "explicit",
-    } as any);
-
+describe("resolveInitProjectContext", () => {
+  test("uses the selected app directory for shared project resolution", async () => {
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "acme",
+          project: "junior",
+          orgDisplay: "Acme",
+          projectDisplay: "Junior",
+          matchStrength: "exact",
+        },
+      ],
+    });
     const { ui } = createMockUI();
-    const context = await resolveInitContext(
-      makeOptions({ team: "backend" }),
+
+    const result = await resolveInitProjectContext(
+      makeContext({ yes: true }),
+      "/work/checkout/apps/junior",
       ui
     );
 
-    expect(context?.isExplicitTeam).toBe(true);
-    expect(context?.team).toBe("backend");
+    expect(result.existingProject?.projectSlug).toBe("junior");
+    expect(resolveAllTargetsSpy).toHaveBeenCalledWith({
+      cwd: "/work/checkout/apps/junior",
+      resolutionMode: "codebase",
+      organizationFilter: "acme",
+    });
+    expect(detectSentrySetupSpy).toHaveBeenCalledWith(
+      "/work/checkout/apps/junior"
+    );
   });
 
-  test("sets isExplicitTeam:false when no --team flag is provided", async () => {
-    const { ui } = createMockUI();
-    const context = await resolveInitContext(makeOptions(), ui);
+  test("offers improvement when both the setup and project are detected", async () => {
+    detectSentrySetupSpy.mockResolvedValue({
+      status: "installed",
+      signals: ["init: src/instrumentation.ts"],
+    });
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "acme",
+          project: "junior",
+          orgDisplay: "Acme",
+          projectDisplay: "Junior",
+          matchStrength: "exact",
+        },
+      ],
+    });
+    const { ui, calls, respond } = createMockUI();
+    const selectSpy = vi.spyOn(ui, "select");
+    respond.select("improve");
 
-    expect(context?.isExplicitTeam).toBe(false);
-  });
-
-  test("keeps the org-scoped fallback for an unattended explicit-team 403", async () => {
-    resolveOrCreateTeamSpy.mockRejectedValueOnce(
-      new ApiError("Forbidden", 403, "No team:admin access")
+    const result = await resolveInitProjectContext(
+      makeContext(),
+      "/work/checkout/apps/junior",
+      ui,
+      { supportsExistingSetupImprovement: true }
     );
 
-    const { ui } = createMockUI();
-    const context = await resolveInitContext(
-      makeOptions({ team: "backend", yes: true }),
-      ui
-    );
-
-    expect(context?.team).toBeUndefined();
-  });
-
-  test("preserves an explicit-team 403 when OAuth recovery can run", async () => {
-    const error = new ApiError("Forbidden", 403, "No team:admin access");
-    resolveOrCreateTeamSpy.mockRejectedValueOnce(error);
-    shouldDelegateScopeRecovery.mockResolvedValueOnce(true);
-
-    const { ui } = createMockUI();
-
-    await expect(
-      resolveInitContext(makeOptions({ team: "backend", yes: false }), ui)
-    ).rejects.toBe(error);
-  });
-
-  test("swallows 403 from listTeams and resolves context with team:undefined", async () => {
-    listTeamsSpy.mockRejectedValueOnce(
-      new ApiError("Forbidden", 403, "No team:read access")
-    );
-
-    const { ui } = createMockUI();
-    const context = await resolveInitContext(makeOptions(), ui);
-
-    // 403 is swallowed so the wizard can proceed to the org-scoped fallback
-    expect(context).not.toBeNull();
-    expect(context?.team).toBeUndefined();
-    expect(getOrganizationSpy).toHaveBeenCalledWith("acme");
-    expect(resolveOrCreateTeamSpy).not.toHaveBeenCalled();
-  });
-
-  test("preserves a 403 when OAuth scope recovery can run", async () => {
-    const error = new ApiError("Forbidden", 403, "No team:read access");
-    listTeamsSpy.mockRejectedValueOnce(error);
-    shouldDelegateScopeRecovery.mockResolvedValueOnce(true);
-
-    const { ui } = createMockUI();
-
-    await expect(
-      resolveInitContext(makeOptions({ yes: false }), ui)
-    ).rejects.toBe(error);
-    expect(shouldDelegateScopeRecovery).toHaveBeenCalledWith(error, {
-      unattended: false,
+    expect(result.existingProject?.projectSlug).toBe("junior");
+    expect(calls.filter((call) => call.kind.startsWith("log."))).toEqual([]);
+    expect(calls).toContainEqual({
+      kind: "select",
+      message:
+        "Sentry detected for project junior in organization acme. What would you like to do?",
+      options: ["improve", "other"],
+    });
+    expect(selectSpy.mock.calls[0]?.[0].options).toEqual([
+      expect.objectContaining({
+        value: "improve",
+        label: "Improve your Sentry setup",
+        description: "Upgrade your current setup and add more Sentry features.",
+      }),
+      expect.objectContaining({
+        value: "other",
+        label: "Use or create another Sentry project",
+        description: "Use another project or create a new one.",
+      }),
+    ]);
+    expect(result).toEqual({
+      org: "acme",
+      project: "junior",
+      existingProject: expect.objectContaining({ projectSlug: "junior" }),
+      setupIntent: "improve-existing",
     });
   });
 
-  test("preserves a recoverable 401 from team lookup", async () => {
-    const error = new ApiError("Unauthorized", 401, "Invalid token");
-    listTeamsSpy.mockRejectedValueOnce(error);
-    shouldDelegateScopeRecovery.mockResolvedValueOnce(true);
-
+  test("canonicalizes numeric DSN identity after loading the project", async () => {
+    const detectedDsn = "https://abc@o1.ingest.sentry.io/42";
+    detectSentrySetupSpy.mockResolvedValue({
+      status: "installed",
+      dsn: detectedDsn,
+      signals: ["init: src/instrumentation.ts"],
+    });
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "1",
+          project: "42",
+          projectId: 42,
+          matchStrength: "exact",
+          detectedDsn: {
+            raw: detectedDsn,
+            protocol: "https",
+            publicKey: "abc",
+            host: "o1.ingest.sentry.io",
+            orgId: "1",
+            projectId: "42",
+            source: "code",
+            sourcePath: "src/instrumentation.ts",
+          },
+        },
+      ],
+    });
+    getProjectSpy.mockResolvedValueOnce({
+      ...makeProject("junior", "Junior"),
+      id: "42",
+      organization: { id: "1", slug: "sentry", name: "Sentry" },
+    });
     const { ui } = createMockUI();
 
-    await expect(
-      resolveInitContext(makeOptions({ yes: false }), ui)
-    ).rejects.toBe(error);
-  });
-
-  test("keeps the org-scoped fallback when OAuth recovery is unattended", async () => {
-    listTeamsSpy.mockRejectedValueOnce(
-      new ApiError("Forbidden", 403, "No team:read access")
+    const result = await resolveInitProjectContext(
+      makeContext({ org: "1", yes: true }),
+      "/work/checkout/apps/junior",
+      ui,
+      { supportsExistingSetupImprovement: true }
     );
 
+    expect(getProjectSpy).toHaveBeenCalledWith("1", "42");
+    expect(tryGetPrimaryDsnSpy).toHaveBeenCalledWith("sentry", "junior");
+    expect(result).toEqual({
+      org: "sentry",
+      project: "junior",
+      existingProject: expect.objectContaining({
+        orgSlug: "sentry",
+        projectSlug: "junior",
+        projectId: "42",
+      }),
+      setupIntent: "improve-existing",
+    });
+  });
+
+  test("keeps auto-resolved detection details out of the dry-run log", async () => {
+    detectSentrySetupSpy.mockResolvedValue({
+      status: "installed",
+      signals: ["init: src/instrumentation.ts"],
+    });
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "acme",
+          project: "junior",
+          matchStrength: "exact",
+        },
+      ],
+    });
+    const { ui, calls } = createMockUI();
+
+    const result = await resolveInitProjectContext(
+      makeContext({ dryRun: true, yes: true }),
+      "/work/checkout/apps/junior",
+      ui,
+      { supportsExistingSetupImprovement: true }
+    );
+
+    expect(result.setupIntent).toBe("improve-existing");
+    expect(calls.filter((call) => call.kind.startsWith("log."))).toEqual([]);
+  });
+
+  test("preserves the detected local DSN when project-key lookup returns none", async () => {
+    tryGetPrimaryDsnSpy.mockResolvedValueOnce(null);
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "acme",
+          project: "junior",
+          orgDisplay: "Acme",
+          projectDisplay: "Junior",
+          matchStrength: "exact",
+          detectedDsn: {
+            protocol: "https",
+            publicKey: "local",
+            host: "o1.ingest.sentry.io",
+            projectId: "id-junior",
+            raw: "https://local@o1.ingest.sentry.io/id-junior",
+            source: "code",
+            sourcePath: "src/instrumentation.ts",
+          },
+        },
+      ],
+    });
     const { ui } = createMockUI();
-    const context = await resolveInitContext(makeOptions({ yes: true }), ui);
 
-    expect(context?.team).toBeUndefined();
-    expect(shouldDelegateScopeRecovery).toHaveBeenCalledWith(
-      expect.any(ApiError),
-      {
-        unattended: true,
-      }
+    const result = await resolveInitProjectContext(
+      makeContext({ yes: true }),
+      "/work/checkout/apps/junior",
+      ui
+    );
+
+    expect(result.existingProject?.dsn).toBe(
+      "https://local@o1.ingest.sentry.io/id-junior"
     );
   });
 
-  test("preserves rich org-not-found guidance when implicit team lookup returns 404", async () => {
-    resolveOrgPrefetchedSpy.mockResolvedValueOnce({ org: "missing-org" });
-    listOrganizationsSpy.mockResolvedValueOnce([
-      { id: "1", slug: "acme", name: "Acme" },
-      { id: "2", slug: "beta", name: "Beta" },
+  test("does not offer improvement when the setup service does not advertise support", async () => {
+    detectSentrySetupSpy.mockResolvedValue({
+      status: "installed",
+      signals: ["init: src/instrumentation.ts"],
+    });
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "acme",
+          project: "junior",
+          matchStrength: "exact",
+        },
+      ],
+    });
+    const { ui, calls, respond } = createMockUI();
+    respond.select("create");
+
+    const result = await resolveInitProjectContext(
+      makeContext(),
+      "/work/checkout/apps/junior",
+      ui,
+      { supportsExistingSetupImprovement: false }
+    );
+
+    expect(result).toEqual({
+      project: "junior-2",
+      existingProject: undefined,
+    });
+    expect(
+      calls.filter((call) => call.kind === "select").map((call) => call.options)
+    ).toEqual([["create", "existing"]]);
+    expect(calls).toContainEqual({
+      kind: "log.warn",
+      message:
+        "The current setup service cannot safely improve this existing Sentry setup. Choose another project or create a new one.",
+    });
+  });
+
+  test("nests create versus existing under the other-project path", async () => {
+    detectSentrySetupSpy.mockResolvedValue({
+      status: "installed",
+      signals: ["init: src/instrumentation.ts"],
+    });
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "acme",
+          project: "junior",
+          orgDisplay: "Acme",
+          projectDisplay: "Junior",
+          matchStrength: "exact",
+        },
+      ],
+    });
+    const { ui, calls, respond } = createMockUI();
+    const selectSpy = vi.spyOn(ui, "select");
+    respond.select("other");
+    respond.select("create");
+
+    const result = await resolveInitProjectContext(
+      makeContext(),
+      "/work/checkout/apps/junior",
+      ui,
+      { suggestedProjectName: "junior" }
+    );
+
+    expect(result).toEqual({
+      project: "junior-2",
+      existingProject: undefined,
+    });
+    expect(
+      calls.filter((call) => call.kind === "select").map((call) => call.options)
+    ).toEqual([
+      ["improve", "other"],
+      ["create", "existing"],
     ]);
-    listTeamsSpy.mockRejectedValueOnce(
-      new ApiError("Not found", 404, "Organization not found")
+    expect(selectSpy.mock.calls[1]?.[0].options[0]).toEqual(
+      expect.objectContaining({
+        label: "+ Create a new Sentry project",
+      })
     );
-
-    const { ui, calls } = createMockUI();
-    await expect(resolveInitContext(makeOptions(), ui)).rejects.toThrow(
-      "Organization 'missing-org'"
-    );
-
-    const errorCall = calls.find(
-      (c): c is Extract<MockCall, { kind: "log.error" }> =>
-        c.kind === "log.error"
-    );
-    expect(errorCall?.message).toContain("Your organizations:");
-    expect(errorCall?.message).toContain("acme");
-    expect(errorCall?.message).toContain("beta");
+    expect(calls).toContainEqual({
+      kind: "log.info",
+      message: "New project junior-2 in organization acme",
+    });
   });
 
-  test("surfaces the enriched detail when implicit listTeams returns 401", async () => {
-    // member-disabled-over-limit: a 401 from listTeams must reach the user with
-    // its actionable detail, not a bare "Failed to list teams" + status line.
-    listTeamsSpy.mockRejectedValueOnce(
-      new ApiError(
-        "Failed to list teams",
-        401,
-        "Your account is disabled in this organization because it is over its member limit."
-      )
+  test("increments the alternate project slug when the first suffix exists", async () => {
+    detectSentrySetupSpy.mockResolvedValue({
+      status: "installed",
+      signals: ["init: src/instrumentation.ts"],
+    });
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "acme",
+          project: "junior",
+          matchStrength: "exact",
+        },
+      ],
+    });
+    getProjectSpy.mockImplementation(async (_org, slug) => {
+      if (slug === "junior" || slug === "junior-2") {
+        return makeProject(slug);
+      }
+      throw new ApiError("not found", 404);
+    });
+    const { ui, respond } = createMockUI();
+    respond.select("other");
+    respond.select("create");
+
+    const result = await resolveInitProjectContext(
+      makeContext(),
+      "/work/checkout/apps/junior",
+      ui,
+      { suggestedProjectName: "junior" }
     );
 
-    const { ui, calls } = createMockUI();
-    await expect(resolveInitContext(makeOptions(), ui)).rejects.toThrow();
-
-    const errorCall = calls.find(
-      (c): c is Extract<MockCall, { kind: "log.error" }> =>
-        c.kind === "log.error"
-    );
-    expect(errorCall?.message).toContain("over its member limit");
+    expect(result.project).toBe("junior-3");
   });
 
-  test("surfaces the enriched detail when explicit --team listTeams returns 401", async () => {
-    resolveOrCreateTeamSpy.mockRejectedValueOnce(
-      new ApiError(
-        "Failed to list teams",
-        401,
-        "Your account is disabled in this organization because it is over its member limit."
-      )
+  test("excludes the detected project from the other existing-project list", async () => {
+    detectSentrySetupSpy.mockResolvedValue({
+      status: "installed",
+      signals: ["init: src/instrumentation.ts"],
+    });
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "acme",
+          project: "junior",
+          matchStrength: "exact",
+        },
+      ],
+    });
+    listProjectsSpy.mockResolvedValue([
+      makeProject("junior"),
+      makeProject("frontend"),
+    ]);
+    const { ui, calls, respond } = createMockUI();
+    respond.select("other");
+    respond.select("existing");
+    respond.select("frontend");
+
+    const result = await resolveInitProjectContext(
+      makeContext(),
+      "/work/checkout/apps/junior",
+      ui
     );
 
+    expect(result.existingProject?.projectSlug).toBe("frontend");
+    expect(calls).toContainEqual({
+      kind: "select",
+      message: "Which existing Sentry project should be used?",
+      options: ["frontend"],
+    });
+  });
+
+  test("reuses a concrete project without an improvement prompt for a fresh setup", async () => {
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "acme",
+          project: "junior",
+          orgDisplay: "Acme",
+          projectDisplay: "Junior",
+          matchStrength: "exact",
+        },
+      ],
+    });
     const { ui, calls } = createMockUI();
+
+    const result = await resolveInitProjectContext(
+      makeContext(),
+      "/work/checkout/apps/junior",
+      ui
+    );
+
+    expect(result.existingProject?.projectSlug).toBe("junior");
+    expect(calls.filter((call) => call.kind === "select")).toHaveLength(0);
+    expect(calls.some((call) => call.kind === "log.success")).toBe(false);
+  });
+
+  test("puts create first when there is no concrete match", async () => {
+    const { ui, respond } = createMockUI();
+    const selectSpy = vi.spyOn(ui, "select");
+    respond.select("create");
+
+    const result = await resolveInitProjectContext(
+      makeContext(),
+      "/work/checkout/apps/new-app",
+      ui
+    );
+
+    expect(result).toEqual({
+      project: undefined,
+      existingProject: undefined,
+    });
+    expect(selectSpy.mock.calls[0]?.[0].options[0]).toEqual(
+      expect.objectContaining({
+        value: "create",
+        label: "+ Create a new Sentry project",
+      })
+    );
+  });
+
+  test("lists projects only after the existing-project choice", async () => {
+    listProjectsSpy.mockResolvedValue([
+      makeProject("backend"),
+      makeProject("frontend"),
+    ]);
+    const { ui, respond } = createMockUI();
+    respond.select("existing");
+    respond.select("frontend");
+
+    const result = await resolveInitProjectContext(
+      makeContext(),
+      "/work/checkout/apps/new-app",
+      ui
+    );
+
+    expect(result.existingProject?.projectSlug).toBe("frontend");
+    expect(listProjectsSpy).toHaveBeenCalledWith("acme");
+  });
+
+  test("confirms an env-backed explicit project with independent canonical evidence", async () => {
+    detectSentrySetupSpy.mockResolvedValue({
+      status: "installed",
+      signals: ["init: src/instrumentation.ts"],
+    });
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "acme",
+          project: "junior",
+          matchStrength: "exact",
+        },
+      ],
+    });
+    const { ui } = createMockUI();
+
+    const result = await resolveInitProjectContext(
+      makeContext({ project: "junior" }),
+      "/work/checkout/apps/junior",
+      ui,
+      { supportsExistingSetupImprovement: true }
+    );
+
+    expect(result.existingProject?.projectSlug).toBe("junior");
+    expect(result.setupIntent).toBe("improve-existing");
+    expect(resolveAllTargetsSpy).toHaveBeenCalled();
+  });
+
+  test("reuses a matching local DSN for an explicit existing project", async () => {
+    tryGetPrimaryDsnSpy.mockResolvedValueOnce(null);
+    detectSentrySetupSpy.mockResolvedValue({
+      dsn: "https://local@o1.ingest.sentry.io/id-junior",
+      signals: ["dsn: code (src/instrumentation.ts)"],
+      status: "installed",
+    });
+    const { ui } = createMockUI();
+
+    const result = await resolveInitProjectContext(
+      makeContext({ project: "junior" }),
+      "/work/checkout/apps/junior",
+      ui,
+      { supportsExistingSetupImprovement: true }
+    );
+
+    expect(result.existingProject?.dsn).toBe(
+      "https://local@o1.ingest.sentry.io/id-junior"
+    );
+  });
+
+  test("treats an explicit project with a different local DSN as another project", async () => {
+    tryGetPrimaryDsnSpy.mockResolvedValueOnce(null);
+    detectSentrySetupSpy.mockResolvedValue({
+      dsn: "https://other@o1.ingest.sentry.io/different-id",
+      signals: ["dsn: code (src/instrumentation.ts)"],
+      status: "installed",
+    });
+    const { ui } = createMockUI();
+
+    const result = await resolveInitProjectContext(
+      makeContext({ project: "junior" }),
+      "/work/checkout/apps/junior",
+      ui,
+      { supportsExistingSetupImprovement: true }
+    );
+
+    expect(result.existingProject).toEqual(
+      expect.objectContaining({ projectSlug: "junior" })
+    );
+    expect(result.existingProject?.dsn).toBeUndefined();
+    expect(result.setupIntent).toBeUndefined();
+  });
+
+  test("improves an existing setup even when project-key lookup is unavailable", async () => {
+    tryGetPrimaryDsnSpy.mockResolvedValueOnce(null);
+    detectSentrySetupSpy.mockResolvedValue({
+      signals: ["init: src/instrumentation.ts"],
+      status: "installed",
+    });
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "acme",
+          project: "junior",
+          matchStrength: "exact",
+        },
+      ],
+    });
+    const { ui } = createMockUI();
+
+    const result = await resolveInitProjectContext(
+      makeContext({ project: "junior" }),
+      "/work/checkout/apps/junior",
+      ui,
+      { supportsExistingSetupImprovement: true }
+    );
+
+    expect(result.existingProject).toEqual(
+      expect.objectContaining({ projectSlug: "junior" })
+    );
+    expect(result.existingProject?.dsn).toBeUndefined();
+    expect(result.setupIntent).toBe("improve-existing");
+  });
+
+  test("does not improve an env-backed explicit project without independent evidence", async () => {
+    tryGetPrimaryDsnSpy.mockResolvedValueOnce(null);
+    detectSentrySetupSpy.mockResolvedValue({
+      signals: ["init: src/instrumentation.ts"],
+      status: "installed",
+    });
+    const { ui } = createMockUI();
+
+    const result = await resolveInitProjectContext(
+      makeContext({ project: "junior" }),
+      "/work/checkout/apps/junior",
+      ui,
+      { supportsExistingSetupImprovement: true }
+    );
+
+    expect(result.existingProject?.projectSlug).toBe("junior");
+    expect(result.setupIntent).toBeUndefined();
+  });
+
+  test("does not match a self-hosted DSN to a SaaS project with the same ID", async () => {
+    tryGetPrimaryDsnSpy.mockResolvedValueOnce(null);
+    detectSentrySetupSpy.mockResolvedValue({
+      dsn: "https://local@sentry.example.com/id-junior",
+      signals: ["dsn: code (src/instrumentation.ts)"],
+      status: "installed",
+    });
+    const { ui } = createMockUI();
+
+    const result = await resolveInitProjectContext(
+      makeContext({ project: "junior" }),
+      "/work/checkout/apps/junior",
+      ui,
+      { supportsExistingSetupImprovement: true }
+    );
+
+    expect(result.setupIntent).toBeUndefined();
+  });
+
+  test("does not mark a missing explicit project as an existing setup improvement", async () => {
+    detectSentrySetupSpy.mockResolvedValue({
+      status: "installed",
+      signals: ["init: src/instrumentation.ts"],
+    });
+    const { ui } = createMockUI();
+
+    const result = await resolveInitProjectContext(
+      makeContext({ project: "brand-new-project" }),
+      "/work/checkout/apps/junior",
+      ui
+    );
+
+    expect(result).toEqual({ project: "brand-new-project" });
+    expect(result.setupIntent).toBeUndefined();
+  });
+
+  test("ignores fuzzy and ambiguous project matches", async () => {
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "acme",
+          project: "junior",
+          orgDisplay: "Acme",
+          projectDisplay: "Junior",
+          matchStrength: "fuzzy",
+        },
+        {
+          org: "acme",
+          project: "backend",
+          orgDisplay: "Acme",
+          projectDisplay: "Backend",
+          matchStrength: "exact",
+        },
+        {
+          org: "acme",
+          project: "frontend",
+          orgDisplay: "Acme",
+          projectDisplay: "Frontend",
+          matchStrength: "exact",
+        },
+      ],
+    });
+    const { ui, respond } = createMockUI();
+    respond.select("create");
+
+    const result = await resolveInitProjectContext(
+      makeContext(),
+      "/work/checkout",
+      ui
+    );
+
+    expect(result.existingProject).toBeUndefined();
+  });
+
+  test("creates non-interactively when no project can be resolved", async () => {
+    const { ui, calls } = createMockUI();
+
+    const result = await resolveInitProjectContext(
+      makeContext({ yes: true }),
+      "/work/checkout/apps/new-app",
+      ui
+    );
+
+    expect(result).toEqual({
+      project: undefined,
+      existingProject: undefined,
+    });
+    expect(calls.filter((call) => call.kind === "select")).toHaveLength(0);
+  });
+
+  test("chooses a non-conflicting slug non-interactively after rejecting a mismatch", async () => {
+    detectSentrySetupSpy.mockResolvedValue({
+      dsn: "https://other@o1.ingest.sentry.io/different-id",
+      signals: ["dsn: code (src/instrumentation.ts)"],
+      status: "installed",
+    });
+    resolveAllTargetsSpy.mockResolvedValue({
+      targets: [
+        {
+          org: "acme",
+          project: "junior",
+          matchStrength: "exact",
+        },
+      ],
+    });
+    const { ui, calls } = createMockUI();
+
+    const result = await resolveInitProjectContext(
+      makeContext({ yes: true }),
+      "/work/checkout/apps/junior",
+      ui
+    );
+
+    expect(result).toEqual({
+      project: "junior-2",
+      existingProject: undefined,
+    });
+    expect(calls.filter((call) => call.kind === "select")).toHaveLength(0);
+  });
+
+  test("propagates cancellation from the project intent prompt", async () => {
+    const { ui } = createMockUI();
+
     await expect(
-      resolveInitContext(makeOptions({ team: "backend" }), ui)
-    ).rejects.toThrow();
-
-    const errorCall = calls.find(
-      (c): c is Extract<MockCall, { kind: "log.error" }> =>
-        c.kind === "log.error"
-    );
-    expect(errorCall?.message).toContain("over its member limit");
-  });
-
-  test("passes a pre-rendered WizardError through team resolution unchanged", async () => {
-    listTeamsSpy.mockRejectedValueOnce(
-      new WizardError("custom preflight failure")
-    );
-
-    const { ui, calls } = createMockUI();
-    await expect(resolveInitContext(makeOptions(), ui)).rejects.toThrow(
-      "custom preflight failure"
-    );
-
-    const errorCall = calls.find(
-      (c): c is Extract<MockCall, { kind: "log.error" }> =>
-        c.kind === "log.error"
-    );
-    expect(errorCall?.message).toBe("custom preflight failure");
-  });
-
-  test.each([
-    ["AuthError", new AuthError("expired")],
-    ["HostScopeError", new HostScopeError("host mismatch")],
-  ])("propagates %s without turning it into a wizard failure", async (_, error) => {
-    listTeamsSpy.mockRejectedValueOnce(error);
-
-    const { ui, calls } = createMockUI();
-    await expect(resolveInitContext(makeOptions(), ui)).rejects.toBe(error);
-
-    expect(calls.some((call) => call.kind === "log.error")).toBe(false);
-    expect(calls.some((call) => call.kind === "cancel")).toBe(false);
-    expect(calls.some((call) => call.kind === "feedback")).toBe(false);
-  });
-
-  test("surfaces a non-API error message from implicit team resolution", async () => {
-    listTeamsSpy.mockRejectedValueOnce(new Error("network down"));
-
-    const { ui, calls } = createMockUI();
-    await expect(resolveInitContext(makeOptions(), ui)).rejects.toThrow(
-      "network down"
-    );
-
-    const errorCall = calls.find(
-      (c): c is Extract<MockCall, { kind: "log.error" }> =>
-        c.kind === "log.error"
-    );
-    expect(errorCall?.message).toContain("network down");
-  });
-
-  test("fails early when listTeams is forbidden and member project creation is disabled", async () => {
-    listTeamsSpy.mockRejectedValueOnce(
-      new ApiError("Forbidden", 403, "No team:read access")
-    );
-    getOrganizationSpy.mockResolvedValueOnce({
-      id: "1",
-      slug: "acme",
-      name: "Acme",
-      access: ["project:read"],
-      allowMemberProjectCreation: false,
-    } as any);
-
-    const { ui } = createMockUI();
-    await expect(resolveInitContext(makeOptions(), ui)).rejects.toThrow(
-      "Project creation is disabled for members"
-    );
-  });
-
-  test("fails early when member project creation is disabled and no Team Admin team exists", async () => {
-    listTeamsSpy.mockResolvedValueOnce([]);
-    getOrganizationSpy.mockResolvedValueOnce({
-      id: "1",
-      slug: "acme",
-      name: "Acme",
-      access: ["project:read"],
-      allowMemberProjectCreation: false,
-    } as any);
-
-    const { ui, calls } = createMockUI();
-    await expect(resolveInitContext(makeOptions(), ui)).rejects.toThrow(
-      "Project creation is disabled for members"
-    );
-
-    const errorCall = calls.find(
-      (c): c is Extract<MockCall, { kind: "log.error" }> =>
-        c.kind === "log.error"
-    );
-    expect(errorCall?.message).toContain("sentry init acme/<project-slug>");
-  });
-
-  test("allows org-scoped creation when member creation is disabled but token has org:write", async () => {
-    listTeamsSpy.mockResolvedValueOnce([]);
-    getOrganizationSpy.mockResolvedValueOnce({
-      id: "1",
-      slug: "acme",
-      name: "Acme",
-      access: ["org:write"],
-      allowMemberProjectCreation: false,
-    } as any);
-
-    const { ui } = createMockUI();
-    const context = await resolveInitContext(makeOptions(), ui);
-
-    expect(context?.team).toBeUndefined();
-  });
-
-  test("allows org-scoped creation when member creation is disabled but user is an admin (project:admin scope)", async () => {
-    listTeamsSpy.mockResolvedValueOnce([]);
-    getOrganizationSpy.mockResolvedValueOnce({
-      id: "1",
-      slug: "acme",
-      name: "Acme",
-      access: ["project:read", "project:write", "project:admin", "team:admin"],
-      allowMemberProjectCreation: false,
-    } as any);
-
-    const { ui } = createMockUI();
-    const context = await resolveInitContext(makeOptions(), ui);
-
-    expect(context?.team).toBeUndefined();
-  });
-
-  test("allows org-scoped creation when member creation is disabled but user has project:write scope", async () => {
-    listTeamsSpy.mockResolvedValueOnce([]);
-    getOrganizationSpy.mockResolvedValueOnce({
-      id: "1",
-      slug: "acme",
-      name: "Acme",
-      access: ["project:read", "project:write"],
-      allowMemberProjectCreation: false,
-    } as any);
-
-    const { ui } = createMockUI();
-    const context = await resolveInitContext(makeOptions(), ui);
-
-    expect(context?.team).toBeUndefined();
-  });
-
-  test("allows org-scoped creation when listTeams returns 403 and user has project:admin scope", async () => {
-    listTeamsSpy.mockRejectedValueOnce(
-      new ApiError("Forbidden", 403, "No team:read access")
-    );
-    getOrganizationSpy.mockResolvedValueOnce({
-      id: "1",
-      slug: "acme",
-      name: "Acme",
-      access: ["project:read", "project:write", "project:admin"],
-      allowMemberProjectCreation: false,
-    } as any);
-
-    const { ui } = createMockUI();
-    const context = await resolveInitContext(makeOptions(), ui);
-
-    expect(context?.team).toBeUndefined();
+      resolveInitProjectContext(
+        makeContext(),
+        "/work/checkout/apps/new-app",
+        ui
+      )
+    ).rejects.toBeInstanceOf(WizardCancelledError);
   });
 });

--- a/packages/cli/test/lib/init/readiness.test.ts
+++ b/packages/cli/test/lib/init/readiness.test.ts
@@ -56,7 +56,13 @@ function makeUI(): { ui: WizardUI; errors: string[]; warns: string[] } {
   return { ui, errors, warns };
 }
 
-const OK_RESPONSE = new Response(null, { status: 200 });
+const OK_RESPONSE = new Response(
+  JSON.stringify({
+    capabilities: ["improve-existing-setup"],
+    status: "ok",
+  }),
+  { status: 200 }
+);
 const ERR_RESPONSE = new Response(null, { status: 503 });
 
 let fetchSpy: ReturnType<typeof spyOn>;
@@ -73,7 +79,9 @@ describe("checkReadiness", () => {
   test("resolves without error when the setup service is reachable", async () => {
     fetchSpy.mockResolvedValue(OK_RESPONSE.clone());
     const { ui, errors, warns } = makeUI();
-    await expect(checkReadiness(ui)).resolves.toBeUndefined();
+    await expect(checkReadiness(ui)).resolves.toEqual({
+      improveExistingSetup: true,
+    });
     expect(errors).toHaveLength(0);
     expect(warns).toHaveLength(0);
   });
@@ -81,7 +89,9 @@ describe("checkReadiness", () => {
   test("resolves but logs a warning when the setup service is unreachable", async () => {
     fetchSpy.mockRejectedValue(new Error("network failure"));
     const { ui, errors, warns } = makeUI();
-    await expect(checkReadiness(ui)).resolves.toBeUndefined();
+    await expect(checkReadiness(ui)).resolves.toEqual({
+      improveExistingSetup: false,
+    });
     expect(errors).toHaveLength(0);
     expect(warns.length).toBeGreaterThanOrEqual(1);
   });
@@ -89,8 +99,21 @@ describe("checkReadiness", () => {
   test("resolves but logs a warning when the setup service returns non-ok status", async () => {
     fetchSpy.mockResolvedValue(ERR_RESPONSE.clone());
     const { ui, errors, warns } = makeUI();
-    await expect(checkReadiness(ui)).resolves.toBeUndefined();
+    await expect(checkReadiness(ui)).resolves.toEqual({
+      improveExistingSetup: false,
+    });
     expect(errors).toHaveLength(0);
     expect(warns.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("treats a reachable older service as lacking improvement support", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ status: "ok" }), { status: 200 })
+    );
+    const { ui } = makeUI();
+
+    await expect(checkReadiness(ui)).resolves.toEqual({
+      improveExistingSetup: false,
+    });
   });
 });

--- a/packages/cli/test/lib/init/tools/create-sentry-project.component.test.ts
+++ b/packages/cli/test/lib/init/tools/create-sentry-project.component.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("../../../../src/lib/api-client.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../../src/lib/api-client.js")>();
+  return Object.fromEntries(
+    Object.entries(actual).map(([key, value]) => [
+      key,
+      typeof value === "function" ? vi.fn(value) : value,
+    ])
+  );
+});
+
+vi.mock("../../../../src/lib/scope-recovery.js", () => ({
+  captureOAuthScopeRecoveryGate: vi.fn(),
+}));
+
+// biome-ignore lint/performance/noNamespaceImport: assertions need module spies
+import * as apiClient from "../../../../src/lib/api-client.js";
+import { ApiError } from "../../../../src/lib/errors.js";
+import { WizardCancelledError } from "../../../../src/lib/init/clack-utils.js";
+import { createSentryProject } from "../../../../src/lib/init/tools/create-sentry-project.js";
+import { executeTool } from "../../../../src/lib/init/tools/registry.js";
+import type { CreateSentryProjectPayload } from "../../../../src/lib/init/types.js";
+// biome-ignore lint/performance/noNamespaceImport: mocked recovery gate needs per-test behavior
+import * as scopeRecovery from "../../../../src/lib/scope-recovery.js";
+
+const payload: CreateSentryProjectPayload = {
+  type: "tool",
+  operation: "create-sentry-project",
+  cwd: "/tmp/test",
+  params: { name: "my-app", platform: "javascript-react" },
+};
+
+const context = {
+  dryRun: false,
+  org: "acme",
+  team: undefined,
+  project: undefined,
+};
+
+const shouldDelegateScopeRecovery = vi.fn();
+
+describe("createSentryProject with the real team resolver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    shouldDelegateScopeRecovery.mockResolvedValue(false);
+    vi.mocked(scopeRecovery.captureOAuthScopeRecoveryGate).mockReturnValue({
+      shouldDelegate: shouldDelegateScopeRecovery,
+    });
+    vi.mocked(apiClient.listTeams).mockResolvedValue([
+      {
+        id: "1",
+        slug: "contributors",
+        name: "Contributors",
+        access: ["team:read"],
+      },
+    ]);
+    vi.mocked(apiClient.getOrganization).mockResolvedValue({
+      id: "1",
+      slug: "acme",
+      name: "Acme",
+      access: ["project:admin", "team:admin"],
+      allowMemberProjectCreation: false,
+    });
+    vi.mocked(apiClient.createTeam).mockResolvedValue({
+      id: "2",
+      slug: "my-app",
+      name: "my-app",
+    });
+    vi.mocked(apiClient.createProjectWithDsn).mockResolvedValue({
+      project: { id: "42", slug: "my-app" } as never,
+      dsn: "https://key@o1.ingest.sentry.io/42",
+      url: "https://sentry.io/settings/acme/projects/my-app/",
+    });
+  });
+
+  test("creates a team and then its project in a restricted organization", async () => {
+    const result = await createSentryProject(payload, context);
+
+    expect(result.ok).toBe(true);
+    expect(apiClient.createTeam).toHaveBeenCalledWith("acme", "my-app");
+    expect(apiClient.createProjectWithDsn).toHaveBeenCalledWith(
+      "acme",
+      "my-app",
+      { name: "my-app", platform: "javascript-react" }
+    );
+    expect(apiClient.createProjectWithAutoTeam).not.toHaveBeenCalled();
+  });
+
+  test("does not try an impossible org fallback if team creation loses permission", async () => {
+    vi.mocked(apiClient.createTeam).mockRejectedValueOnce(
+      new ApiError("Forbidden", 403, "Missing team permission")
+    );
+    shouldDelegateScopeRecovery.mockResolvedValueOnce(true);
+
+    await expect(
+      executeTool(payload, {
+        directory: "/tmp/test",
+        yes: true,
+        ...context,
+      })
+    ).rejects.toMatchObject({
+      status: 403,
+      detail: expect.stringContaining("team:admin"),
+    });
+    expect(apiClient.createTeam).toHaveBeenCalledOnce();
+    expect(apiClient.createProjectWithDsn).not.toHaveBeenCalled();
+    expect(apiClient.createProjectWithAutoTeam).not.toHaveBeenCalled();
+  });
+
+  test("propagates cancellation from the interactive team chooser", async () => {
+    vi.mocked(apiClient.listTeams).mockResolvedValueOnce([
+      {
+        id: "1",
+        slug: "platform",
+        name: "Platform",
+        access: ["team:admin"],
+      },
+    ]);
+
+    await expect(
+      executeTool(
+        payload,
+        {
+          directory: "/tmp/test",
+          yes: false,
+          ...context,
+        },
+        {
+          chooseTeam: async () => {
+            throw new WizardCancelledError();
+          },
+        }
+      )
+    ).rejects.toBeInstanceOf(WizardCancelledError);
+    expect(apiClient.createProjectWithDsn).not.toHaveBeenCalled();
+    expect(apiClient.createProjectWithAutoTeam).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/lib/init/tools/create-sentry-project.test.ts
+++ b/packages/cli/test/lib/init/tools/create-sentry-project.test.ts
@@ -22,12 +22,11 @@ import {
   createSentryProject,
   createSentryProjectTool,
 } from "../../../../src/lib/init/tools/create-sentry-project.js";
-import { executeTool } from "../../../../src/lib/init/tools/registry.js";
 import type {
   CreateSentryProjectPayload,
   EnsureSentryProjectPayload,
 } from "../../../../src/lib/init/types.js";
-// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
+// biome-ignore lint/performance/noNamespaceImport: mocked at the module boundary
 import * as scopeRecovery from "../../../../src/lib/scope-recovery.js";
 
 vi.mock("../../../../src/lib/resolve-team.js", async (importOriginal) => {
@@ -84,10 +83,13 @@ const sampleAutoTeamResult = {
   team_slug: "team-testuser",
 };
 
+const autoSelectedTeam = {
+  slug: "platform",
+  source: "auto-selected" as const,
+};
+
 let createProjectWithDsnSpy: ReturnType<typeof spyOn>;
 let createProjectWithAutoTeamSpy: ReturnType<typeof spyOn>;
-let getProjectSpy: ReturnType<typeof spyOn>;
-let tryGetPrimaryDsnSpy: ReturnType<typeof spyOn>;
 let resolveOrCreateTeamSpy: ReturnType<typeof spyOn>;
 let shouldDelegateScopeRecovery: ReturnType<typeof vi.fn>;
 
@@ -112,29 +114,16 @@ beforeEach(() => {
   createProjectWithAutoTeamSpy = vi
     .spyOn(apiClient, "createProjectWithAutoTeam")
     .mockResolvedValue(sampleAutoTeamResult);
-  getProjectSpy = vi.spyOn(apiClient, "getProject").mockResolvedValue({
-    id: "42",
-    slug: "my-app",
-    name: "my-app",
-    platform: "javascript-react",
-    dateCreated: "2026-04-16T00:00:00Z",
-  } as any);
-  tryGetPrimaryDsnSpy = vi
-    .spyOn(apiClient, "tryGetPrimaryDsn")
-    .mockResolvedValue("https://abc@o1.ingest.sentry.io/42");
   resolveOrCreateTeamSpy = vi
     .spyOn(resolveTeam, "resolveOrCreateTeam")
-    .mockResolvedValue({
-      slug: "generated-team",
-      source: "auto-created",
-    } as any);
+    .mockImplementation(async (_org, options) =>
+      options.team ? { slug: options.team, source: "explicit" } : undefined
+    );
 });
 
 afterEach(() => {
   createProjectWithDsnSpy.mockRestore();
   createProjectWithAutoTeamSpy.mockRestore();
-  getProjectSpy.mockRestore();
-  tryGetPrimaryDsnSpy.mockRestore();
   resolveOrCreateTeamSpy.mockRestore();
   vi.mocked(scopeRecovery.captureOAuthScopeRecoveryGate).mockReset();
 });
@@ -143,7 +132,6 @@ describe("createSentryProject", () => {
   test("returns the pre-resolved existing project without creating", async () => {
     const result = await createSentryProject(makePayload(), {
       dryRun: false,
-      yes: false,
       org: "acme",
       team: undefined,
       project: "my-app",
@@ -157,7 +145,9 @@ describe("createSentryProject", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(result.message).toContain("Using existing project");
+    expect(result.data).toEqual(
+      expect.objectContaining({ ensuredVia: "existing" })
+    );
     expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
     expect(resolveOrCreateTeamSpy).not.toHaveBeenCalled();
   });
@@ -165,7 +155,6 @@ describe("createSentryProject", () => {
   test("accepts the legacy ensure-sentry-project alias", async () => {
     const result = await createSentryProject(makeEnsurePayload(), {
       dryRun: false,
-      yes: false,
       org: "acme",
       team: undefined,
       project: "my-app",
@@ -179,14 +168,61 @@ describe("createSentryProject", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(result.message).toContain("Using existing project");
+    expect(result.data).toEqual(
+      expect.objectContaining({ ensuredVia: "existing" })
+    );
+    expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
+  });
+
+  test("fails early when a newly selected existing project has no readable DSN", async () => {
+    const result = await createSentryProject(makePayload(), {
+      dryRun: false,
+      org: "acme",
+      team: undefined,
+      project: "my-app",
+      existingProject: {
+        orgSlug: "acme",
+        projectSlug: "my-app",
+        projectId: "42",
+        url: "https://sentry.io/settings/acme/projects/my-app/",
+      },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: expect.stringContaining("Could not obtain a DSN"),
+    });
+    expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
+  });
+
+  test("allows an existing setup improvement to preserve its current DSN source", async () => {
+    const result = await createSentryProject(makePayload(), {
+      dryRun: false,
+      org: "acme",
+      team: undefined,
+      project: "my-app",
+      setupIntent: "improve-existing",
+      existingProject: {
+        orgSlug: "acme",
+        projectSlug: "my-app",
+        projectId: "42",
+        url: "https://sentry.io/settings/acme/projects/my-app/",
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      data: expect.objectContaining({
+        ensuredVia: "existing",
+        projectSlug: "my-app",
+      }),
+    });
     expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
   });
 
   test("returns error when project name produces an empty slug", async () => {
     const result = await createSentryProject(makePayload({ name: "---" }), {
       dryRun: false,
-      yes: false,
       org: "acme",
       team: undefined,
       project: undefined,
@@ -197,14 +233,11 @@ describe("createSentryProject", () => {
     expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
   });
 
-  test("creates a new project with the pre-resolved org and team", async () => {
-    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
-
+  test("creates a new project with the explicit preflight team", async () => {
     const result = await createSentryProject(makePayload(), {
       dryRun: false,
-      yes: false,
       org: "acme",
-      team: "platform",
+      team: { slug: "platform", source: "explicit" },
       project: undefined,
     });
 
@@ -219,45 +252,24 @@ describe("createSentryProject", () => {
     );
   });
 
-  test("re-checks for an existing project before creating when the slug is known", async () => {
+  test("does not silently reuse a project after creation was selected", async () => {
     const result = await createSentryProject(makePayload(), {
       dryRun: false,
-      yes: false,
       org: "acme",
-      team: "platform",
+      team: { slug: "platform", source: "explicit" },
       project: undefined,
     });
 
     expect(result.ok).toBe(true);
-    expect(result.message).toContain("Using existing project");
-    expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
-    expect(resolveOrCreateTeamSpy).not.toHaveBeenCalled();
-  });
-
-  test("surfaces lookup failures before creating when a known slug cannot be verified", async () => {
-    getProjectSpy.mockRejectedValueOnce(new Error("temporary failure"));
-
-    const result = await createSentryProject(makePayload(), {
-      dryRun: false,
-      yes: false,
-      org: "acme",
-      team: "platform",
-      project: undefined,
-    });
-
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain("temporary failure");
-    expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
+    expect(createProjectWithDsnSpy).toHaveBeenCalledOnce();
+    expect(apiClient.getProject).not.toHaveBeenCalled();
   });
 
   test("returns dry-run placeholder project data", async () => {
-    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
-
     const result = await createSentryProject(makePayload(), {
       dryRun: true,
-      yes: true,
       org: "acme",
-      team: "platform",
+      team: { slug: "platform", source: "explicit" },
       project: undefined,
     });
 
@@ -272,18 +284,18 @@ describe("createSentryProject", () => {
   });
 
   test("uses org-scoped auto-team creation when preflight did not resolve a team", async () => {
-    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
-
     const result = await createSentryProject(makePayload(), {
       dryRun: false,
-      yes: false,
       org: "acme",
       team: undefined,
       project: undefined,
     });
 
     expect(result.ok).toBe(true);
-    expect(resolveOrCreateTeamSpy).not.toHaveBeenCalled();
+    expect(resolveOrCreateTeamSpy).toHaveBeenCalledWith(
+      "acme",
+      expect.objectContaining({ autoCreateSlug: "my-app" })
+    );
     expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
     expect(createProjectWithAutoTeamSpy).toHaveBeenCalledWith("acme", {
       name: "my-app",
@@ -292,7 +304,6 @@ describe("createSentryProject", () => {
   });
 
   test("returns clear error with sentry-init guidance when org disables member creation", async () => {
-    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
     createProjectWithAutoTeamSpy.mockRejectedValueOnce(
       new ApiError(
         "Failed to create project: 403 Forbidden",
@@ -305,7 +316,6 @@ describe("createSentryProject", () => {
 
     const result = await createSentryProject(makePayload(), {
       dryRun: false,
-      yes: false,
       org: "acme",
       team: undefined,
       project: undefined,
@@ -329,16 +339,15 @@ describe("createSentryProject", () => {
   });
 
   test("falls back to org-scoped endpoint on 403 from team-based creation", async () => {
-    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
+    resolveOrCreateTeamSpy.mockResolvedValueOnce(autoSelectedTeam);
     createProjectWithDsnSpy.mockRejectedValueOnce(
       new ApiError("Forbidden", 403, "No project:write access")
     );
 
     const result = await createSentryProject(makePayload(), {
       dryRun: false,
-      yes: false,
       org: "acme",
-      team: "platform",
+      team: undefined,
       project: undefined,
     });
 
@@ -349,18 +358,45 @@ describe("createSentryProject", () => {
     });
   });
 
-  test("suppresses fallback when team was set via --team (isExplicitTeam)", async () => {
-    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
+  test("retries an invalid platform on the concrete fallback route", async () => {
+    resolveOrCreateTeamSpy.mockResolvedValueOnce(autoSelectedTeam);
     createProjectWithDsnSpy.mockRejectedValueOnce(
       new ApiError("Forbidden", 403, "No project:write access")
+    );
+    createProjectWithAutoTeamSpy
+      .mockRejectedValueOnce(
+        new ApiError("Bad request", 400, "Invalid platform")
+      )
+      .mockResolvedValueOnce(sampleAutoTeamResult);
+
+    const result = await createSentryProject(makePayload(), {
+      dryRun: false,
+      org: "acme",
+      team: undefined,
+      project: undefined,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(createProjectWithDsnSpy).toHaveBeenCalledOnce();
+    expect(createProjectWithAutoTeamSpy).toHaveBeenNthCalledWith(1, "acme", {
+      name: "my-app",
+      platform: "javascript-react",
+    });
+    expect(createProjectWithAutoTeamSpy).toHaveBeenNthCalledWith(2, "acme", {
+      name: "my-app",
+      platform: undefined,
+    });
+  });
+
+  test("suppresses fallback for an explicitly resolved team", async () => {
+    createProjectWithDsnSpy.mockRejectedValueOnce(
+      new ApiError("Forbidden", 403, "You do not have permission")
     );
 
     const result = await createSentryProject(makePayload(), {
       dryRun: false,
-      yes: false,
       org: "acme",
-      team: "backend",
-      isExplicitTeam: true,
+      team: { slug: "backend", source: "explicit" },
       project: undefined,
     });
 
@@ -368,80 +404,9 @@ describe("createSentryProject", () => {
     expect(createProjectWithAutoTeamSpy).not.toHaveBeenCalled();
   });
 
-  test("lets a recoverable 403 escape the real tool registry", async () => {
+  test("identifies the team scope hidden by a team-scoped policy 403", async () => {
     shouldDelegateScopeRecovery.mockResolvedValueOnce(true);
-    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
-    createProjectWithAutoTeamSpy.mockRejectedValueOnce(
-      new ApiError("Forbidden", 403, "No project:write access")
-    );
-
-    const error = await executeTool(makePayload(), {
-      directory: "/tmp/test",
-      yes: false,
-      dryRun: false,
-      org: "acme",
-      team: undefined,
-    }).catch((caught: unknown) => caught);
-
-    expect(error).toBeInstanceOf(ApiError);
-    expect((error as ApiError).status).toBe(403);
-    expect(shouldDelegateScopeRecovery).toHaveBeenCalledWith(
-      expect.any(ApiError),
-      {
-        unattended: false,
-      }
-    );
-  });
-
-  test("keeps the tool fallback when OAuth recovery is unattended", async () => {
-    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
-    createProjectWithAutoTeamSpy.mockRejectedValueOnce(
-      new ApiError("Forbidden", 403, "No project:write access")
-    );
-
-    const result = await createSentryProject(makePayload(), {
-      dryRun: false,
-      yes: true,
-      org: "acme",
-      team: undefined,
-      project: undefined,
-    });
-
-    expect(result.ok).toBe(false);
-    expect(shouldDelegateScopeRecovery).toHaveBeenCalledWith(
-      expect.any(ApiError),
-      {
-        unattended: true,
-      }
-    );
-  });
-
-  test("keeps the policy-specific error when OAuth scopes are stale", async () => {
-    shouldDelegateScopeRecovery.mockResolvedValueOnce(true);
-    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
-    createProjectWithAutoTeamSpy.mockRejectedValueOnce(
-      new ApiError(
-        "Forbidden",
-        403,
-        "Your organization has disabled this feature for members."
-      )
-    );
-
-    const result = await createSentryProject(makePayload(), {
-      dryRun: false,
-      yes: false,
-      org: "acme",
-      team: undefined,
-      project: undefined,
-    });
-
-    expect(result.ok).toBe(false);
-    expect(result.error).toContain("disabled for members");
-    expect(shouldDelegateScopeRecovery).not.toHaveBeenCalled();
-  });
-
-  test("does not fall back on team-scoped policy 403", async () => {
-    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
+    resolveOrCreateTeamSpy.mockResolvedValueOnce(autoSelectedTeam);
     createProjectWithDsnSpy.mockRejectedValueOnce(
       new ApiError(
         "Forbidden",
@@ -450,28 +415,27 @@ describe("createSentryProject", () => {
       )
     );
 
-    const result = await createSentryProject(makePayload(), {
-      dryRun: false,
-      yes: false,
-      org: "acme",
-      team: "platform",
-      project: undefined,
+    await expect(
+      createSentryProject(makePayload(), {
+        dryRun: false,
+        org: "acme",
+        team: undefined,
+        project: undefined,
+      })
+    ).rejects.toMatchObject({
+      status: 403,
+      detail: expect.stringContaining("team:admin"),
     });
-
-    expect(result.ok).toBe(false);
     expect(createProjectWithAutoTeamSpy).not.toHaveBeenCalled();
-    expect(result.error).toContain("disabled for members");
   });
 
   test("surfaces friendly 409 error when fallback project already exists", async () => {
     createProjectWithAutoTeamSpy.mockRejectedValueOnce(
       new ApiError("Conflict", 409, "Slug already in use")
     );
-    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
 
     const result = await createSentryProject(makePayload(), {
       dryRun: false,
-      yes: false,
       org: "acme",
       team: undefined,
       project: undefined,
@@ -483,19 +447,19 @@ describe("createSentryProject", () => {
 
   // ── dry-run ──────────────────────────────────────────────────────────────
 
-  test("does not resolve a team for org-scoped dry-run mode", async () => {
-    getProjectSpy.mockRejectedValueOnce(new ApiError("Not found", 404));
-
+  test("resolves team policy without mutating during dry-run", async () => {
     const result = await createSentryProject(makePayload(), {
       dryRun: true,
-      yes: true,
       org: "acme",
       team: undefined,
       project: undefined,
     });
 
     expect(result.ok).toBe(true);
-    expect(resolveOrCreateTeamSpy).not.toHaveBeenCalled();
+    expect(resolveOrCreateTeamSpy).toHaveBeenCalledWith(
+      "acme",
+      expect.objectContaining({ dryRun: true })
+    );
     expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/test/lib/init/tools/detect-sentry.test.ts
+++ b/packages/cli/test/lib/init/tools/detect-sentry.test.ts
@@ -1,0 +1,261 @@
+/** Tests for deterministic existing-Sentry detection used by init. */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { detectSentrySetup } from "../../../../src/lib/init/tools/detect-sentry.js";
+
+const temporaryDirectories: string[] = [];
+
+async function makeProject(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), "sentry-init-detect-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map(
+        async (directory) =>
+          await rm(directory, { recursive: true, force: true })
+      )
+  );
+});
+
+describe("detectSentrySetup", () => {
+  test("detects an environment-backed Node setup without a literal DSN", async () => {
+    const directory = await makeProject();
+    await mkdir(path.join(directory, "src"));
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ dependencies: { "@sentry/node": "^10.0.0" } })
+    );
+    await writeFile(
+      path.join(directory, "src/instrumentation.ts"),
+      'import * as Sentry from "@sentry/node";\nSentry.init({ dsn: process.env.SENTRY_DSN });\n'
+    );
+
+    const result = await detectSentrySetup(directory);
+
+    expect(result.status).toBe("installed");
+    expect(result.signals).toContain("init: src/instrumentation.ts");
+    expect(result.features).toEqual(["errorMonitoring"]);
+  });
+
+  test("reports features configured by an existing setup", async () => {
+    const directory = await makeProject();
+    await mkdir(path.join(directory, "src"));
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({
+        dependencies: {
+          "@sentry/node": "^10.0.0",
+          "@sentry/profiling-node": "^10.0.0",
+        },
+      })
+    );
+    await writeFile(
+      path.join(directory, "src/instrumentation.ts"),
+      [
+        'import * as Sentry from "@sentry/node";',
+        "Sentry.init({",
+        "  enableLogs: true,",
+        "  tracesSampleRate: 0.2,",
+        '  profileLifecycle: "trace",',
+        "  profileSessionSampleRate: 0.1,",
+        "});",
+      ].join("\n")
+    );
+
+    const result = await detectSentrySetup(directory);
+
+    expect(result.features).toEqual([
+      "errorMonitoring",
+      "performanceMonitoring",
+      "profiling",
+      "logs",
+    ]);
+  });
+
+  test("does not infer features from commented examples", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "sentry.server.config.ts"),
+      "// enableLogs: true\nexport const setup = true;\n"
+    );
+
+    const result = await detectSentrySetup(directory);
+
+    expect(result.features).toEqual(["errorMonitoring"]);
+  });
+
+  test("classifies an SDK dependency without initialization as partial", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ dependencies: { "@sentry/node": "^10.0.0" } })
+    );
+
+    const result = await detectSentrySetup(directory);
+
+    expect(result.status).toBe("partial");
+    expect(result.signals).toContain("sdk: package.json");
+  });
+
+  test.each([
+    "@sentry/react-router",
+    "@sentry/tanstackstart-react",
+  ])("recognizes the official %s SDK", async (sdkPackage) => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ dependencies: { [sdkPackage]: "^10.0.0" } })
+    );
+
+    const result = await detectSentrySetup(directory);
+
+    expect(result.status).toBe("partial");
+    expect(result.signals).toContain("sdk: package.json");
+  });
+
+  test("does not confuse unrelated @sentry scoped packages with SDKs", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({
+        dependencies: {
+          "@sentry/junior": "workspace:*",
+          "@sentry/starlight-theme": "^1.0.0",
+        },
+      })
+    );
+
+    await expect(detectSentrySetup(directory)).resolves.toEqual({
+      evidence: [],
+      status: "none",
+      signals: [],
+    });
+  });
+
+  test("treats a Sentry config file as an installed setup", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "sentry.server.config.ts"),
+      "export const tracesSampleRate = 1;\n"
+    );
+
+    const result = await detectSentrySetup(directory);
+
+    expect(result.status).toBe("installed");
+    expect(result.signals).toContain("config: sentry.server.config.ts");
+  });
+
+  test.each([
+    ["src/main.rs", "let _guard = sentry::init((dsn, options));"],
+    ["src/index.php", String.raw`\Sentry\init(["dsn" => $dsn]);`],
+    ["Sources/App.swift", "SentrySDK.start { options in }"],
+    ["app/src/Main.kt", "SentryAndroid.init(context) { options -> }"],
+    ["lib/app.rb", "Sentry.init do |config|\nend"],
+    ["src/main.cpp", "sentry_init(&options);"],
+  ])("detects runtime initialization in %s", async (relativePath, source) => {
+    const directory = await makeProject();
+    await mkdir(path.dirname(path.join(directory, relativePath)), {
+      recursive: true,
+    });
+    await writeFile(path.join(directory, relativePath), source);
+
+    const result = await detectSentrySetup(directory);
+
+    expect(result.status).toBe("installed");
+    expect(result.signals).toContain(`init: ${relativePath}`);
+  });
+
+  test("classifies auxiliary Sentry CLI config alone as partial", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "sentry.properties"),
+      "defaults.org=acme"
+    );
+
+    const result = await detectSentrySetup(directory);
+
+    expect(result.status).toBe("partial");
+    expect(result.signals).toContain("config: sentry.properties");
+  });
+
+  test.each([
+    [
+      "composer.json",
+      JSON.stringify({ require: { "sentry/sentry-laravel": "^4.0" } }),
+    ],
+    ["mix.exs", 'defp deps, do: [{:sentry, "~> 11.0"}]'],
+  ])("detects a framework-managed SDK dependency in %s", async (file, source) => {
+    const directory = await makeProject();
+    await writeFile(path.join(directory, file), source);
+
+    const result = await detectSentrySetup(directory);
+
+    expect(result.status).toBe("partial");
+    expect(result.signals).toContain(`sdk: ${file}`);
+  });
+
+  test.each([
+    ["config/sentry.php", "<?php return ['dsn' => env('SENTRY_LARAVEL_DSN')];"],
+    ["config/runtime.exs", 'config :sentry, dsn: System.get_env("SENTRY_DSN")'],
+  ])("detects framework-managed Sentry configuration in %s", async (file, source) => {
+    const directory = await makeProject();
+    await mkdir(path.dirname(path.join(directory, file)), { recursive: true });
+    await writeFile(path.join(directory, file), source);
+
+    const result = await detectSentrySetup(directory);
+
+    expect(result.status).toBe("installed");
+  });
+
+  test("does not treat test fixtures as an installed application setup", async () => {
+    const directory = await makeProject();
+    await mkdir(path.join(directory, "tests", "fixtures"), { recursive: true });
+    await writeFile(
+      path.join(directory, "tests", "fixtures", "setup.ts"),
+      "Sentry.init({ dsn: 'example' });"
+    );
+
+    await expect(detectSentrySetup(directory)).resolves.toEqual({
+      evidence: [],
+      status: "none",
+      signals: [],
+    });
+  });
+
+  test("does not treat commented initialization examples as installed", async () => {
+    const directory = await makeProject();
+    await mkdir(path.join(directory, "src"));
+    await writeFile(
+      path.join(directory, "src", "example.ts"),
+      "// Sentry.init({ dsn: 'example' });"
+    );
+
+    await expect(detectSentrySetup(directory)).resolves.toEqual({
+      evidence: [],
+      status: "none",
+      signals: [],
+    });
+  });
+
+  test("returns none for a project with no Sentry evidence", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ dependencies: { react: "^19.0.0" } })
+    );
+
+    await expect(detectSentrySetup(directory)).resolves.toEqual({
+      evidence: [],
+      status: "none",
+      signals: [],
+    });
+  });
+});

--- a/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
+++ b/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
@@ -23,15 +23,17 @@ function makeContext(directory: string): ResolvedInitContext {
 }
 
 let testDir: string;
-let detectDsnSpy: ReturnType<typeof spyOn>;
+let detectAllDsnOccurrencesSpy: ReturnType<typeof spyOn>;
 
 beforeEach(() => {
   testDir = fs.mkdtempSync(path.join("/tmp", "init-tools-"));
-  detectDsnSpy = vi.spyOn(dsnIndex, "detectDsn").mockResolvedValue(null);
+  detectAllDsnOccurrencesSpy = vi
+    .spyOn(dsnIndex, "detectAllDsnOccurrences")
+    .mockResolvedValue([]);
 });
 
 afterEach(() => {
-  detectDsnSpy.mockRestore();
+  detectAllDsnOccurrencesSpy.mockRestore();
   fs.rmSync(testDir, { recursive: true, force: true });
 });
 
@@ -1148,6 +1150,65 @@ describe("filesystem tools", () => {
     ).toContain("sntrys_test_token_123");
   });
 
+  test("create patches never overwrite existing files", async () => {
+    const filePath = path.join(testDir, "instrumentation.ts");
+    fs.writeFileSync(filePath, "const dsn = process.env.SENTRY_DSN;\n");
+
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "apply-patchset",
+        cwd: testDir,
+        params: {
+          patches: [
+            {
+              path: "instrumentation.ts",
+              action: "create",
+              patch: 'Sentry.init({ dsn: "https://public@example" });\n',
+            },
+          ],
+        },
+      },
+      makeContext(testDir)
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("target already exists");
+    expect(fs.readFileSync(filePath, "utf-8")).toBe(
+      "const dsn = process.env.SENTRY_DSN;\n"
+    );
+  });
+
+  test("concurrent create patches atomically allow only one writer", async () => {
+    const makePayload = (patch: string) => ({
+      type: "tool" as const,
+      operation: "apply-patchset" as const,
+      cwd: testDir,
+      params: {
+        patches: [
+          {
+            path: "raced-instrumentation.ts",
+            action: "create" as const,
+            patch,
+          },
+        ],
+      },
+    });
+    const contents = ["first writer\n", "second writer\n"];
+    const results = await Promise.all(
+      contents.map((content) =>
+        executeTool(makePayload(content), makeContext(testDir))
+      )
+    );
+
+    expect(results.filter((result) => result.ok)).toHaveLength(1);
+    const rejected = results.find((result) => !result.ok);
+    expect(rejected?.error).toContain("target appeared after validation");
+    expect(contents).toContain(
+      fs.readFileSync(path.join(testDir, "raced-instrumentation.ts"), "utf-8")
+    );
+  });
+
   test("rejects unsafe apply-patchset paths before writing", async () => {
     const unsafePaths: unknown[] = [
       null,
@@ -1275,7 +1336,7 @@ describe("filesystem tools", () => {
   });
 
   test("reports installed Sentry signals when a DSN is detected", async () => {
-    detectDsnSpy.mockResolvedValue({
+    const detectedDsn = {
       publicKey: "abc",
       protocol: "https",
       host: "o1.ingest.sentry.io",
@@ -1283,7 +1344,8 @@ describe("filesystem tools", () => {
       raw: "https://abc@o1.ingest.sentry.io/42",
       source: "env_file" as const,
       sourcePath: ".env",
-    });
+    };
+    detectAllDsnOccurrencesSpy.mockResolvedValue([detectedDsn]);
 
     const result = await executeTool(
       {

--- a/packages/cli/test/lib/init/tools/run-commands-spawn.mocked.test.ts
+++ b/packages/cli/test/lib/init/tools/run-commands-spawn.mocked.test.ts
@@ -9,11 +9,17 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { RunCommandsPayload } from "../../../../src/lib/init/types.js";
 
 const originalComSpec = process.env.ComSpec;
+const originalUppercasePnpmVersionConfig =
+  process.env.NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS;
 const { spawnCalls } = vi.hoisted(() => ({
   spawnCalls: [] as Array<{
     command: string;
     args: string[];
-    options: { shell?: boolean; windowsVerbatimArguments?: boolean };
+    options: {
+      env?: NodeJS.ProcessEnv;
+      shell?: boolean;
+      windowsVerbatimArguments?: boolean;
+    };
   }>,
 }));
 
@@ -34,7 +40,11 @@ vi.mock("node:child_process", async () => {
     spawn: (
       command: string,
       args: string[],
-      options: { shell?: boolean; windowsVerbatimArguments?: boolean }
+      options: {
+        env?: NodeJS.ProcessEnv;
+        shell?: boolean;
+        windowsVerbatimArguments?: boolean;
+      }
     ) => {
       spawnCalls.push({ command, args, options });
       const child = new EventEmitter() as any;
@@ -74,6 +84,7 @@ function makePayload(command: string): RunCommandsPayload {
 beforeEach(() => {
   spawnCalls.splice(0);
   delete process.env.ComSpec;
+  process.env.NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS = "false";
 });
 
 afterEach(() => {
@@ -82,6 +93,12 @@ afterEach(() => {
     delete process.env.ComSpec;
   } else {
     process.env.ComSpec = originalComSpec;
+  }
+  if (originalUppercasePnpmVersionConfig === undefined) {
+    delete process.env.NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS;
+  } else {
+    process.env.NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS =
+      originalUppercasePnpmVersionConfig;
   }
 });
 
@@ -96,7 +113,12 @@ describe("runCommands spawn options", () => {
     expect(result.ok).toBe(true);
     expect(spawnCalls[0]).toMatchObject({
       command: "cmd.exe",
-      args: ["/d", "/s", "/c", '""C:\\Tools\\pnpm.CMD" "--version""'],
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        '""C:\\Tools\\pnpm.CMD" "--config.manage-package-manager-versions=true" "--version""',
+      ],
       options: { shell: false, windowsVerbatimArguments: true },
     });
   });
@@ -116,7 +138,7 @@ describe("runCommands spawn options", () => {
         "/d",
         "/s",
         "/c",
-        '""C:\\Tools\\pnpm.CMD" "--filter" "./apps/web app" "add" "@sentry/nextjs@^8.0.0""',
+        '""C:\\Tools\\pnpm.CMD" "--config.manage-package-manager-versions=true" "--filter" "./apps/web app" "add" "@sentry/nextjs@^8.0.0""',
       ],
       options: { shell: false, windowsVerbatimArguments: true },
     });
@@ -136,7 +158,7 @@ describe("runCommands spawn options", () => {
         "/d",
         "/s",
         "/c",
-        '""C:\\Tools\\pnpm.CMD" "add" "C:\\some\\path\\\\""',
+        '""C:\\Tools\\pnpm.CMD" "--config.manage-package-manager-versions=true" "add" "C:\\some\\path\\\\""',
       ],
       options: { shell: false, windowsVerbatimArguments: true },
     });
@@ -153,6 +175,9 @@ describe("runCommands spawn options", () => {
     const commandLine = spawnCalls[0]?.args.at(-1) ?? "";
 
     expect(result.ok).toBe(true);
+    expect(commandLine).toContain(
+      '"--config.manage-package-manager-versions=true"'
+    );
     expect(commandLine).toContain('"value ""quoted"""');
     expect(commandLine).not.toContain('\\"');
     expect(spawnCalls[0]).toMatchObject({
@@ -194,6 +219,7 @@ describe("runCommands spawn options", () => {
       options: { shell: false },
     });
     expect(spawnCalls[0]?.options.windowsVerbatimArguments).toBeUndefined();
+    expect(spawnCalls[0]?.options.env).toBeUndefined();
   });
 
   test("keeps POSIX command execution shell-free", async () => {
@@ -206,9 +232,57 @@ describe("runCommands spawn options", () => {
     expect(result.ok).toBe(true);
     expect(spawnCalls[0]).toMatchObject({
       command: "/usr/local/bin/pnpm",
-      args: ["--version"],
+      args: ["--config.manage-package-manager-versions=true", "--version"],
       options: { shell: false },
     });
     expect(spawnCalls[0]?.options.windowsVerbatimArguments).toBeUndefined();
+    expect(
+      spawnCalls[0]?.options.env?.npm_config_manage_package_manager_versions
+    ).toBeUndefined();
+    expect(
+      spawnCalls[0]?.options.env?.NPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS
+    ).toBeUndefined();
+  });
+
+  test.each([
+    [
+      "python3 -m pip install sentry-sdk",
+      "python3",
+      ["-m", "pip", "install", "sentry-sdk"],
+    ],
+    ["uv add sentry-sdk", "uv", ["add", "sentry-sdk"]],
+    ["cargo add sentry", "cargo", ["add", "sentry"]],
+  ])("does not rewrite non-pnpm package-manager commands: %s", async (command, executableName, expectedArgs) => {
+    setPlatform("darwin");
+
+    const result = await runCommands(makePayload(command), {
+      dryRun: false,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(spawnCalls[0]).toMatchObject({
+      command: `/usr/local/bin/${executableName}`,
+      args: expectedArgs,
+      options: { shell: false },
+    });
+    expect(spawnCalls[0]?.options.env).toBeUndefined();
+  });
+
+  test("does not duplicate an explicit pnpm version-management option", async () => {
+    setPlatform("darwin");
+
+    const result = await runCommands(
+      makePayload(
+        "pnpm --config.manage-package-manager-versions=true add @sentry/node"
+      ),
+      { dryRun: false }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(spawnCalls[0]?.args).toEqual([
+      "--config.manage-package-manager-versions=true",
+      "add",
+      "@sentry/node",
+    ]);
   });
 });

--- a/packages/cli/test/lib/init/ui/file-tree.test.ts
+++ b/packages/cli/test/lib/init/ui/file-tree.test.ts
@@ -6,7 +6,7 @@
  * Two builders share `flattenTree`:
  *   - `buildFileTree(changed)` — sorts directories first, then alpha
  *   - `buildReadTree(reads)`   — preserves insertion order so the
- *     OpenTUI scrollbox's sticky-bottom tracking feels right
+ *     Files panel can present read chronology from the top
  *
  * The tests below exercise the second builder explicitly since it's
  * new in this PR; the changed-files builder already has implicit
@@ -60,8 +60,7 @@ describe("buildReadTree", () => {
   test("preserves insertion order (no sort)", () => {
     // Sorting would put `aa.ts` before `bb.ts`. We deliberately
     // insert in reverse-alphabetical order to verify that the
-    // builder doesn't reorder — sticky-bottom scrollbox tracking
-    // depends on newly-added files always landing at the end.
+    // builder doesn't reorder, so the UI starts with the earliest reads.
     const tree = buildReadTree([
       { path: "src/zz.ts", status: "analyzed" },
       { path: "src/aa.ts", status: "analyzed" },

--- a/packages/cli/test/lib/init/ui/ink-app.snapshot.test.tsx
+++ b/packages/cli/test/lib/init/ui/ink-app.snapshot.test.tsx
@@ -1,9 +1,9 @@
 /**
  * Smoke-test the Ink App by mounting it with mocked stdin/stdout
- * inside `bun test`. Verifies the full-screen layout (tabbed
+ * inside Vitest. Verifies the full-screen layout (tabbed
  * content and keyboard hints) without needing a real TTY.
  *
- * Note: The first Ink render() in a bun test CI worker can hang
+ * Note: The first Ink render() in a CI worker can hang
  * indefinitely (Ink's internal reconciler keeps the event loop
  * alive in non-TTY). Tests that call renderApp() rely on a 500ms
  * timeout race to prevent blocking.
@@ -29,14 +29,15 @@ const LEARN_HEADER_RE = /How Sentry Works/;
 const TASKS_HEADER_RE = /Tasks\b/;
 const STATUS_TAB_RE = /Status/;
 const FILES_TAB_RE = /Files/;
-const FILES_HEADER_PINNED_RE = /Files analyzed\s+\d+\/\d+/;
-const FILES_HEADER_UNPINNED_RE = /Files analyzed\s+\u2191\s+\d+\/\d+/;
+const FILES_HEADER_AT_TOP_RE = /Files analyzed\s+\d+\/\d+/;
+const FILES_HEADER_SCROLLED_RE = /Files analyzed\s+\u2191\s+\d+\/\d+/;
 const KEYBOARD_HINT_RE = /switch tab/;
 const SPACE_TOGGLE_HINT_RE = /space\s+toggle/;
 const A_ALL_HINT_RE = /a\s+all/;
 const ENTER_CONTINUE_HINT_RE = /enter\s+continue/;
 const ESC_CANCEL_HINT_RE = /esc\s+cancel/;
 const COMPLETED_SELECTING_FEATURES_RE = /✔\s+Selecting features/;
+const DOTS_SPINNER_GLYPH_RE = /[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/gu;
 const ANSI_ESCAPE_PREFIX = "\u001B[";
 const CURSOR_TO_LINE_START = "\u001B[G";
 // biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI escape sequences in captured Ink output
@@ -170,6 +171,23 @@ function hasForcedWhiteForeground(output: string): boolean {
     output.includes(`${ANSI_ESCAPE_PREFIX}97m`) ||
     output.includes(`${ANSI_ESCAPE_PREFIX}38;2;255;255;255m`)
   );
+}
+
+async function waitForLatestFrame(
+  output: CaptureStream,
+  expectedText: string
+): Promise<string> {
+  let frame = "";
+  await vi.waitFor(
+    () => {
+      frame = stripAnsi(output.latestFrame());
+      if (!frame.includes(expectedText)) {
+        throw new Error(`Waiting for Ink frame containing: ${expectedText}`);
+      }
+    },
+    { interval: 20, timeout: 2000 }
+  );
+  return frame;
 }
 
 function withoutFeedbackBanner(output: string): string {
@@ -374,6 +392,208 @@ describe("Ink App snapshot", () => {
       renderedOptions[0]?.hintColumn,
       renderedOptions[0]?.hintColumn,
     ]);
+  });
+
+  test("select option descriptions render as muted lines below their labels", async () => {
+    const store = new WizardStore({ bannerRows: [], layout: "intro" });
+    store.setPrompt({
+      kind: "select",
+      message: "What would you like to do with this Sentry setup?",
+      options: [
+        {
+          value: "improve",
+          label: "Improve your Sentry setup",
+          description:
+            "Add features like tracing or Replay, repair issues, or upgrade your current setup.",
+        },
+        {
+          value: "other",
+          label: "Use or create another Sentry project",
+          description: "Use another project or create a new one.",
+        },
+      ],
+      initialIndex: 0,
+      resolve: ignorePromptResolution,
+    });
+
+    const previousChalkLevel = chalk.level;
+    chalk.level = 3;
+    let rawFrame: string;
+    try {
+      rawFrame = (await renderApp(store, 80)).allOutput();
+    } finally {
+      chalk.level = previousChalkLevel;
+    }
+    const frame = stripAnsi(rawFrame);
+    const lines = frame.split(LINE_SPLIT_RE);
+    const improveLabelLine = lines.findIndex((line) =>
+      line.includes("Improve your Sentry setup")
+    );
+    const improveDescriptionFirstLine = lines.findIndex((line) =>
+      line.includes("Add features like tracing or Replay")
+    );
+    const improveDescriptionLastLine = lines.findIndex((line) =>
+      line.includes("setup.")
+    );
+    const otherLabelLine = lines.findIndex((line) =>
+      line.includes("Use or create another Sentry project")
+    );
+    const otherDescriptionLine = lines.findIndex((line) =>
+      line.includes("Use another project or create a new one.")
+    );
+
+    expect(frame).toContain("Add features like tracing or Replay");
+    expect(frame.replaceAll(/\s+/g, " ")).toContain(
+      "Add features like tracing or Replay, repair issues, or upgrade your current setup."
+    );
+    expect(frame).toContain("Use another project or create a new one.");
+    expect(rawFrame).toContain(
+      `${ANSI_ESCAPE_PREFIX}38;2;137;130;148mAdd features like tracing or Replay`
+    );
+    expect(improveDescriptionFirstLine).toBe(improveLabelLine + 1);
+    expect(improveDescriptionLastLine).toBe(improveDescriptionFirstLine + 1);
+    expect(otherLabelLine).toBe(improveDescriptionLastLine + 1);
+    expect(otherDescriptionLine).toBe(otherLabelLine + 1);
+  });
+
+  test("holds the target selector until the next setup prompt is ready", async () => {
+    const store = new WizardStore({ bannerRows: [] });
+    store.setPrompt({
+      kind: "select",
+      message: "Select the target application or package:",
+      options: [
+        { value: "junior", label: "Junior", hint: "Sentry detected" },
+        { value: "docs", label: "Junior Docs", hint: "Astro" },
+      ],
+      initialIndex: 0,
+      resolve: ignorePromptResolution,
+    });
+    const out = new CaptureStream(120, 40);
+    const stdin = makeStdin();
+    const instance = render(createElement(App, { store }), {
+      stdout: out as unknown as NodeJS.WriteStream,
+      stderr: out as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+      exitOnCtrlC: false,
+      // This test exercises live frame transitions. Ink otherwise switches to
+      // non-interactive mode in CI and emits only the final frame on unmount.
+      interactive: true,
+    });
+
+    try {
+      // Wait for the selector to be committed before freezing presentation.
+      // A fixed delay can race Ink's first render on slower CI workers, which
+      // would freeze an empty initial snapshot instead of the selector.
+      await waitForLatestFrame(
+        out,
+        "Select the target application or package:"
+      );
+      const transitionFrameIndex = out.frames.length;
+      store.holdPresentation();
+      store.appendLog("success", "Selecting target application");
+      store.startSpinner("Checking for your existing Sentry setup");
+      store.setStepStatus("check-existing-sentry", "in_progress");
+      store.appendLog("success", "Sentry setup analyzed");
+      await sleep(FRAME_SETTLE_MS * 3);
+
+      const heldFrame = await waitForLatestFrame(
+        out,
+        "Select the target application or package:"
+      );
+      const heldOutput = stripAnsi(
+        out.frames.slice(transitionFrameIndex).join("")
+      );
+      const heldSpinnerGlyphs = new Set(
+        heldOutput.match(DOTS_SPINNER_GLYPH_RE) ?? []
+      );
+      expect(heldFrame).toContain("Select the target application or package:");
+      expect(heldFrame).toContain("Junior");
+      expect(heldFrame).not.toContain("▸ Junior");
+      expect(heldSpinnerGlyphs.size).toBeGreaterThanOrEqual(2);
+      expect(heldFrame).not.toContain("Selecting target application");
+      expect(heldFrame).not.toContain(
+        "Checking for your existing Sentry setup"
+      );
+      expect(heldFrame).not.toContain("Sentry setup analyzed");
+
+      store.setOverlay({
+        kind: "health",
+        message: "Connection interrupted, retrying...",
+        retryCount: 1,
+      });
+      await sleep(FRAME_SETTLE_MS);
+      const recoveryFrame = await waitForLatestFrame(
+        out,
+        "Connection interrupted, retrying..."
+      );
+      expect(recoveryFrame).toContain(
+        "Select the target application or package:"
+      );
+      expect(recoveryFrame).toContain("Connection interrupted, retrying...");
+      expect(store.getSnapshot().presentationHold).toBe(true);
+      store.clearOverlay();
+
+      store.stopSpinner();
+      store.setPrompt({
+        kind: "select",
+        message:
+          "Sentry detected for project junior in organization Sentry. What would you like to do?",
+        options: [
+          { value: "improve", label: "Improve your Sentry setup" },
+          {
+            value: "other",
+            label: "Use or create another Sentry project",
+          },
+        ],
+        initialIndex: 0,
+        resolve: ignorePromptResolution,
+      });
+      await sleep(FRAME_SETTLE_MS);
+
+      const transitionOutput = stripAnsi(
+        out.frames.slice(transitionFrameIndex).join("")
+      );
+      const nextFrame = await waitForLatestFrame(
+        out,
+        "Sentry detected for project junior"
+      );
+      expect(transitionOutput).not.toContain("Selecting target application");
+      expect(transitionOutput).not.toContain(
+        "Checking for your existing Sentry setup"
+      );
+      expect(transitionOutput).not.toContain("Sentry setup analyzed");
+      expect(nextFrame).toContain("Sentry detected for project junior");
+      expect(nextFrame).toContain("in organization Sentry");
+      expect(nextFrame).toContain("What would you");
+      expect(nextFrame).toContain("like to do?");
+      expect(nextFrame).toContain("Tasks");
+      expect(nextFrame).not.toContain("Selecting target application");
+      expect(nextFrame).not.toContain(
+        "Checking for your existing Sentry setup"
+      );
+      expect(nextFrame).not.toContain("Sentry setup analyzed");
+    } finally {
+      instance.unmount();
+    }
+  });
+
+  test("dry-run auto-resolution renders only the user-facing scan status", async () => {
+    const store = new WizardStore({ bannerRows: [] });
+    store.appendLog("warn", "Dry-run mode: no files will be modified.");
+    store.setStepStatus("discover-context", "completed");
+    store.setStepStatus("detect-platform", "in_progress");
+    store.startSpinner("Scanning project files...");
+
+    const frame = stripAnsi((await renderApp(store, 120)).latestFrame());
+
+    expect(frame).toContain("Dry-run mode: no files will be modified.");
+    expect(frame).toContain("Scanning project files...");
+    expect(frame).not.toContain("Selecting target application");
+    expect(frame).not.toContain("Auto-selected existing Sentry setup");
+    expect(frame).not.toContain("Sentry setup analyzed");
+    expect(frame).not.toContain("Sentry detected");
+    expect(frame).not.toContain("Project junior in organization Sentry");
   });
 
   test("workflow screen hides logo and shows feedback banner", async () => {
@@ -1119,6 +1339,57 @@ describe("Ink App snapshot", () => {
     expect(scrolledFrame).toContain("Team 8");
   });
 
+  test("wrapped select descriptions account for every row when windowing", async () => {
+    const store = new WizardStore({ bannerRows: [] });
+    store.setPrompt({
+      kind: "select",
+      message: "Choose an action",
+      options: Array.from({ length: 8 }, (_value, index) => ({
+        value: `action-${index + 1}`,
+        label: `Action ${index + 1}`,
+        description: `Description ${index + 1} has enough supporting detail to wrap onto another line.`,
+      })),
+      initialIndex: 0,
+      resolve: ignorePromptResolution,
+    });
+
+    const rendered = await renderApp(store, 80, { rows: 16 });
+    const frame = stripFinalLineBreak(stripAnsi(rendered.latestFrame()));
+    const frameLines = frame.split(LINE_SPLIT_RE);
+    const descriptionTwoLine = frameLines.findIndex((line) =>
+      line.includes("Description 2 has enough supporting detail")
+    );
+    expect(frame).toContain("(1/8)");
+    expect(descriptionTwoLine).toBeGreaterThanOrEqual(0);
+    expect(frameLines[descriptionTwoLine + 1]).toContain(
+      "to wrap onto another line."
+    );
+    expect(frame).not.toContain("Action 3");
+    expect(frameLines.length).toBeLessThanOrEqual(16);
+
+    const scrolledFrame = stripFinalLineBreak(
+      stripAnsi(
+        (
+          await renderApp(store, 80, {
+            input: Array.from({ length: 7 }, () => DOWN_ARROW),
+            rows: 16,
+          })
+        ).latestFrame()
+      )
+    );
+    const scrolledLines = scrolledFrame.split(LINE_SPLIT_RE);
+    const descriptionEightLine = scrolledLines.findIndex((line) =>
+      line.includes("Description 8 has enough supporting detail")
+    );
+    expect(scrolledFrame).toContain("(8/8)");
+    expect(scrolledFrame).toContain("Action 8");
+    expect(descriptionEightLine).toBeGreaterThanOrEqual(0);
+    expect(scrolledLines[descriptionEightLine + 1]).toContain(
+      "to wrap onto another line."
+    );
+    expect(scrolledLines.length).toBeLessThanOrEqual(16);
+  });
+
   test("long multiselect prompts only render options that fit the terminal", async () => {
     const store = new WizardStore({ bannerRows: [] });
     store.appendLog(
@@ -1231,7 +1502,7 @@ describe("Ink App snapshot", () => {
         rows: 16,
       })
     ).allOutput();
-    expect(shortFrame).toMatch(FILES_HEADER_PINNED_RE);
+    expect(shortFrame).toMatch(FILES_HEADER_AT_TOP_RE);
     expect(shortFrame).not.toContain("scroll");
 
     const tallTree = new WizardStore({ bannerRows: [] });
@@ -1239,14 +1510,23 @@ describe("Ink App snapshot", () => {
     tallTree.recordFilesReading(readFiles);
     tallTree.markFilesAnalyzed(readFiles);
 
-    const tallFrame = (
-      await renderApp(tallTree, 120, {
-        input: [RIGHT_ARROW],
-        rows: 16,
-      })
-    ).allOutput();
-    expect(tallFrame).toMatch(FILES_HEADER_PINNED_RE);
+    const tallRendered = await renderApp(tallTree, 120, {
+      input: [RIGHT_ARROW],
+      rows: 16,
+    });
+    const tallFrame = stripAnsi(tallRendered.latestFrame());
+    expect(tallFrame).toMatch(FILES_HEADER_AT_TOP_RE);
     expect(tallFrame).toContain("scroll");
+    expect(tallFrame).toContain("file-01.ts");
+    expect(tallFrame).not.toContain("file-12.ts");
+
+    const scrolledRendered = await renderApp(tallTree, 120, {
+      input: [RIGHT_ARROW, ...Array.from({ length: 20 }, () => DOWN_ARROW)],
+      rows: 16,
+    });
+    const scrolledFrame = stripAnsi(scrolledRendered.latestFrame());
+    expect(scrolledFrame).toMatch(FILES_HEADER_SCROLLED_RE);
+    expect(scrolledFrame).toContain("file-12.ts");
   });
 
   test("Status screen shows logs and banner, not file tree", async () => {
@@ -1257,8 +1537,8 @@ describe("Ink App snapshot", () => {
 
     const frame = (await renderApp(store, 120)).allOutput();
     expect(frame).toContain("Checking project...");
-    expect(frame).not.toMatch(FILES_HEADER_PINNED_RE);
-    expect(frame).not.toMatch(FILES_HEADER_UNPINNED_RE);
+    expect(frame).not.toMatch(FILES_HEADER_AT_TOP_RE);
+    expect(frame).not.toMatch(FILES_HEADER_SCROLLED_RE);
   });
 
   test("SummaryPanel renders featureBlurbs as Here's what we set up section", async () => {

--- a/packages/cli/test/lib/init/ui/ink-ui-telemetry.test.ts
+++ b/packages/cli/test/lib/init/ui/ink-ui-telemetry.test.ts
@@ -258,6 +258,61 @@ describe("InkUI prompt telemetry", () => {
     await ui[Symbol.asyncDispose]();
   });
 
+  test("holds a resolved workflow select until the next prompt is mounted", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const { ui, store } = createUi();
+    const snapshots: Array<{
+      held: boolean;
+      layout: string;
+      prompt: string | null;
+    }> = [];
+    const unsubscribe = store.subscribe(() => {
+      const snapshot = store.getSnapshot();
+      snapshots.push({
+        held: snapshot.presentationHold,
+        layout: snapshot.layout,
+        prompt: snapshot.prompt?.kind ?? null,
+      });
+    });
+
+    const resultPromise = ui.select({
+      message: "Select target",
+      options: [{ label: "Junior", value: "junior" }],
+      holdPresentationOnResolve: true,
+    });
+    const prompt = store.getSnapshot().prompt;
+    expect(prompt?.kind).toBe("select");
+    if (prompt?.kind !== "select") {
+      throw new Error("Expected a select prompt");
+    }
+    prompt.resolve("junior");
+
+    await expect(resultPromise).resolves.toBe("junior");
+    expect(store.getSnapshot().presentationHold).toBe(true);
+    const nextPrompt = ui.select({
+      message: "What would you like to do with this Sentry setup?",
+      options: [{ label: "Improve Sentry", value: "improve" }],
+    });
+    expect(snapshots).toEqual([
+      { held: false, layout: "workflow", prompt: "select" },
+      { held: true, layout: "workflow", prompt: "select" },
+      { held: false, layout: "workflow", prompt: "select" },
+    ]);
+    const mountedPrompt = store.getSnapshot().prompt;
+    if (mountedPrompt?.kind !== "select") {
+      throw new Error("Expected the next select prompt");
+    }
+    mountedPrompt.resolve("improve");
+    await expect(nextPrompt).resolves.toBe("improve");
+    expect(
+      snapshots
+        .slice(0, 3)
+        .some(({ prompt: promptKind }) => promptKind === null)
+    ).toBe(false);
+    unsubscribe();
+    await ui[Symbol.asyncDispose]();
+  });
+
   test("attributes workflow prompts to the active step", async () => {
     const metricSpy = vi.spyOn(Sentry.metrics, "distribution");
     const startSpanSpy = vi.spyOn(Sentry, "startSpan");

--- a/packages/cli/test/lib/init/ui/mock-ui.ts
+++ b/packages/cli/test/lib/init/ui/mock-ui.ts
@@ -139,6 +139,7 @@ export function createMockUI(options: MockUIOptions = {}): {
   }
 
   const ui: WizardUI = {
+    supportsInteractivePrompts: true,
     banner: (art) => calls.push({ kind: "banner", art }),
     intro: (title) => calls.push({ kind: "intro", title }),
     summary: (summary) => calls.push({ kind: "summary", summary }),

--- a/packages/cli/test/lib/init/ui/wizard-store.test.ts
+++ b/packages/cli/test/lib/init/ui/wizard-store.test.ts
@@ -13,7 +13,7 @@
  * dev/binary builds. This test file focuses on the pure data layer.
  */
 
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import {
   CANONICAL_STEP_ORDER,
   CHECKLIST_VISIBLE_STEPS,
@@ -419,6 +419,24 @@ describe("WizardStore overlay lifecycle", () => {
     });
   });
 
+  test("a recovery overlay preserves a held presentation", () => {
+    const store = new WizardStore();
+    store.holdPresentation();
+
+    store.setOverlay({
+      kind: "health",
+      message: "Connection interrupted, retrying...",
+      retryCount: 1,
+    });
+
+    expect(store.getSnapshot().presentationHold).toBe(true);
+    expect(store.getSnapshot().overlay).toEqual({
+      kind: "health",
+      message: "Connection interrupted, retrying...",
+      retryCount: 1,
+    });
+  });
+
   test("clearOverlay nulls the overlay and notifies", () => {
     const store = new WizardStore();
     store.setOverlay({ kind: "health", message: "x", retryCount: 0 });
@@ -430,6 +448,25 @@ describe("WizardStore overlay lifecycle", () => {
     unsubscribe();
     expect(notifications).toBe(1);
     expect(store.getSnapshot().overlay).toBeNull();
+  });
+});
+
+describe("WizardStore presentation hold", () => {
+  test("the success screen releases a held prompt frame", () => {
+    const store = new WizardStore();
+    store.holdPresentation();
+
+    store.setOutro({
+      kind: "success",
+      dismiss: vi.fn(),
+      actions: {
+        openUrl: vi.fn(),
+        track: vi.fn(),
+      },
+    });
+
+    expect(store.getSnapshot().presentationHold).toBe(false);
+    expect(store.getSnapshot().outroState?.kind).toBe("success");
   });
 });
 

--- a/packages/cli/test/lib/init/wizard-runner.test.ts
+++ b/packages/cli/test/lib/init/wizard-runner.test.ts
@@ -38,6 +38,8 @@ import * as preflight from "../../../src/lib/init/preflight.js";
 import * as readiness from "../../../src/lib/init/readiness.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as registry from "../../../src/lib/init/tools/registry.js";
+// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
+import * as toolShared from "../../../src/lib/init/tools/shared.js";
 import type {
   ResolvedInitContext,
   SuspendPayload,
@@ -95,7 +97,7 @@ function makeContext(
     yes: true,
     dryRun: false,
     org: "acme",
-    team: "platform",
+    team: { slug: "platform", source: "explicit" },
     authToken: "test-token",
     ...overrides,
   };
@@ -104,6 +106,7 @@ function makeContext(
 let mockStartResult: WorkflowRunResult;
 let mockResumeResults: WorkflowRunResult[];
 let resumeCallCount = 0;
+let resumeCallArgs: Record<string, unknown>[];
 let sharedResumeAsyncMock: ReturnType<typeof mock>;
 let startAsyncMock: ReturnType<typeof mock>;
 let mockRunByIdResult: WorkflowRunResult | Error;
@@ -116,11 +119,14 @@ let formatErrorSpy: ReturnType<typeof spyOn>;
 let checkGitStatusSpy: ReturnType<typeof spyOn>;
 let handleInteractiveSpy: ReturnType<typeof spyOn>;
 let resolveInitContextSpy: ReturnType<typeof spyOn>;
+let resolveInitProjectContextSpy: ReturnType<typeof spyOn>;
 let describeToolSpy: ReturnType<typeof spyOn>;
 let executeToolSpy: ReturnType<typeof spyOn>;
+let validateToolSandboxSpy: ReturnType<typeof spyOn>;
 let precomputeDirListingSpy: ReturnType<typeof spyOn>;
+let precomputeSentrySetupTargetsSpy: ReturnType<typeof spyOn>;
+let precomputeWorkspaceInventorySpy: ReturnType<typeof spyOn>;
 let preReadCommonFilesSpy: ReturnType<typeof spyOn>;
-let precomputeSentryDetectionSpy: ReturnType<typeof spyOn>;
 let getWorkflowSpy: ReturnType<typeof spyOn>;
 let stderrSpy: ReturnType<typeof spyOn>;
 /**
@@ -223,6 +229,7 @@ beforeEach(() => {
     result: { exitCode: 0, platform: "React" },
   };
   mockResumeResults = [];
+  resumeCallArgs = [];
   resumeCallCount = 0;
   mockRunByIdResult = new Error("runById not configured");
   testRequestSequence = 0;
@@ -249,7 +256,9 @@ beforeEach(() => {
   };
   getUISpy = vi.spyOn(uiFactory, "getUIAsync").mockResolvedValue(wrapped);
 
-  vi.spyOn(readiness, "checkReadiness").mockResolvedValue(undefined);
+  vi.spyOn(readiness, "checkReadiness").mockResolvedValue({
+    improveExistingSetup: true,
+  });
   formatBannerSpy = vi.spyOn(banner, "formatBanner").mockReturnValue("BANNER");
   formatResultSpy = vi.spyOn(fmt, "formatResult").mockImplementation(noop);
   formatErrorSpy = vi.spyOn(fmt, "formatError").mockImplementation(noop);
@@ -262,6 +271,12 @@ beforeEach(() => {
   resolveInitContextSpy = vi
     .spyOn(preflight, "resolveInitContext")
     .mockResolvedValue(makeContext());
+  resolveInitProjectContextSpy = vi
+    .spyOn(preflight, "resolveInitProjectContext")
+    .mockImplementation(async (context) => ({
+      project: context.project,
+      existingProject: context.existingProject,
+    }));
   describeToolSpy = vi
     .spyOn(registry, "describeTool")
     .mockReturnValue("Running tool...");
@@ -269,18 +284,21 @@ beforeEach(() => {
     ok: true,
     data: { results: [] },
   });
+  validateToolSandboxSpy = vi
+    .spyOn(toolShared, "validateToolSandbox")
+    .mockImplementation((payload) => ({ cwd: payload.cwd }));
   precomputeDirListingSpy = vi
     .spyOn(workflowInputs, "precomputeDirListing")
     .mockResolvedValue([]);
+  precomputeSentrySetupTargetsSpy = vi
+    .spyOn(workflowInputs, "precomputeSentrySetupTargets")
+    .mockResolvedValue([]);
+  precomputeWorkspaceInventorySpy = vi
+    .spyOn(workflowInputs, "precomputeWorkspaceTargetInventory")
+    .mockResolvedValue({ complete: false, targets: [] });
   preReadCommonFilesSpy = vi
     .spyOn(workflowInputs, "preReadCommonFiles")
     .mockResolvedValue({});
-  precomputeSentryDetectionSpy = vi
-    .spyOn(workflowInputs, "precomputeSentryDetection")
-    .mockResolvedValue({
-      ok: true,
-      data: { status: "none", signals: [] },
-    });
   stderrSpy = vi
     .spyOn(process.stderr, "write")
     .mockImplementation(() => true as any);
@@ -293,7 +311,8 @@ beforeEach(() => {
       ? Promise.reject(mockRunByIdResult)
       : Promise.resolve(withV1SuspendEnvelopes(mockRunByIdResult))
   );
-  sharedResumeAsyncMock = vi.fn(() => {
+  sharedResumeAsyncMock = vi.fn((args: Record<string, unknown>) => {
+    resumeCallArgs.push(args);
     const result = mockResumeResults[resumeCallCount] ?? {
       status: "success",
       result: { exitCode: 0 },
@@ -337,11 +356,14 @@ afterEach(() => {
   checkGitStatusSpy.mockRestore();
   handleInteractiveSpy.mockRestore();
   resolveInitContextSpy.mockRestore();
+  resolveInitProjectContextSpy.mockRestore();
   describeToolSpy.mockRestore();
   executeToolSpy.mockRestore();
+  validateToolSandboxSpy.mockRestore();
   precomputeDirListingSpy.mockRestore();
+  precomputeSentrySetupTargetsSpy.mockRestore();
+  precomputeWorkspaceInventorySpy.mockRestore();
   preReadCommonFilesSpy.mockRestore();
-  precomputeSentryDetectionSpy.mockRestore();
   getWorkflowSpy.mockRestore();
   stderrSpy.mockRestore();
 
@@ -681,6 +703,325 @@ describe("runWizard", () => {
     expect(spinnerMock.message).toHaveBeenCalledWith("Running tool...");
   });
 
+  test("resolves the project from the selected app detection before platform analysis", async () => {
+    const detectionPayload: ToolPayload = {
+      type: "tool",
+      operation: "detect-sentry",
+      cwd: "/tmp/test/apps/junior",
+      params: {},
+    };
+    const creationPayload: ToolPayload = {
+      type: "tool",
+      operation: "create-sentry-project",
+      cwd: "/tmp/test/apps/junior",
+      params: { name: "junior", platform: "javascript-nextjs" },
+    };
+    const existingProject = {
+      orgSlug: "acme",
+      projectSlug: "junior",
+      projectId: "42",
+      dsn: "https://key@o1.ingest.sentry.io/42",
+      url: "https://sentry.io/settings/acme/projects/junior/",
+      platform: "javascript-nextjs",
+    };
+    resolveInitProjectContextSpy.mockResolvedValue({
+      project: "junior",
+      existingProject,
+      setupIntent: "improve-existing",
+    });
+    executeToolSpy.mockImplementation(async (payload, executionContext) => {
+      if (payload.operation === "detect-sentry") {
+        return {
+          ok: true,
+          data: {
+            status: "installed",
+            signals: ["init: instrumentation.ts"],
+          },
+        };
+      }
+      expect(executionContext.existingProject).toBe(existingProject);
+      return { ok: true, data: {} };
+    });
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["check-existing-sentry"]],
+      steps: {
+        "check-existing-sentry": { suspendPayload: detectionPayload },
+      },
+    };
+    mockResumeResults = [
+      {
+        status: "suspended",
+        suspended: [["ensure-sentry-project"]],
+        steps: {
+          "ensure-sentry-project": { suspendPayload: creationPayload },
+        },
+      },
+      { status: "success", result: { exitCode: 0 } },
+    ];
+
+    await runWizard(makeOptions());
+
+    expect(resolveInitProjectContextSpy).toHaveBeenCalledTimes(1);
+    expect(resolveInitProjectContextSpy).toHaveBeenCalledWith(
+      makeContext(),
+      "/tmp/test/apps/junior",
+      expect.anything(),
+      {
+        setup: {
+          status: "installed",
+          signals: ["init: instrumentation.ts"],
+        },
+        suggestedProjectName: "junior",
+        supportsExistingSetupImprovement: true,
+      }
+    );
+    expect(resumeCallArgs[0]?.resumeData).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          setupIntent: "improve-existing",
+        }),
+      })
+    );
+    expect(executeToolSpy).toHaveBeenCalledTimes(2);
+    expect(spinnerMock.stop).not.toHaveBeenCalledWith("Sentry setup analyzed");
+  });
+
+  test("passes an older service's missing improvement capability to project resolution", async () => {
+    vi.mocked(readiness.checkReadiness).mockResolvedValueOnce({
+      improveExistingSetup: false,
+    });
+    const detectionPayload: ToolPayload = {
+      type: "tool",
+      operation: "detect-sentry",
+      cwd: "/tmp/test",
+      params: {},
+    };
+    executeToolSpy.mockResolvedValue({
+      ok: true,
+      data: {
+        status: "installed",
+        signals: ["init: instrumentation.ts"],
+      },
+    });
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["check-existing-sentry"]],
+      steps: {
+        "check-existing-sentry": { suspendPayload: detectionPayload },
+      },
+    };
+    mockResumeResults = [{ status: "success", result: { exitCode: 0 } }];
+
+    await runWizard(makeOptions());
+
+    expect(resolveInitProjectContextSpy).toHaveBeenCalledWith(
+      makeContext(),
+      "/tmp/test",
+      expect.anything(),
+      expect.objectContaining({ supportsExistingSetupImprovement: false })
+    );
+  });
+
+  test("keeps the workflow layout visible between app selection and the setup decision", async () => {
+    const { ui, calls, respond } = createMockUI();
+    respond.select("continue");
+    useMockUI(ui, calls);
+    resolveInitContextSpy.mockResolvedValue(
+      makeContext({ yes: false, dryRun: false })
+    );
+    handleInteractiveSpy.mockResolvedValue({ selectedApp: "junior" });
+
+    const detectionPayload: ToolPayload = {
+      type: "tool",
+      operation: "detect-sentry",
+      cwd: "/tmp/test/packages/junior",
+      params: {},
+    };
+    executeToolSpy.mockResolvedValue({
+      ok: true,
+      data: {
+        status: "installed",
+        signals: ["init: src/instrumentation.ts"],
+      },
+    });
+    resolveInitProjectContextSpy.mockImplementation(async () => {
+      const latestLayoutChange = calls.findLast(
+        (call) => call.kind === "setIntroMode"
+      );
+      expect(latestLayoutChange).toEqual({
+        kind: "setIntroMode",
+        enabled: false,
+      });
+      return {
+        project: "junior",
+        existingProject: {
+          orgSlug: "sentry",
+          projectSlug: "junior",
+          projectId: "42",
+          dsn: "https://key@o1.ingest.sentry.io/42",
+          url: "https://sentry.io/settings/sentry/projects/junior/",
+        },
+      };
+    });
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["select-target-app"]],
+      steps: {
+        "select-target-app": {
+          suspendPayload: {
+            type: "interactive",
+            kind: "select",
+            prompt: "Select the target application or package:",
+            options: ["junior", "docs", "example"],
+          },
+        },
+      },
+    };
+    mockResumeResults = [
+      {
+        status: "suspended",
+        suspended: [["check-existing-sentry"]],
+        steps: {
+          "check-existing-sentry": { suspendPayload: detectionPayload },
+        },
+      },
+      { status: "success", result: { exitCode: 0 } },
+    ];
+
+    await forceStdinTty(() =>
+      runWizard(makeOptions({ yes: false, dryRun: false }))
+    );
+
+    const layoutChanges = calls.filter((call) => call.kind === "setIntroMode");
+    expect(layoutChanges).toEqual([
+      { kind: "setIntroMode", enabled: true },
+      { kind: "setIntroMode", enabled: false },
+    ]);
+    const detectionStepIndex = calls.findIndex(
+      (call) =>
+        call.kind === "setStep" && call.stepId === "check-existing-sentry"
+    );
+    expect(detectionStepIndex).toBeGreaterThanOrEqual(0);
+    expect(handleInteractiveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "select" }),
+      expect.anything(),
+      expect.anything(),
+      { holdPresentationOnSelect: true }
+    );
+    expect(spinnerMock.stop).not.toHaveBeenCalledWith(
+      "Selecting target application"
+    );
+    expect(spinnerMock.stop).not.toHaveBeenCalledWith("Sentry setup analyzed");
+  });
+
+  test("does not inspect project context when app-scoped detection is sandbox-blocked", async () => {
+    const payload: ToolPayload = {
+      type: "tool",
+      operation: "detect-sentry",
+      cwd: "/outside/project",
+      params: {},
+    };
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["check-existing-sentry"]],
+      steps: {
+        "check-existing-sentry": { suspendPayload: payload },
+      },
+    };
+    mockResumeResults = [{ status: "success", result: { exitCode: 0 } }];
+    validateToolSandboxSpy.mockReturnValueOnce({
+      ok: false,
+      error: "Blocked by sandbox",
+    });
+
+    await runWizard(makeOptions());
+
+    expect(executeToolSpy).not.toHaveBeenCalled();
+    expect(resolveInitProjectContextSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not resolve a project for an out-of-sandbox creation fallback", async () => {
+    const payload: ToolPayload = {
+      type: "tool",
+      operation: "create-sentry-project",
+      cwd: "/outside/project",
+      params: { name: "outside", platform: "javascript-node" },
+    };
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["ensure-sentry-project"]],
+      steps: {
+        "ensure-sentry-project": { suspendPayload: payload },
+      },
+    };
+    mockResumeResults = [{ status: "success", result: { exitCode: 0 } }];
+    validateToolSandboxSpy.mockReturnValueOnce({
+      ok: false,
+      error: "Blocked by sandbox",
+    });
+
+    await runWizard(makeOptions());
+
+    expect(executeToolSpy).not.toHaveBeenCalled();
+    expect(resolveInitProjectContextSpy).not.toHaveBeenCalled();
+  });
+
+  test("gives interactive project creation a narrow team-choice capability", async () => {
+    const { ui, calls, respond } = createMockUI();
+    respond.select("continue");
+    respond.select("existing");
+    useMockUI(ui, calls);
+    const payload: ToolPayload = {
+      type: "tool",
+      operation: "create-sentry-project",
+      cwd: "/tmp/test",
+      params: { name: "my-app", platform: "javascript-react" },
+    };
+    const context = makeContext({ yes: false, team: undefined });
+    resolveInitContextSpy.mockResolvedValue(context);
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["ensure-sentry-project"]],
+      steps: {
+        "ensure-sentry-project": { suspendPayload: payload },
+      },
+    };
+    mockResumeResults = [{ status: "success", result: { exitCode: 0 } }];
+    executeToolSpy.mockImplementation(
+      async (_payload, _context, capabilities) => {
+        const choice = await capabilities?.chooseTeam?.([
+          {
+            id: "1",
+            slug: "platform",
+            name: "Platform",
+            access: ["team:admin"],
+          },
+        ]);
+        expect(choice).toEqual({ kind: "existing", slug: "platform" });
+        return { ok: true, data: { results: [] } };
+      }
+    );
+
+    await forceStdinTty(() => runWizard(makeOptions({ yes: false })));
+
+    expect(executeToolSpy).toHaveBeenCalledWith(payload, context, {
+      chooseTeam: expect.any(Function),
+    });
+    expect(calls).toContainEqual({
+      kind: "select",
+      message: "Choose a team for the new project",
+      options: ["create", "existing"],
+    });
+    expect(spinnerMock.stop).toHaveBeenCalledWith("Found available teams");
+    expect(spinnerMock.stop).not.toHaveBeenCalledWith(
+      "Project context analyzed"
+    );
+    expect(spinnerMock.start).toHaveBeenCalledWith(
+      "Creating Sentry project..."
+    );
+  });
+
   test("keeps v1 transport metadata out of local tool payloads", async () => {
     const requestId = "8c7ee6b9-e955-4514-9164-f01844584a28";
     const toolPayload: ToolPayload = {
@@ -745,7 +1086,8 @@ describe("runWizard", () => {
         prompt: "Continue?",
       },
       makeContext(),
-      expect.anything()
+      expect.anything(),
+      {}
     );
     expect(sharedResumeAsyncMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -895,7 +1237,7 @@ describe("runWizard", () => {
     expect(lastFeedbackOutcome()).toBe("failed");
   });
 
-  test("preserves 403 errors thrown for command-level scope inspection", async () => {
+  test("preserves a missing-scope 403 for global OAuth recovery", async () => {
     const payload: ToolPayload = {
       type: "tool",
       operation: "create-sentry-project",
@@ -909,16 +1251,22 @@ describe("runWizard", () => {
         "ensure-sentry-project": { suspendPayload: payload },
       },
     };
-    const scopeError = new ApiError("Forbidden", 403);
+    const scopeError = new ApiError(
+      "Cannot create project",
+      403,
+      "This operation requires the 'team:admin' authorization scope."
+    );
     executeToolSpy.mockRejectedValue(scopeError);
 
-    await expect(runWizard(makeOptions())).rejects.toBe(scopeError);
+    const error = await runWizard(makeOptions()).catch((cause) => cause);
 
+    expect(error).toBe(scopeError);
+    expect(error).not.toBeInstanceOf(WizardError);
     expect(spinnerMock.stop).toHaveBeenCalledWith(
-      "Sentry API request denied",
+      "Authorization update required",
       1
     );
-    expect(lastCancelMessage()).toBe("Sentry API request denied");
+    expect(lastCancelMessage()).toBe("Authorization update required");
   });
 
   test("tears down forwarding and stops the spinner on cancellation", async () => {
@@ -980,6 +1328,34 @@ describe("runWizard", () => {
     expect(lastFeedbackOutcome()).toBe("failed");
   });
 
+  test("shows the reason for a WizardError that has not been rendered", async () => {
+    const payload: ToolPayload = {
+      type: "tool",
+      operation: "run-commands",
+      cwd: "/tmp/test",
+      params: { commands: ["npm install @sentry/node"] },
+    };
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["apply-codemods"]],
+      steps: {
+        "apply-codemods": { suspendPayload: payload },
+      },
+    };
+    executeToolSpy.mockRejectedValue(
+      new WizardError("The setup service cannot improve this setup.", {
+        rendered: false,
+      })
+    );
+
+    await expect(runWizard(makeOptions())).rejects.toThrow(WizardError);
+
+    expect(lastCancelMessage()).toBe(
+      "The setup service cannot improve this setup."
+    );
+    expect(lastFeedbackOutcome()).toBe("failed");
+  });
+
   test("shows count-based messages while reading and analyzing files", async () => {
     mockStartResult = {
       status: "suspended",
@@ -1009,19 +1385,33 @@ describe("runWizard", () => {
     expect(messages).toContain("Analyzing 2 files...");
   });
 
-  test("passes precomputed dirListing/fileCache/existingSentry via initialState, not inputData", async () => {
+  test("passes precomputed dirListing/fileCache via initialState and defers Sentry detection", async () => {
     const dirListing = [
       { name: "package.json", path: "package.json", type: "file" as const },
     ];
     const fileCache = { "package.json": '{"name":"app"}' };
-    const detectedSentry = { status: "none" as const, signals: [] };
-
+    const sentrySetupTargets = [
+      {
+        autoSelect: true,
+        name: "junior",
+        path: "/tmp/test/packages/junior",
+      },
+    ];
+    const workspaceTargets = [
+      {
+        label: "Junior",
+        name: "junior",
+        path: "/tmp/test/packages/junior",
+        role: "runtime" as const,
+      },
+    ];
     precomputeDirListingSpy.mockResolvedValue(dirListing);
-    preReadCommonFilesSpy.mockResolvedValue(fileCache);
-    precomputeSentryDetectionSpy.mockResolvedValue({
-      ok: true,
-      data: detectedSentry,
+    precomputeSentrySetupTargetsSpy.mockResolvedValue(sentrySetupTargets);
+    precomputeWorkspaceInventorySpy.mockResolvedValue({
+      complete: true,
+      targets: workspaceTargets,
     });
+    preReadCommonFilesSpy.mockResolvedValue(fileCache);
 
     await runWizard(makeOptions());
 
@@ -1047,7 +1437,10 @@ describe("runWizard", () => {
     });
     expect(args.initialState?.dirListing).toEqual(dirListing);
     expect(args.initialState?.fileCache).toEqual(fileCache);
-    expect(args.initialState?.existingSentry).toEqual(detectedSentry);
+    expect(args.initialState?.sentrySetupTargets).toEqual(sentrySetupTargets);
+    expect(args.initialState?.workspaceTargets).toEqual(workspaceTargets);
+    expect(args.initialState?.workspaceTargetsComplete).toBe(true);
+    expect(args.initialState).not.toHaveProperty("existingSentry");
   });
 
   test("renders tool result messages as a transient spinner message, not a persisted line", async () => {
@@ -1698,6 +2091,58 @@ describe("runWizard — resumeWithRetry stale-step recovery", () => {
     expect(runByIdMock).toHaveBeenCalledTimes(1);
   });
 
+  test("continues from suspendedPaths when a timed-out resume already advanced", async () => {
+    vi.useFakeTimers();
+    const nextPayload: ToolPayload = {
+      type: "tool",
+      operation: "run-commands",
+      cwd: "/tmp/test",
+      params: { commands: ["echo next-step"] },
+    };
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["detect-platform"]],
+      steps: { "detect-platform": { suspendPayload: toolPayload } },
+    };
+    mockRunByIdResult = {
+      status: "suspended",
+      activeStepsPath: {},
+      suspendedPaths: { "ensure-sentry-project": [5] },
+      steps: {
+        "detect-platform": { status: "success" },
+        "ensure-sentry-project": {
+          status: "suspended",
+          suspendPayload: nextPayload,
+        },
+      },
+    };
+
+    let resumeCount = 0;
+    makeStaleStepRun(() => {
+      resumeCount += 1;
+      if (resumeCount === 1) {
+        return new Promise<WorkflowRunResult>(() => {
+          /* The server advances, but the original response never arrives. */
+        });
+      }
+      return Promise.resolve({ status: "success", result: { exitCode: 0 } });
+    });
+
+    const run = runWizard(makeOptions());
+    await vi.advanceTimersByTimeAsync(210_000);
+    await run;
+
+    expect(runByIdMock).toHaveBeenCalledWith(
+      "test-run-id",
+      expect.objectContaining({
+        fields: expect.arrayContaining(["suspendedPaths"]),
+      })
+    );
+    expect(executeToolSpy).toHaveBeenCalledWith(nextPayload, makeContext());
+    expect(resumeCount).toBe(2);
+    expect(formatResultSpy).toHaveBeenCalled();
+  });
+
   test("throws when stale-step error occurs and runById keeps failing", async () => {
     vi.useFakeTimers();
     mockStartResult = {
@@ -2136,7 +2581,7 @@ describe("runWizard — additional coverage", () => {
     });
   });
 
-  test("uses existing platform name in detect-platform spinner label", async () => {
+  test("does not present stale project metadata as the detected platform", async () => {
     resolveInitContextSpy.mockResolvedValue(
       makeContext({ existingProject: { platform: "javascript-nextjs" } })
     );
@@ -2161,7 +2606,8 @@ describe("runWizard — additional coverage", () => {
     const messages = spinnerMock.message.mock.calls.map(
       (c: unknown[]) => c[0] as string
     );
-    expect(messages.some((m) => m.includes("javascript-nextjs"))).toBe(true);
+    expect(messages).toContain("Analyzing project and Sentry support...");
+    expect(messages.some((m) => m.includes("javascript-nextjs"))).toBe(false);
   });
 });
 

--- a/packages/cli/test/lib/init/workflow-inputs.test.ts
+++ b/packages/cli/test/lib/init/workflow-inputs.test.ts
@@ -1,0 +1,544 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import type { DirEntry } from "../../../src/lib/init/types.js";
+import {
+  precomputeSentrySetupTargets,
+  precomputeWorkspaceTargetInventory,
+} from "../../../src/lib/init/workflow-inputs.js";
+
+const temporaryDirectories: string[] = [];
+
+async function makeProject(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), "sentry-init-targets-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map(
+        async (directory) =>
+          await rm(directory, { recursive: true, force: true })
+      )
+  );
+});
+
+describe("precomputeSentrySetupTargets", () => {
+  test("uses a non-empty identifier for a setup at the repository root", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "root-application" })
+    );
+    await writeFile(
+      path.join(directory, "instrumentation.ts"),
+      "Sentry.init({ dsn: process.env.SENTRY_DSN });"
+    );
+
+    await expect(precomputeSentrySetupTargets(directory)).resolves.toEqual([
+      { autoSelect: true, name: ".", path: directory },
+    ]);
+  });
+
+  test("maps a runtime initialization signal to its nearest workspace package", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "workspace-root" })
+    );
+    await mkdir(path.join(directory, "packages", "junior", "src"), {
+      recursive: true,
+    });
+    await writeFile(
+      path.join(directory, "packages", "junior", "package.json"),
+      JSON.stringify({
+        name: "@sentry/junior",
+        dependencies: { "@sentry/node": "^10.0.0" },
+      })
+    );
+    await writeFile(
+      path.join(directory, "packages", "junior", "src", "instrumentation.ts"),
+      "Sentry.init({ dsn: process.env.SENTRY_DSN });"
+    );
+
+    await expect(precomputeSentrySetupTargets(directory)).resolves.toEqual([
+      {
+        autoSelect: true,
+        name: "packages/junior",
+        path: path.join(directory, "packages", "junior"),
+      },
+    ]);
+  });
+
+  test("does not promote packages that only use the @sentry organization scope", async () => {
+    const directory = await makeProject();
+    await mkdir(path.join(directory, "packages", "docs"), { recursive: true });
+    await writeFile(
+      path.join(directory, "packages", "docs", "package.json"),
+      JSON.stringify({
+        name: "@sentry/junior-docs",
+        dependencies: { "@sentry/starlight-theme": "^1.0.0" },
+      })
+    );
+
+    await expect(precomputeSentrySetupTargets(directory)).resolves.toEqual([]);
+  });
+
+  test("uses a non-JavaScript manifest as the nearest project boundary", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "workspace-root" })
+    );
+    await mkdir(path.join(directory, "apps", "api", "src"), {
+      recursive: true,
+    });
+    await writeFile(path.join(directory, "apps", "api", "setup.py"), "");
+    await writeFile(
+      path.join(directory, "apps", "api", "src", "main.py"),
+      "sentry_sdk.init(dsn=os.environ['SENTRY_DSN'])"
+    );
+
+    await expect(precomputeSentrySetupTargets(directory)).resolves.toEqual([
+      {
+        autoSelect: true,
+        name: "apps/api",
+        path: path.join(directory, "apps", "api"),
+      },
+    ]);
+  });
+
+  test.each([
+    ["requirements-prod.txt", "main.py", "sentry_sdk.init()"],
+    ["deno.json", "main.ts", "Sentry.init({})"],
+    ["app.rockspec", "main.lua", "Sentry.init({})"],
+  ])("recognizes %s as an application boundary", async (manifest, sourceFile, source) => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "workspace-root" })
+    );
+    const appDir = path.join(directory, "apps", "worker");
+    await mkdir(appDir, { recursive: true });
+    await writeFile(path.join(appDir, manifest), "");
+    await writeFile(path.join(appDir, sourceFile), source);
+
+    await expect(precomputeSentrySetupTargets(directory)).resolves.toEqual([
+      { autoSelect: true, name: "apps/worker", path: appDir },
+    ]);
+  });
+
+  test("keeps multiple detected setups ambiguous", async () => {
+    const directory = await makeProject();
+    for (const name of ["api", "web"]) {
+      await mkdir(path.join(directory, "apps", name, "src"), {
+        recursive: true,
+      });
+      await writeFile(
+        path.join(directory, "apps", name, "package.json"),
+        JSON.stringify({ name })
+      );
+      await writeFile(
+        path.join(directory, "apps", name, "src", "instrumentation.ts"),
+        "Sentry.init({ dsn: process.env.SENTRY_DSN });"
+      );
+    }
+
+    const targets = await precomputeSentrySetupTargets(directory);
+
+    expect(targets.map((target) => target.name)).toEqual([
+      "apps/api",
+      "apps/web",
+    ]);
+    expect(targets.every((target) => target.autoSelect)).toBe(true);
+  });
+
+  test("maps every DSN-only workspace instead of only the primary DSN", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "workspace-root" })
+    );
+    const fixtures = [
+      ["api", "https://abc@o1.ingest.sentry.io/41"],
+      ["web", "https://def@o2.ingest.sentry.io/42"],
+    ] as const;
+    for (const [name, dsn] of fixtures) {
+      const appDir = path.join(directory, "apps", name);
+      await mkdir(appDir, { recursive: true });
+      await writeFile(
+        path.join(appDir, "package.json"),
+        JSON.stringify({ name })
+      );
+      await writeFile(path.join(appDir, ".env"), `SENTRY_DSN=${dsn}\n`);
+    }
+
+    const targets = await precomputeSentrySetupTargets(directory);
+
+    expect(targets.map((target) => target.name)).toEqual([
+      "apps/api",
+      "apps/web",
+    ]);
+  });
+
+  test("keeps separate sources when workspaces share the same DSN", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "workspace-root" })
+    );
+    const dsn = "https://abc@o1.ingest.sentry.io/42";
+    for (const name of ["api", "web"]) {
+      const appDir = path.join(directory, "apps", name);
+      await mkdir(appDir, { recursive: true });
+      await writeFile(
+        path.join(appDir, "package.json"),
+        JSON.stringify({ name })
+      );
+      await writeFile(path.join(appDir, ".env"), `SENTRY_DSN=${dsn}\n`);
+    }
+
+    const targets = await precomputeSentrySetupTargets(directory);
+
+    expect(targets.map((target) => target.name)).toEqual([
+      "apps/api",
+      "apps/web",
+    ]);
+  });
+
+  test("disables automatic selection when strong evidence is truncated", async () => {
+    const directory = await makeProject();
+    const appDir = path.join(directory, "apps", "api");
+    await mkdir(path.join(appDir, "src"), { recursive: true });
+    await writeFile(
+      path.join(appDir, "package.json"),
+      JSON.stringify({ name: "api" })
+    );
+    await Promise.all(
+      Array.from(
+        { length: 101 },
+        async (_, index) =>
+          await writeFile(
+            path.join(appDir, "src", `instrumentation-${index}.ts`),
+            "Sentry.init({ dsn: process.env.SENTRY_DSN });"
+          )
+      )
+    );
+
+    await expect(precomputeSentrySetupTargets(directory)).resolves.toEqual([
+      { autoSelect: false, name: "apps/api", path: appDir },
+    ]);
+  });
+
+  test("does not follow package manifests outside the workspace", async () => {
+    const directory = await makeProject();
+    const external = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "workspace-root" })
+    );
+    await writeFile(
+      path.join(external, "package.json"),
+      JSON.stringify({ name: "external-secret-name" })
+    );
+    const appDir = path.join(directory, "packages", "app");
+    await mkdir(path.join(appDir, "src"), { recursive: true });
+    await symlink(
+      path.join(external, "package.json"),
+      path.join(appDir, "package.json")
+    );
+    await writeFile(
+      path.join(appDir, "src", "instrumentation.ts"),
+      "Sentry.init({ dsn: process.env.SENTRY_DSN });"
+    );
+
+    await expect(precomputeSentrySetupTargets(directory)).resolves.toEqual([
+      { autoSelect: true, name: ".", path: directory },
+    ]);
+  });
+
+  test("rejects a package directory symlinked outside the workspace", async () => {
+    const directory = await makeProject();
+    const external = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "workspace-root" })
+    );
+    await writeFile(
+      path.join(external, "package.json"),
+      JSON.stringify({ name: "external-secret-name" })
+    );
+    await writeFile(
+      path.join(external, ".env"),
+      "SENTRY_DSN=https://abc@o1.ingest.sentry.io/42\n"
+    );
+    await mkdir(path.join(directory, "packages"), { recursive: true });
+    await symlink(external, path.join(directory, "packages", "external"));
+
+    await expect(precomputeSentrySetupTargets(directory)).resolves.toEqual([]);
+  });
+});
+
+describe("precomputeWorkspaceTargetInventory", () => {
+  test("inventories Junior's runtime, documentation site, and reference app", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "junior-monorepo" })
+    );
+    await writeFile(
+      path.join(directory, "pnpm-workspace.yaml"),
+      'packages:\n  - "apps/*"\n  - "packages/*"\n'
+    );
+
+    const exampleDir = path.join(directory, "apps", "example");
+    const docsDir = path.join(directory, "packages", "docs");
+    const runtimeDir = path.join(directory, "packages", "junior");
+    const dashboardDir = path.join(directory, "packages", "junior-dashboard");
+    await Promise.all(
+      [exampleDir, docsDir, runtimeDir, dashboardDir].map(
+        async (target) => await mkdir(target, { recursive: true })
+      )
+    );
+    await writeFile(
+      path.join(exampleDir, "package.json"),
+      JSON.stringify({
+        name: "@sentry/junior-example",
+        devDependencies: { nitro: "3.0.0" },
+      })
+    );
+    await writeFile(
+      path.join(exampleDir, "README.md"),
+      "This app is the canonical Junior consumer app and test bed."
+    );
+    await writeFile(path.join(exampleDir, "nitro.config.ts"), "");
+    await writeFile(
+      path.join(docsDir, "package.json"),
+      JSON.stringify({
+        name: "@sentry/junior-docs",
+        dependencies: { astro: "6.0.0", "@astrojs/starlight": "0.39.0" },
+      })
+    );
+    await writeFile(path.join(docsDir, "astro.config.mjs"), "");
+    await writeFile(
+      path.join(runtimeDir, "package.json"),
+      JSON.stringify({
+        name: "@sentry/junior",
+        exports: { ".": "./dist/index.js" },
+      })
+    );
+    await writeFile(
+      path.join(dashboardDir, "package.json"),
+      JSON.stringify({
+        name: "@sentry/junior-dashboard",
+        exports: { ".": "./dist/index.js" },
+      })
+    );
+
+    const listing = [
+      "pnpm-workspace.yaml",
+      "apps/example/package.json",
+      "apps/example/README.md",
+      "apps/example/nitro.config.ts",
+      "packages/docs/package.json",
+      "packages/docs/astro.config.mjs",
+      "packages/junior/package.json",
+      "packages/junior-dashboard/package.json",
+    ].map(
+      (filePath): DirEntry => ({
+        name: path.basename(filePath),
+        path: filePath,
+        type: "file",
+      })
+    );
+
+    await expect(
+      precomputeWorkspaceTargetInventory(directory, listing, [
+        { autoSelect: true, name: "junior", path: runtimeDir },
+      ])
+    ).resolves.toEqual({
+      complete: true,
+      targets: [
+        {
+          framework: "Nitro",
+          label: "Junior Example",
+          name: "apps/example",
+          path: exampleDir,
+          role: "example",
+        },
+        {
+          framework: "Astro",
+          label: "Junior Docs",
+          name: "packages/docs",
+          path: docsDir,
+          role: "documentation",
+        },
+        {
+          label: "Junior",
+          name: "packages/junior",
+          path: runtimeDir,
+          role: "runtime",
+        },
+      ],
+    });
+  });
+
+  test("uses README context to recognize a reference application", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "junior-monorepo" })
+    );
+    const consumerDir = path.join(directory, "apps", "consumer");
+    await mkdir(consumerDir, { recursive: true });
+    await writeFile(
+      path.join(consumerDir, "package.json"),
+      JSON.stringify({
+        name: "@sentry/junior-consumer",
+        devDependencies: { nitro: "3.0.0" },
+      })
+    );
+    await writeFile(
+      path.join(consumerDir, "README.md"),
+      "Use this as the canonical consumer app and end-to-end test bed."
+    );
+    await writeFile(path.join(consumerDir, "nitro.config.ts"), "");
+
+    const listing: DirEntry[] = [
+      {
+        name: "package.json",
+        path: "apps/consumer/package.json",
+        type: "file",
+      },
+      {
+        name: "README.md",
+        path: "apps/consumer/README.md",
+        type: "file",
+      },
+      {
+        name: "nitro.config.ts",
+        path: "apps/consumer/nitro.config.ts",
+        type: "file",
+      },
+    ];
+
+    await expect(
+      precomputeWorkspaceTargetInventory(directory, listing, [])
+    ).resolves.toEqual({
+      complete: false,
+      targets: [
+        {
+          framework: "Nitro",
+          label: "Junior Consumer",
+          name: "apps/consumer",
+          path: consumerDir,
+          role: "example",
+        },
+      ],
+    });
+  });
+
+  test("does not classify every Astro application as documentation", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "company-workspace" })
+    );
+    const websiteDir = path.join(directory, "apps", "website");
+    await mkdir(websiteDir, { recursive: true });
+    await writeFile(
+      path.join(websiteDir, "package.json"),
+      JSON.stringify({
+        name: "@company/website",
+        dependencies: { astro: "6.0.0" },
+        scripts: { deploy: "astro build" },
+      })
+    );
+    await writeFile(path.join(websiteDir, "astro.config.mjs"), "");
+
+    const listing = [
+      "apps/website/package.json",
+      "apps/website/astro.config.mjs",
+    ].map(
+      (filePath): DirEntry => ({
+        name: path.basename(filePath),
+        path: filePath,
+        type: "file",
+      })
+    );
+
+    await expect(
+      precomputeWorkspaceTargetInventory(directory, listing, [])
+    ).resolves.toEqual({
+      complete: false,
+      targets: [
+        {
+          framework: "Astro",
+          label: "Company Website",
+          name: "apps/website",
+          path: websiteDir,
+          role: "application",
+        },
+      ],
+    });
+  });
+
+  test("marks a partial JavaScript inventory incomplete in a mixed-language workspace", async () => {
+    const directory = await makeProject();
+    await writeFile(
+      path.join(directory, "package.json"),
+      JSON.stringify({ name: "mixed-workspace" })
+    );
+    await writeFile(
+      path.join(directory, "pnpm-workspace.yaml"),
+      'packages:\n  - "apps/*"\n'
+    );
+    const webDir = path.join(directory, "apps", "web");
+    const workerDir = path.join(directory, "crates", "worker");
+    await Promise.all([
+      mkdir(webDir, { recursive: true }),
+      mkdir(workerDir, { recursive: true }),
+    ]);
+    await writeFile(
+      path.join(webDir, "package.json"),
+      JSON.stringify({ name: "web" })
+    );
+    await writeFile(path.join(webDir, "next.config.ts"), "");
+    await writeFile(
+      path.join(workerDir, "Cargo.toml"),
+      '[package]\nname = "worker"\nversion = "0.1.0"\n'
+    );
+
+    const listing = [
+      "pnpm-workspace.yaml",
+      "apps/web/package.json",
+      "apps/web/next.config.ts",
+      "crates/worker/Cargo.toml",
+    ].map(
+      (filePath): DirEntry => ({
+        name: path.basename(filePath),
+        path: filePath,
+        type: "file",
+      })
+    );
+
+    await expect(
+      precomputeWorkspaceTargetInventory(directory, listing, [])
+    ).resolves.toEqual({
+      complete: false,
+      targets: [
+        {
+          framework: "Next.js",
+          label: "Mixed Web",
+          name: "apps/web",
+          path: webDir,
+          role: "application",
+        },
+      ],
+    });
+  });
+});

--- a/packages/cli/test/lib/project-creation.test.ts
+++ b/packages/cli/test/lib/project-creation.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("../../src/lib/api/projects.js");
+
+// biome-ignore lint/performance/noNamespaceImport: needed for vi.spyOn mocking
+import * as projectsApi from "../../src/lib/api/projects.js";
+import { MEMBER_PROJECT_CREATION_DISABLED_DETAIL } from "../../src/lib/api-client.js";
+import { ApiError } from "../../src/lib/errors.js";
+import {
+  createProjectWithTeamFallback,
+  ProjectCreationApiError,
+} from "../../src/lib/project-creation.js";
+
+const projectDetails = {
+  project: {
+    id: "42",
+    slug: "my-project",
+    name: "My Project",
+    platform: "javascript",
+  },
+  dsn: "https://public@example.com/42",
+  url: "https://acme.sentry.io/projects/my-project/",
+};
+
+const autoTeamDetails = {
+  ...projectDetails,
+  team_slug: "my-project-team",
+};
+
+describe("createProjectWithTeamFallback", () => {
+  const createProjectWithDsnSpy = vi.mocked(projectsApi.createProjectWithDsn);
+  const createProjectWithAutoTeamSpy = vi.mocked(
+    projectsApi.createProjectWithAutoTeam
+  );
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("uses org-scoped creation when no team is resolved", async () => {
+    createProjectWithAutoTeamSpy.mockResolvedValueOnce(autoTeamDetails);
+
+    const result = await createProjectWithTeamFallback({
+      orgSlug: "acme",
+      name: "My Project",
+      platform: "javascript",
+    });
+
+    expect(createProjectWithAutoTeamSpy).toHaveBeenCalledWith("acme", {
+      name: "My Project",
+      platform: "javascript",
+    });
+    expect(createProjectWithDsnSpy).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      teamSlug: "my-project-team",
+      teamSource: "auto-created",
+    });
+  });
+
+  test("uses the resolved team when team-scoped creation succeeds", async () => {
+    createProjectWithDsnSpy.mockResolvedValueOnce(projectDetails);
+
+    const result = await createProjectWithTeamFallback({
+      orgSlug: "acme",
+      name: "My Project",
+      team: { slug: "platform", source: "auto-selected" },
+    });
+
+    expect(createProjectWithDsnSpy).toHaveBeenCalledWith("acme", "platform", {
+      name: "My Project",
+      platform: undefined,
+    });
+    expect(createProjectWithAutoTeamSpy).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      teamSlug: "platform",
+      teamSource: "auto-selected",
+    });
+  });
+
+  test("falls back to org-scoped creation after an implicit team 403", async () => {
+    createProjectWithDsnSpy.mockRejectedValueOnce(
+      new ApiError("Forbidden", 403, "You do not have permission")
+    );
+    createProjectWithAutoTeamSpy.mockResolvedValueOnce(autoTeamDetails);
+
+    const result = await createProjectWithTeamFallback({
+      orgSlug: "acme",
+      name: "My Project",
+      team: { slug: "platform", source: "auto-selected" },
+    });
+
+    expect(createProjectWithAutoTeamSpy).toHaveBeenCalledOnce();
+    expect(result.teamSource).toBe("auto-created");
+  });
+
+  test("does not replace an explicitly requested team after a 403", async () => {
+    const error = new ApiError("Forbidden", 403, "You do not have permission");
+    createProjectWithDsnSpy.mockRejectedValueOnce(error);
+
+    await expect(
+      createProjectWithTeamFallback({
+        orgSlug: "acme",
+        name: "My Project",
+        team: { slug: "platform", source: "explicit" },
+      })
+    ).rejects.toMatchObject({ cause: error, route: "team" });
+    expect(createProjectWithAutoTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not replace an interactively selected team after a 403", async () => {
+    const error = new ApiError("Forbidden", 403, "You do not have permission");
+    createProjectWithDsnSpy.mockRejectedValueOnce(error);
+
+    await expect(
+      createProjectWithTeamFallback({
+        orgSlug: "acme",
+        name: "My Project",
+        team: { slug: "platform", source: "selected" },
+      })
+    ).rejects.toMatchObject({ cause: error, route: "team" });
+    expect(createProjectWithAutoTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("identifies stale authorization for an interactively selected Team Admin team", async () => {
+    const error = new ApiError(
+      "Forbidden",
+      403,
+      `This organization has ${MEMBER_PROJECT_CREATION_DISABLED_DETAIL} for members`
+    );
+    createProjectWithDsnSpy.mockRejectedValueOnce(error);
+
+    await expect(
+      createProjectWithTeamFallback({
+        orgSlug: "acme",
+        name: "My Project",
+        team: { slug: "platform", source: "selected" },
+      })
+    ).rejects.toThrow("team:admin");
+    expect(createProjectWithAutoTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("identifies the real team-scope failure hidden by the policy detail", async () => {
+    const error = new ApiError(
+      "Forbidden",
+      403,
+      `This organization has ${MEMBER_PROJECT_CREATION_DISABLED_DETAIL} for members`
+    );
+    createProjectWithDsnSpy.mockRejectedValueOnce(error);
+
+    await expect(
+      createProjectWithTeamFallback({
+        orgSlug: "acme",
+        name: "My Project",
+        team: { slug: "platform", source: "auto-selected" },
+      })
+    ).rejects.toThrow("team:admin");
+    expect(createProjectWithAutoTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not reinterpret a policy 403 for an explicit team", async () => {
+    const error = new ApiError(
+      "Forbidden",
+      403,
+      `This organization has ${MEMBER_PROJECT_CREATION_DISABLED_DETAIL} for members`
+    );
+    createProjectWithDsnSpy.mockRejectedValueOnce(error);
+
+    await expect(
+      createProjectWithTeamFallback({
+        orgSlug: "acme",
+        name: "My Project",
+        team: { slug: "platform", source: "explicit" },
+      })
+    ).rejects.toMatchObject({ cause: error, route: "team" });
+    expect(createProjectWithAutoTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("preserves organization-route provenance after a team fallback", async () => {
+    createProjectWithDsnSpy.mockRejectedValueOnce(
+      new ApiError("Forbidden", 403, "You do not have permission")
+    );
+    const orgError = new ApiError("Not found", 404, "Endpoint unavailable");
+    createProjectWithAutoTeamSpy.mockRejectedValueOnce(orgError);
+
+    const error = await createProjectWithTeamFallback({
+      orgSlug: "acme",
+      name: "My Project",
+      team: { slug: "platform", source: "auto-selected" },
+    }).catch((cause) => cause);
+
+    expect(error).toBeInstanceOf(ProjectCreationApiError);
+    expect(error).toMatchObject({ cause: orgError, route: "organization" });
+  });
+
+  test("preserves org policy errors from the organization fallback", async () => {
+    createProjectWithDsnSpy.mockRejectedValueOnce(
+      new ApiError("Forbidden", 403, "You do not have permission")
+    );
+    createProjectWithAutoTeamSpy.mockRejectedValueOnce(
+      new ApiError(
+        "Forbidden",
+        403,
+        `This organization has ${MEMBER_PROJECT_CREATION_DISABLED_DETAIL} for members`
+      )
+    );
+
+    const error = await createProjectWithTeamFallback({
+      orgSlug: "acme",
+      name: "My Project",
+      team: { slug: "platform", source: "auto-selected" },
+    }).catch((cause) => cause);
+
+    expect(error).toBeInstanceOf(ProjectCreationApiError);
+    expect(error).toMatchObject({
+      route: "organization",
+      detail: expect.stringContaining(MEMBER_PROJECT_CREATION_DISABLED_DETAIL),
+    });
+    expect(error.message).not.toContain("team:admin");
+  });
+});

--- a/packages/cli/test/lib/resolve-target-listing.test.ts
+++ b/packages/cli/test/lib/resolve-target-listing.test.ts
@@ -185,6 +185,10 @@ describe("resolveOrgProjectTarget", () => {
 
   beforeEach(() => {
     findProjectsBySlugSpy = vi.spyOn(apiClient, "findProjectsBySlug");
+    // Earlier resolver tests can exercise the real same-module call graph and
+    // leave calls on the underlying mocked export. Each assertion in this
+    // block should observe only the current test.
+    findProjectsBySlugSpy.mockClear();
     resolveOrgAndProjectSpy = vi.spyOn(
       resolveTargetModule,
       "resolveOrgAndProject"

--- a/packages/cli/test/lib/resolve-target.mocked.test.ts
+++ b/packages/cli/test/lib/resolve-target.mocked.test.ts
@@ -41,6 +41,11 @@ const {
   mockGetProject,
   mockFindProjectByDsnKey,
   mockFindProjectsByPattern,
+  mockFindProjectsBySlug,
+  mockInferRepositoryName,
+  mockInferRepositoryRoot,
+  mockLoadSentryCliRc,
+  mockGetGlobalPaths,
   mockListOrganizationsUncached,
   mockGetOrgByNumericId,
 } = vi.hoisted(() => ({
@@ -77,6 +82,15 @@ const {
   mockGetProject: vi.fn(() => Promise.resolve({ slug: "test", name: "Test" })),
   mockFindProjectByDsnKey: vi.fn(() => Promise.resolve(null)),
   mockFindProjectsByPattern: vi.fn(() => Promise.resolve([])),
+  mockFindProjectsBySlug: vi.fn(() =>
+    Promise.resolve({ projects: [], orgs: [] })
+  ),
+  mockInferRepositoryName: vi.fn(
+    () => undefined as { name: string; remote: string } | undefined
+  ),
+  mockInferRepositoryRoot: vi.fn(() => undefined as string | undefined),
+  mockLoadSentryCliRc: vi.fn(() => Promise.resolve({ sources: {} })),
+  mockGetGlobalPaths: vi.fn(() => new Set(["/global/.sentryclirc"])),
   mockListOrganizationsUncached: vi.fn(() => Promise.resolve([])),
   mockGetOrgByNumericId: vi.fn(
     () => undefined as { slug: string; regionUrl: string } | undefined
@@ -114,6 +128,17 @@ vi.mock("../../src/lib/db/dsn-cache.js", () => ({
   setCachedDsn: mockSetCachedDsn,
 }));
 
+vi.mock("../../src/lib/git.js", () => ({
+  inferRepositoryName: mockInferRepositoryName,
+  inferRepositoryRoot: mockInferRepositoryRoot,
+}));
+
+vi.mock("../../src/lib/sentryclirc.js", () => ({
+  CONFIG_FILENAME: ".sentryclirc",
+  getGlobalPaths: mockGetGlobalPaths,
+  loadSentryCliRc: mockLoadSentryCliRc,
+}));
+
 vi.mock("../../src/lib/db/regions.js", () => ({
   getOrgByNumericId: mockGetOrgByNumericId,
   getOrgRegion: vi.fn(() => {
@@ -145,7 +170,7 @@ vi.mock("../../src/lib/api-client.js", () => ({
   getProject: mockGetProject,
   findProjectByDsnKey: mockFindProjectByDsnKey,
   findProjectsByPattern: mockFindProjectsByPattern,
-  findProjectsBySlug: vi.fn(() => Promise.resolve({ projects: [], orgs: [] })),
+  findProjectsBySlug: mockFindProjectsBySlug,
   listOrganizations: vi.fn(() => Promise.resolve([])),
   listOrganizationsUncached: mockListOrganizationsUncached,
   listProjects: vi.fn(() => Promise.resolve([])),
@@ -179,6 +204,11 @@ function resetAllMocks() {
   mockGetProject.mockReset();
   mockFindProjectByDsnKey.mockReset();
   mockFindProjectsByPattern.mockReset();
+  mockFindProjectsBySlug.mockReset();
+  mockInferRepositoryName.mockReset();
+  mockInferRepositoryRoot.mockReset();
+  mockLoadSentryCliRc.mockReset();
+  mockGetGlobalPaths.mockReset();
   mockListOrganizationsUncached.mockReset();
   mockGetOrgByNumericId.mockReset();
 
@@ -203,6 +233,11 @@ function resetAllMocks() {
   mockGetCachedProjectByDsnKey.mockReturnValue(null);
   mockGetCachedDsn.mockReturnValue(null);
   mockFindProjectsByPattern.mockResolvedValue([]);
+  mockFindProjectsBySlug.mockResolvedValue({ projects: [], orgs: [] });
+  mockInferRepositoryName.mockReturnValue(undefined);
+  mockInferRepositoryRoot.mockReturnValue(undefined);
+  mockLoadSentryCliRc.mockResolvedValue({ sources: {} });
+  mockGetGlobalPaths.mockReturnValue(new Set(["/global/.sentryclirc"]));
   mockListOrganizationsUncached.mockResolvedValue([]);
   mockGetOrgByNumericId.mockReturnValue(undefined);
 }
@@ -629,6 +664,180 @@ describe("resolveOrgAndProject", () => {
     expect(result?.project).toBe("dsn-project");
   });
 
+  test("resolves an exact project slug from the git repository name", async () => {
+    mockInferRepositoryName.mockReturnValue({
+      name: "getsentry/junior",
+      remote: "origin",
+    });
+    mockFindProjectsBySlug.mockImplementation((slug: string) =>
+      Promise.resolve({
+        projects:
+          slug === "junior"
+            ? [
+                {
+                  id: "789",
+                  slug: "junior",
+                  name: "Junior",
+                  orgSlug: "sentry",
+                  organization: {
+                    id: "1",
+                    slug: "sentry",
+                    name: "Sentry",
+                  },
+                },
+              ]
+            : [],
+        orgs: [],
+      })
+    );
+
+    const result = await resolveOrgAndProject({ cwd: "/work/checkout" });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        org: "sentry",
+        project: "junior",
+        detectedFrom: 'git origin remote "getsentry/junior"',
+      })
+    );
+    expect(mockFindProjectsBySlug).toHaveBeenCalledWith("junior");
+    expect(mockFindProjectsByPattern).not.toHaveBeenCalled();
+  });
+
+  test("resolves an exact project slug from the working-directory name", async () => {
+    mockInferRepositoryRoot.mockReturnValue("/work/junior");
+    mockFindProjectRoot.mockResolvedValue({
+      projectRoot: "/work/junior",
+      detectedFrom: "package.json",
+    });
+    mockFindProjectsBySlug.mockResolvedValue({
+      projects: [
+        {
+          id: "789",
+          slug: "junior",
+          name: "Junior",
+          orgSlug: "sentry",
+          organization: { id: "1", slug: "sentry", name: "Sentry" },
+        },
+      ],
+      orgs: [],
+    });
+
+    const result = await resolveOrgAndProject({ cwd: "/work/junior" });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        org: "sentry",
+        project: "junior",
+        detectedFrom: 'working directory name "junior"',
+      })
+    );
+    expect(mockFindProjectsBySlug).toHaveBeenCalledWith("junior");
+    expect(mockFindProjectRoot).toHaveBeenCalledWith("/work/junior");
+    expect(mockFindProjectsByPattern).not.toHaveBeenCalled();
+  });
+
+  test("prefers the specific working directory over the repository root", async () => {
+    mockInferRepositoryRoot.mockReturnValue("/work/monorepo");
+    mockFindProjectRoot.mockResolvedValue({
+      projectRoot: "/work/monorepo/packages/frontend",
+      detectedFrom: "package.json",
+    });
+    mockInferRepositoryName.mockReturnValue({
+      name: "getsentry/monorepo",
+      remote: "origin",
+    });
+    mockFindProjectsBySlug.mockImplementation((slug: string) =>
+      Promise.resolve({
+        projects:
+          slug === "frontend"
+            ? [
+                {
+                  id: "789",
+                  slug: "frontend",
+                  name: "Frontend",
+                  orgSlug: "sentry",
+                },
+              ]
+            : [],
+        orgs: [],
+      })
+    );
+
+    const result = await resolveOrgAndProject({
+      cwd: "/work/monorepo/packages/frontend",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({ org: "sentry", project: "frontend" })
+    );
+    expect(mockInferRepositoryName).not.toHaveBeenCalled();
+  });
+
+  test("prefers the git remote over a conflicting checkout-root name", async () => {
+    mockInferRepositoryRoot.mockReturnValue("/work/checkout");
+    mockFindProjectRoot.mockResolvedValue({
+      projectRoot: "/work/checkout",
+      detectedFrom: "vcs",
+    });
+    mockInferRepositoryName.mockReturnValue({
+      name: "getsentry/junior",
+      remote: "origin",
+    });
+    mockFindProjectsBySlug.mockImplementation((slug: string) =>
+      Promise.resolve({
+        projects: [
+          {
+            id: slug === "junior" ? "789" : "790",
+            slug,
+            name: slug,
+            orgSlug: "sentry",
+          },
+        ],
+        orgs: [],
+      })
+    );
+
+    const result = await resolveOrgAndProject({ cwd: "/work/checkout" });
+
+    expect(result).toEqual(
+      expect.objectContaining({ org: "sentry", project: "junior" })
+    );
+  });
+
+  test("does not treat a common nested cwd as a monorepo app root", async () => {
+    mockInferRepositoryRoot.mockReturnValue("/work/junior");
+    mockFindProjectRoot.mockResolvedValue({
+      projectRoot: "/work/junior",
+      detectedFrom: "vcs",
+    });
+    mockInferRepositoryName.mockReturnValue({
+      name: "getsentry/junior",
+      remote: "origin",
+    });
+    mockFindProjectsBySlug.mockImplementation((slug: string) =>
+      Promise.resolve({
+        projects: [
+          {
+            id: slug === "junior" ? "789" : "790",
+            slug,
+            name: slug,
+            orgSlug: "sentry",
+          },
+        ],
+        orgs: [],
+      })
+    );
+
+    const result = await resolveOrgAndProject({
+      cwd: "/work/junior/src",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({ org: "sentry", project: "junior" })
+    );
+  });
+
   test("falls back to directory inference when DSN detection fails", async () => {
     mockGetDefaultOrganization.mockReturnValue(null);
     mockGetDefaultProject.mockReturnValue(null);
@@ -666,6 +875,39 @@ describe("resolveOrgAndProject", () => {
     mockFindProjectsByPattern.mockResolvedValue([]);
 
     const result = await resolveOrgAndProject({ cwd: "/home/user/ab" });
+
+    expect(result).toBeNull();
+  });
+
+  test("does not choose the first cross-org exact match", async () => {
+    mockInferRepositoryName.mockReturnValue({
+      name: "getsentry/junior",
+      remote: "origin",
+    });
+    mockFindProjectsBySlug.mockImplementation((slug: string) =>
+      Promise.resolve({
+        projects:
+          slug === "junior"
+            ? [
+                {
+                  id: "789",
+                  slug: "junior",
+                  name: "Junior",
+                  orgSlug: "sentry",
+                },
+                {
+                  id: "790",
+                  slug: "junior",
+                  name: "Junior",
+                  orgSlug: "personal",
+                },
+              ]
+            : [],
+        orgs: [],
+      })
+    );
+
+    const result = await resolveOrgAndProject({ cwd: "/work/checkout" });
 
     expect(result).toBeNull();
   });
@@ -707,6 +949,227 @@ describe("resolveAllTargets", () => {
     expect(result.targets).toHaveLength(1);
     expect(result.targets[0].org).toBe("default-org");
     expect(result.targets[0].project).toBe("default-project");
+  });
+
+  test("codebase mode ignores global config and account defaults in favor of a local DSN", async () => {
+    mockLoadSentryCliRc.mockResolvedValue({
+      org: "global-org",
+      project: "global-project",
+      sources: {
+        org: "/global/.sentryclirc",
+        project: "/global/.sentryclirc",
+      },
+    });
+    mockGetDefaultOrganization.mockReturnValue("default-org");
+    mockGetDefaultProject.mockReturnValue("default-project");
+    mockDetectAllDsns.mockResolvedValue({
+      primary: {
+        raw: "https://abc@o123.ingest.sentry.io/456",
+        protocol: "https",
+        publicKey: "abc",
+        host: "o123.ingest.sentry.io",
+        projectId: "456",
+        orgId: "123",
+        source: "env-file",
+      },
+      all: [
+        {
+          raw: "https://abc@o123.ingest.sentry.io/456",
+          protocol: "https",
+          publicKey: "abc",
+          host: "o123.ingest.sentry.io",
+          projectId: "456",
+          orgId: "123",
+          source: "env-file",
+        },
+      ],
+      hasMultiple: false,
+      fingerprint: "abc",
+    });
+    mockGetCachedProject.mockReturnValue({
+      orgSlug: "local-org",
+      orgName: "Local Org",
+      projectSlug: "local-project",
+      projectName: "Local Project",
+      projectId: "456",
+    });
+
+    const result = await resolveAllTargets({
+      cwd: "/work/checkout",
+      resolutionMode: "codebase",
+    });
+
+    expect(result.targets).toEqual([
+      expect.objectContaining({
+        org: "local-org",
+        project: "local-project",
+      }),
+    ]);
+    expect(mockGetDefaultOrganization).not.toHaveBeenCalled();
+    expect(mockGetDefaultProject).not.toHaveBeenCalled();
+  });
+
+  test("codebase mode accepts a project from a local sentryclirc", async () => {
+    mockLoadSentryCliRc.mockResolvedValue({
+      org: "local-org",
+      project: "local-project",
+      sources: {
+        org: "/global/.sentryclirc",
+        project: "/work/.sentryclirc",
+      },
+    });
+
+    const result = await resolveAllTargets({
+      cwd: "/work/checkout",
+      resolutionMode: "codebase",
+    });
+
+    expect(result.targets).toEqual([
+      expect.objectContaining({
+        org: "local-org",
+        project: "local-project",
+      }),
+    ]);
+    expect(mockDetectAllDsns).not.toHaveBeenCalled();
+  });
+
+  test("organization filter skips an incompatible local config and continues", async () => {
+    mockLoadSentryCliRc.mockResolvedValue({
+      org: "other-org",
+      project: "other-project",
+      sources: {
+        org: "/work/.sentryclirc",
+        project: "/work/.sentryclirc",
+      },
+    });
+    mockInferRepositoryRoot.mockReturnValue("/work/checkout");
+    mockInferRepositoryName.mockReturnValue({
+      name: "getsentry/junior",
+      remote: "origin",
+    });
+    mockFindProjectsBySlug.mockImplementation((slug: string) =>
+      Promise.resolve({
+        projects:
+          slug === "junior"
+            ? [
+                {
+                  id: "789",
+                  slug: "junior",
+                  name: "Junior",
+                  orgSlug: "acme",
+                },
+              ]
+            : [],
+        orgs: [],
+      })
+    );
+
+    const result = await resolveAllTargets({
+      cwd: "/work/checkout",
+      resolutionMode: "codebase",
+      organizationFilter: "acme",
+    });
+
+    expect(result.targets).toEqual([
+      expect.objectContaining({ org: "acme", project: "junior" }),
+    ]);
+  });
+
+  test("organization filter skips a fully resolved DSN from another org", async () => {
+    const dsn = {
+      raw: "https://abc@o123.ingest.sentry.io/456",
+      protocol: "https",
+      publicKey: "abc",
+      host: "o123.ingest.sentry.io",
+      projectId: "456",
+      orgId: "123",
+      source: "env-file" as const,
+    };
+    mockDetectAllDsns.mockResolvedValue({
+      primary: dsn,
+      all: [dsn],
+      hasMultiple: false,
+      fingerprint: "abc",
+    });
+    mockGetCachedProject.mockReturnValue({
+      orgSlug: "other-org",
+      orgName: "Other Org",
+      projectSlug: "other-project",
+      projectName: "Other Project",
+      projectId: "456",
+    });
+    mockInferRepositoryRoot.mockReturnValue("/work/checkout");
+    mockInferRepositoryName.mockReturnValue({
+      name: "getsentry/junior",
+      remote: "origin",
+    });
+    mockFindProjectsBySlug.mockImplementation((slug: string) =>
+      Promise.resolve({
+        projects:
+          slug === "junior"
+            ? [
+                {
+                  id: "789",
+                  slug: "junior",
+                  name: "Junior",
+                  orgSlug: "acme",
+                },
+              ]
+            : [],
+        orgs: [],
+      })
+    );
+
+    const result = await resolveAllTargets({
+      cwd: "/work/checkout",
+      resolutionMode: "codebase",
+      organizationFilter: "acme",
+    });
+
+    expect(result.targets).toEqual([
+      expect.objectContaining({ org: "acme", project: "junior" }),
+    ]);
+  });
+
+  test("organization filter validates a cold numeric DSN in the selected org", async () => {
+    const dsn = {
+      raw: "https://abc@o123.ingest.sentry.io/456",
+      protocol: "https",
+      publicKey: "abc",
+      host: "o123.ingest.sentry.io",
+      projectId: "456",
+      orgId: "123",
+      source: "env-file" as const,
+    };
+    mockDetectAllDsns.mockResolvedValue({
+      primary: dsn,
+      all: [dsn],
+      hasMultiple: false,
+      fingerprint: "abc",
+    });
+    mockGetProject.mockResolvedValue({
+      id: "456",
+      slug: "junior",
+      name: "Junior",
+      organization: { id: "123", slug: "acme", name: "Acme" },
+    });
+
+    const result = await resolveAllTargets({
+      cwd: "/work/checkout",
+      resolutionMode: "codebase",
+      organizationFilter: "acme",
+    });
+
+    expect(mockGetProject).toHaveBeenCalledWith("acme", "456");
+    expect(mockFindProjectByDsnKey).not.toHaveBeenCalled();
+    expect(result.targets).toEqual([
+      expect.objectContaining({
+        org: "acme",
+        project: "junior",
+        projectId: 456,
+        detectedDsn: dsn,
+      }),
+    ]);
   });
 
   test("resolves multiple DSNs in monorepo", async () => {
@@ -854,6 +1317,82 @@ describe("resolveAllTargets", () => {
     expect(result.targets).toHaveLength(1);
     expect(result.targets[0].org).toBe("inferred-org");
     expect(result.targets[0].project).toBe("my-app");
+    expect(result.targets[0].matchStrength).toBe("exact");
+  });
+
+  test("marks a non-exact project-root match as fuzzy", async () => {
+    mockFindProjectRoot.mockResolvedValue({
+      projectRoot: "/home/user/junior",
+      detectedFrom: "package.json",
+    });
+    mockFindProjectsByPattern.mockResolvedValue([
+      {
+        id: "789",
+        slug: "junior-api",
+        name: "Junior API",
+        orgSlug: "inferred-org",
+        organization: { id: "1", slug: "inferred-org", name: "Inferred Org" },
+      },
+    ]);
+
+    const result = await resolveAllTargets({ cwd: "/work/checkout" });
+
+    expect(result.targets).toEqual([
+      expect.objectContaining({
+        project: "junior-api",
+        matchStrength: "fuzzy",
+      }),
+    ]);
+  });
+
+  test("preserves ambiguous cross-org git repository matches", async () => {
+    mockInferRepositoryName.mockReturnValue({
+      name: "getsentry/junior",
+      remote: "upstream",
+    });
+    mockFindProjectsBySlug.mockImplementation((slug: string) =>
+      Promise.resolve({
+        projects:
+          slug === "junior"
+            ? [
+                {
+                  id: "789",
+                  slug: "junior",
+                  name: "Junior",
+                  orgSlug: "sentry",
+                  organization: {
+                    id: "1",
+                    slug: "sentry",
+                    name: "Sentry",
+                  },
+                },
+                {
+                  id: "790",
+                  slug: "junior",
+                  name: "Junior",
+                  orgSlug: "personal",
+                  organization: {
+                    id: "2",
+                    slug: "personal",
+                    name: "Personal",
+                  },
+                },
+              ]
+            : [],
+        orgs: [],
+      })
+    );
+
+    const result = await resolveAllTargets({ cwd: "/work/checkout" });
+
+    expect(
+      result.targets.map(({ org, project }) => ({ org, project }))
+    ).toEqual([
+      { org: "sentry", project: "junior" },
+      { org: "personal", project: "junior" },
+    ]);
+    expect(result.footer).toContain("2 projects matching git repository");
+    expect(mockFindProjectsByPattern).not.toHaveBeenCalled();
   });
 
   test("returns empty targets when a public-key DSN cannot be resolved", async () => {
@@ -1089,6 +1628,42 @@ describe("env var resolution: SENTRY_ORG + SENTRY_PROJECT", () => {
 
     expect(result.targets[0]?.org).toBe("env-org");
     expect(mockGetDefaultOrganization).not.toHaveBeenCalled();
+  });
+
+  test("resolveAllTargets: organization filter skips incompatible env target", async () => {
+    process.env.SENTRY_ORG = "other-org";
+    process.env.SENTRY_PROJECT = "other-project";
+    mockInferRepositoryRoot.mockReturnValue("/work/checkout");
+    mockInferRepositoryName.mockReturnValue({
+      name: "getsentry/junior",
+      remote: "origin",
+    });
+    mockFindProjectsBySlug.mockImplementation((slug: string) =>
+      Promise.resolve({
+        projects:
+          slug === "junior"
+            ? [
+                {
+                  id: "789",
+                  slug: "junior",
+                  name: "Junior",
+                  orgSlug: "acme",
+                },
+              ]
+            : [],
+        orgs: [],
+      })
+    );
+
+    const result = await resolveAllTargets({
+      cwd: "/work/checkout",
+      resolutionMode: "codebase",
+      organizationFilter: "acme",
+    });
+
+    expect(result.targets).toEqual([
+      expect.objectContaining({ org: "acme", project: "junior" }),
+    ]);
   });
 
   // --- resolveOrgsForListing ---

--- a/packages/cli/test/lib/resolve-target.test.ts
+++ b/packages/cli/test/lib/resolve-target.test.ts
@@ -6,6 +6,9 @@
  * the complexity of mocking module dependencies in Bun's test environment.
  */
 
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { array, constantFrom, assert as fcAssert, property } from "fast-check";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { parseOrgProjectArg } from "../../src/lib/arg-parsing.js";
@@ -346,6 +349,62 @@ describe("Environment variable resolution (SENTRY_ORG / SENTRY_PROJECT)", () => 
     process.env.SENTRY_ORG = "env-org";
     const result = await resolveOrgsForListing(undefined, "/tmp");
     expect(result.orgs).toContain("env-org");
+  });
+});
+
+describe("local codebase evidence resolution", () => {
+  useTestConfigDir("test-resolve-target-evidence-");
+
+  let originalFetch: typeof globalThis.fetch;
+  let projectDir: string;
+
+  beforeEach(async () => {
+    originalFetch = globalThis.fetch;
+    projectDir = await mkdtemp(path.join(tmpdir(), "resolve-target-evidence-"));
+    delete process.env.SENTRY_ORG;
+    delete process.env.SENTRY_PROJECT;
+    delete process.env.SENTRY_DSN;
+    await setAuthToken("test-token");
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    delete process.env.SENTRY_ORG;
+    delete process.env.SENTRY_PROJECT;
+    delete process.env.SENTRY_DSN;
+    await rm(projectDir, { force: true, recursive: true });
+  });
+
+  test("uses numeric DSN identity without a project discovery request", async () => {
+    await writeFile(
+      path.join(projectDir, ".env"),
+      "SENTRY_DSN=https://public@o1.ingest.sentry.io/42\n"
+    );
+    let requestCount = 0;
+    globalThis.fetch = mockFetch(async () => {
+      requestCount += 1;
+      return new Response(JSON.stringify({ detail: "Unexpected request" }), {
+        status: 500,
+      });
+    });
+
+    const result = await resolveAllTargets({
+      cwd: projectDir,
+      resolutionMode: "codebase",
+    });
+
+    expect(result.targets).toEqual([
+      expect.objectContaining({
+        org: "1",
+        project: "42",
+        projectId: 42,
+        detectedDsn: expect.objectContaining({
+          projectId: "42",
+          sourcePath: ".env",
+        }),
+      }),
+    ]);
+    expect(requestCount).toBe(0);
   });
 });
 

--- a/packages/cli/test/lib/resolve-team.test.ts
+++ b/packages/cli/test/lib/resolve-team.test.ts
@@ -9,15 +9,290 @@ vi.mock("../../src/lib/api/teams.js");
 vi.mock("../../src/lib/api/organizations.js");
 
 // biome-ignore lint/performance/noNamespaceImport: needed for vi.spyOn mocking
+import * as organizationsApi from "../../src/lib/api/organizations.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for vi.spyOn mocking
 import * as teamsApi from "../../src/lib/api/teams.js";
 import { ApiError, ResolutionError } from "../../src/lib/errors.js";
 import { resolveOrCreateTeam } from "../../src/lib/resolve-team.js";
 
 describe("resolveOrCreateTeam", () => {
   const listTeamsSpy = vi.mocked(teamsApi.listTeams);
+  const createTeamSpy = vi.mocked(teamsApi.createTeam);
+  const getOrganizationSpy = vi.mocked(organizationsApi.getOrganization);
 
   afterEach(() => {
-    listTeamsSpy.mockReset();
+    vi.resetAllMocks();
+  });
+
+  test("preserves an explicit team without listing teams", async () => {
+    const result = await resolveOrCreateTeam("acme", {
+      team: "backend",
+      usageHint: "sentry init",
+      autoCreateSlug: "my-app",
+    });
+
+    expect(result).toEqual({ slug: "backend", source: "explicit" });
+    expect(listTeamsSpy).not.toHaveBeenCalled();
+  });
+
+  test("uses the team selected by an interactive caller", async () => {
+    listTeamsSpy.mockResolvedValue([
+      {
+        id: "1",
+        slug: "contributors",
+        name: "Contributors",
+        access: ["team:read"],
+      },
+      {
+        id: "2",
+        slug: "platform",
+        name: "Platform",
+        access: ["team:admin"],
+      },
+      {
+        id: "3",
+        slug: "web",
+        name: "Web",
+        access: ["team:admin"],
+      },
+    ]);
+
+    const result = await resolveOrCreateTeam("acme", {
+      usageHint: "sentry init",
+      autoCreateSlug: "my-app",
+      chooseTeam: async () => ({ kind: "existing", slug: "web" }),
+    });
+
+    expect(result).toEqual({ slug: "web", source: "selected" });
+    expect(getOrganizationSpy).not.toHaveBeenCalled();
+  });
+
+  test("auto-selects one eligible team without an interactive caller", async () => {
+    listTeamsSpy.mockResolvedValue([
+      {
+        id: "2",
+        slug: "platform",
+        name: "Platform",
+        access: ["team:admin"],
+      },
+    ]);
+
+    const result = await resolveOrCreateTeam("acme", {
+      usageHint: "sentry init --yes",
+      autoCreateSlug: "my-app",
+    });
+
+    expect(result).toEqual({ slug: "platform", source: "auto-selected" });
+  });
+
+  test("requires --team for multiple eligible teams without a prompt", async () => {
+    listTeamsSpy.mockResolvedValue([
+      {
+        id: "2",
+        slug: "platform",
+        name: "Platform",
+        access: ["team:admin"],
+      },
+      {
+        id: "3",
+        slug: "web",
+        name: "Web",
+        access: ["team:admin"],
+      },
+    ]);
+
+    await expect(
+      resolveOrCreateTeam("acme", {
+        usageHint: "sentry init",
+        autoCreateSlug: "my-app",
+      })
+    ).rejects.toThrow("Choose one explicitly with --team");
+  });
+
+  test("creates a new team when the interactive caller chooses create", async () => {
+    listTeamsSpy.mockResolvedValue([
+      {
+        id: "2",
+        slug: "platform",
+        name: "Platform",
+        access: ["team:admin"],
+      },
+    ]);
+    getOrganizationSpy.mockResolvedValue({
+      id: "1",
+      slug: "acme",
+      name: "Acme",
+      access: ["project:read"],
+      allowMemberProjectCreation: true,
+    });
+
+    const result = await resolveOrCreateTeam("acme", {
+      usageHint: "sentry init",
+      autoCreateSlug: "my-app",
+      chooseTeam: async () => ({ kind: "create" }),
+    });
+
+    expect(result).toBeUndefined();
+    expect(getOrganizationSpy).toHaveBeenCalledWith("acme");
+  });
+
+  test("creates a team for a project admin with no eligible team", async () => {
+    listTeamsSpy.mockResolvedValue([]);
+    getOrganizationSpy.mockResolvedValue({
+      id: "1",
+      slug: "acme",
+      name: "Acme",
+      access: ["project:admin", "team:admin"],
+      allowMemberProjectCreation: false,
+    });
+    createTeamSpy.mockResolvedValue({
+      id: "2",
+      slug: "my-app",
+      name: "my-app",
+    });
+
+    const result = await resolveOrCreateTeam("acme", {
+      usageHint: "sentry init",
+      autoCreateSlug: "my-app",
+    });
+
+    expect(createTeamSpy).toHaveBeenCalledWith("acme", "my-app");
+    expect(result).toEqual({ slug: "my-app", source: "auto-created" });
+  });
+
+  test("retries a unique team slug after a conflict", async () => {
+    listTeamsSpy.mockResolvedValue([]);
+    getOrganizationSpy.mockResolvedValue({
+      id: "1",
+      slug: "acme",
+      name: "Acme",
+      access: ["project:admin", "team:admin"],
+      allowMemberProjectCreation: false,
+    });
+    createTeamSpy
+      .mockRejectedValueOnce(new ApiError("conflict", 409))
+      .mockResolvedValueOnce({
+        id: "2",
+        slug: "my-app-team",
+        name: "my-app-team",
+      });
+
+    const result = await resolveOrCreateTeam("acme", {
+      usageHint: "sentry init",
+      autoCreateSlug: "my-app",
+    });
+
+    expect(createTeamSpy).toHaveBeenNthCalledWith(1, "acme", "my-app");
+    expect(createTeamSpy).toHaveBeenNthCalledWith(2, "acme", "my-app-team");
+    expect(result?.slug).toBe("my-app-team");
+  });
+
+  test("surfaces team:admin when restricted team creation returns 403", async () => {
+    listTeamsSpy.mockResolvedValue([]);
+    getOrganizationSpy.mockResolvedValue({
+      id: "1",
+      slug: "acme",
+      name: "Acme",
+      access: ["project:admin", "team:admin"],
+      allowMemberProjectCreation: false,
+    });
+    createTeamSpy.mockRejectedValueOnce(
+      new ApiError("Forbidden", 403, "You do not have permission")
+    );
+
+    await expect(
+      resolveOrCreateTeam("acme", {
+        usageHint: "sentry init",
+        autoCreateSlug: "my-app",
+      })
+    ).rejects.toThrow("team:admin");
+  });
+
+  test("leaves team undefined for the org-scoped member route", async () => {
+    listTeamsSpy.mockResolvedValue([]);
+    getOrganizationSpy.mockResolvedValue({
+      id: "1",
+      slug: "acme",
+      name: "Acme",
+      access: ["project:read"],
+      allowMemberProjectCreation: true,
+    });
+
+    const result = await resolveOrCreateTeam("acme", {
+      usageHint: "sentry init",
+      autoCreateSlug: "my-app",
+    });
+
+    expect(result).toBeUndefined();
+    expect(createTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("prefers atomic org-scoped creation when member creation is allowed", async () => {
+    listTeamsSpy.mockResolvedValue([]);
+    getOrganizationSpy.mockResolvedValue({
+      id: "1",
+      slug: "acme",
+      name: "Acme",
+      access: ["project:admin"],
+      allowMemberProjectCreation: true,
+    });
+
+    const result = await resolveOrCreateTeam("acme", {
+      usageHint: "sentry init",
+      autoCreateSlug: "my-app",
+    });
+
+    expect(result).toBeUndefined();
+    expect(createTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("prefers org-scoped creation for an org manager", async () => {
+    listTeamsSpy.mockResolvedValue([]);
+    getOrganizationSpy.mockResolvedValue({
+      id: "1",
+      slug: "acme",
+      name: "Acme",
+      access: ["org:write", "project:admin"],
+      allowMemberProjectCreation: false,
+    });
+
+    const result = await resolveOrCreateTeam("acme", {
+      usageHint: "sentry init",
+      autoCreateSlug: "my-app",
+    });
+
+    expect(result).toBeUndefined();
+    expect(createTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not create an unusable team when OAuth lacks team:admin", async () => {
+    listTeamsSpy.mockResolvedValue([]);
+    getOrganizationSpy.mockResolvedValue({
+      id: "1",
+      slug: "acme",
+      name: "Acme",
+      access: ["project:admin"],
+      allowMemberProjectCreation: false,
+    });
+
+    await expect(
+      resolveOrCreateTeam("acme", {
+        usageHint: "sentry init",
+        autoCreateSlug: "my-app",
+      })
+    ).rejects.toThrow("team:admin");
+    expect(createTeamSpy).not.toHaveBeenCalled();
+  });
+
+  test("uses the org-scoped route when teams cannot be listed", async () => {
+    listTeamsSpy.mockRejectedValueOnce(new ApiError("Forbidden", 403));
+
+    const result = await resolveOrCreateTeam("acme", {
+      usageHint: "sentry init",
+      autoCreateSlug: "my-app",
+    });
+
+    expect(result).toBeUndefined();
   });
 
   test("re-throws the original ApiError when listTeams returns 401", async () => {

--- a/packages/cli/test/lib/team-choice.test.ts
+++ b/packages/cli/test/lib/team-choice.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  chooseProjectTeam,
+  type ProjectTeamSelect,
+} from "../../src/lib/team-choice.js";
+import type { SentryTeam } from "../../src/types/index.js";
+
+const platform: SentryTeam = {
+  id: "1",
+  slug: "platform",
+  name: "Platform",
+  access: ["team:admin"],
+};
+const web: SentryTeam = {
+  id: "2",
+  slug: "web",
+  name: "Web",
+  access: ["team:admin"],
+};
+
+function makeSelect(...answers: string[]): {
+  calls: Parameters<ProjectTeamSelect>[0][];
+  select: ProjectTeamSelect;
+} {
+  const calls: Parameters<ProjectTeamSelect>[0][] = [];
+  const select: ProjectTeamSelect = vi.fn(async (options) => {
+    calls.push(options);
+    const answer = answers.shift();
+    const selected = options.options.find((option) => option.value === answer);
+    if (!selected) {
+      throw new Error(`Missing test option: ${answer}`);
+    }
+    return selected.value;
+  });
+  return { calls, select };
+}
+
+describe("chooseProjectTeam", () => {
+  test("shows create first and the only eligible team directly", async () => {
+    const prompt = makeSelect("existing");
+
+    const result = await chooseProjectTeam([platform], prompt.select);
+
+    expect(result).toEqual({ kind: "existing", slug: "platform" });
+    expect(prompt.calls).toHaveLength(1);
+    expect(prompt.calls[0]?.options).toEqual([
+      {
+        value: "create",
+        label: "+ Create a new team",
+      },
+      {
+        value: "existing",
+        label: "Use #platform",
+      },
+    ]);
+    expect(prompt.calls[0]?.initialValue).toBe("existing");
+  });
+
+  test("keeps create outside the team selector when several teams exist", async () => {
+    const prompt = makeSelect("existing", "web");
+
+    const result = await chooseProjectTeam([platform, web], prompt.select);
+
+    expect(result).toEqual({ kind: "existing", slug: "web" });
+    expect(prompt.calls).toHaveLength(2);
+    expect(prompt.calls[0]?.options).toEqual([
+      { value: "create", label: "+ Create a new team" },
+      { value: "existing", label: "Select an existing team" },
+    ]);
+    expect(prompt.calls[1]?.message).toBe("Select an existing team");
+    expect(prompt.calls[1]?.options).toEqual([
+      { value: "platform", label: "#platform", hint: "Platform" },
+      { value: "web", label: "#web", hint: "Web" },
+    ]);
+    expect(
+      prompt.calls[1]?.options.some((option) => option.value === "create")
+    ).toBe(false);
+  });
+
+  test("does not open the team selector after create is chosen", async () => {
+    const prompt = makeSelect("create");
+
+    const result = await chooseProjectTeam([platform, web], prompt.select);
+
+    expect(result).toEqual({ kind: "create" });
+    expect(prompt.calls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

- make `sentry init` resolve the organization early, then resolve the project from the concrete selected application instead of the monorepo root
- reuse an existing project only for an unambiguous canonical repository match; otherwise keep create-new as the default path
- share project and team creation policy between `sentry init` and `sentry project create`, including complete team pagination, Team Admin choices, personal-team creation, and accurate organization-policy errors
- surface detected installations as an explicit improve-existing flow while preserving the separate use-or-create-another-project path
- carry detected features into the richer feature selector and keep the existing DSN expression and setup structure intact
- improve monorepo target labels and roles using repository name, workspace manifests, framework/deployment configuration, and package structure
- keep create-new-team visible above the team list, open the Files view at the top, and remove transient setup-analysis chrome between selections

## OAuth support

Merged PR #1373 adds `team:admin` to the standard OAuth scope set and supports one bounded refresh for older eligible interactive grants. Unattended, JSON, dry-run, and environment-token execution do not start OAuth.

## Validation

- `pnpm --filter sentry typecheck`
- 144 focused tests covering project creation, team resolution, init preflight, and the init project tool
- 44 Ink UI tests under `CI=1`, including repeated transition coverage
- scoped Biome checks and `git diff --check`
- the previous rebased revision passed the complete GitHub unit, lint/typecheck, E2E, binary, package, and security workflows

Closes #1375.

Terminal-height overflow remains separate in #1376.
## Follow-up: large existing files

- keep model reads paginated while checking the complete local before/after contents before any file-change batch is written
- preserve detected initialization, DSN and environment sources, known feature configuration, and source-map settings without requiring a complete server-side cache entry
- retain a valid resolved project when another DSN cannot be resolved; the selected setup DSN must still match before reuse
- 61 focused file-change/detection tests, CLI typecheck, scoped Biome, and diff checks pass

Known limitation: a single source line longer than the 40 KB read page is not yet readable by the agent.
