### PR TITLE
fix(init): improve task panel readability

### DIFF
--- a/packages/cli/src/lib/init/ui/ink-app.tsx
+++ b/packages/cli/src/lib/init/ui/ink-app.tsx
@@ -78,8 +78,10 @@ import type {
 
 /** Sentry blurple — primary brand accent. */
 const ACCENT = "#7553FF";
-const MUTED = "gray";
-const MUTED_DIM = "#555555";
+/** De-emphasized text that still clears dark terminal backgrounds. */
+const MUTED = "#898294";
+/** Lowest-contrast treatment for borders, counters, and supporting details. */
+const MUTED_DIM = "#68616F";
 /** Sentry purple — spinners, in-progress states. */
 const PRIMARY = "#8B6AC8";
 
@@ -87,6 +89,7 @@ const COLOR_INFO = "#9C84D4";
 const COLOR_WARN = "#FDB81B";
 const COLOR_ERROR = "#fe4144";
 const COLOR_SUCCESS = "#83da90";
+const ACTIVE_TASK_PULSE_INTERVAL_MS = 600;
 
 const ICON_BY_SEVERITY: Record<LogSeverity, { glyph: string; color?: string }> =
   {
@@ -105,6 +108,7 @@ const ICONS = {
   squareFilled: "\u25FC",
   squareOpen: "\u25FB",
   triangleRight: "\u25B6",
+  triangleRightOutline: "\u25B7",
   triangleSmallRight: "\u25B8",
   bullet: "\u2022",
 } as const;
@@ -544,8 +548,6 @@ function ActionList<T extends string>({
     <Box flexDirection="column" width={listWidth}>
       {choices.map((choice, index) => {
         const isCursor = index === highlighted;
-        // biome-ignore lint/nursery/noLeakedRender: variable assignment, not JSX expression
-        const labelColor = isCursor ? undefined : MUTED;
         if (centered) {
           return (
             <Box
@@ -557,12 +559,8 @@ function ActionList<T extends string>({
               <Text color={ACCENT}>
                 {isCursor ? `${ICONS.triangleSmallRight} ` : "  "}
               </Text>
-              <Text bold={isCursor} color={labelColor}>
-                {choice.label}
-              </Text>
-              {choice.hint ? (
-                <Text color={MUTED_DIM}> {choice.hint}</Text>
-              ) : null}
+              <Text bold={isCursor}>{choice.label}</Text>
+              {choice.hint ? <Text color={MUTED}> {choice.hint}</Text> : null}
             </Box>
           );
         }
@@ -573,10 +571,8 @@ function ActionList<T extends string>({
                 {isCursor ? ICONS.triangleSmallRight : " "}
               </Text>
             </Box>
-            <Text bold={isCursor} color={labelColor}>
-              {choice.label}
-            </Text>
-            {choice.hint ? <Text color={MUTED_DIM}> {choice.hint}</Text> : null}
+            <Text bold={isCursor}>{choice.label}</Text>
+            {choice.hint ? <Text color={MUTED}> {choice.hint}</Text> : null}
           </Box>
         );
       })}
@@ -851,7 +847,7 @@ function ProgressPanel({ steps }: { steps: StepEntry[] }): React.ReactNode {
   const totalCount = steps.length;
 
   const headerRight = totalCount > 0 ? `${completedCount}/${totalCount}` : "";
-  const badgeColor = completedCount === totalCount ? COLOR_SUCCESS : MUTED_DIM;
+  const badgeColor = completedCount === totalCount ? COLOR_SUCCESS : MUTED;
 
   return (
     <Box
@@ -862,7 +858,7 @@ function ProgressPanel({ steps }: { steps: StepEntry[] }): React.ReactNode {
       paddingX={1}
     >
       <Box justifyContent="space-between">
-        <Text bold color={MUTED}>
+        <Text bold color={ACCENT}>
           {ICONS.diamondOpen} Tasks
         </Text>
         {headerRight ? <Text color={badgeColor}>{headerRight}</Text> : null}
@@ -873,7 +869,7 @@ function ProgressPanel({ steps }: { steps: StepEntry[] }): React.ReactNode {
           <Text color={PRIMARY}>
             <Spinner type="dots" />
           </Text>
-          <Text dimColor>Analyzing project...</Text>
+          <Text>Analyzing project...</Text>
         </Box>
       ) : null}
       {steps.map((entry) => (
@@ -884,61 +880,81 @@ function ProgressPanel({ steps }: { steps: StepEntry[] }): React.ReactNode {
 }
 
 function ProgressRow({ entry }: { entry: StepEntry }): React.ReactNode {
-  const { glyph, glyphColor, labelColor, dimLabel } = progressStyle(entry);
+  const { boldLabel, glyph, glyphColor, labelColor } = progressStyle(entry);
   return (
     <Box flexDirection="row" flexShrink={0}>
       <Box flexShrink={0} width={3}>
-        <Text color={glyphColor}>{glyph}</Text>
+        {entry.status === "in_progress" ? (
+          <ActiveTaskGlyph />
+        ) : (
+          <Text color={glyphColor}>{glyph}</Text>
+        )}
       </Box>
-      <Text color={labelColor} dimColor={dimLabel}>
+      <Text bold={boldLabel} color={labelColor}>
         {entry.label}
       </Text>
     </Box>
   );
 }
 
+function ActiveTaskGlyph(): React.ReactNode {
+  const [isFilled, setIsFilled] = useState(true);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setIsFilled((current) => !current);
+    }, ACTIVE_TASK_PULSE_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, []);
+
+  return isFilled ? (
+    <Text color={PRIMARY}>{ICONS.triangleRight}</Text>
+  ) : (
+    <Text color={PRIMARY}>{ICONS.triangleRightOutline}</Text>
+  );
+}
+
 function progressStyle(entry: StepEntry): {
+  boldLabel: boolean;
   glyph: string;
   glyphColor: string;
   labelColor?: string;
-  dimLabel: boolean;
 } {
   if (entry.status === "in_progress") {
     return {
+      boldLabel: true,
       glyph: ICONS.triangleRight,
       glyphColor: PRIMARY,
-      dimLabel: false,
     };
   }
   if (entry.status === "completed") {
     return {
+      boldLabel: false,
       glyph: ICONS.squareFilled,
       glyphColor: COLOR_SUCCESS,
       labelColor: MUTED,
-      dimLabel: false,
     };
   }
   if (entry.status === "failed") {
     return {
+      boldLabel: true,
       glyph: "\u2716",
       glyphColor: COLOR_ERROR,
       labelColor: COLOR_ERROR,
-      dimLabel: false,
     };
   }
   if (entry.status === "skipped") {
     return {
+      boldLabel: false,
       glyph: "\u25CC",
       glyphColor: MUTED_DIM,
-      labelColor: MUTED_DIM,
-      dimLabel: true,
+      labelColor: MUTED,
     };
   }
   return {
+    boldLabel: false,
     glyph: ICONS.squareOpen,
-    glyphColor: MUTED_DIM,
-    labelColor: MUTED,
-    dimLabel: true,
+    glyphColor: MUTED,
   };
 }
 
@@ -1394,18 +1410,15 @@ function SelectPromptOptionRow({
   isCursor: boolean;
   option: SelectPromptOptionData;
 }): React.ReactNode {
-  const labelColor = isCursor ? undefined : MUTED;
   if (centered) {
     return (
       <Box flexDirection="row" justifyContent="center" width="100%">
         <Text color={ACCENT}>
           {isCursor ? `${ICONS.triangleSmallRight} ` : "  "}
         </Text>
-        <Text bold={isCursor} color={labelColor}>
-          {option.label}
-        </Text>
+        <Text bold={isCursor}>{option.label}</Text>
         {option.hint !== undefined && option.hint !== "" ? (
-          <Text color={MUTED_DIM}> {option.hint}</Text>
+          <Text color={MUTED}> {option.hint}</Text>
         ) : null}
       </Box>
     );
@@ -1415,11 +1428,9 @@ function SelectPromptOptionRow({
       <Box flexShrink={0} width={3}>
         <Text color={ACCENT}>{isCursor ? ICONS.triangleSmallRight : " "}</Text>
       </Box>
-      <Text bold={isCursor} color={labelColor}>
-        {option.label}
-      </Text>
+      <Text bold={isCursor}>{option.label}</Text>
       {option.hint !== undefined && option.hint !== "" ? (
-        <Text color={MUTED_DIM}> {option.hint}</Text>
+        <Text color={MUTED}> {option.hint}</Text>
       ) : null}
     </Box>
   );
@@ -1662,7 +1673,7 @@ function MultiSelectPromptOptionRow({
   option: MultiSelectPromptOptionData;
 }): React.ReactNode {
   const marker = isSelected ? ICONS.squareFilled : ICONS.squareOpen;
-  const markerColor = isSelected ? COLOR_SUCCESS : MUTED_DIM;
+  const markerColor = isSelected ? COLOR_SUCCESS : MUTED;
   if (centered) {
     return (
       <Box flexDirection="row" justifyContent="center" width="100%">
@@ -1672,7 +1683,7 @@ function MultiSelectPromptOptionRow({
         <Text color={markerColor}>{marker} </Text>
         <Text bold={isCursor}>{option.label}</Text>
         {option.hint !== undefined && option.hint !== "" ? (
-          <Text color={MUTED_DIM}> {option.hint}</Text>
+          <Text color={MUTED}> {option.hint}</Text>
         ) : null}
       </Box>
     );
@@ -1685,7 +1696,7 @@ function MultiSelectPromptOptionRow({
       <Text color={markerColor}>{marker} </Text>
       <Text bold={isCursor}>{option.label}</Text>
       {option.hint !== undefined && option.hint !== "" ? (
-        <Text color={MUTED_DIM}> {option.hint}</Text>
+        <Text color={MUTED}> {option.hint}</Text>
       ) : null}
     </Box>
   );

--- a/packages/cli/test/lib/init/ui/ink-app.snapshot.test.tsx
+++ b/packages/cli/test/lib/init/ui/ink-app.snapshot.test.tsx
@@ -13,7 +13,7 @@ import { Readable, Writable } from "node:stream";
 import { setTimeout as sleep } from "node:timers/promises";
 import { render } from "ink";
 import { createElement } from "react";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import {
   bannerLinesWidth,
   FULL_BANNER_LINES,
@@ -129,6 +129,27 @@ async function renderApp(
   return out;
 }
 
+async function renderActiveTaskFrameAfter(elapsedMs: number): Promise<string> {
+  const out = new CaptureStream(120, 40);
+  const stdin = makeStdin();
+  const store = new WizardStore();
+  store.setStepStatus("detect-platform", "in_progress");
+  const instance = render(createElement(App, { store }), {
+    stdout: out as unknown as NodeJS.WriteStream,
+    stderr: out as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+    exitOnCtrlC: false,
+  });
+
+  try {
+    await vi.advanceTimersByTimeAsync(elapsedMs);
+  } finally {
+    instance.unmount();
+  }
+  return stripAnsi(out.allOutput());
+}
+
 function hasForcedWhiteForeground(output: string): boolean {
   return (
     output.includes(`${ANSI_ESCAPE_PREFIX}37m`) ||
@@ -230,6 +251,19 @@ describe("Ink App snapshot", () => {
     const frame = stripAnsi((await renderApp(store, 120)).allOutput());
     expect(frame).toContain("Did you know?");
     expect(frame.indexOf("Tasks")).toBeLessThan(frame.indexOf("Did you know?"));
+  });
+
+  test("pulses the active task arrow without changing its width", async () => {
+    vi.useFakeTimers();
+    try {
+      const initialFrame = await renderActiveTaskFrameAfter(1);
+      expect(initialFrame).toContain("▶  Detecting platform");
+
+      const pulsedFrame = await renderActiveTaskFrameAfter(601);
+      expect(pulsedFrame).toContain("▷  Detecting platform");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("renders single-column layout at narrow width", async () => {


### PR DESCRIPTION
## Summary

Improve the contrast of inactive init options and pending task labels while keeping primary text compatible with light and dark terminal themes. The Tasks card now has a clearer status hierarchy and a purple header, and the active task arrow pulses between filled and outlined states without shifting the layout.

The Tasks card stays above the rotating learning card, so changing tips do not move the progress list.

Closes #1377.

## Test plan

- `cd packages/cli && pnpm exec vitest run test/lib/init/ui/ink-app.snapshot.test.tsx` — 22 tests passed
- `pnpm run lint` — 973 files checked
- `pnpm run generate:schema && pnpm run typecheck`
- Manual TTY smoke test covering pending, active, completed, skipped, and failed tasks