### PR TITLE
fix(init): skip binary automatic pre-reads

### DIFF
--- a/packages/cli/src/lib/init/workflow-inputs.ts
+++ b/packages/cli/src/lib/init/workflow-inputs.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isLikelyBinary } from "../scan/index.js";
 import { MAX_FILE_BYTES } from "./constants.js";
 import { detectSentry } from "./tools/detect-sentry.js";
 import { listDir } from "./tools/list-dir.js";
@@ -131,7 +132,12 @@ export async function preReadCommonFiles(
       if (stat.size > MAX_FILE_BYTES) {
         continue;
       }
-      const content = await fs.promises.readFile(absPath, "utf-8");
+      const buffer = await fs.promises.readFile(absPath);
+      if (isLikelyBinary(buffer)) {
+        cache[filePath] = null;
+        continue;
+      }
+      const content = buffer.toString("utf-8");
       if (totalBytes + content.length <= MAX_PREREAD_TOTAL_BYTES) {
         cache[filePath] = content;
         totalBytes += content.length;

--- a/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
+++ b/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
@@ -103,6 +103,26 @@ describe("filesystem tools", () => {
     expect((existsResult.data as any).exists["missing.txt"]).toBe(false);
   });
 
+  test("reads binary content when the workflow explicitly requests it", async () => {
+    const content = Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x00, 0xff]);
+    fs.writeFileSync(path.join(testDir, "sentry-wizard"), content);
+
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { paths: ["sentry-wizard"] },
+      },
+      makeContext(testDir)
+    );
+
+    expect(result.ok).toBe(true);
+    expect((result.data as any).files["sentry-wizard"]).toBe(
+      content.toString("utf-8")
+    );
+  });
+
   test("applies patchsets and injects auth tokens into env files", async () => {
     const result = await executeTool(
       {

--- a/packages/cli/test/lib/safe-read.test.ts
+++ b/packages/cli/test/lib/safe-read.test.ts
@@ -272,4 +272,18 @@ describe("workflow-inputs preReadCommonFiles FIFO safety", () => {
     expect(cache["package.json"]).toBe('{"name":"x"}');
     expect(cache["tsconfig.json"]).toBeNull();
   });
+
+  test("does not pre-read binary content disguised as a common config", async () => {
+    writeFileSync(
+      join(dir, "package.json"),
+      Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x00, 0xff])
+    );
+
+    const listing: DirEntry[] = [
+      { name: "package.json", path: "package.json", type: "file" },
+    ];
+    const cache = await preReadCommonFiles(dir, listing);
+
+    expect(cache["package.json"]).toBeNull();
+  });
 });


### PR DESCRIPTION
The init preflight eagerly reads a small allowlist of common manifests and config files into initial workflow state. A binary file masquerading under one of those names should not be decoded and injected before any agent has asked for it.

## Summary

- Read automatic preflight candidates as bytes and apply the existing bounded NUL-byte classifier before UTF-8 decoding
- Store the existing null sentinel when an automatic pre-read candidate is binary
- Leave the full directory listing unchanged, including binary paths
- Deliberately leave the generic read-files tool unchanged: after an agent selects a path from the listing, the existing maxBytes-bounded read is allowed
- Add a regression test proving that automatic binary pre-reads are skipped while an explicitly requested binary path remains readable

The follow-up getsentry/cli#1404 adds scan and read diagnostics without changing that distinction.

## Test plan

- [x] 21 focused pre-read and filesystem-tool tests
- [x] Biome check on changed files
- [x] pnpm typecheck