### PR TITLE
fix(init): detect existing installations safely

### DIFF
--- a/packages/cli/src/lib/init/interactive.ts
+++ b/packages/cli/src/lib/init/interactive.ts
@@ -50,6 +50,46 @@ const DEFAULT_FEATURE_RANK = new Map<string, number>(
 const UNSUPPORTED_INIT_FEATURES = new Set(["userFeedback"]);
 const FEATURE_SELECTION_CONTEXT =
   "Based on your project, these features are available to set up.";
+const TRAILING_SLASHES_RE = /\/+$/;
+
+function appFlagAliases(app: AppEntry): string[] {
+  const normalizedPath = app.path
+    .replaceAll("\\", "/")
+    .replace(TRAILING_SLASHES_RE, "");
+  const pathBasename = normalizedPath.split("/").at(-1);
+  return [app.name, app.path, pathBasename]
+    .filter((value): value is string => Boolean(value))
+    .map((value) => value.toLowerCase());
+}
+
+function resolveAppFlag(apps: AppEntry[], requestedApp: string): AppEntry[] {
+  const requested = requestedApp.toLowerCase();
+  const exactMatches = apps.filter(
+    (app) =>
+      app.name.toLowerCase() === requested ||
+      app.path.toLowerCase() === requested
+  );
+  return exactMatches.length > 0
+    ? exactMatches
+    : apps.filter((app) => appFlagAliases(app).includes(requested));
+}
+
+function buildAmbiguousAppMessage(
+  requested: string,
+  matches: AppEntry[]
+): string {
+  return [
+    `App alias "${requested}" is ambiguous in this monorepo.`,
+    "",
+    "Matching apps:",
+    ...formatAppList(
+      matches,
+      matches.map((app) => app.name)
+    ),
+    "",
+    "Re-run with the exact app name or full path.",
+  ].join("\n");
+}
 
 function sortFeatureOptions(features: string[]): string[] {
   return features.slice().sort((a, b) => {
@@ -152,6 +192,34 @@ function buildAppNotFoundMessage(
   ].join("\n");
 }
 
+function selectAppByFlag(
+  requestedApp: string,
+  apps: AppEntry[],
+  ui: WizardUI
+): Record<string, unknown> {
+  const matches = resolveAppFlag(apps, requestedApp);
+  if (matches.length !== 1) {
+    const message =
+      matches.length > 1
+        ? buildAmbiguousAppMessage(requestedApp, matches)
+        : buildAppNotFoundMessage(
+            requestedApp,
+            apps,
+            apps.map((app) => app.name)
+          );
+    ui.log.error(message);
+    throw new WizardError(message, { rendered: true });
+  }
+  const match = matches.at(0);
+  if (!match) {
+    throw new WizardError("App selection unexpectedly failed.", {
+      rendered: false,
+    });
+  }
+  ui.log.info(`Using app: ${match.name}`);
+  return { selectedApp: match.name };
+}
+
 async function handleSelect(
   payload: SelectPayload,
   options: InteractiveContext,
@@ -167,16 +235,7 @@ async function handleSelect(
   }
 
   if (options.app && payload.apps && payload.apps.length > 0) {
-    const match = items.find(
-      (item) => item.toLowerCase() === options.app?.toLowerCase()
-    );
-    if (!match) {
-      const message = buildAppNotFoundMessage(options.app, apps, items);
-      ui.log.error(message);
-      throw new WizardError(message, { rendered: true });
-    }
-    ui.log.info(`Using app: ${match}`);
-    return { selectedApp: match };
+    return selectAppByFlag(options.app, apps, ui);
   }
 
   if (options.yes && items.length === 1) {

--- a/packages/cli/src/lib/init/tools/detect-sentry.ts
+++ b/packages/cli/src/lib/init/tools/detect-sentry.ts
@@ -1,24 +1,163 @@
+import {
+  collectGlob,
+  collectGrep,
+  DEFAULT_SKIP_DIRS,
+  DSN_ADDITIONAL_SKIP_DIRS,
+  isMonorepoPackageDir,
+} from "../../scan/index.js";
 import type { DetectSentryPayload, ToolResult } from "../types.js";
 import type { InitToolDefinition } from "./types.js";
+
+const SKIP_DIRS = [...DEFAULT_SKIP_DIRS, ...DSN_ADDITIONAL_SKIP_DIRS];
+const MAX_SCAN_DEPTH = 6;
+
+const CONFIG_PATTERNS = [
+  "sentry.properties",
+  "sentry.config.*",
+  "sentry.*.config.*",
+  "config/sentry.php",
+  "config/packages/sentry.yaml",
+];
+
+const MANIFEST_PATTERNS = [
+  "package.json",
+  "requirements*.txt",
+  "pyproject.toml",
+  "Pipfile",
+  "Gemfile",
+  "composer.json",
+  "go.mod",
+  "Cargo.toml",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+  "libs.versions.toml",
+  "*.csproj",
+  "*.fsproj",
+  "*.vbproj",
+  "Directory.Packages.props",
+  "packages.config",
+  "Package.swift",
+  "Podfile",
+  "pubspec.yaml",
+  "mix.exs",
+];
+
+const SOURCE_PATTERNS = [
+  "*.{ts,tsx,js,jsx,mjs,cjs,astro,vue,svelte}",
+  "*.{py,go,rb,erb,php,java,kt,kts,scala,groovy}",
+  "*.{cs,fs,vb,rs,swift,m,mm,dart,ex,exs,erl,lua}",
+  "*.{xml,properties,yaml,yml}",
+];
+
+const SDK_PATTERN = String.raw`(?:@sentry\/(?!(?:cli|wizard|vite-plugin|webpack-plugin|rollup-plugin|esbuild-plugin|bundler-plugin-core)(?:["'\s/@]|$))|sentry-sdk|sentry-(?:ruby|rails|sidekiq|delayed_job|resque)|sentry\/sentry|github\.com\/getsentry\/sentry-go|io\.sentry|Package(?:Reference|Version)[^>]+Include=["']Sentry(?:\.[^"']+)?|\bsentry_flutter\b|\bsentry_dart\b|\bsentry-cocoa\b|\bpod\s+["']Sentry(?:\/[^"']+)?["']|\{\s*:sentry\b|\bsentry\s*=\s*["']|\bsentry\s*:)`;
+
+const INIT_PATTERN = String.raw`(?:\bSentry[A-Za-z0-9_]*\s*(?:\.|::)\s*(?:init|Init|start)\s*(?:\(|\b)|\bsentry_sdk\s*\.\s*init\s*\(|\bsentry\s*\.\s*(?:init|Init)\s*\(|\bsentry\s*::\s*init\s*\(|\\Sentry\\init\s*\(|\bconfig\s+:sentry\b|\.(?:UseSentry|AddSentry)\s*\(|\[\s*SentrySDK\s+startWithConfigureOptions\s*:|\bio\.sentry\.(?:auto-init|dsn)\b|\bsentry\.dsn\s*=)`;
+
+const COMMENT_PREFIX_RE = /^(?:\/\/|\/\*|\*|#|<!--|--)/;
+
+function nextDepth(relativePath: string, currentDepth: number): number {
+  return isMonorepoPackageDir(relativePath) ? 0 : currentDepth + 1;
+}
+
+const scanOptions = {
+  alwaysSkipDirs: SKIP_DIRS,
+  descentHook: nextDepth,
+  hidden: true,
+  maxDepth: MAX_SCAN_DEPTH,
+  nestedGitignore: true,
+  respectGitignore: true,
+} as const;
+
+async function detectScopedDsn(cwd: string) {
+  const { detectFromEnvFiles, scanCodeForFirstDsn } = await import(
+    "../../dsn/index.js"
+  );
+
+  const [codeDsn, envFileDsn] = await Promise.all([
+    scanCodeForFirstDsn(cwd),
+    detectFromEnvFiles(cwd),
+  ]);
+  return codeDsn ?? envFileDsn;
+}
+
+function firstRuntimeInitMatch<T extends { line: string }>(
+  matches: T[]
+): T | undefined {
+  return matches.find(
+    (match) => !COMMENT_PREFIX_RE.test(match.line.trimStart())
+  );
+}
 
 /**
  * Detect existing Sentry signals in the local project directory.
  */
 export async function detectSentry(cwd: string): Promise<ToolResult> {
-  const { detectDsn } = await import("../../dsn/index.js");
-  const dsn = await detectDsn(cwd);
+  const [dsn, sdkResult, initResult, configResult] = await Promise.all([
+    detectScopedDsn(cwd),
+    collectGrep({
+      cwd,
+      pattern: SDK_PATTERN,
+      include: MANIFEST_PATTERNS,
+      maxResults: 1,
+      stopOnFirst: true,
+      ...scanOptions,
+    }),
+    collectGrep({
+      cwd,
+      pattern: INIT_PATTERN,
+      include: SOURCE_PATTERNS,
+      maxResults: 20,
+      stopOnFirst: false,
+      ...scanOptions,
+    }),
+    collectGlob({
+      cwd,
+      patterns: CONFIG_PATTERNS,
+      maxResults: 1,
+      ...scanOptions,
+    }),
+  ]);
 
-  if (!dsn) {
-    return { ok: true, data: { status: "none", signals: [] } };
+  const signals: string[] = [];
+  if (dsn) {
+    signals.push(
+      `dsn: ${dsn.source}${dsn.sourcePath ? ` (${dsn.sourcePath})` : ""}`
+    );
+  }
+  const sdkMatch = sdkResult.matches[0];
+  if (sdkMatch) {
+    signals.push(`sdk: ${sdkMatch.path}`);
+  }
+  const configPath = configResult.files[0];
+  // sentry.properties is also used by build-only debug-symbol/source-map
+  // upload tooling. Treat it as runtime evidence only when corroborated by a
+  // runtime SDK or init signal.
+  if (configPath && configPath !== "sentry.properties") {
+    signals.push(`config: ${configPath}`);
+  }
+  const initMatch = firstRuntimeInitMatch(initResult.matches);
+  if (initMatch) {
+    signals.push(`init: ${initMatch.path}:${initMatch.lineNum}`);
   }
 
-  const signals = [
-    `dsn: ${dsn.source}${dsn.sourcePath ? ` (${dsn.sourcePath})` : ""}`,
-  ];
+  const hasStrongRuntimeSignal = Boolean(dsn || initMatch);
+  const hasSdkAndConfig = Boolean(sdkMatch && configPath);
+  let status: "installed" | "partial" | "none" = "none";
+  if (hasStrongRuntimeSignal || hasSdkAndConfig) {
+    status = "installed";
+  } else if (signals.length > 0) {
+    status = "partial";
+  }
 
   return {
     ok: true,
-    data: { status: "installed", signals, dsn: dsn.raw },
+    data: {
+      cwd: cwd.replaceAll("\\", "/"),
+      status,
+      signals,
+      ...(dsn ? { dsn: dsn.raw } : {}),
+    },
   };
 }
 

--- a/packages/cli/test/lib/init/interactive.test.ts
+++ b/packages/cli/test/lib/init/interactive.test.ts
@@ -210,6 +210,68 @@ describe("handleSelect with --app flag", () => {
     expect(result).toEqual({ selectedApp: "Web" });
   });
 
+  test("matches --app against app names even when options use different values", async () => {
+    const { ui } = createMockUI();
+    const result = await handleInteractive(
+      {
+        type: "interactive",
+        prompt: "Select the target application:",
+        kind: "select",
+        apps: [
+          { name: "web", path: "/repo/apps/web" },
+          { name: "api", path: "/repo/apps/api" },
+        ],
+        options: ["/repo/apps/web", "/repo/apps/api"],
+      },
+      makeOptions({ app: "web" }),
+      ui
+    );
+
+    expect(result).toEqual({ selectedApp: "web" });
+  });
+
+  test("matches --app against the app path basename when the agent decorates its name", async () => {
+    const { ui } = createMockUI();
+    const result = await handleInteractive(
+      {
+        type: "interactive",
+        prompt: "Select the target application:",
+        kind: "select",
+        apps: [
+          {
+            name: "empty (example Strapi app)",
+            path: "/repo/examples/empty",
+          },
+        ],
+        options: ["empty (example Strapi app)"],
+      },
+      makeOptions({ app: "empty" }),
+      ui
+    );
+
+    expect(result).toEqual({ selectedApp: "empty (example Strapi app)" });
+  });
+
+  test("rejects an ambiguous --app path basename", async () => {
+    const { ui } = createMockUI();
+    await expect(
+      handleInteractive(
+        {
+          type: "interactive",
+          prompt: "Select the target application:",
+          kind: "select",
+          apps: [
+            { name: "primary web", path: "/repo/apps/web" },
+            { name: "example web", path: "/repo/examples/web" },
+          ],
+          options: ["primary web", "example web"],
+        },
+        makeOptions({ app: "web" }),
+        ui
+      )
+    ).rejects.toThrow("ambiguous");
+  });
+
   test("throws WizardError when --app name is not found", async () => {
     const { ui, calls } = createMockUI();
     await expect(

--- a/packages/cli/test/lib/init/tools/detect-sentry.test.ts
+++ b/packages/cli/test/lib/init/tools/detect-sentry.test.ts
@@ -1,0 +1,270 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+// biome-ignore lint/performance/noNamespaceImport: spyOn requires module namespaces
+import * as dsnIndex from "../../../../src/lib/dsn/index.js";
+import { detectSentry } from "../../../../src/lib/init/tools/detect-sentry.js";
+
+let testDir: string;
+let codeDsnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  testDir = fs.mkdtempSync(path.join("/tmp", "detect-sentry-"));
+  codeDsnSpy = vi
+    .spyOn(dsnIndex, "scanCodeForFirstDsn")
+    .mockResolvedValue(null);
+  vi.spyOn(dsnIndex, "detectFromEnvFiles").mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  fs.rmSync(testDir, { recursive: true, force: true });
+});
+
+describe("detectSentry", () => {
+  test("returns none when the project has no Sentry evidence", async () => {
+    fs.writeFileSync(path.join(testDir, "package.json"), '{"dependencies":{}}');
+
+    await expect(detectSentry(testDir)).resolves.toEqual({
+      ok: true,
+      data: { cwd: testDir, status: "none", signals: [] },
+    });
+  });
+
+  test("returns partial for an SDK dependency without runtime setup", async () => {
+    fs.writeFileSync(
+      path.join(testDir, "package.json"),
+      '{"dependencies":{"@sentry/nextjs":"^10.0.0"}}'
+    );
+
+    const result = await detectSentry(testDir);
+
+    expect(result.data).toEqual({
+      cwd: testDir,
+      status: "partial",
+      signals: ["sdk: package.json"],
+    });
+  });
+
+  test("does not mistake Sentry build tooling for a runtime installation", async () => {
+    fs.writeFileSync(
+      path.join(testDir, "package.json"),
+      '{"devDependencies":{"@sentry/cli":"^3.0.0","@sentry/wizard":"^6.0.0","@sentry/vite-plugin":"^4.0.0"}}'
+    );
+    fs.writeFileSync(path.join(testDir, ".sentryclirc"), "[defaults]\n");
+
+    const result = await detectSentry(testDir);
+
+    expect(result.data).toEqual({ cwd: testDir, status: "none", signals: [] });
+  });
+
+  test("returns partial for a config artifact without SDK or init evidence", async () => {
+    fs.writeFileSync(
+      path.join(testDir, "sentry.client.config.ts"),
+      "export {};\n"
+    );
+
+    const result = await detectSentry(testDir);
+
+    expect(result.data).toEqual({
+      cwd: testDir,
+      status: "partial",
+      signals: ["config: sentry.client.config.ts"],
+    });
+  });
+
+  test("does not treat build-only sentry.properties as runtime setup", async () => {
+    fs.writeFileSync(
+      path.join(testDir, "sentry.properties"),
+      "defaults.org=example\ndefaults.project=mobile\n"
+    );
+
+    const result = await detectSentry(testDir);
+
+    expect(result.data).toEqual({ cwd: testDir, status: "none", signals: [] });
+  });
+
+  test("returns installed when SDK and config evidence are both present", async () => {
+    fs.writeFileSync(
+      path.join(testDir, "package.json"),
+      '{"dependencies":{"@sentry/react":"^10.0.0"}}'
+    );
+    fs.writeFileSync(
+      path.join(testDir, "sentry.client.config.ts"),
+      "export {};\n"
+    );
+
+    const result = await detectSentry(testDir);
+
+    expect(result.data).toEqual({
+      cwd: testDir,
+      status: "installed",
+      signals: ["sdk: package.json", "config: sentry.client.config.ts"],
+    });
+  });
+
+  test("returns installed for an SDK init call even without a literal DSN", async () => {
+    fs.mkdirSync(path.join(testDir, "src"));
+    fs.writeFileSync(
+      path.join(testDir, "src", "instrumentation.ts"),
+      "Sentry.init({ dsn: process.env.SENTRY_DSN });\n"
+    );
+
+    const result = await detectSentry(testDir);
+
+    expect(result.data).toEqual({
+      cwd: testDir,
+      status: "installed",
+      signals: ["init: src/instrumentation.ts:1"],
+    });
+  });
+
+  test("recognizes non-JavaScript SDK manifests and init calls", async () => {
+    fs.writeFileSync(
+      path.join(testDir, "go.mod"),
+      "module example.com/app\n\nrequire github.com/getsentry/sentry-go v0.36.0\n"
+    );
+    fs.writeFileSync(
+      path.join(testDir, "main.go"),
+      "package main\n\nfunc main() { sentry.Init(sentry.ClientOptions{}) }\n"
+    );
+
+    const result = await detectSentry(testDir);
+
+    expect(result.data).toEqual({
+      cwd: testDir,
+      status: "installed",
+      signals: ["sdk: go.mod", "init: main.go:3"],
+    });
+  });
+
+  test("returns installed for a DSN from code or an env file", async () => {
+    codeDsnSpy.mockResolvedValue({
+      publicKey: "abc",
+      protocol: "https",
+      host: "o1.ingest.sentry.io",
+      projectId: "42",
+      raw: "https://abc@o1.ingest.sentry.io/42",
+      source: "env_file",
+      sourcePath: ".env",
+    });
+
+    const result = await detectSentry(testDir);
+
+    expect(result.data).toEqual({
+      cwd: testDir,
+      status: "installed",
+      signals: ["dsn: env_file (.env)"],
+      dsn: "https://abc@o1.ingest.sentry.io/42",
+    });
+  });
+
+  test("does not treat test fixtures as an existing installation", async () => {
+    fs.mkdirSync(path.join(testDir, "tests"));
+    fs.writeFileSync(
+      path.join(testDir, "tests", "fixture.ts"),
+      "Sentry.init({ dsn: 'fixture' });\n"
+    );
+
+    const result = await detectSentry(testDir);
+
+    expect(result.data).toEqual({ cwd: testDir, status: "none", signals: [] });
+  });
+
+  test("keeps detection scoped to the selected monorepo app", async () => {
+    const webDir = path.join(testDir, "apps", "web");
+    const apiDir = path.join(testDir, "apps", "api");
+    fs.mkdirSync(webDir, { recursive: true });
+    fs.mkdirSync(apiDir, { recursive: true });
+    fs.writeFileSync(path.join(webDir, "app.ts"), "export {};\n");
+    fs.writeFileSync(path.join(apiDir, "app.ts"), "Sentry.init({});\n");
+
+    const result = await detectSentry(webDir);
+
+    expect(result.data).toEqual({ cwd: webDir, status: "none", signals: [] });
+  });
+
+  test("ignores an ambient DSN that is not owned by the selected project", async () => {
+    vi.stubEnv("SENTRY_DSN", "https://ambient@o1.ingest.sentry.io/999999");
+    fs.writeFileSync(path.join(testDir, "package.json"), '{"dependencies":{}}');
+
+    const result = await detectSentry(testDir);
+
+    expect(result.data).toEqual({ cwd: testDir, status: "none", signals: [] });
+  });
+
+  test("ignores commented-out init calls", async () => {
+    fs.writeFileSync(
+      path.join(testDir, "instrumentation.ts"),
+      "// Sentry.init({ dsn: process.env.SENTRY_DSN });\n"
+    );
+
+    const result = await detectSentry(testDir);
+
+    expect(result.data).toEqual({ cwd: testDir, status: "none", signals: [] });
+  });
+
+  test.each([
+    ["config.exs", 'config :sentry, dsn: System.get_env("SENTRY_DSN")'],
+    ["Program.cs", "builder.WebHost.UseSentry();"],
+    [
+      "AppDelegate.m",
+      "[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {}];",
+    ],
+    [
+      "AndroidManifest.xml",
+      '<meta-data android:name="io.sentry.auto-init" android:value="true" />',
+    ],
+  ])("recognizes an automatic runtime init in %s", async (file, contents) => {
+    fs.writeFileSync(path.join(testDir, file), `${contents}\n`);
+
+    const result = await detectSentry(testDir);
+
+    expect(result.data).toEqual({
+      cwd: testDir,
+      status: "installed",
+      signals: [`init: ${file}:1`],
+    });
+  });
+
+  test("recognizes a Laravel runtime package and config", async () => {
+    fs.mkdirSync(path.join(testDir, "config"));
+    fs.writeFileSync(
+      path.join(testDir, "composer.json"),
+      '{"require":{"sentry/sentry-laravel":"^4.0"}}'
+    );
+    fs.writeFileSync(
+      path.join(testDir, "config", "sentry.php"),
+      "<?php return [];\n"
+    );
+
+    const result = await detectSentry(testDir);
+
+    expect(result.data).toEqual({
+      cwd: testDir,
+      status: "installed",
+      signals: ["sdk: composer.json", "config: config/sentry.php"],
+    });
+  });
+
+  test("recognizes Sentry from a Gradle version catalog", async () => {
+    fs.writeFileSync(
+      path.join(testDir, "libs.versions.toml"),
+      '[libraries]\nsentry = { module = "io.sentry:sentry-android", version = "8.0.0" }\n'
+    );
+    fs.writeFileSync(
+      path.join(testDir, "AndroidManifest.xml"),
+      '<meta-data android:name="io.sentry.dsn" android:value="$' +
+        '{SENTRY_DSN}" />\n'
+    );
+
+    const result = await detectSentry(testDir);
+
+    expect(result.data).toEqual({
+      cwd: testDir,
+      status: "installed",
+      signals: ["sdk: libs.versions.toml", "init: AndroidManifest.xml:1"],
+    });
+  });
+});

--- a/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
+++ b/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
@@ -22,15 +22,22 @@ function makeContext(directory: string): ResolvedInitContext {
 }
 
 let testDir: string;
-let detectDsnSpy: ReturnType<typeof spyOn>;
+let scanCodeForFirstDsnSpy: ReturnType<typeof spyOn>;
+let detectFromEnvFilesSpy: ReturnType<typeof spyOn>;
 
 beforeEach(() => {
   testDir = fs.mkdtempSync(path.join("/tmp", "init-tools-"));
-  detectDsnSpy = vi.spyOn(dsnIndex, "detectDsn").mockResolvedValue(null);
+  scanCodeForFirstDsnSpy = vi
+    .spyOn(dsnIndex, "scanCodeForFirstDsn")
+    .mockResolvedValue(null);
+  detectFromEnvFilesSpy = vi
+    .spyOn(dsnIndex, "detectFromEnvFiles")
+    .mockResolvedValue(null);
 });
 
 afterEach(() => {
-  detectDsnSpy.mockRestore();
+  scanCodeForFirstDsnSpy.mockRestore();
+  detectFromEnvFilesSpy.mockRestore();
   fs.rmSync(testDir, { recursive: true, force: true });
 });
 
@@ -253,7 +260,7 @@ describe("filesystem tools", () => {
   });
 
   test("reports installed Sentry signals when a DSN is detected", async () => {
-    detectDsnSpy.mockResolvedValue({
+    scanCodeForFirstDsnSpy.mockResolvedValue({
       publicKey: "abc",
       protocol: "https",
       host: "o1.ingest.sentry.io",


### PR DESCRIPTION
## Summary

The init preflight now determines existing Sentry state from evidence owned by the selected app directory instead of ambient process state. It reports partial as well as complete installations, ignores build-only tooling on its own, recognizes runtime SDKs and initialization across the supported ecosystems, and returns the scanned cwd so the server can verify that cached detection is scoped to the target.

This also makes non-interactive monorepo selection accept an exact app name, full path, or unique path basename. Exact matches take precedence, while ambiguous basename aliases fail with the matching apps instead of selecting the wrong target.

## Rollout compatibility

This is the CLI side of [getsentry/cli-init-api#216](https://github.com/getsentry/cli-init-api/pull/216). That server change treats both partial and installed state as a safety bail, trusts precomputed state only when its cwd matches the selected app, and falls back to its own scoped detection for older clients. Existing servers can ignore the additive cwd field, so the CLI and server changes do not need an atomic rollout.

## Test plan

- [x] 59 targeted interactive, filesystem-tool, and detect-sentry tests
- [x] pnpm typecheck
- [x] pnpm lint
- [x] pnpm check:deps
- [x] pnpm check:errors
- [x] pnpm check:patches
- [x] pnpm check:stale-refs
- [x] pnpm check:fragments
- [x] pnpm check:docs-sections
- [x] git diff --check