### PR TITLE
fix(init): keep select prompts within terminal

### DIFF
--- a/packages/cli/src/lib/init/ui/ink-app.tsx
+++ b/packages/cli/src/lib/init/ui/ink-app.tsx
@@ -1277,6 +1277,60 @@ type MultiSelectPromptOptionData = Extract<
   { kind: "multiselect" }
 >["options"][number];
 
+/**
+ * Rows unavailable to option lists: workflow chrome reserves the tab/shortcut
+ * footers, while centered prompts also reserve intro padding, the full banner,
+ * and the extra controls shown by multiselect prompts.
+ */
+const WORKFLOW_PROMPT_RESERVED_ROWS = 10;
+const CENTERED_SELECT_RESERVED_ROWS = 20;
+const CENTERED_MULTISELECT_RESERVED_ROWS = 23;
+
+/**
+ * Returns the half-open option range that keeps the highlighted item visible.
+ * The range never exceeds the requested viewport size or the option count.
+ */
+export function getOptionWindow(
+  totalCount: number,
+  highlighted: number,
+  maxVisible: number
+): readonly [number, number] {
+  const normalizedTotal = Math.max(0, Math.floor(totalCount));
+  if (normalizedTotal === 0) {
+    return [0, 0];
+  }
+
+  const viewportSize = Math.min(
+    normalizedTotal,
+    Math.max(1, Math.floor(maxVisible))
+  );
+  const normalizedHighlight = Math.min(
+    normalizedTotal - 1,
+    Math.max(0, Math.floor(highlighted))
+  );
+  const centeredStart = normalizedHighlight - Math.floor(viewportSize / 2);
+  const start = Math.min(
+    normalizedTotal - viewportSize,
+    Math.max(0, centeredStart)
+  );
+  return [start, start + viewportSize];
+}
+
+function getPromptOptionLimit(
+  terminalRows: number,
+  alignment: PromptAlignment,
+  kind: "select" | "multiselect"
+): number {
+  let reservedRows = WORKFLOW_PROMPT_RESERVED_ROWS;
+  if (alignment === "center") {
+    reservedRows =
+      kind === "multiselect"
+        ? CENTERED_MULTISELECT_RESERVED_ROWS
+        : CENTERED_SELECT_RESERVED_ROWS;
+  }
+  return Math.max(1, terminalRows - reservedRows);
+}
+
 function PromptArea({
   alignment = "start",
   prompt,
@@ -1284,23 +1338,38 @@ function PromptArea({
   alignment?: PromptAlignment;
   prompt: ActivePrompt;
 }): React.ReactNode {
+  const { rows } = useInkFrameSize();
   if (prompt.kind === "select") {
-    return <SelectPrompt alignment={alignment} prompt={prompt} />;
+    return (
+      <SelectPrompt
+        alignment={alignment}
+        maxVisibleOptions={getPromptOptionLimit(rows, alignment, prompt.kind)}
+        prompt={prompt}
+      />
+    );
   }
   if (prompt.kind === "confirm") {
     return <ConfirmPrompt alignment={alignment} prompt={prompt} />;
   }
   if (prompt.kind === "multiselect") {
-    return <MultiSelectPrompt alignment={alignment} prompt={prompt} />;
+    return (
+      <MultiSelectPrompt
+        alignment={alignment}
+        maxVisibleOptions={getPromptOptionLimit(rows, alignment, prompt.kind)}
+        prompt={prompt}
+      />
+    );
   }
   return null;
 }
 
 function SelectPrompt({
   alignment,
+  maxVisibleOptions,
   prompt,
 }: {
   alignment: PromptAlignment;
+  maxVisibleOptions: number;
   prompt: Extract<ActivePrompt, { kind: "select" }>;
 }): React.ReactNode {
   const isCentered = alignment === "center";
@@ -1309,6 +1378,13 @@ function SelectPrompt({
   const [highlighted, setHighlighted] = useState<number>(() =>
     Math.min(Math.max(prompt.initialIndex, 0), Math.max(0, totalCount - 1))
   );
+  const [windowStart, windowEnd] = getOptionWindow(
+    totalCount,
+    highlighted,
+    maxVisibleOptions
+  );
+  const visibleOptions = prompt.options.slice(windowStart, windowEnd);
+  const isWindowed = visibleOptions.length < totalCount;
 
   const shortcuts = useMemo<ShortcutBinding[]>(
     () => [
@@ -1357,8 +1433,13 @@ function SelectPrompt({
       width={promptWidth}
     >
       {isCentered ? (
-        <Box justifyContent="center" marginBottom={1} width="100%">
+        <Box gap={1} justifyContent="center" marginBottom={1} width="100%">
           <Text bold>{prompt.message}</Text>
+          {isWindowed ? (
+            <Text color={MUTED_DIM}>
+              ({highlighted + 1}/{totalCount})
+            </Text>
+          ) : null}
         </Box>
       ) : (
         <Box gap={1} marginBottom={1}>
@@ -1366,10 +1447,16 @@ function SelectPrompt({
             {ICONS.diamondOpen}
           </Text>
           <Text bold>{prompt.message}</Text>
+          {isWindowed ? (
+            <Text color={MUTED_DIM}>
+              ({highlighted + 1}/{totalCount})
+            </Text>
+          ) : null}
         </Box>
       )}
       <Box flexDirection="column" width={promptWidth}>
-        {prompt.options.map((option, idx) => {
+        {visibleOptions.map((option, visibleIndex) => {
+          const idx = windowStart + visibleIndex;
           const isCursor = idx === highlighted;
           return (
             <SelectPromptOptionRow
@@ -1397,7 +1484,13 @@ function SelectPromptOptionRow({
   const labelColor = isCursor ? undefined : MUTED;
   if (centered) {
     return (
-      <Box flexDirection="row" justifyContent="center" width="100%">
+      <Box
+        flexDirection="row"
+        height={1}
+        justifyContent="center"
+        overflow="hidden"
+        width="100%"
+      >
         <Text color={ACCENT}>
           {isCursor ? `${ICONS.triangleSmallRight} ` : "  "}
         </Text>
@@ -1411,7 +1504,7 @@ function SelectPromptOptionRow({
     );
   }
   return (
-    <Box flexDirection="row">
+    <Box flexDirection="row" height={1} overflow="hidden">
       <Box flexShrink={0} width={3}>
         <Text color={ACCENT}>{isCursor ? ICONS.triangleSmallRight : " "}</Text>
       </Box>
@@ -1499,9 +1592,11 @@ function ConfirmPrompt({
 
 function MultiSelectPrompt({
   alignment,
+  maxVisibleOptions,
   prompt,
 }: {
   alignment: PromptAlignment;
+  maxVisibleOptions: number;
   prompt: Extract<ActivePrompt, { kind: "multiselect" }>;
 }): React.ReactNode {
   const isCentered = alignment === "center";
@@ -1511,6 +1606,13 @@ function MultiSelectPrompt({
   );
   const [highlighted, setHighlighted] = useState<number>(0);
   const totalCount = prompt.options.length;
+  const [windowStart, windowEnd] = getOptionWindow(
+    totalCount,
+    highlighted,
+    maxVisibleOptions
+  );
+  const visibleOptions = prompt.options.slice(windowStart, windowEnd);
+  const isWindowed = visibleOptions.length < totalCount;
 
   const toggleAt = useCallback(
     (idx: number) => {
@@ -1596,7 +1698,9 @@ function MultiSelectPrompt({
   );
   useInkShortcuts("multiselect-prompt", shortcuts);
   const shortcutText = `space toggle ${ICONS.bullet} a all ${ICONS.bullet} enter confirm ${ICONS.bullet} esc cancel`;
-  const selectedCount = `${selected.size}/${totalCount}`;
+  const selectedCount = isWindowed
+    ? `${selected.size}/${totalCount} selected ${ICONS.bullet} ${highlighted + 1}/${totalCount}`
+    : `${selected.size}/${totalCount}`;
 
   return (
     <Box
@@ -1632,7 +1736,8 @@ function MultiSelectPrompt({
         </Box>
       ) : null}
       <Box flexDirection="column" width={promptWidth}>
-        {prompt.options.map((option, idx) => {
+        {visibleOptions.map((option, visibleIndex) => {
+          const idx = windowStart + visibleIndex;
           const isSelected = selected.has(option.value);
           const isCursor = idx === highlighted;
           return (
@@ -1665,7 +1770,13 @@ function MultiSelectPromptOptionRow({
   const markerColor = isSelected ? COLOR_SUCCESS : MUTED_DIM;
   if (centered) {
     return (
-      <Box flexDirection="row" justifyContent="center" width="100%">
+      <Box
+        flexDirection="row"
+        height={1}
+        justifyContent="center"
+        overflow="hidden"
+        width="100%"
+      >
         <Text color={ACCENT}>
           {isCursor ? `${ICONS.triangleSmallRight} ` : "  "}
         </Text>
@@ -1678,7 +1789,7 @@ function MultiSelectPromptOptionRow({
     );
   }
   return (
-    <Box flexDirection="row">
+    <Box flexDirection="row" height={1} overflow="hidden">
       <Box flexShrink={0} width={3}>
         <Text color={ACCENT}>{isCursor ? ICONS.triangleSmallRight : " "}</Text>
       </Box>

--- a/packages/cli/src/lib/init/ui/ink-app.tsx
+++ b/packages/cli/src/lib/init/ui/ink-app.tsx
@@ -35,6 +35,8 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import stringWidth from "string-width";
+import wrapAnsi from "wrap-ansi";
 import {
   type BannerLine,
   bannerLinesForWidth,
@@ -393,7 +395,7 @@ function ActivityPane({
         </Box>
       )}
       {visibleLogs.length > 0 ? (
-        <Box flexDirection="column">
+        <Box flexDirection="column" flexShrink={1} overflow="hidden">
           {visibleLogs.map((log) => (
             <LogLine entry={log} key={log.id} />
           ))}
@@ -401,7 +403,12 @@ function ActivityPane({
       ) : null}
       {spinner.active ? <SpinnerRow state={spinner} /> : null}
       {summary ? <SummaryPanel summary={summary} /> : null}
-      {prompt ? <PromptArea prompt={prompt} /> : null}
+      {prompt ? (
+        <PromptArea
+          occupiedRows={visibleLogs.length + (spinner.active ? 2 : 0)}
+          prompt={prompt}
+        />
+      ) : null}
     </Box>
   );
 }
@@ -719,7 +726,11 @@ function IntroPreflightContent({
 
   const promptContent = prompt ? (
     <Box alignItems="center" width="100%">
-      <PromptArea alignment="center" prompt={prompt} />
+      <PromptArea
+        alignment="center"
+        occupiedRows={spinner.active ? 2 : 0}
+        prompt={prompt}
+      />
     </Box>
   ) : null;
 
@@ -1316,11 +1327,19 @@ export function getOptionWindow(
   return [start, start + viewportSize];
 }
 
-function getPromptOptionLimit(
-  terminalRows: number,
-  alignment: PromptAlignment,
-  kind: "select" | "multiselect"
-): number {
+function getPromptOptionLimit({
+  terminalRows,
+  alignment,
+  kind,
+  occupiedRows,
+  messageRows,
+}: {
+  terminalRows: number;
+  alignment: PromptAlignment;
+  kind: "select" | "multiselect";
+  occupiedRows: number;
+  messageRows: number;
+}): number {
   let reservedRows = WORKFLOW_PROMPT_RESERVED_ROWS;
   if (alignment === "center") {
     reservedRows =
@@ -1328,22 +1347,86 @@ function getPromptOptionLimit(
         ? CENTERED_MULTISELECT_RESERVED_ROWS
         : CENTERED_SELECT_RESERVED_ROWS;
   }
-  return Math.max(1, terminalRows - reservedRows);
+  const extraMessageRows = Math.max(0, messageRows - 1);
+  return Math.max(
+    1,
+    terminalRows - reservedRows - occupiedRows - extraMessageRows
+  );
+}
+
+function getPromptContentWidth(
+  terminalColumns: number,
+  alignment: PromptAlignment
+): number {
+  const frameWidth = getInkFrameWidth(terminalColumns);
+  if (alignment === "center") {
+    return Math.min(frameWidth, 84);
+  }
+  return frameWidth >= 80 ? Math.floor((frameWidth - 1) * 0.6) : frameWidth;
+}
+
+function getPromptMessageRows({
+  message,
+  terminalColumns,
+  alignment,
+  kind,
+  totalCount,
+}: {
+  message: string;
+  terminalColumns: number;
+  alignment: PromptAlignment;
+  kind: "select" | "multiselect";
+  totalCount: number;
+}): number {
+  let availableWidth = getPromptContentWidth(terminalColumns, alignment);
+  const countDigits = String(Math.max(1, totalCount)).length;
+
+  if (kind === "select") {
+    const positionWidth = stringWidth(
+      `(${"9".repeat(countDigits)}/${"9".repeat(countDigits)})`
+    );
+    availableWidth -= positionWidth + (alignment === "center" ? 1 : 3);
+  } else if (alignment === "start") {
+    const count = "9".repeat(countDigits);
+    availableWidth -=
+      stringWidth(`${count}/${count} selected • ${count}/${count}`) + 4;
+  }
+
+  return wrapAnsi(message, Math.max(1, availableWidth), {
+    hard: true,
+    trim: false,
+    wordWrap: true,
+  }).split("\n").length;
 }
 
 function PromptArea({
   alignment = "start",
+  occupiedRows = 0,
   prompt,
 }: {
   alignment?: PromptAlignment;
+  occupiedRows?: number;
   prompt: ActivePrompt;
 }): React.ReactNode {
-  const { rows } = useInkFrameSize();
+  const { columns, rows } = useInkFrameSize();
   if (prompt.kind === "select") {
+    const messageRows = getPromptMessageRows({
+      message: prompt.message,
+      terminalColumns: columns,
+      alignment,
+      kind: prompt.kind,
+      totalCount: prompt.options.length,
+    });
     return (
       <SelectPrompt
         alignment={alignment}
-        maxVisibleOptions={getPromptOptionLimit(rows, alignment, prompt.kind)}
+        maxVisibleOptions={getPromptOptionLimit({
+          terminalRows: rows,
+          alignment,
+          kind: prompt.kind,
+          occupiedRows,
+          messageRows,
+        })}
         prompt={prompt}
       />
     );
@@ -1352,10 +1435,23 @@ function PromptArea({
     return <ConfirmPrompt alignment={alignment} prompt={prompt} />;
   }
   if (prompt.kind === "multiselect") {
+    const messageRows = getPromptMessageRows({
+      message: prompt.message,
+      terminalColumns: columns,
+      alignment,
+      kind: prompt.kind,
+      totalCount: prompt.options.length,
+    });
     return (
       <MultiSelectPrompt
         alignment={alignment}
-        maxVisibleOptions={getPromptOptionLimit(rows, alignment, prompt.kind)}
+        maxVisibleOptions={getPromptOptionLimit({
+          terminalRows: rows,
+          alignment,
+          kind: prompt.kind,
+          occupiedRows,
+          messageRows,
+        })}
         prompt={prompt}
       />
     );

--- a/packages/cli/test/lib/init/ui/ink-app.property.test.ts
+++ b/packages/cli/test/lib/init/ui/ink-app.property.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Property tests for terminal-height option windowing in the Ink prompt UI.
+ */
+
+import { assert as fcAssert, integer, property } from "fast-check";
+import { describe, expect, test } from "vitest";
+import { getOptionWindow } from "../../../../src/lib/init/ui/ink-app.js";
+import { DEFAULT_NUM_RUNS } from "../../../model-based/helpers.js";
+
+describe("property: Ink prompt option window", () => {
+  test("stays bounded and always contains the highlighted option", () => {
+    fcAssert(
+      property(
+        integer({ min: 0, max: 500 }),
+        integer({ min: -1000, max: 1000 }),
+        integer({ min: -50, max: 200 }),
+        (totalCount, highlighted, maxVisible) => {
+          const [start, end] = getOptionWindow(
+            totalCount,
+            highlighted,
+            maxVisible
+          );
+          const expectedSize = Math.min(totalCount, Math.max(1, maxVisible));
+
+          expect(start).toBeGreaterThanOrEqual(0);
+          expect(end).toBeLessThanOrEqual(totalCount);
+          expect(end - start).toBe(expectedSize);
+
+          if (totalCount > 0) {
+            const normalizedHighlight = Math.min(
+              totalCount - 1,
+              Math.max(0, highlighted)
+            );
+            expect(start).toBeLessThanOrEqual(normalizedHighlight);
+            expect(end).toBeGreaterThan(normalizedHighlight);
+          }
+        }
+      ),
+      { numRuns: DEFAULT_NUM_RUNS }
+    );
+  });
+});

--- a/packages/cli/test/lib/init/ui/ink-app.snapshot.test.tsx
+++ b/packages/cli/test/lib/init/ui/ink-app.snapshot.test.tsx
@@ -597,9 +597,10 @@ describe("Ink App snapshot", () => {
       "error",
       "An error remains visible while choosing features"
     );
+    store.appendLog("warn", "A second warning also remains visible");
     store.setPrompt({
       kind: "multiselect",
-      message: "Select features",
+      message: "Select features\nReview the monitoring choices",
       options: Array.from({ length: 20 }, (_value, index) => ({
         value: `feature-${index + 1}`,
         label: `Feature ${index + 1}`,
@@ -612,21 +613,27 @@ describe("Ink App snapshot", () => {
     const rendered = await renderApp(store, 120, { rows: 16 });
     const frame = stripFinalLineBreak(stripAnsi(rendered.latestFrame()));
     expect(frame).toContain("0/20 selected • 1/20");
-    expect(frame).toContain("Feature 6");
-    expect(frame).not.toContain("Feature 7");
+    expect(frame).toContain("Review the monitoring choices");
+    expect(frame).toContain("A second warning also remains visible");
+    expect(frame).toContain("Feature 2");
+    expect(frame).not.toContain("Feature 3");
     expect(frame.split(LINE_SPLIT_RE).length).toBeLessThanOrEqual(16);
     expect(frame).toContain(FEEDBACK_BANNER_TEXT);
 
-    const scrolledFrame = stripAnsi(
-      (
-        await renderApp(store, 120, {
-          input: Array.from({ length: 19 }, () => DOWN_ARROW),
-          rows: 16,
-        })
-      ).allOutput()
+    const scrolledFrame = stripFinalLineBreak(
+      stripAnsi(
+        (
+          await renderApp(store, 120, {
+            input: Array.from({ length: 19 }, () => DOWN_ARROW),
+            rows: 16,
+          })
+        ).latestFrame()
+      )
     );
     expect(scrolledFrame).toContain("0/20 selected • 20/20");
     expect(scrolledFrame).toContain("Feature 20");
+    expect(scrolledFrame.split(LINE_SPLIT_RE).length).toBeLessThanOrEqual(16);
+    expect(scrolledFrame).toContain(FEEDBACK_BANNER_TEXT);
   });
 
   test("centered multiselect prompts fit with the full banner", async () => {
@@ -636,7 +643,7 @@ describe("Ink App snapshot", () => {
     });
     store.setPrompt({
       kind: "multiselect",
-      message: "Select features",
+      message: "Select features\nReview the monitoring choices",
       options: Array.from({ length: 20 }, (_value, index) => ({
         value: `feature-${index + 1}`,
         label: `Feature ${index + 1}`,
@@ -648,8 +655,9 @@ describe("Ink App snapshot", () => {
 
     const rendered = await renderApp(store, 120, { rows: 30 });
     const frame = stripFinalLineBreak(stripAnsi(rendered.latestFrame()));
-    expect(frame).toContain("Feature 7");
-    expect(frame).not.toContain("Feature 8");
+    expect(frame).toContain("Review the monitoring choices");
+    expect(frame).toContain("Feature 6");
+    expect(frame).not.toContain("Feature 7");
     expect(frame.split(LINE_SPLIT_RE).length).toBeLessThanOrEqual(30);
     expect(frame).toContain(FEEDBACK_BANNER_TEXT);
   });

--- a/packages/cli/test/lib/init/ui/ink-app.snapshot.test.tsx
+++ b/packages/cli/test/lib/init/ui/ink-app.snapshot.test.tsx
@@ -42,6 +42,7 @@ const ANSI_CSI_RE = /\u001B\[[0-9;?]*[ -/]*[@-~]/g;
 // biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI escape sequences in captured Ink output
 const ANSI_OSC_RE = /\u001B\][^\u0007]*(?:\u0007|\u001B\\)/g;
 const LINE_SPLIT_RE = /\r?\n/;
+const DOWN_ARROW = "\u001B[B";
 const RIGHT_ARROW = "\u001B[C";
 const FEEDBACK_BANNER_TEXT = '$ sentry cli feedback "what worked or broke"';
 
@@ -53,6 +54,7 @@ const TEST_BANNER_ROWS = [
 
 class CaptureStream extends Writable {
   frames: string[] = [];
+  lastRenderedFrame = "";
   columns: number;
   rows: number;
   isTTY = true;
@@ -113,6 +115,8 @@ async function renderApp(
     await sleep(20);
   }
   await sleep(FRAME_SETTLE_MS);
+  out.lastRenderedFrame =
+    out.frames.findLast((frame) => frame.includes(FEEDBACK_BANNER_TEXT)) ?? "";
   instance.unmount();
   // waitUntilExit() hangs in CI — race with a short unref'd timeout.
   await Promise.race([
@@ -533,6 +537,137 @@ describe("Ink App snapshot", () => {
     expect(frame).toContain("confirm");
     expect(frame).toContain("cancel");
     expect(frame).not.toContain("switch tab");
+  });
+
+  test("long select prompts only render options that fit the terminal", async () => {
+    const store = new WizardStore({
+      bannerRows: FULL_BANNER_LINES,
+      layout: "intro",
+    });
+    store.setPrompt({
+      kind: "select",
+      message: "Which team should own this project?",
+      options: Array.from({ length: 20 }, (_value, index) => ({
+        value: `team-${index + 1}`,
+        label: `Team ${index + 1}`,
+      })),
+      initialIndex: 0,
+      resolve: ignorePromptResolution,
+    });
+
+    const rendered = await renderApp(store, 120, { rows: 24 });
+    const frame = stripAnsi(rendered.allOutput());
+    const lastFrame = stripAnsi(rendered.lastRenderedFrame);
+    expect(frame).toContain("Which team should own this project?");
+    expect(frame).toContain("(1/20)");
+    expect(frame).toContain("Team 4");
+    expect(frame).not.toContain("Team 5");
+    expect(lastFrame.split(LINE_SPLIT_RE)).toHaveLength(24);
+    expect(lastFrame).toContain(FEEDBACK_BANNER_TEXT);
+
+    const scrolledFrame = stripAnsi(
+      (
+        await renderApp(store, 120, {
+          input: Array.from({ length: 7 }, () => DOWN_ARROW),
+          rows: 24,
+        })
+      ).allOutput()
+    );
+    expect(scrolledFrame).toContain("(8/20)");
+    expect(scrolledFrame).toContain("Team 8");
+  });
+
+  test("long multiselect prompts only render options that fit the terminal", async () => {
+    const store = new WizardStore({ bannerRows: [] });
+    store.appendLog(
+      "warn",
+      "A warning remains visible while choosing features"
+    );
+    store.appendLog(
+      "error",
+      "An error remains visible while choosing features"
+    );
+    store.setPrompt({
+      kind: "multiselect",
+      message: "Select features",
+      options: Array.from({ length: 20 }, (_value, index) => ({
+        value: `feature-${index + 1}`,
+        label: `Feature ${index + 1}`,
+      })),
+      initialSelected: [],
+      required: false,
+      resolve: ignorePromptResolution,
+    });
+
+    const rendered = await renderApp(store, 120, { rows: 16 });
+    const frame = stripAnsi(rendered.allOutput());
+    const lastFrame = stripAnsi(rendered.lastRenderedFrame);
+    expect(frame).toContain("0/20 selected • 1/20");
+    expect(frame).toContain("Feature 6");
+    expect(frame).not.toContain("Feature 7");
+    expect(lastFrame.split(LINE_SPLIT_RE)).toHaveLength(16);
+    expect(lastFrame).toContain(FEEDBACK_BANNER_TEXT);
+
+    const scrolledFrame = stripAnsi(
+      (
+        await renderApp(store, 120, {
+          input: Array.from({ length: 19 }, () => DOWN_ARROW),
+          rows: 16,
+        })
+      ).allOutput()
+    );
+    expect(scrolledFrame).toContain("0/20 selected • 20/20");
+    expect(scrolledFrame).toContain("Feature 20");
+  });
+
+  test("centered multiselect prompts fit with the full banner", async () => {
+    const store = new WizardStore({
+      bannerRows: FULL_BANNER_LINES,
+      layout: "intro",
+    });
+    store.setPrompt({
+      kind: "multiselect",
+      message: "Select features",
+      options: Array.from({ length: 20 }, (_value, index) => ({
+        value: `feature-${index + 1}`,
+        label: `Feature ${index + 1}`,
+      })),
+      initialSelected: [],
+      required: false,
+      resolve: ignorePromptResolution,
+    });
+
+    const rendered = await renderApp(store, 120, { rows: 30 });
+    const frame = stripAnsi(rendered.allOutput());
+    const lastFrame = stripAnsi(rendered.lastRenderedFrame);
+    expect(frame).toContain("Feature 7");
+    expect(frame).not.toContain("Feature 8");
+    expect(lastFrame.split(LINE_SPLIT_RE)).toHaveLength(30);
+    expect(lastFrame).toContain(FEEDBACK_BANNER_TEXT);
+  });
+
+  test("long option hints stay on one terminal row", async () => {
+    const store = new WizardStore({ bannerRows: [], layout: "intro" });
+    store.setPrompt({
+      kind: "select",
+      message: "Choose a team",
+      options: [
+        {
+          value: "team-1",
+          label: "A",
+          hint: "This deliberately long team name would wrap onto another row UNIQUE_TAIL",
+        },
+        { value: "team-2", label: "Team 2" },
+      ],
+      initialIndex: 0,
+      resolve: ignorePromptResolution,
+    });
+
+    const frame = stripAnsi(
+      (await renderApp(store, 40, { rows: 24 })).allOutput()
+    );
+    expect(frame).toContain("A");
+    expect(frame).not.toContain("UNIQUE_TAIL");
   });
 
   test("file scroll shortcut appears only when the file tree overflows", async () => {

--- a/packages/cli/test/lib/init/ui/ink-app.snapshot.test.tsx
+++ b/packages/cli/test/lib/init/ui/ink-app.snapshot.test.tsx
@@ -37,6 +37,7 @@ const ENTER_CONFIRM_HINT_RE = /enter\s+confirm/;
 const ESC_CANCEL_HINT_RE = /esc\s+cancel/;
 const COMPLETED_SELECTING_FEATURES_RE = /✔\s+Selecting features/;
 const ANSI_ESCAPE_PREFIX = "\u001B[";
+const CURSOR_TO_LINE_START = "\u001B[G";
 // biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI escape sequences in captured Ink output
 const ANSI_CSI_RE = /\u001B\[[0-9;?]*[ -/]*[@-~]/g;
 // biome-ignore lint/suspicious/noControlCharactersInRegex: matching ANSI escape sequences in captured Ink output
@@ -54,7 +55,7 @@ const TEST_BANNER_ROWS = [
 
 class CaptureStream extends Writable {
   frames: string[] = [];
-  lastRenderedFrame = "";
+  settledOutput = "";
   columns: number;
   rows: number;
   isTTY = true;
@@ -69,6 +70,13 @@ class CaptureStream extends Writable {
   }
   allOutput(): string {
     return this.frames.join("");
+  }
+  latestFrame(): string {
+    const output = this.settledOutput || this.allOutput();
+    const redrawStart = output.lastIndexOf(CURSOR_TO_LINE_START);
+    return redrawStart === -1
+      ? output
+      : output.slice(redrawStart + CURSOR_TO_LINE_START.length);
   }
 }
 
@@ -115,8 +123,7 @@ async function renderApp(
     await sleep(20);
   }
   await sleep(FRAME_SETTLE_MS);
-  out.lastRenderedFrame =
-    out.frames.findLast((frame) => frame.includes(FEEDBACK_BANNER_TEXT)) ?? "";
+  out.settledOutput = out.allOutput();
   instance.unmount();
   // waitUntilExit() hangs in CI — race with a short unref'd timeout.
   await Promise.race([
@@ -146,6 +153,10 @@ function withoutFeedbackBanner(output: string): string {
     .split(LINE_SPLIT_RE)
     .filter((line) => !line.includes(FEEDBACK_BANNER_TEXT))
     .join("\n");
+}
+
+function stripFinalLineBreak(output: string): string {
+  return output.endsWith("\n") ? output.slice(0, -1) : output;
 }
 
 function stripAnsi(output: string): string {
@@ -556,14 +567,13 @@ describe("Ink App snapshot", () => {
     });
 
     const rendered = await renderApp(store, 120, { rows: 24 });
-    const frame = stripAnsi(rendered.allOutput());
-    const lastFrame = stripAnsi(rendered.lastRenderedFrame);
+    const frame = stripFinalLineBreak(stripAnsi(rendered.latestFrame()));
     expect(frame).toContain("Which team should own this project?");
     expect(frame).toContain("(1/20)");
     expect(frame).toContain("Team 4");
     expect(frame).not.toContain("Team 5");
-    expect(lastFrame.split(LINE_SPLIT_RE)).toHaveLength(24);
-    expect(lastFrame).toContain(FEEDBACK_BANNER_TEXT);
+    expect(frame.split(LINE_SPLIT_RE).length).toBeLessThanOrEqual(24);
+    expect(frame).toContain(FEEDBACK_BANNER_TEXT);
 
     const scrolledFrame = stripAnsi(
       (
@@ -600,13 +610,12 @@ describe("Ink App snapshot", () => {
     });
 
     const rendered = await renderApp(store, 120, { rows: 16 });
-    const frame = stripAnsi(rendered.allOutput());
-    const lastFrame = stripAnsi(rendered.lastRenderedFrame);
+    const frame = stripFinalLineBreak(stripAnsi(rendered.latestFrame()));
     expect(frame).toContain("0/20 selected • 1/20");
     expect(frame).toContain("Feature 6");
     expect(frame).not.toContain("Feature 7");
-    expect(lastFrame.split(LINE_SPLIT_RE)).toHaveLength(16);
-    expect(lastFrame).toContain(FEEDBACK_BANNER_TEXT);
+    expect(frame.split(LINE_SPLIT_RE).length).toBeLessThanOrEqual(16);
+    expect(frame).toContain(FEEDBACK_BANNER_TEXT);
 
     const scrolledFrame = stripAnsi(
       (
@@ -638,12 +647,11 @@ describe("Ink App snapshot", () => {
     });
 
     const rendered = await renderApp(store, 120, { rows: 30 });
-    const frame = stripAnsi(rendered.allOutput());
-    const lastFrame = stripAnsi(rendered.lastRenderedFrame);
+    const frame = stripFinalLineBreak(stripAnsi(rendered.latestFrame()));
     expect(frame).toContain("Feature 7");
     expect(frame).not.toContain("Feature 8");
-    expect(lastFrame.split(LINE_SPLIT_RE)).toHaveLength(30);
-    expect(lastFrame).toContain(FEEDBACK_BANNER_TEXT);
+    expect(frame.split(LINE_SPLIT_RE).length).toBeLessThanOrEqual(30);
+    expect(frame).toContain(FEEDBACK_BANNER_TEXT);
   });
 
   test("long option hints stay on one terminal row", async () => {


### PR DESCRIPTION
## Summary

Keep Ink select and multiselect prompts within the available terminal height by rendering a moving option window. Long labels stay on one row, and position indicators make hidden options discoverable without changing keyboard navigation.

This covers the `sentry init` team picker and the shared prompt UI used by other long lists.

Closes #1376.

## Test plan

- `pnpm exec vitest run test/lib/init/ui/ink-app.snapshot.test.tsx test/lib/init/ui/ink-app.property.test.ts` — 26 tests passed
- `pnpm run lint` — 972 files checked
- `pnpm run typecheck`
- `pnpm run check:fragments` — passed with the existing unrelated `proguard upload` coverage warning
- Manual TTY smoke test at 24x120 with 26 teams: navigated from `(1/26)` to `(26/26)` while the footer remained visible
- Full unit suite: 9,039 passed and 17 skipped; reproduced the same 8 environment-dependent failures already documented on unchanged `main` (6 timezone assertions and 2 bash completion shell simulations)