### PR TITLE
fix(init): refresh auth before wizard startup

### DIFF
--- a/apps/cli-docs/src/fragments/commands/init.md
+++ b/apps/cli-docs/src/fragments/commands/init.md
@@ -2,7 +2,7 @@
 
 > **Experimental:** `sentry init` is experimental and may modify your source files. Always review changes before committing.
 
-**Prerequisites:** You must be authenticated first. Run `sentry auth` if you haven't already.
+**Authentication:** Interactive runs start the OAuth login flow automatically when credentials are missing or the stored session has expired. Non-interactive and CI runs must authenticate before running `sentry init`.
 
 ## Examples
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -247,6 +247,9 @@ export async function runCli(cliArgs: string[]): Promise<void> {
     "./lib/auto-auth.js"
   );
   const { getEnvLogLevel, setLogLevel } = await import("./lib/logger.js");
+  const { scheduleInitForceExitIfRequested } = await import(
+    "./lib/init/force-exit.js"
+  );
   const { isTrialEligible, promptAndStartTrial } = await import(
     "./lib/seer-trial.js"
   );
@@ -722,6 +725,9 @@ export async function runCli(cliArgs: string[]): Promise<void> {
   } finally {
     // Abort any pending version check to allow clean exit
     abortPendingVersionCheck();
+    // Runs after auto-auth, scope recovery, and command retry have reached a
+    // terminal result, so the init-specific macOS timer cannot interrupt them.
+    scheduleInitForceExitIfRequested();
   }
 
   // Show update notification after command completes

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -23,6 +23,7 @@ import type { SentryContext } from "../context.js";
 import { findProjectsBySlug } from "../lib/api/projects.js";
 import { looksLikePath, parseOrgProjectArg } from "../lib/arg-parsing.js";
 import { buildCommand } from "../lib/command.js";
+import { refreshToken } from "../lib/db/auth.js";
 import { ContextError, ValidationError } from "../lib/errors.js";
 import { warmOrgDetection } from "../lib/init/org-prefetch.js";
 import { runWizard } from "../lib/init/wizard-runner.js";
@@ -399,6 +400,11 @@ export const initCommand = buildCommand<
     //    the name for a new project (org resolved later by the wizard).
     const { org: explicitOrg, project: explicitProject } =
       await resolveTarget(targetArg);
+
+    // Mastra requires an explicit bearer, unlike regular Sentry API requests
+    // that refresh OAuth lazily. Resolve it before opening the wizard so an
+    // AuthError can trigger auto-login without leaving a stale screen behind.
+    await refreshToken();
 
     // 5. Start background org detection when org is not yet known.
     //    The prefetch runs concurrently with the preamble, the wizard startup,

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -18,15 +18,14 @@
  */
 
 import path from "node:path";
-import { isatty } from "node:tty";
 import { setTag } from "@sentry/node-core/light";
 import type { SentryContext } from "../context.js";
 import { findProjectsBySlug } from "../lib/api/projects.js";
 import { looksLikePath, parseOrgProjectArg } from "../lib/arg-parsing.js";
-import { shouldAutoAuth } from "../lib/auto-auth.js";
 import { buildCommand } from "../lib/command.js";
 import { refreshToken } from "../lib/db/auth.js";
 import { ContextError, ValidationError } from "../lib/errors.js";
+import { requestInitForceExit } from "../lib/init/force-exit.js";
 import { warmOrgDetection } from "../lib/init/org-prefetch.js";
 import { runWizard } from "../lib/init/wizard-runner.js";
 import { validateResourceId } from "../lib/input-validation.js";
@@ -368,6 +367,7 @@ export const initCommand = buildCommand<
       t: "team",
     },
   },
+  // biome-ignore lint/correctness/useYield: init renders through WizardUI instead of command output
   async *func(
     this: SentryContext,
     flags: InitFlags,
@@ -416,61 +416,23 @@ export const initCommand = buildCommand<
       warmOrgDetection(targetDir);
     }
 
-    // 6. Run the wizard.
-    //
-    // Wrapped in try/catch/finally so the macOS force-exit safety net (step 7)
-    // is scheduled on terminal exit paths without interrupting the global
-    // auto-auth middleware when it owns login and command retry.
-    let deferForceExitToAutoAuth = false;
-    try {
-      await runWizard({
-        directory: targetDir,
-        yes: flags.yes,
-        dryRun: flags["dry-run"],
-        features: featuresList,
-        team: flags.team,
-        app: flags.app,
-        org: explicitOrg,
-        project: explicitProject,
-        // `flags.tui` defaults to `true`. `--no-tui` (auto-generated
-        // by stricli's flag negation) flips it to `false` — that's the
-        // signal we forward to the factory as `forceLegacyUi`.
-        forceLegacyUi: flags.tui === false,
-      });
-    } catch (error) {
-      deferForceExitToAutoAuth = shouldAutoAuth(error, () => isatty(0));
-      throw error;
-    } finally {
-      // 7. macOS-only force-exit safety net.
-      //
-      // On Darwin, `InkUI` opens a fresh `/dev/tty` `tty.ReadStream`
-      // (so Ink's `useInput` actually receives keystrokes — Bun's
-      // `process.stdin` doesn't deliver `readable` events properly,
-      // see oven-sh/bun#6862 / vadimdemedes/ink#636). The fresh
-      // stream is destroyed in the InkUI dispose path, but Bun's
-      // libuv handle for it can linger past `destroy()` on Darwin
-      // (oven-sh/bun#29126), keeping the event loop ref'd so the
-      // process hangs until the user presses a key.
-      //
-      // The .unref() timer doesn't hold the loop itself, so it's a no-op
-      // in the happy path (Linux: handle drains naturally; `--yes`
-      // on Darwin: LoggingUI doesn't open /dev/tty, may still drain
-      // naturally). On the Darwin hang path, it force-exits after a
-      // 100ms grace window — imperceptible to the user and enough
-      // for Sentry telemetry + stdio flushes to complete first.
-      //
-      // Skipped under `bun test` (which sets NODE_ENV=test automatically)
-      // because the test runner calls `initCommand.func` directly; an
-      // unref'd timer would still fire and terminate the runner mid-suite.
-      if (
-        !deferForceExitToAutoAuth &&
-        process.platform === "darwin" &&
-        process.env.NODE_ENV !== "test"
-      ) {
-        setTimeout(() => {
-          process.exit(process.exitCode ?? 0);
-        }, 100).unref();
-      }
-    }
+    // 6. Run the wizard. The outer CLI pipeline schedules the macOS/Bun
+    // force-exit safety net after recovery middleware (including auto-auth)
+    // has finished, so it cannot interrupt login or command retry.
+    requestInitForceExit();
+    await runWizard({
+      directory: targetDir,
+      yes: flags.yes,
+      dryRun: flags["dry-run"],
+      features: featuresList,
+      team: flags.team,
+      app: flags.app,
+      org: explicitOrg,
+      project: explicitProject,
+      // `flags.tui` defaults to `true`. `--no-tui` (auto-generated
+      // by stricli's flag negation) flips it to `false` — that's the
+      // signal we forward to the factory as `forceLegacyUi`.
+      forceLegacyUi: flags.tui === false,
+    });
   },
 });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -18,10 +18,12 @@
  */
 
 import path from "node:path";
+import { isatty } from "node:tty";
 import { setTag } from "@sentry/node-core/light";
 import type { SentryContext } from "../context.js";
 import { findProjectsBySlug } from "../lib/api/projects.js";
 import { looksLikePath, parseOrgProjectArg } from "../lib/arg-parsing.js";
+import { shouldAutoAuth } from "../lib/auto-auth.js";
 import { buildCommand } from "../lib/command.js";
 import { refreshToken } from "../lib/db/auth.js";
 import { ContextError, ValidationError } from "../lib/errors.js";
@@ -416,11 +418,10 @@ export const initCommand = buildCommand<
 
     // 6. Run the wizard.
     //
-    // Wrapped in try/finally so the macOS force-exit safety net (step 7)
-    // is scheduled on every exit path: success, WizardError, user cancel,
-    // and any other thrown error. Without finally, a thrown WizardError
-    // would skip the timer and the process would hang on the error
-    // display — exactly what Cursor Bugbot flagged on an earlier revision.
+    // Wrapped in try/catch/finally so the macOS force-exit safety net (step 7)
+    // is scheduled on terminal exit paths without interrupting the global
+    // auto-auth middleware when it owns login and command retry.
+    let deferForceExitToAutoAuth = false;
     try {
       await runWizard({
         directory: targetDir,
@@ -436,6 +437,9 @@ export const initCommand = buildCommand<
         // signal we forward to the factory as `forceLegacyUi`.
         forceLegacyUi: flags.tui === false,
       });
+    } catch (error) {
+      deferForceExitToAutoAuth = shouldAutoAuth(error, () => isatty(0));
+      throw error;
     } finally {
       // 7. macOS-only force-exit safety net.
       //
@@ -458,7 +462,11 @@ export const initCommand = buildCommand<
       // Skipped under `bun test` (which sets NODE_ENV=test automatically)
       // because the test runner calls `initCommand.func` directly; an
       // unref'd timer would still fire and terminate the runner mid-suite.
-      if (process.platform === "darwin" && process.env.NODE_ENV !== "test") {
+      if (
+        !deferForceExitToAutoAuth &&
+        process.platform === "darwin" &&
+        process.env.NODE_ENV !== "test"
+      ) {
         setTimeout(() => {
           process.exit(process.exitCode ?? 0);
         }, 100).unref();

--- a/packages/cli/src/lib/init/force-exit.ts
+++ b/packages/cli/src/lib/init/force-exit.ts
@@ -1,0 +1,32 @@
+/**
+ * macOS/Bun can retain the fresh `/dev/tty` handle used by the init UI after
+ * teardown. Track when init is about to enter the wizard, then schedule the
+ * existing force-exit safety net only after the CLI's outer recovery
+ * middleware has finished. This keeps OAuth login/retry alive while still
+ * covering success, cancellation, and terminal error paths.
+ */
+
+let initForceExitRequested = false;
+
+/** Mark that an init run may need the macOS force-exit safety net. */
+export function requestInitForceExit(): void {
+  initForceExitRequested = true;
+}
+
+/**
+ * Schedule the requested safety net after all CLI recovery middleware has
+ * completed. The unref'd timer only fires when another handle keeps the event
+ * loop alive, so it remains a no-op on normal exits.
+ */
+export function scheduleInitForceExitIfRequested(): void {
+  if (!initForceExitRequested) {
+    return;
+  }
+  initForceExitRequested = false;
+
+  if (process.platform === "darwin" && process.env.NODE_ENV !== "test") {
+    setTimeout(() => {
+      process.exit(process.exitCode ?? 0);
+    }, 100).unref();
+  }
+}

--- a/packages/cli/src/lib/init/preflight.ts
+++ b/packages/cli/src/lib/init/preflight.ts
@@ -5,7 +5,7 @@ import {
   listTeams,
 } from "../api-client.js";
 import { getAuthToken } from "../db/auth.js";
-import { ApiError, WizardError } from "../errors.js";
+import { ApiError, AuthError, HostScopeError, WizardError } from "../errors.js";
 import { buildOrgNotFoundError, resolveOrCreateTeam } from "../resolve-team.js";
 import { slugify } from "../utils.js";
 import { WizardCancelledError } from "./clack-utils.js";
@@ -80,6 +80,10 @@ async function withPreflightHandling(
       ui.feedback("cancelled");
       process.exitCode = 0;
       return null;
+    }
+
+    if (error instanceof AuthError || error instanceof HostScopeError) {
+      throw error;
     }
 
     const message = error instanceof Error ? error.message : String(error);
@@ -316,6 +320,9 @@ async function resolveExistingProjectChoice(opts: {
  * format() instead of collapsing to its bare message + status line.
  */
 function toPreflightWizardError(error: unknown): WizardError {
+  if (error instanceof AuthError || error instanceof HostScopeError) {
+    throw error;
+  }
   if (error instanceof WizardError) {
     return error;
   }

--- a/packages/cli/src/lib/init/readiness.ts
+++ b/packages/cli/src/lib/init/readiness.ts
@@ -1,13 +1,12 @@
 /**
- * Pre-Flight Readiness Check
+ * Setup Service Readiness Check
  *
- * Verifies critical dependencies before entering the wizard flow.
- * Fails fast with actionable errors instead of failing mid-run.
+ * Checks setup-service availability before entering the remote workflow and
+ * warns when it may be slow or unreachable. Authentication is handled before
+ * the wizard UI is created.
  */
 
 import { customFetch } from "../custom-ca.js";
-import { getAuthToken } from "../db/auth.js";
-import { WizardError } from "../errors.js";
 import { logger } from "../logger.js";
 import { MASTRA_API_URL } from "./constants.js";
 import type { WizardUI } from "./ui/types.js";
@@ -16,39 +15,15 @@ import type { WizardUI } from "./ui/types.js";
 const HEALTH_CHECK_TIMEOUT_MS = 5000;
 
 /**
- * Run pre-flight checks: auth token present, Mastra API reachable.
- * Throws `WizardError` on hard failures; logs warnings for soft issues.
+ * Check whether the setup service is reachable before starting the workflow.
+ * Authentication is resolved before the wizard UI is created so recoverable
+ * OAuth failures can use the CLI's global auto-auth flow.
  */
 export async function checkReadiness(ui: WizardUI): Promise<void> {
   const spin = ui.spinner();
   spin.start("Checking prerequisites...");
 
-  const [authResult, apiResult] = await Promise.allSettled([
-    checkAuth(),
-    checkMastraApi(),
-  ]);
-
-  const authOk = authResult.status === "fulfilled" && authResult.value;
-  const apiOk = apiResult.status === "fulfilled" && apiResult.value;
-
-  if (!(authOk || apiOk)) {
-    spin.stop("Prerequisites failed", 1);
-    ui.log.error("Authentication and setup service are both unavailable.");
-    ui.log.info("Run `sentry auth login` to authenticate.");
-    ui.log.info("Check your network connection and try again.");
-    ui.cancel("Setup failed");
-    ui.feedback("failed");
-    throw new WizardError("Pre-flight checks failed");
-  }
-
-  if (!authOk) {
-    spin.stop("Prerequisites failed", 1);
-    ui.log.error("No authentication token found.");
-    ui.log.info("Run `sentry auth login` to authenticate, then try again.");
-    ui.cancel("Setup failed");
-    ui.feedback("failed");
-    throw new WizardError("Not authenticated");
-  }
+  const apiOk = await checkMastraApi();
 
   if (apiOk) {
     spin.stop("");
@@ -58,11 +33,6 @@ export async function checkReadiness(ui: WizardUI): Promise<void> {
       "Setup service may be slow or unreachable. The wizard will retry if needed."
     );
   }
-}
-
-async function checkAuth(): Promise<boolean> {
-  const token = await getAuthToken();
-  return token !== undefined && token !== "";
 }
 
 async function checkMastraApi(): Promise<boolean> {

--- a/packages/cli/src/lib/init/stdin-reopen.ts
+++ b/packages/cli/src/lib/init/stdin-reopen.ts
@@ -21,9 +21,9 @@
  * `process.platform === "darwin"`. It comes with a side cost — opening a
  * second `tty.ReadStream` leaks a libuv handle that keeps the event loop
  * alive after the wizard completes (upstream oven-sh/bun#29126), so the
- * `initCommand.func` caller pairs this install with a
- * `setTimeout(process.exit, 100).unref()` safety net to force-exit on
- * macOS once the wizard returns.
+ * outer CLI pipeline pairs init with a
+ * `setTimeout(process.exit, 100).unref()` safety net after recovery
+ * middleware finishes.
  */
 
 import { openSync } from "node:fs";

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -12,6 +12,8 @@ import { initCommand } from "../../src/commands/init.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as projectsApi from "../../src/lib/api/projects.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
+import * as autoAuthModule from "../../src/lib/auto-auth.js";
+// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as authModule from "../../src/lib/db/auth.js";
 import {
   AuthError,
@@ -301,6 +303,51 @@ describe("init command func", () => {
 
       expect(warmSpy).not.toHaveBeenCalled();
       expect(runWizardSpy).not.toHaveBeenCalled();
+    });
+
+    test("does not schedule the macOS force-exit timer during auto-auth", async () => {
+      const authError = new AuthError("expired");
+      runWizardSpy.mockRejectedValueOnce(authError);
+      const shouldAutoAuthSpy = vi
+        .spyOn(autoAuthModule, "shouldAutoAuth")
+        .mockReturnValue(true);
+      const timeout = { unref: vi.fn() } as unknown as ReturnType<
+        typeof setTimeout
+      >;
+      const setTimeoutSpy = vi
+        .spyOn(globalThis, "setTimeout")
+        .mockReturnValue(timeout);
+      const originalPlatform = process.platform;
+      const originalNodeEnv = process.env.NODE_ENV;
+      Object.defineProperty(process, "platform", {
+        value: "darwin",
+        configurable: true,
+      });
+      process.env.NODE_ENV = "production";
+
+      try {
+        await expect(func.call(makeContext(), DEFAULT_FLAGS)).rejects.toBe(
+          authError
+        );
+
+        expect(shouldAutoAuthSpy).toHaveBeenCalledWith(
+          authError,
+          expect.any(Function)
+        );
+        expect(setTimeoutSpy).not.toHaveBeenCalled();
+      } finally {
+        shouldAutoAuthSpy.mockRestore();
+        setTimeoutSpy.mockRestore();
+        Object.defineProperty(process, "platform", {
+          value: originalPlatform,
+          configurable: true,
+        });
+        if (originalNodeEnv === undefined) {
+          delete process.env.NODE_ENV;
+        } else {
+          process.env.NODE_ENV = originalNodeEnv;
+        }
+      }
     });
   });
 

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -12,14 +12,14 @@ import { initCommand } from "../../src/commands/init.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as projectsApi from "../../src/lib/api/projects.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
-import * as autoAuthModule from "../../src/lib/auto-auth.js";
-// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as authModule from "../../src/lib/db/auth.js";
 import {
   AuthError,
   ContextError,
   ValidationError,
 } from "../../src/lib/errors.js";
+// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
+import * as forceExitModule from "../../src/lib/init/force-exit.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as prefetchNs from "../../src/lib/init/org-prefetch.js";
 import { resetPrefetch } from "../../src/lib/init/org-prefetch.js";
@@ -39,6 +39,7 @@ let runWizardSpy: ReturnType<typeof spyOn>;
 let findProjectsSpy: ReturnType<typeof spyOn>;
 let warmSpy: ReturnType<typeof spyOn>;
 let refreshTokenSpy: ReturnType<typeof spyOn>;
+let requestForceExitSpy: ReturnType<typeof spyOn>;
 
 const func = (await initCommand.loader()) as unknown as (
   this: {
@@ -91,6 +92,7 @@ beforeEach(() => {
   refreshTokenSpy = vi
     .spyOn(authModule, "refreshToken")
     .mockResolvedValue({ token: "oauth-token", refreshed: false });
+  requestForceExitSpy = vi.spyOn(forceExitModule, "requestInitForceExit");
 });
 
 afterEach(() => {
@@ -98,6 +100,8 @@ afterEach(() => {
   findProjectsSpy.mockRestore();
   warmSpy.mockRestore();
   refreshTokenSpy.mockRestore();
+  requestForceExitSpy.mockRestore();
+  forceExitModule.scheduleInitForceExitIfRequested();
   resetPrefetch();
 });
 
@@ -289,9 +293,11 @@ describe("init command func", () => {
       expect(refreshTokenSpy).toHaveBeenCalledTimes(1);
       const refreshOrder = refreshTokenSpy.mock.invocationCallOrder[0];
       const warmOrder = warmSpy.mock.invocationCallOrder[0];
+      const forceExitOrder = requestForceExitSpy.mock.invocationCallOrder[0];
       const wizardOrder = runWizardSpy.mock.invocationCallOrder[0];
       expect(refreshOrder).toBeLessThan(warmOrder ?? 0);
-      expect(refreshOrder).toBeLessThan(wizardOrder ?? 0);
+      expect(refreshOrder).toBeLessThan(forceExitOrder ?? 0);
+      expect(forceExitOrder).toBeLessThan(wizardOrder ?? 0);
     });
 
     test("propagates AuthError before background work or wizard startup", async () => {
@@ -302,52 +308,8 @@ describe("init command func", () => {
       await expect(func.call(ctx, DEFAULT_FLAGS)).rejects.toBe(authError);
 
       expect(warmSpy).not.toHaveBeenCalled();
+      expect(requestForceExitSpy).not.toHaveBeenCalled();
       expect(runWizardSpy).not.toHaveBeenCalled();
-    });
-
-    test("does not schedule the macOS force-exit timer during auto-auth", async () => {
-      const authError = new AuthError("expired");
-      runWizardSpy.mockRejectedValueOnce(authError);
-      const shouldAutoAuthSpy = vi
-        .spyOn(autoAuthModule, "shouldAutoAuth")
-        .mockReturnValue(true);
-      const timeout = { unref: vi.fn() } as unknown as ReturnType<
-        typeof setTimeout
-      >;
-      const setTimeoutSpy = vi
-        .spyOn(globalThis, "setTimeout")
-        .mockReturnValue(timeout);
-      const originalPlatform = process.platform;
-      const originalNodeEnv = process.env.NODE_ENV;
-      Object.defineProperty(process, "platform", {
-        value: "darwin",
-        configurable: true,
-      });
-      process.env.NODE_ENV = "production";
-
-      try {
-        await expect(func.call(makeContext(), DEFAULT_FLAGS)).rejects.toBe(
-          authError
-        );
-
-        expect(shouldAutoAuthSpy).toHaveBeenCalledWith(
-          authError,
-          expect.any(Function)
-        );
-        expect(setTimeoutSpy).not.toHaveBeenCalled();
-      } finally {
-        shouldAutoAuthSpy.mockRestore();
-        setTimeoutSpy.mockRestore();
-        Object.defineProperty(process, "platform", {
-          value: originalPlatform,
-          configurable: true,
-        });
-        if (originalNodeEnv === undefined) {
-          delete process.env.NODE_ENV;
-        } else {
-          process.env.NODE_ENV = originalNodeEnv;
-        }
-      }
     });
   });
 

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -11,7 +11,13 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { initCommand } from "../../src/commands/init.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as projectsApi from "../../src/lib/api/projects.js";
-import { ContextError, ValidationError } from "../../src/lib/errors.js";
+// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
+import * as authModule from "../../src/lib/db/auth.js";
+import {
+  AuthError,
+  ContextError,
+  ValidationError,
+} from "../../src/lib/errors.js";
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as prefetchNs from "../../src/lib/init/org-prefetch.js";
 import { resetPrefetch } from "../../src/lib/init/org-prefetch.js";
@@ -30,6 +36,7 @@ let capturedArgs: Record<string, unknown> | undefined;
 let runWizardSpy: ReturnType<typeof spyOn>;
 let findProjectsSpy: ReturnType<typeof spyOn>;
 let warmSpy: ReturnType<typeof spyOn>;
+let refreshTokenSpy: ReturnType<typeof spyOn>;
 
 const func = (await initCommand.loader()) as unknown as (
   this: {
@@ -79,12 +86,16 @@ beforeEach(() => {
     // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op mock
     () => {}
   );
+  refreshTokenSpy = vi
+    .spyOn(authModule, "refreshToken")
+    .mockResolvedValue({ token: "oauth-token", refreshed: false });
 });
 
 afterEach(() => {
   runWizardSpy.mockRestore();
   findProjectsSpy.mockRestore();
   warmSpy.mockRestore();
+  refreshTokenSpy.mockRestore();
   resetPrefetch();
 });
 
@@ -264,6 +275,32 @@ describe("init command func", () => {
       await func.call(ctx, { yes: false, "dry-run": true });
       expect(capturedArgs?.dryRun).toBe(true);
       expect(runWizardSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("authentication preflight", () => {
+    test("refreshes auth before background work and wizard startup", async () => {
+      const ctx = makeContext();
+
+      await func.call(ctx, DEFAULT_FLAGS);
+
+      expect(refreshTokenSpy).toHaveBeenCalledTimes(1);
+      const refreshOrder = refreshTokenSpy.mock.invocationCallOrder[0];
+      const warmOrder = warmSpy.mock.invocationCallOrder[0];
+      const wizardOrder = runWizardSpy.mock.invocationCallOrder[0];
+      expect(refreshOrder).toBeLessThan(warmOrder ?? 0);
+      expect(refreshOrder).toBeLessThan(wizardOrder ?? 0);
+    });
+
+    test("propagates AuthError before background work or wizard startup", async () => {
+      const authError = new AuthError("expired");
+      refreshTokenSpy.mockRejectedValueOnce(authError);
+      const ctx = makeContext();
+
+      await expect(func.call(ctx, DEFAULT_FLAGS)).rejects.toBe(authError);
+
+      expect(warmSpy).not.toHaveBeenCalled();
+      expect(runWizardSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/test/lib/init/force-exit.test.ts
+++ b/packages/cli/test/lib/init/force-exit.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  requestInitForceExit,
+  scheduleInitForceExitIfRequested,
+} from "../../../src/lib/init/force-exit.js";
+
+const originalPlatform = process.platform;
+const originalNodeEnv = process.env.NODE_ENV;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  setPlatform("linux");
+  process.env.NODE_ENV = "test";
+  scheduleInitForceExitIfRequested();
+});
+
+afterEach(() => {
+  process.env.NODE_ENV = "test";
+  scheduleInitForceExitIfRequested();
+  vi.restoreAllMocks();
+  setPlatform(originalPlatform);
+  if (originalNodeEnv === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = originalNodeEnv;
+  }
+});
+
+describe("init force-exit safety net", () => {
+  test("does nothing until init requests the safety net", () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    scheduleInitForceExitIfRequested();
+
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+
+  test("schedules the macOS safety net after the outer pipeline finishes", () => {
+    const unref = vi.fn();
+    const timeout = { unref } as unknown as ReturnType<typeof setTimeout>;
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockReturnValue(timeout);
+    setPlatform("darwin");
+    process.env.NODE_ENV = "production";
+    requestInitForceExit();
+
+    scheduleInitForceExitIfRequested();
+
+    expect(setTimeoutSpy).toHaveBeenCalledOnce();
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 100);
+    expect(unref).toHaveBeenCalledOnce();
+  });
+
+  test("consumes requests without scheduling outside macOS", () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    requestInitForceExit();
+
+    scheduleInitForceExitIfRequested();
+    setPlatform("darwin");
+    process.env.NODE_ENV = "production";
+    scheduleInitForceExitIfRequested();
+
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/lib/init/preflight.test.ts
+++ b/packages/cli/test/lib/init/preflight.test.ts
@@ -46,7 +46,12 @@ vi.mock("../../../src/lib/dsn/index.js", async (importOriginal) => {
 
 // biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
 import * as dsnIndex from "../../../src/lib/dsn/index.js";
-import { ApiError, WizardError } from "../../../src/lib/errors.js";
+import {
+  ApiError,
+  AuthError,
+  HostScopeError,
+  WizardError,
+} from "../../../src/lib/errors.js";
 
 vi.mock("../../../src/lib/init/org-prefetch.js", async (importOriginal) => {
   const actual =
@@ -640,6 +645,20 @@ describe("resolveInitContext", () => {
         c.kind === "log.error"
     );
     expect(errorCall?.message).toBe("custom preflight failure");
+  });
+
+  test.each([
+    ["AuthError", new AuthError("expired")],
+    ["HostScopeError", new HostScopeError("host mismatch")],
+  ])("propagates %s without turning it into a wizard failure", async (_, error) => {
+    listTeamsSpy.mockRejectedValueOnce(error);
+
+    const { ui, calls } = createMockUI();
+    await expect(resolveInitContext(makeOptions(), ui)).rejects.toBe(error);
+
+    expect(calls.some((call) => call.kind === "log.error")).toBe(false);
+    expect(calls.some((call) => call.kind === "cancel")).toBe(false);
+    expect(calls.some((call) => call.kind === "feedback")).toBe(false);
   });
 
   test("surfaces a non-API error message from implicit team resolution", async () => {

--- a/packages/cli/test/lib/init/readiness.test.ts
+++ b/packages/cli/test/lib/init/readiness.test.ts
@@ -1,7 +1,4 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-// biome-ignore lint/performance/noNamespaceImport: spyOn requires object reference
-import * as authModule from "../../../src/lib/db/auth.js";
-import { WizardError } from "../../../src/lib/errors.js";
 import { checkReadiness } from "../../../src/lib/init/readiness.js";
 import type { WizardUI } from "../../../src/lib/init/ui/types.js";
 
@@ -62,22 +59,18 @@ function makeUI(): { ui: WizardUI; errors: string[]; warns: string[] } {
 const OK_RESPONSE = new Response(null, { status: 200 });
 const ERR_RESPONSE = new Response(null, { status: 503 });
 
-let getAuthTokenSpy: ReturnType<typeof spyOn>;
 let fetchSpy: ReturnType<typeof spyOn>;
 
 beforeEach(() => {
-  getAuthTokenSpy = vi.spyOn(authModule, "getAuthToken");
   fetchSpy = vi.spyOn(globalThis, "fetch");
 });
 
 afterEach(() => {
-  getAuthTokenSpy.mockRestore();
   fetchSpy.mockRestore();
 });
 
 describe("checkReadiness", () => {
-  test("resolves without error when auth and API are both ok", async () => {
-    getAuthTokenSpy.mockResolvedValue("tok_test");
+  test("resolves without error when the setup service is reachable", async () => {
     fetchSpy.mockResolvedValue(OK_RESPONSE.clone());
     const { ui, errors, warns } = makeUI();
     await expect(checkReadiness(ui)).resolves.toBeUndefined();
@@ -85,8 +78,7 @@ describe("checkReadiness", () => {
     expect(warns).toHaveLength(0);
   });
 
-  test("resolves but logs a warning when auth is ok and API is unreachable", async () => {
-    getAuthTokenSpy.mockResolvedValue("tok_test");
+  test("resolves but logs a warning when the setup service is unreachable", async () => {
     fetchSpy.mockRejectedValue(new Error("network failure"));
     const { ui, errors, warns } = makeUI();
     await expect(checkReadiness(ui)).resolves.toBeUndefined();
@@ -94,30 +86,11 @@ describe("checkReadiness", () => {
     expect(warns.length).toBeGreaterThanOrEqual(1);
   });
 
-  test("resolves but logs a warning when auth is ok and API returns non-ok status", async () => {
-    getAuthTokenSpy.mockResolvedValue("tok_test");
+  test("resolves but logs a warning when the setup service returns non-ok status", async () => {
     fetchSpy.mockResolvedValue(ERR_RESPONSE.clone());
     const { ui, errors, warns } = makeUI();
     await expect(checkReadiness(ui)).resolves.toBeUndefined();
     expect(errors).toHaveLength(0);
     expect(warns.length).toBeGreaterThanOrEqual(1);
-  });
-
-  test("throws WizardError when auth token is missing", async () => {
-    getAuthTokenSpy.mockResolvedValue(undefined);
-    fetchSpy.mockResolvedValue(OK_RESPONSE.clone());
-    const { ui } = makeUI();
-    await expect(checkReadiness(ui)).rejects.toThrow(WizardError);
-    await expect(checkReadiness(ui)).rejects.toThrow("Not authenticated");
-  });
-
-  test("throws WizardError when both auth and API fail", async () => {
-    getAuthTokenSpy.mockResolvedValue(undefined);
-    fetchSpy.mockRejectedValue(new Error("network failure"));
-    const { ui } = makeUI();
-    await expect(checkReadiness(ui)).rejects.toThrow(WizardError);
-    await expect(checkReadiness(ui)).rejects.toThrow(
-      "Pre-flight checks failed"
-    );
   });
 });


### PR DESCRIPTION
## Summary

Make `sentry init` use the CLI's shared OAuth refresh and auto-login path before constructing the wizard UI. An expired stored access token with a valid refresh token is now refreshed immediately; missing or expired interactive credentials reach the global auto-auth middleware, which logs in and retries the command.

The readiness check now only probes the setup service, and init preflight preserves `AuthError` and `HostScopeError` instead of collapsing them into generic wizard failures. On macOS, init requests its existing force-exit safety net and the outer CLI pipeline schedules it only after auth recovery reaches a terminal result, so it cannot interrupt login/retry and still covers failed or cancelled login. Non-interactive runs still require credentials up front.

Closes #1383.

## Test plan

- `pnpm exec vitest run test/commands/init.test.ts test/lib/auto-auth.test.ts test/lib/init` — 35 files, 510 tests passed
- `pnpm run typecheck`
- `pnpm run lint` — 973 files checked
- `pnpm run check:fragments` — passed with the existing unrelated `proguard upload` coverage warning