### PR TITLE
fix(bundle): stop writing a Bun polyfill onto globalThis

### DIFF
--- a/packages/cli/script/node-polyfills.ts
+++ b/packages/cli/script/node-polyfills.ts
@@ -14,10 +14,6 @@ import { compare as semverCompare } from "semver";
 import { glob } from "tinyglobby";
 import { uuidv7 } from "uuidv7";
 
-declare global {
-  var Bun: typeof BunPolyfill;
-}
-
 const BunPolyfill = {
   file(path: string) {
     return {
@@ -241,4 +237,15 @@ if (
   ): Promise<Buffer> => nodeZstdDecompress(toBufferForCompression(data));
 }
 
-globalThis.Bun = BunPolyfill as typeof Bun;
+/**
+ * The polyfill is exported rather than assigned to `globalThis`, because esbuild's `inject`
+ * substitutes unbound `Bun` identifiers in the bundle with this binding. Writing the global
+ * instead broke consumers in both directions: under Bun the global is readonly, so importing the
+ * package threw `Attempted to assign to readonly property`, and under Node it left a `Bun` object
+ * on `globalThis` that made unrelated libraries take their Bun code path and call methods the
+ * polyfill does not have, such as `Bun.serve`.
+ *
+ * The real Bun is preferred when present, so running under Bun keeps the genuine implementation.
+ */
+export const Bun: typeof BunPolyfill =
+  (globalThis as { Bun?: typeof BunPolyfill }).Bun ?? BunPolyfill;


### PR DESCRIPTION
I opened a PR that is using the new CLI instead of the old `@sentry/cli@2`: https://github.com/getsentry/sentry-javascript/pull/23398 

Some E2E tests failed with `TypeError: Bun.serve is not a function`, because we actually check internally if `Bun` would be an option. With that polyfill in this CLI this behavior is now forced, without Bun actually being there. Idk why this actually exists, but exporting `Bun` instead fixes it. 

---

AI description:

The Node polyfills were installed with `globalThis.Bun = BunPolyfill`, which broke consumers of the npm package in both directions.

Under Bun the global is readonly, so merely importing the package threw "Attempted to assign to readonly property" and took the whole process down. Under Node it left an object named `Bun` on the global, so unrelated libraries that feature-detect `typeof Bun !== "undefined"` took their Bun code path and called methods the polyfill does not implement, failing with errors like "Bun.serve is not a function". Both are reachable by anyone who merely depends on this package, since importing it is enough.

The polyfills are already delivered through esbuild's `inject`, which substitutes unbound identifiers with exported bindings, so exporting `Bun` gives the bundle the same value lexically without touching the global. The real Bun is preferred when present, so running under Bun keeps the genuine implementation rather than shadowing it.

Verified by importing the built bundle in Node: `globalThis.Bun` stays undefined, where it previously became an object whose `serve` and `version` were missing.