### PR TITLE
feat(init): echo workflow request IDs when resuming

### DIFF
--- a/packages/cli/src/lib/init/constants.ts
+++ b/packages/cli/src/lib/init/constants.ts
@@ -6,6 +6,9 @@ export const MASTRA_API_URL =
 
 export const WORKFLOW_ID = "sentry-wizard";
 
+export const INIT_PROTOCOL_VERSION = 1 as const;
+export const INIT_REQUEST_CONFLICT_CODE = "init_request_conflict" as const;
+
 export const SENTRY_DOCS_URL = "https://docs.sentry.io/platforms/";
 
 export const MAX_FILE_BYTES = 262_144; // 256KB per file

--- a/packages/cli/src/lib/init/types.ts
+++ b/packages/cli/src/lib/init/types.ts
@@ -66,6 +66,11 @@ export type InteractiveContext = Pick<
   "yes" | "dryRun" | "app"
 >;
 
+export type InitProtocolEnvelope = {
+  protocolVersion: 1;
+  requestId: string;
+};
+
 // Tool suspend payloads
 export type ToolPayload =
   | ListDirPayload
@@ -273,7 +278,13 @@ export type ConfirmPayload = {
   prompt: string;
 };
 
-export type SuspendPayload = ToolPayload | InteractivePayload;
+type LegacyInitProtocolEnvelope = {
+  protocolVersion?: never;
+  requestId?: never;
+};
+
+export type SuspendPayload = (ToolPayload | InteractivePayload) &
+  (InitProtocolEnvelope | LegacyInitProtocolEnvelope);
 
 export type WorkflowRunResult = {
   status: "suspended" | "success" | "failed";

--- a/packages/cli/src/lib/init/wizard-runner.ts
+++ b/packages/cli/src/lib/init/wizard-runner.ts
@@ -44,6 +44,8 @@ import {
   EXIT_DEPENDENCY_INSTALL_FAILED,
   EXIT_PLATFORM_NOT_DETECTED,
   EXIT_VERIFICATION_FAILED,
+  INIT_PROTOCOL_VERSION,
+  INIT_REQUEST_CONFLICT_CODE,
   MASTRA_API_URL,
   VERIFY_CHANGES_STEP,
   WORKFLOW_ID,
@@ -135,6 +137,20 @@ function hasHttpStatus(value: unknown): value is { status: number } {
     "status" in value &&
     typeof value.status === "number"
   );
+}
+
+/** Read a complete v1 identity while keeping legacy server payloads valid. */
+function initProtocolEnvelope(
+  payload: SuspendPayload
+): { protocolVersion: 1; requestId: string } | undefined {
+  return payload.protocolVersion === INIT_PROTOCOL_VERSION &&
+    typeof payload.requestId === "string" &&
+    payload.requestId.length > 0
+    ? {
+        protocolVersion: INIT_PROTOCOL_VERSION,
+        requestId: payload.requestId,
+      }
+    : undefined;
 }
 
 function hasActiveStepsPath(value: Record<string, unknown>): value is Record<
@@ -479,6 +495,7 @@ function assertWorkflowResult(raw: unknown): WorkflowRunResult {
   return obj as WorkflowRunResult;
 }
 
+/** Parse legacy or complete v1 suspend payloads, rejecting partial envelopes. */
 function assertSuspendPayload(raw: unknown): SuspendPayload {
   if (!raw || typeof raw !== "object") {
     throw new Error("Invalid suspend payload: expected object");
@@ -490,7 +507,13 @@ function assertSuspendPayload(raw: unknown): SuspendPayload {
   ) {
     throw new Error(`Unknown suspend payload type: ${String(obj.type)}`);
   }
-  return obj as SuspendPayload;
+  const payload = obj as SuspendPayload;
+  const hasProtocolFields =
+    Object.hasOwn(obj, "protocolVersion") || Object.hasOwn(obj, "requestId");
+  if (hasProtocolFields && !initProtocolEnvelope(payload)) {
+    throw new Error("Invalid init protocol envelope");
+  }
+  return payload;
 }
 
 function withTimeout<T>(
@@ -666,6 +689,19 @@ function isStepAlreadyAdvancedError(err: unknown): boolean {
   return err instanceof Error && err.message.includes("was not suspended");
 }
 
+/** Match the API's stable stale-request response, not mutable error prose. */
+function isInitProtocolConflictError(err: unknown): boolean {
+  if (httpStatus(err) !== 409 || typeof err !== "object" || err === null) {
+    return false;
+  }
+  const body = Reflect.get(err, "body") as unknown;
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    Reflect.get(body, "code") === INIT_REQUEST_CONFLICT_CODE
+  );
+}
+
 function httpStatus(err: unknown): number | undefined {
   return hasHttpStatus(err) ? err.status : undefined;
 }
@@ -684,6 +720,11 @@ function runStateRecoveryBackoffMs(): number[] {
   return delays;
 }
 
+/**
+ * A v1 request advances only when the active request ID changed. Legacy
+ * servers fall back to payload equality during the temporary compatibility
+ * window.
+ */
 function isRecoverableRunState(
   result: WorkflowRunResult,
   resumedStepId: string,
@@ -696,6 +737,12 @@ function isRecoverableRunState(
   const recovered = extractSuspendPayload(result, resumedStepId);
   if (!recovered) {
     return false;
+  }
+
+  const resumedEnvelope = initProtocolEnvelope(resumedPayload);
+  const recoveredEnvelope = initProtocolEnvelope(recovered.payload);
+  if (resumedEnvelope && recoveredEnvelope) {
+    return recoveredEnvelope.requestId !== resumedEnvelope.requestId;
   }
 
   return !(
@@ -762,6 +809,10 @@ async function tryRecoverCurrentRunState(
   return null;
 }
 
+/**
+ * Resume once, then recover by observing durable run state. This never
+ * re-executes the local tool when a response was lost or its request is stale.
+ */
 async function resumeWithRecovery(
   args: ResumeRetryArgs
 ): Promise<WorkflowRunResult> {
@@ -776,10 +827,17 @@ async function resumeWithRecovery(
     ui,
     progressRotation,
   } = args;
+  const envelope = initProtocolEnvelope(payload);
+  const wireResumeData = envelope ? { ...resumeData, ...envelope } : resumeData;
   try {
     const raw = await withTimeout(
       withInitServiceAuthClassification(
-        () => run.resumeAsync({ step: stepId, resumeData, tracingOptions }),
+        () =>
+          run.resumeAsync({
+            step: stepId,
+            resumeData: wireResumeData,
+            tracingOptions,
+          }),
         WORKFLOW_RESUME_ASYNC_ENDPOINT
       ),
       API_TIMEOUT_MS,
@@ -787,7 +845,7 @@ async function resumeWithRecovery(
     );
     return assertWorkflowResult(raw);
   } catch (err) {
-    if (isStepAlreadyAdvancedError(err)) {
+    if (isStepAlreadyAdvancedError(err) || isInitProtocolConflictError(err)) {
       progressRotation?.pause();
       spin.message("Reconnecting...");
       const recovered = await tryRecoverCurrentRunState(
@@ -847,6 +905,7 @@ async function resumeWithRecovery(
   }
 }
 
+/** Run the wizard while negotiating v1 and echoing each suspended request ID. */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: sequential wizard orchestration with error handling branches
 export async function runWizard(initialOptions: WizardOptions): Promise<void> {
   // Note: a previous `forwardFreshTtyToStdin()` call lived here as a
@@ -980,6 +1039,10 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
           () =>
             run.startAsync({
               inputData: {
+                client: {
+                  cliVersion: CLI_VERSION,
+                  protocolVersion: INIT_PROTOCOL_VERSION,
+                },
                 directory,
                 yes,
                 dryRun,

--- a/packages/cli/test/lib/init/wizard-runner.test.ts
+++ b/packages/cli/test/lib/init/wizard-runner.test.ts
@@ -40,6 +40,7 @@ import * as readiness from "../../../src/lib/init/readiness.js";
 import * as registry from "../../../src/lib/init/tools/registry.js";
 import type {
   ResolvedInitContext,
+  SuspendPayload,
   ToolPayload,
   WizardOptions,
   WorkflowRunResult,
@@ -103,6 +104,7 @@ function makeContext(
 let mockStartResult: WorkflowRunResult;
 let mockResumeResults: WorkflowRunResult[];
 let resumeCallCount = 0;
+let sharedResumeAsyncMock: ReturnType<typeof mock>;
 let startAsyncMock: ReturnType<typeof mock>;
 let mockRunByIdResult: WorkflowRunResult | Error;
 let runByIdMock: ReturnType<typeof mock>;
@@ -231,16 +233,17 @@ beforeEach(() => {
       ? Promise.reject(mockRunByIdResult)
       : Promise.resolve(mockRunByIdResult)
   );
+  sharedResumeAsyncMock = vi.fn(() => {
+    const result = mockResumeResults[resumeCallCount] ?? {
+      status: "success",
+    };
+    resumeCallCount += 1;
+    return Promise.resolve(result);
+  });
   const run = {
     runId: "test-run-id",
     startAsync: startAsyncMock,
-    resumeAsync: vi.fn(() => {
-      const result = mockResumeResults[resumeCallCount] ?? {
-        status: "success",
-      };
-      resumeCallCount += 1;
-      return Promise.resolve(result);
-    }),
+    resumeAsync: sharedResumeAsyncMock,
   };
   const workflow = {
     createRun: vi.fn(() => Promise.resolve(run)),
@@ -617,6 +620,7 @@ describe("runWizard", () => {
   });
 
   test("dispatches interactive payloads to the prompt handler", async () => {
+    const requestId = "8c7ee6b9-e955-4514-9164-f01844584a28";
     mockStartResult = {
       status: "suspended",
       suspended: [["pick-feature"]],
@@ -626,6 +630,8 @@ describe("runWizard", () => {
             type: "interactive",
             kind: "confirm",
             prompt: "Continue?",
+            protocolVersion: 1,
+            requestId,
           },
         },
       },
@@ -639,9 +645,19 @@ describe("runWizard", () => {
         type: "interactive",
         kind: "confirm",
         prompt: "Continue?",
+        protocolVersion: 1,
+        requestId,
       },
       makeContext(),
       expect.anything()
+    );
+    expect(sharedResumeAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resumeData: expect.objectContaining({
+          protocolVersion: 1,
+          requestId,
+        }),
+      })
     );
   });
 
@@ -669,6 +685,7 @@ describe("runWizard", () => {
   });
 
   test("skips verify-changes interactive prompts during dry-run", async () => {
+    const requestId = "3bc6b6f4-e2f5-40e4-9ac5-bbd69bf7af70";
     resolveInitContextSpy.mockResolvedValue(makeContext({ dryRun: true }));
     mockStartResult = {
       status: "suspended",
@@ -679,6 +696,8 @@ describe("runWizard", () => {
             type: "interactive",
             kind: "confirm",
             prompt: "Verify changes?",
+            protocolVersion: 1,
+            requestId,
           },
         },
       },
@@ -688,6 +707,14 @@ describe("runWizard", () => {
     await runWizard(makeOptions({ dryRun: true }));
 
     expect(handleInteractiveSpy).not.toHaveBeenCalled();
+    expect(sharedResumeAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resumeData: expect.objectContaining({
+          protocolVersion: 1,
+          requestId,
+        }),
+      })
+    );
   });
 
   test("surfaces malformed suspend payload types", async () => {
@@ -889,6 +916,10 @@ describe("runWizard", () => {
     expect(args.inputData).not.toHaveProperty("dirListing");
     expect(args.inputData).not.toHaveProperty("fileCache");
     expect(args.inputData).not.toHaveProperty("existingSentry");
+    expect(args.inputData?.client).toEqual({
+      cliVersion: expect.any(String),
+      protocolVersion: 1,
+    });
     expect(args.initialState?.dirListing).toEqual(dirListing);
     expect(args.initialState?.fileCache).toEqual(fileCache);
     expect(args.initialState?.existingSentry).toEqual(detectedSentry);
@@ -1105,10 +1136,10 @@ describe("runWizard — resumeWithRetry stale-step recovery", () => {
   function httpError(
     status: number,
     body: unknown
-  ): Error & { status: number } {
+  ): Error & { body: unknown; status: number } {
     return Object.assign(
       new Error(`HTTP error! status: ${status} - ${JSON.stringify(body)}`),
-      { status }
+      { body, status }
     );
   }
 
@@ -1125,6 +1156,16 @@ describe("runWizard — resumeWithRetry stale-step recovery", () => {
     });
   }
 
+  function protocolConflictError(): Error & {
+    body: unknown;
+    status: number;
+  } {
+    return httpError(409, {
+      code: "init_request_conflict",
+      error: "The init tool result does not match the active suspended request",
+    });
+  }
+
   function selectWorkflowFields(
     result: WorkflowRunResult,
     fields: string[] | undefined
@@ -1138,6 +1179,64 @@ describe("runWizard — resumeWithRetry stale-step recovery", () => {
     }
     return selected;
   }
+
+  test("echoes the v1 request identity with the local tool result", async () => {
+    const protocolPayload: SuspendPayload = {
+      ...toolPayload,
+      protocolVersion: 1,
+      requestId: "8c7ee6b9-e955-4514-9164-f01844584a28",
+    };
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["tool-step"]],
+      steps: { "tool-step": { suspendPayload: protocolPayload } },
+    };
+    let capturedResume: Record<string, unknown> | undefined;
+    makeStaleStepRun((args) => {
+      capturedResume = args.resumeData as Record<string, unknown>;
+      return Promise.resolve({ status: "success" });
+    });
+
+    await runWizard(makeOptions());
+
+    expect(capturedResume).toMatchObject({
+      protocolVersion: 1,
+      requestId: protocolPayload.requestId,
+    });
+  });
+
+  test("uses request identity instead of mutable payload details during recovery", async () => {
+    vi.useFakeTimers();
+    const requestId = "8c7ee6b9-e955-4514-9164-f01844584a28";
+    const protocolPayload: SuspendPayload = {
+      ...toolPayload,
+      protocolVersion: 1,
+      requestId,
+    };
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["tool-step"]],
+      steps: { "tool-step": { suspendPayload: protocolPayload } },
+    };
+    runByIdMock
+      .mockResolvedValueOnce({
+        status: "suspended",
+        suspendPayload: { ...protocolPayload, detail: "new display text" },
+      })
+      .mockResolvedValueOnce({ status: "success" });
+    let resumeCount = 0;
+    makeStaleStepRun(() => {
+      resumeCount += 1;
+      return Promise.reject(staleRunError(409));
+    });
+
+    const run = runWizard(makeOptions());
+    await vi.advanceTimersByTimeAsync(250);
+    await run;
+
+    expect(runByIdMock).toHaveBeenCalledTimes(2);
+    expect(resumeCount).toBe(1);
+  });
 
   test("recovers from a sparse 409 stale-resume conflict", async () => {
     mockStartResult = {
@@ -1177,6 +1276,33 @@ describe("runWizard — resumeWithRetry stale-step recovery", () => {
       })
     );
     // Recovery succeeded on the first attempt — resumeAsync was not called again.
+    expect(resumeCount).toBe(1);
+  });
+
+  test("recovers from a v1 request-correlation conflict", async () => {
+    const protocolPayload: SuspendPayload = {
+      ...toolPayload,
+      protocolVersion: 1,
+      requestId: "8c7ee6b9-e955-4514-9164-f01844584a28",
+    };
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["tool-step"]],
+      steps: { "tool-step": { suspendPayload: protocolPayload } },
+    };
+    runByIdMock.mockResolvedValue({
+      status: "success",
+      suspended: [],
+    });
+    let resumeCount = 0;
+    makeStaleStepRun(() => {
+      resumeCount += 1;
+      return Promise.reject(protocolConflictError());
+    });
+
+    await runWizard(makeOptions());
+
+    expect(runByIdMock).toHaveBeenCalledTimes(1);
     expect(resumeCount).toBe(1);
   });
 


### PR DESCRIPTION
## Summary

This teaches `sentry init` to announce protocol v1 and echo the request identity attached to every suspended tool or interactive request. That gives the API an immutable correlation key for retries and recovery instead of relying on mutable payload equality.

When the API reports `init_request_conflict`, the runner fetches the current durable run state and continues from what is actually suspended. It never re-executes the local filesystem or shell operation. The envelope remains optional so this CLI is compatible with API deployments that predate protocol v1.

The companion API PR should be deployed first with legacy support set to `allow`; this CLI can then be released before the short legacy cutoff.

## Test plan

- `pnpm --filter sentry exec vitest run test/lib/init test/commands/init` — 35 files / 550 tests
- `pnpm --filter sentry exec tsc --noEmit -p tsconfig.json`
- `pnpm lint`

Companion API PR: https://github.com/getsentry/cli-init-api/pull/232
