### PR TITLE
fix(sdk): pass each positional argument as its own argv token

### DIFF
--- a/packages/cli/script/generate-sdk.ts
+++ b/packages/cli/script/generate-sdk.ts
@@ -182,9 +182,12 @@ function extractSdkFlags(command: Command): SdkFlagInfo[] {
  * - Single or compound placeholder → { name, variadic: false }
  * - Variadic (e.g., "<args...>") → { name, variadic: true }
  */
+/** One entry of a tuple positional, mapped to its own SDK param. */
+type PositionalEntry = { name: string; brief?: string };
+
 type PositionalInfo =
   | null
-  | { name: string; variadic: false }
+  | { entries: PositionalEntry[]; variadic: false }
   | { name: string; variadic: true };
 
 function derivePositional(command: Command): PositionalInfo {
@@ -200,13 +203,15 @@ function derivePositional(command: Command): PositionalInfo {
   }
 
   if (params.kind === "tuple" && params.parameters.length > 0) {
-    // For tuple positionals, combine all placeholders into a single string param.
-    // The command's internal parser handles splitting (e.g., "org/project/trace-id").
-    const placeholders = params.parameters.map(
-      (p, i) => p.placeholder ?? `arg${i}`
-    );
-    const name = placeholders.join("/").replace(PLACEHOLDER_CLEAN_RE, "");
-    return { name, variadic: false };
+    // One param per tuple entry. A compound placeholder is a single entry whose own parser
+    // splits it ("org/version" → orgVersion), but separate entries are separate argv tokens:
+    // joining them into one param made every multi-positional command unusable, because the
+    // whole string arrived as argv[0] and the remaining arguments were simply missing.
+    const entries = params.parameters.map((p, i) => ({
+      name: (p.placeholder ?? `arg${i}`).replace(PLACEHOLDER_CLEAN_RE, ""),
+      brief: p.brief,
+    }));
+    return { entries, variadic: false };
   }
 
   return null;
@@ -321,8 +326,10 @@ function generateParamsInterface(
   const lines: string[] = [];
 
   if (positional && !positional.variadic) {
-    lines.push("  /** Positional argument */");
-    lines.push(`  ${camelCase(positional.name)}?: string;`);
+    for (const entry of positional.entries) {
+      lines.push(`  /** ${entry.brief ?? "Positional argument"} */`);
+      lines.push(`  ${camelCase(entry.name)}?: string;`);
+    }
   }
 
   for (const flag of flags) {
@@ -360,9 +367,17 @@ function buildInvokeArgs(
   if (positional) {
     if (positional.variadic) {
       positionalExpr = "positional";
-    } else {
-      const camel = camelCase(positional.name);
+    } else if (positional.entries.length === 1) {
+      const [entry] = positional.entries;
+      const camel = camelCase(entry?.name ?? "");
       positionalExpr = `params?.${camel} ? [params.${camel}] : []`;
+    } else {
+      // Arity matters here, so the values cannot simply be filtered: dropping an omitted
+      // entry would shift every later argument into the wrong slot.
+      const args = positional.entries
+        .map((entry) => `params?.${camelCase(entry.name)}`)
+        .join(", ");
+      positionalExpr = `positionals(${args})`;
     }
   }
 
@@ -664,6 +679,21 @@ const output = [
     : "// No commands have parameters.",
   "",
   "// --- SDK factory ---",
+  "",
+  "/**",
+  " * Positional arguments for a command that takes more than one, in declaration order.",
+  " *",
+  " * Trailing omissions are dropped so optional tail arguments stay optional, but an omission",
+  " * in the middle becomes an empty string rather than disappearing - collapsing it would move",
+  " * every later argument into the wrong slot and silently run a different command.",
+  " */",
+  "function positionals(...values: (string | undefined)[]): string[] {",
+  "  let end = values.length;",
+  "  while (end > 0 && values[end - 1] === undefined) {",
+  "    end--;",
+  "  }",
+  '  return values.slice(0, end).map((value) => value ?? "");',
+  "}",
   "",
   "/** Invoke function type from sdk-invoke.ts */",
   "type Invoke = ReturnType<typeof buildInvoker>;",

--- a/packages/cli/test/lib/sdk-positionals.test.ts
+++ b/packages/cli/test/lib/sdk-positionals.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit Tests for Generated SDK Positional Arguments
+ *
+ * Commands whose positionals are declared as a tuple of several parameters must forward one argv
+ * token per parameter. The generator used to join their placeholders into a single param, so the
+ * whole string arrived as argv[0] and every later argument was missing - `release deploy` and
+ * `snapshots diff` failed outright because their second positional is required.
+ *
+ * These tests drive the generated method tree with a recording invoker, so they fail if the
+ * generator regresses without anyone having to read the generated output.
+ */
+
+import { describe, expect, test } from "vitest";
+import { createSDKMethods } from "../../src/sdk.generated.js";
+
+type RecordedCall = { path: string[]; positional: string[] };
+
+function createRecordingSDK(): {
+  calls: RecordedCall[];
+  sdk: ReturnType<typeof createSDKMethods>;
+} {
+  const calls: RecordedCall[] = [];
+  const invoke = ((path: string[], _flags: unknown, positional: string[]) => {
+    calls.push({ path, positional });
+    return Promise.resolve(undefined);
+  }) as Parameters<typeof createSDKMethods>[0];
+
+  return { calls, sdk: createSDKMethods(invoke) };
+}
+
+describe("generated SDK positional arguments", () => {
+  test("release deploy passes version, environment and name as separate tokens", async () => {
+    const { calls, sdk } = createRecordingSDK();
+
+    await sdk.release.deploy({
+      orgVersion: "1.0.0",
+      environment: "production",
+      name: "Deploy #42",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.path).toEqual(["release", "deploy"]);
+    expect(calls[0]?.positional).toEqual(["1.0.0", "production", "Deploy #42"]);
+  });
+
+  test("release deploy omits a trailing optional positional", async () => {
+    const { calls, sdk } = createRecordingSDK();
+
+    await sdk.release.deploy({ orgVersion: "1.0.0", environment: "production" });
+
+    expect(calls[0]?.positional).toEqual(["1.0.0", "production"]);
+  });
+
+  test("a missing middle positional keeps later arguments in their own slots", async () => {
+    const { calls, sdk } = createRecordingSDK();
+
+    // Dropping the hole instead would make "Deploy #42" the environment, quietly recording the
+    // deploy against an environment the caller never named.
+    await sdk.release.deploy({ orgVersion: "1.0.0", name: "Deploy #42" });
+
+    expect(calls[0]?.positional).toEqual(["1.0.0", "", "Deploy #42"]);
+  });
+
+  test("snapshots diff passes both directories", async () => {
+    const { calls, sdk } = createRecordingSDK();
+
+    await sdk.snapshots.diff({ baseDir: "./base", headDir: "./head" });
+
+    expect(calls[0]?.positional).toEqual(["./base", "./head"]);
+  });
+
+  test("commands with a single compound positional still pass one token", async () => {
+    const { calls, sdk } = createRecordingSDK();
+
+    // "org/version" is one placeholder that the command splits itself, not two positionals.
+    await sdk.release.finalize({ orgVersion: "my-org/1.0.0" });
+
+    expect(calls[0]?.positional).toEqual(["my-org/1.0.0"]);
+  });
+
+  test("a command with no positionals passes none", async () => {
+    const { calls, sdk } = createRecordingSDK();
+
+    await sdk.release.deploy({});
+
+    expect(calls[0]?.positional).toEqual([]);
+  });
+});

--- a/packages/cli/test/lib/sdk-positionals.test.ts
+++ b/packages/cli/test/lib/sdk-positionals.test.ts
@@ -46,7 +46,10 @@ describe("generated SDK positional arguments", () => {
   test("release deploy omits a trailing optional positional", async () => {
     const { calls, sdk } = createRecordingSDK();
 
-    await sdk.release.deploy({ orgVersion: "1.0.0", environment: "production" });
+    await sdk.release.deploy({
+      orgVersion: "1.0.0",
+      environment: "production",
+    });
 
     expect(calls[0]?.positional).toEqual(["1.0.0", "production"]);
   });


### PR DESCRIPTION
FYI this PR has been generated with AI, but verified in our SDK cli v2 -> this cli updagrade

The issue was that we couldn't use `release.deploy` and had to use the `.run()` escape hatch

---

Commands that declare several positionals as a tuple had every placeholder joined into a single generated param. `release deploy` takes `<org/version> <environment> [<name>]`, but the SDK exposed one `orgVersionEnvironmentName` string and forwarded it as a single argv token:

```ts
// before
deploy: params => invoke(["release","deploy"], {...},
  params?.orgVersionEnvironmentName ? [params.orgVersionEnvironmentName] : [])
```

The whole string landed in the handler's first parameter and the rest were `undefined`. No value could fix that from the caller's side, since the emitted array always had exactly one element:

```
$ sentry release deploy "1.0.0 production"
Expected argument for environment
```

`<environment>` is required, so `release.deploy()` could never succeed through the SDK. `snapshots diff` had the same fate; `init` and `trial start` degraded more quietly, ignoring their second argument because it is optional.

_Root cause_

The join was written for compound placeholders — `<org/version>` genuinely is one token that the command splits itself, which is what the original comment describes. The same code path also ran for genuinely separate positionals and joined those with `/` too, so a real compound (`orgVersion`) and a mashed-together trio (`orgVersionEnvironmentName`) came out indistinguishable. `PositionalInfo` had no way to represent more than one positional, so the collapse was structural rather than a stray line.

The runtime was never at fault: `sdk-invoke` already spread whatever array it received into the handler.

_Decisions_

The single-placeholder path is deliberately untouched, so every single-positional command generates byte-identically and the regenerated output differs only for the four affected commands.

Omitted entries could not simply be filtered out. All positional params are optional in the generated types, and dropping a hole shifts later arguments into earlier slots — for `release deploy` that silently records against an environment the caller never named. The `positionals()` helper therefore trims only trailing omissions and pads interior gaps with an empty string, letting the command reject it.

I left one related flaw alone: the generator discards each positional's `optional` flag, so required positionals are still typed `?: string` and `params` itself stays optional even when a command requires arguments. Fixing that is correct but flips `params?:` to `params:` across many commands, which is a far wider type break than this bug warrants.

_Breaking change_

Four params are renamed in the published type declarations:

| Command | Before | After |
|---|---|---|
| `release deploy` | `orgVersionEnvironmentName` | `orgVersion`, `environment`, `name` |
| `snapshots diff` | `baseDirHeadDir` | `baseDir`, `headDir` |
| `init` | `targetDirectory` | `target`, `directory` |
| `trial start` | `nameOrg` | `name`, `org` |

`release deploy` and `snapshots diff` already threw at runtime, so no working caller exists for those. `init` and `trial start` are the real compat surface, since a single-argument call worked there before. If that matters, the old key could be kept as a deprecated alias feeding the first positional — happy to add it.

_Follow-up worth considering_

The added tests name specific commands, so they would not catch a **new** multi-positional command regressing — which is how this shipped in the first place. A structural sweep asserting "declared placeholder count equals emitted param count" across all 108 commands would close that, along with coverage for `init` / `trial start` and an assertion that flags still arrive correctly alongside positionals. Not in this PR; say the word and I'll add them.

_Verification_

Beyond the unit tests, this was exercised end to end from the Sentry JavaScript SDK, whose bundler plugin drives `release deploy` through the `run()` escape hatch precisely because the typed method was unusable. With this branch linked in, the adapter switches to `release.deploy({ orgVersion, environment, name, ... })` and the deploy reaches `POST /api/0/organizations/<org>/releases/1.0.0/deploys/` against a mock Sentry server. Every other CLI call that SDK makes — `release.create`, `release.finalize`, `release['set-commits']`, `sourcemap.inject`, `sourcemap.upload`, `run('info')` — behaves identically before and after.
