### PR TITLE
fix(init): surface directory read errors

### DIFF
--- a/packages/cli/src/lib/init/tools/list-dir.ts
+++ b/packages/cli/src/lib/init/tools/list-dir.ts
@@ -72,14 +72,6 @@ type WalkState = {
   truncated: boolean;
 };
 
-async function readDirEntries(dir: string): Promise<fs.Dirent[]> {
-  try {
-    return await fs.promises.readdir(dir, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-}
-
 function omissionReason(
   entry: fs.Dirent,
   state: WalkState,
@@ -147,7 +139,9 @@ async function walkDirectory(
     return;
   }
 
-  for (const entry of await readDirEntries(dir)) {
+  for (const entry of await fs.promises.readdir(dir, {
+    withFileTypes: true,
+  })) {
     if (state.entries.length >= state.maxEntries) {
       state.truncated = true;
       return;

--- a/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
+++ b/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
@@ -49,6 +49,21 @@ describe("filesystem tools", () => {
     expect(result.error).toContain("outside project directory");
   });
 
+  test("returns a failed tool result when a directory cannot be read", async () => {
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "list-dir",
+        cwd: testDir,
+        params: { path: "does-not-exist" },
+      },
+      makeContext(testDir)
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("ENOENT");
+  });
+
   test("lists and precomputes directory contents", async () => {
     fs.writeFileSync(path.join(testDir, "index.ts"), "export {};\n");
     fs.mkdirSync(path.join(testDir, "src"));

--- a/packages/cli/test/lib/init/tools/list-dir.test.ts
+++ b/packages/cli/test/lib/init/tools/list-dir.test.ts
@@ -327,12 +327,9 @@ describe("listDir", () => {
     }
   });
 
-  test("returns empty entries for a missing subpath", async () => {
-    // `safePath` allows nonexistent paths under the sandbox; `readdir`
-    // throws, which the walker swallows.
-    const entries = entriesOf(
-      await listDir(makePayload(testDir, { path: "does-not-exist" }))
-    );
-    expect(entries).toEqual([]);
+  test("surfaces readdir errors for a missing subpath", async () => {
+    await expect(
+      listDir(makePayload(testDir, { path: "does-not-exist" }))
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 });


### PR DESCRIPTION
The init directory walker currently catches every readdir failure and returns an empty array. A missing or unreadable directory is therefore indistinguishable from a genuinely empty repository and can produce a misleading no-files or unknown-platform bail.

## Summary

- Let readdir failures propagate from the directory walker
- Preserve registry behavior that converts suspended tool failures into an explicit ok false result for the server
- Make direct pre-scan failures surface to the CLI instead of silently starting with an empty listing

## Stack

This PR is based on getsentry/cli#1404 because both touch the directory walker. Its own diff only removes the silent readdir fallback and adds error-path coverage; scan metadata and exclusion policy remain in the preceding PR.

## Test plan

- [x] 25 targeted list-dir and filesystem-tool tests
- [x] Biome check on changed files
- [x] pnpm typecheck