### PR TITLE
fix(init): sort and align selector options

### DIFF
--- a/packages/cli/src/lib/init/preflight.ts
+++ b/packages/cli/src/lib/init/preflight.ts
@@ -437,7 +437,9 @@ async function resolveImplicitTeam(
     return;
   }
 
-  const candidateTeams = teams.filter(canCreateProjectInTeam);
+  const candidateTeams = teams
+    .filter(canCreateProjectInTeam)
+    .sort((left, right) => left.slug.localeCompare(right.slug));
   if (candidateTeams.length === 0) {
     await assertOrgScopedCreationCanProceed(org);
     return;
@@ -508,6 +510,10 @@ async function resolveOrgSlug(
   } catch (error) {
     return handleOrgListError(error);
   }
+  orgs.sort(
+    (left, right) =>
+      left.name.localeCompare(right.name) || left.slug.localeCompare(right.slug)
+  );
   if (orgs.length === 0) {
     return {
       ok: false,

--- a/packages/cli/src/lib/init/ui/ink-app.tsx
+++ b/packages/cli/src/lib/init/ui/ink-app.tsx
@@ -1303,6 +1303,27 @@ type MultiSelectPromptOptionData = Extract<
   ActivePrompt,
   { kind: "multiselect" }
 >["options"][number];
+type CenteredSelectLayout = {
+  labelWidth: number;
+  width: number;
+};
+
+function getCenteredSelectLayout(
+  options: SelectPromptOptionData[]
+): CenteredSelectLayout {
+  const labelWidth = Math.max(
+    0,
+    ...options.map((option) => stringWidth(option.label))
+  );
+  const hintWidth = Math.max(
+    0,
+    ...options.map((option) => stringWidth(option.hint ?? ""))
+  );
+  return {
+    labelWidth,
+    width: 2 + labelWidth + (hintWidth > 0 ? hintWidth + 1 : 0),
+  };
+}
 
 /**
  * Rows unavailable to option lists: workflow chrome reserves the tab/shortcut
@@ -1486,6 +1507,13 @@ function SelectPrompt({
 }): React.ReactNode {
   const isCentered = alignment === "center";
   const promptWidth = isCentered ? "100%" : undefined;
+  const { columns } = useInkFrameSize();
+  const centeredLayout = isCentered
+    ? getCenteredSelectLayout(prompt.options)
+    : null;
+  const centeredOptionsWidth = centeredLayout
+    ? Math.min(centeredLayout.width, getPromptContentWidth(columns, alignment))
+    : undefined;
   const totalCount = prompt.options.length;
   const [highlighted, setHighlighted] = useState<number>(() =>
     Math.min(Math.max(prompt.initialIndex, 0), Math.max(0, totalCount - 1))
@@ -1566,19 +1594,25 @@ function SelectPrompt({
           ) : null}
         </Box>
       )}
-      <Box flexDirection="column" width={promptWidth}>
-        {visibleOptions.map((option, visibleIndex) => {
-          const idx = windowStart + visibleIndex;
-          const isCursor = idx === highlighted;
-          return (
-            <SelectPromptOptionRow
-              centered={isCentered}
-              isCursor={isCursor}
-              key={option.value}
-              option={option}
-            />
-          );
-        })}
+      <Box
+        justifyContent={isCentered ? "center" : "flex-start"}
+        width={promptWidth}
+      >
+        <Box flexDirection="column" width={centeredOptionsWidth}>
+          {visibleOptions.map((option, visibleIndex) => {
+            const idx = windowStart + visibleIndex;
+            const isCursor = idx === highlighted;
+            return (
+              <SelectPromptOptionRow
+                centered={isCentered}
+                centeredLabelWidth={centeredLayout?.labelWidth}
+                isCursor={isCursor}
+                key={option.value}
+                option={option}
+              />
+            );
+          })}
+        </Box>
       </Box>
     </Box>
   );
@@ -1586,26 +1620,26 @@ function SelectPrompt({
 
 function SelectPromptOptionRow({
   centered,
+  centeredLabelWidth,
   isCursor,
   option,
 }: {
   centered: boolean;
+  centeredLabelWidth?: number;
   isCursor: boolean;
   option: SelectPromptOptionData;
 }): React.ReactNode {
   if (centered) {
     return (
-      <Box
-        flexDirection="row"
-        height={1}
-        justifyContent="center"
-        overflow="hidden"
-        width="100%"
-      >
-        <Text color={ACCENT}>
-          {isCursor ? `${ICONS.triangleSmallRight} ` : "  "}
-        </Text>
-        <Text bold={isCursor}>{option.label}</Text>
+      <Box flexDirection="row" height={1} overflow="hidden" width="100%">
+        <Box flexShrink={0} width={2}>
+          <Text color={ACCENT}>
+            {isCursor ? ICONS.triangleSmallRight : " "}
+          </Text>
+        </Box>
+        <Box flexShrink={0} width={centeredLabelWidth}>
+          <Text bold={isCursor}>{option.label}</Text>
+        </Box>
         {option.hint !== undefined && option.hint !== "" ? (
           <Text color={MUTED}> {option.hint}</Text>
         ) : null}

--- a/packages/cli/test/lib/init/preflight.test.ts
+++ b/packages/cli/test/lib/init/preflight.test.ts
@@ -409,20 +409,20 @@ describe("resolveInitContext", () => {
   });
 
   test("prompts when multiple Team Admin teams are available", async () => {
-    const { ui, respond } = createMockUI();
+    const { ui, calls, respond } = createMockUI();
     respond.select("mobile");
     listTeamsSpy.mockResolvedValueOnce([
       {
         id: "1",
-        slug: "mobile",
-        name: "Mobile",
+        slug: "platform",
+        name: "Platform",
         access: ["team:admin"],
         isMember: true,
       } as any,
       {
         id: "2",
-        slug: "platform",
-        name: "Platform",
+        slug: "mobile",
+        name: "Mobile",
         access: ["team:admin"],
         isMember: true,
       } as any,
@@ -431,21 +431,23 @@ describe("resolveInitContext", () => {
     const context = await resolveInitContext(makeOptions({ yes: false }), ui);
 
     expect(context?.team).toBe("mobile");
+    const selectCall = calls.find((call) => call.kind === "select");
+    expect(selectCall?.options).toEqual(["mobile", "platform"]);
   });
 
-  test("selects the first Team Admin team in --yes mode", async () => {
+  test("selects the first alphabetical Team Admin team in --yes mode", async () => {
     listTeamsSpy.mockResolvedValueOnce([
       {
         id: "1",
-        slug: "mobile",
-        name: "Mobile",
+        slug: "platform",
+        name: "Platform",
         access: ["team:admin"],
         isMember: true,
       } as any,
       {
         id: "2",
-        slug: "platform",
-        name: "Platform",
+        slug: "mobile",
+        name: "Mobile",
         access: ["team:admin"],
         isMember: true,
       } as any,
@@ -455,6 +457,38 @@ describe("resolveInitContext", () => {
     const context = await resolveInitContext(makeOptions({ yes: true }), ui);
 
     expect(context?.team).toBe("mobile");
+  });
+
+  test("sorts organization options alphabetically by name", async () => {
+    resolveOrgPrefetchedSpy.mockResolvedValue(null);
+    listOrganizationsSpy.mockResolvedValue([
+      { id: "1", slug: "z-org", name: "Alpha" },
+      { id: "2", slug: "beta", name: "Beta" },
+      { id: "3", slug: "a-org", name: "Alpha" },
+    ]);
+
+    const { ui, calls, respond } = createMockUI();
+    respond.select("a-org");
+
+    const context = await resolveInitContext(makeOptions({ yes: false }), ui);
+
+    expect(context?.org).toBe("a-org");
+    const selectCall = calls.find((call) => call.kind === "select");
+    expect(selectCall?.options).toEqual(["a-org", "z-org", "beta"]);
+  });
+
+  test("sorts organizations in the --yes error", async () => {
+    resolveOrgPrefetchedSpy.mockResolvedValue(null);
+    listOrganizationsSpy.mockResolvedValue([
+      { id: "1", slug: "z-org", name: "Zulu" },
+      { id: "2", slug: "a-org", name: "Alpha" },
+    ]);
+
+    const { ui } = createMockUI();
+
+    await expect(
+      resolveInitContext(makeOptions({ yes: true }), ui)
+    ).rejects.toThrow("Multiple organizations found (a-org, z-org).");
   });
 
   test("returns null when the user cancels an org selection", async () => {

--- a/packages/cli/test/lib/init/ui/ink-app.snapshot.test.tsx
+++ b/packages/cli/test/lib/init/ui/ink-app.snapshot.test.tsx
@@ -329,6 +329,50 @@ describe("Ink App snapshot", () => {
     expect(hasForcedWhiteForeground(withoutFeedbackBanner(frame))).toBe(false);
   });
 
+  test("centered select options share aligned label and hint columns", async () => {
+    const options = [
+      { value: "short", label: "Short", hint: "short-slug" },
+      { value: "empower", label: "Empower Plant", hint: "demo" },
+      { value: "sdks", label: "Sentry SDKs", hint: "sentry-sdks" },
+    ];
+    const store = new WizardStore({ bannerRows: [], layout: "intro" });
+    store.setPrompt({
+      kind: "select",
+      message: "Choose a project",
+      options,
+      initialIndex: 0,
+      resolve: ignorePromptResolution,
+    });
+
+    const frame = stripAnsi((await renderApp(store, 80)).allOutput());
+    const lines = frame.split(LINE_SPLIT_RE);
+    const renderedOptions = options.map(({ label, hint }) => {
+      const line = lines.find((candidate) => candidate.includes(label));
+      if (!line) {
+        throw new Error(`Missing rendered option: ${label}`);
+      }
+      const hintColumn = line.indexOf(hint);
+      if (hintColumn < 0) {
+        throw new Error(`Missing rendered hint: ${hint}`);
+      }
+      return {
+        hintColumn,
+        labelColumn: line.indexOf(label),
+      };
+    });
+
+    expect(renderedOptions.map(({ labelColumn }) => labelColumn)).toEqual([
+      renderedOptions[0]?.labelColumn,
+      renderedOptions[0]?.labelColumn,
+      renderedOptions[0]?.labelColumn,
+    ]);
+    expect(renderedOptions.map(({ hintColumn }) => hintColumn)).toEqual([
+      renderedOptions[0]?.hintColumn,
+      renderedOptions[0]?.hintColumn,
+      renderedOptions[0]?.hintColumn,
+    ]);
+  });
+
   test("workflow screen hides logo and shows feedback banner", async () => {
     const store = new WizardStore({
       bannerRows: TEST_BANNER_ROWS,


### PR DESCRIPTION
## Summary

Sort organization and eligible team options before showing them, so interactive prompts and `--yes` use the same deterministic order.

Centered Ink selects now render as one bounded block with stable cursor, label, and hint columns. Long display names no longer shift individual rows, while the existing narrow-terminal clipping behavior stays intact.

## Test plan

- `pnpm exec vitest run test/lib/init/preflight.test.ts test/lib/init/ui/ink-app.snapshot.test.tsx test/lib/init/ui/ink-app.property.test.ts` — 62 tests passed
- `pnpm run lint` — 974 files checked
- `pnpm run generate:schema && pnpm run typecheck`
