### PR TITLE
feat(docs): add Vercel analytics and speed insights

### DIFF
--- a/apps/cli-docs/astro.config.mjs
+++ b/apps/cli-docs/astro.config.mjs
@@ -64,6 +64,7 @@ export default defineConfig({
       ],
       plugins: [sentryStarlightTheme(), sentryAgentMarkdown()],
       components: {
+        PageFrame: "./src/components/PageFrame.astro",
         Header: "./src/components/Header.astro",
         // The custom landing page should not render the docs theme footer.
         Footer: "./src/components/Footer.astro",

--- a/apps/cli-docs/package.json
+++ b/apps/cli-docs/package.json
@@ -12,6 +12,8 @@
     "@astrojs/starlight": "^0.41.5",
     "@sentry/astro": "^10.38.0",
     "@sentry/starlight-theme": "^0.8.0",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "astro": "^7.1.1",
     "sharp": "^0.35.0",
     "shiki": "^3.21.0"

--- a/apps/cli-docs/src/components/PageFrame.astro
+++ b/apps/cli-docs/src/components/PageFrame.astro
@@ -1,0 +1,15 @@
+---
+import Default from "@astrojs/starlight/components/PageFrame.astro";
+import Analytics from "@vercel/analytics/astro";
+import SpeedInsights from "@vercel/speed-insights/astro";
+---
+
+<!-- Starlight owns the layout; this wrapper preserves its slots and only mounts global telemetry. -->
+<Default>
+  <slot />
+  <slot name="header" slot="header" />
+  <slot name="sidebar" slot="sidebar" />
+</Default>
+
+<Analytics />
+<SpeedInsights />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,12 @@ importers:
       '@sentry/starlight-theme':
         specifier: ^0.8.0
         version: 0.8.1(@astrojs/starlight@0.41.6(@astrojs/markdown-remark@7.2.2)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.13.3)(tsx@4.23.5)(yaml@2.9.0))(typescript@5.9.3))
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(react@19.2.8)
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(react@19.2.8)
       astro:
         specifier: ^7.1.1
         version: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@24.13.3)(tsx@4.23.5)(yaml@2.9.0)
@@ -1894,6 +1900,61 @@ packages:
 
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
@@ -6387,6 +6448,14 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.3': {}
+
+  '@vercel/analytics@2.0.1(react@19.2.8)':
+    optionalDependencies:
+      react: 19.2.8
+
+  '@vercel/speed-insights@2.0.0(react@19.2.8)':
+    optionalDependencies:
+      react: 19.2.8
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:


### PR DESCRIPTION
## Summary

- mount Vercel Web Analytics and Speed Insights on every Starlight page
- preserve Starlight's default page frame and named slots through a small wrapper
- add the two Vercel packages to the docs workspace

## Test plan

- pnpm run generate:schema
- pnpm run generate:docs
- pnpm --filter sentry-cli-docs build — 47 pages built
- confirmed the generated homepage and getting-started page contain both Vercel telemetry components