### PR TITLE
chore(deps): upgrade Mastra client to 1.38

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -87,7 +87,7 @@
     "@biomejs/biome": "2.3.8",
     "@clack/prompts": "0.11.0",
     "@hono/node-server": "^2.0.10",
-    "@mastra/client-js": "^1.26.0",
+    "@mastra/client-js": "^1.38.0",
     "@sentry/api": "^0.256.0",
     "@sentry/core": "10.63.0",
     "@sentry/node-core": "10.63.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,8 +77,8 @@ importers:
         specifier: ^2.0.10
         version: 2.1.0(hono@4.12.34)
       '@mastra/client-js':
-        specifier: ^1.26.0
-        version: 1.36.0(express@5.2.1)(zod@4.4.3)
+        specifier: ^1.38.0
+        version: 1.38.0(express@5.2.1)(zod@4.4.3)
       '@sentry/api':
         specifier: ^0.256.0
         version: 0.256.0(valibot@1.4.2(typescript@5.9.3))(zod@4.4.3)
@@ -271,8 +271,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@5.0.11':
-    resolution: {integrity: sha512-7/96wE+ZsKB35iS9ASyllrE4Ym/EolXEB7AkuJ5FI++fmS85BVTAs77890C+1Z2jwHfBKjBQSBmsliOsAh0iFQ==}
+  '@ai-sdk/provider-utils@5.0.13':
+    resolution: {integrity: sha512-fScDJMDnTbx32kLDQqp0MvPjvwkgiwvlBxlmIg7XW5PbS91LG6JjH3PQG+34oMFglqfpQA355e24OdGj5PPoDw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -289,8 +289,8 @@ packages:
     resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/provider@4.0.3':
-    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+  '@ai-sdk/provider@4.0.4':
+    resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
     engines: {node: '>=22'}
 
   '@ai-sdk/ui-utils@1.2.11':
@@ -1200,20 +1200,20 @@ packages:
     resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
     engines: {node: '>=8'}
 
-  '@mastra/client-js@1.36.0':
-    resolution: {integrity: sha512-azukjlQ6WBbrSj1QP7p1TSryXHE5GlMZ1KycehelRdCC0is2qt3gwJXaIndZ9Zq2EYZa/qrb9KprJ+7UTKc4pA==}
+  '@mastra/client-js@1.38.0':
+    resolution: {integrity: sha512-dSCfoLVMbEkchL2/6Ea3fltVt7fYHIPFkIRJ423EOy8Qg17xD84FHdLZxbUnG1YKHZFuwyVN9wTIVRjYQcIgNQ==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@mastra/core@1.55.0':
-    resolution: {integrity: sha512-h6Ic64TE3KbmbjUXOxSXfyhAGyT8AzCJgfe8GnC4zQukXhpfz0J7jUgOUr9B+O9sC6EQ1LsHjjsmXBfE0xNSrw==}
+  '@mastra/core@1.57.0':
+    resolution: {integrity: sha512-2ud56Ow5wwyAFegxXkkOHcQfCG0W9Sz1ex2qVf3y/704zwwYZl/RBZXZV/7277RIxWFk8Bnw8pmGtGQ4tZVWEg==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@mastra/schema-compat@1.3.4':
-    resolution: {integrity: sha512-2ObUsd21KIVelQy+eKPxJvnMxtmKnWacsIkZovhEYjVcQX9OYTDQ+u4E4RboIJZvurJnFx++/ujQLFznUaEYMg==}
+  '@mastra/schema-compat@1.3.5':
+    resolution: {integrity: sha512-9CdBZZ2Fb8q6Ms4r6hs0msH8MTmVn99Zrc+i8BnNNuqKlIrywIoH3BghmPr5VsvkBUx7u/GjdYAsJ6i9nPcZZA==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -4746,9 +4746,9 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@5.0.11(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.13(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider': 4.0.4
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
@@ -4766,7 +4766,7 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@4.0.3':
+  '@ai-sdk/provider@4.0.4':
     dependencies:
       json-schema: 0.4.0
 
@@ -5640,12 +5640,12 @@ snapshots:
     dependencies:
       '@lukeed/csprng': 1.1.0
 
-  '@mastra/client-js@1.36.0(express@5.2.1)(zod@4.4.3)':
+  '@mastra/client-js@1.38.0(express@5.2.1)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/ui-utils': 1.2.11(zod@4.4.3)
       '@lukeed/uuid': 2.0.1
-      '@mastra/core': 1.55.0(express@5.2.1)(zod@4.4.3)
-      '@mastra/schema-compat': 1.3.4(zod@4.4.3)
+      '@mastra/core': 1.57.0(express@5.2.1)(zod@4.4.3)
+      '@mastra/schema-compat': 1.3.5(zod@4.4.3)
       canonicalize: 1.0.8
       jose: 6.2.3
       json-schema: 0.4.0
@@ -5662,18 +5662,18 @@ snapshots:
       - utf-8-validate
       - workflow
 
-  '@mastra/core@1.55.0(express@5.2.1)(zod@4.4.3)':
+  '@mastra/core@1.57.0(express@5.2.1)(zod@4.4.3)':
     dependencies:
       '@a2a-js/sdk': 0.3.14(express@5.2.1)
       '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.30(zod@4.4.3)'
       '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.40(zod@4.4.3)'
-      '@ai-sdk/provider-utils-v7': '@ai-sdk/provider-utils@5.0.11(zod@4.4.3)'
+      '@ai-sdk/provider-utils-v7': '@ai-sdk/provider-utils@5.0.13(zod@4.4.3)'
       '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.3'
       '@ai-sdk/provider-v6': '@ai-sdk/provider@3.0.14'
-      '@ai-sdk/provider-v7': '@ai-sdk/provider@4.0.3'
+      '@ai-sdk/provider-v7': '@ai-sdk/provider@4.0.4'
       '@isaacs/ttlcache': 2.1.5
       '@lukeed/uuid': 2.0.1
-      '@mastra/schema-compat': 1.3.4(zod@4.4.3)
+      '@mastra/schema-compat': 1.3.5(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.30.0(zod@4.4.3)
       '@sindresorhus/slugify': 2.2.1
       '@standard-schema/spec': 1.1.0
@@ -5708,7 +5708,7 @@ snapshots:
       - utf-8-validate
       - workflow
 
-  '@mastra/schema-compat@1.3.4(zod@4.4.3)':
+  '@mastra/schema-compat@1.3.5(zod@4.4.3)':
     dependencies:
       json-schema-to-zod: 2.8.1
       zod: 4.4.3


### PR DESCRIPTION
## Summary

- upgrade `@mastra/client-js` to 1.38
- align the CLI's bundled Mastra Core with 1.57 for the upcoming native agent suspend/resume work
- include the 1.38 streamed UTF-8 decoding fix

The manifest still declared `^1.26.0`, but the lockfile already resolved 1.36.0. The effective runtime change in this PR is therefore client 1.36.0 → 1.38.0 and Core 1.55.0 → 1.57.0.

## CLI size

Measured from clean `origin/main` and this branch with the same `SENTRY_CLIENT_ID` and build commands:

| Artifact | Before | After | Delta |
| --- | ---: | ---: | ---: |
| npm CJS bundle | 4,436,770 B | 4,421,081 B | -15,689 B (-0.354%) |
| npm ESM bundle | 4,430,445 B | 4,414,748 B | -15,697 B (-0.354%) |
| npm package, packed | 4,427,924 B | 4,426,976 B | -948 B (-0.021%) |
| npm package, unpacked | 15,432,004 B | 15,400,618 B | -31,386 B (-0.203%) |
| standalone JS payload | 4,378,769 B | 4,363,073 B | -15,696 B (-0.358%) |
| macOS arm64 binary | 107,027,744 B | 107,011,328 B | -16,416 B (-0.015%) |
| macOS arm64 gzip | 27,971,571 B | 27,971,237 B | -334 B (-0.001%) |

No size regression: every measured artifact is slightly smaller.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter sentry run typecheck`
- `pnpm --filter sentry run lint`
- `pnpm --filter sentry run check:deps`
- `SENTRY_CLIENT_ID=ci-fork-pr-dummy pnpm --filter sentry run bundle`
- `SENTRY_CLIENT_ID=ci-fork-pr-dummy RELEASE_BUILD=1 pnpm --filter sentry run build`
- Mastra init transport tests: 68 passed
- npm bundle smoke on Node 20.20.2: `--help` and `auth status`
- full unit suite: 9,109 passed; two Bash-completion tests fail identically on clean `origin/main`
