### PR TITLE
feat(init): add bounded stateless file reads

### DIFF
--- a/packages/cli/src/lib/init/tools/read-files.ts
+++ b/packages/cli/src/lib/init/tools/read-files.ts
@@ -11,65 +11,99 @@ import type {
 import { safePath } from "./shared.js";
 import type { InitToolDefinition } from "./types.js";
 
-const PATH_SEGMENT_RE = /[/\\]/u;
-const UTF8_CONTINUATION_MIN = 0x80;
-const UTF8_CONTINUATION_MAX = 0xbf;
+const DEFAULT_MAX_LINES = 1000;
+const MAX_SCAN_BYTES = 4 * 1024 * 1024;
+const MAX_V2_CONTENT_BYTES = 40_000;
+const MAX_READ_LINES = 2000;
+const MAX_READ_PATHS = 20;
+const PATH_SEGMENT_RE = /[/\\\\]/u;
+const SENSITIVE_PATH_TOKEN_RE = /[\\/{},()[\]!+@?*]+/u;
+const SENSITIVE_PATH_TOKENS = new Set([
+  ".git",
+  ".git-credentials",
+  ".hg",
+  ".netrc",
+  ".npmrc",
+  ".pypirc",
+  ".svn",
+  ".yarnrc",
+  ".yarnrc.yml",
+]);
+
+type ReadBounds = {
+  maxBytes: number;
+  maxLines: number;
+  startLine: number;
+};
+
+type OpenedProjectFile = {
+  handle: fs.promises.FileHandle;
+  stat: fs.Stats;
+};
 
 /**
  * Read one or more files from the sandboxed project directory.
+ *
+ * Legacy requests keep their original string-or-null response. V2 requests
+ * return independent, bounded line ranges; callers may issue another read or
+ * use grep when they need different evidence. The CLI keeps no continuation
+ * state between calls.
  */
 export async function readFiles(
   payload: ReadFilesPayload
 ): Promise<ToolResult> {
-  if (payload.params.resultVersion === 2) {
-    return readFilesV2(payload, boundedMaxBytes(payload.params.maxBytes));
+  const error = validateReadRequest(payload);
+  if (error) {
+    return { error, ok: false };
   }
+
+  if (payload.params.resultVersion === 2) {
+    return readFilesV2(payload, boundedV2MaxBytes(payload.params.maxBytes));
+  }
+  const maxBytes = boundedLegacyMaxBytes(payload.params.maxBytes);
 
   const results = await Promise.all(
     payload.params.paths.map(async (filePath) => {
-      const content = await readSingleFileV1(
-        payload.cwd,
-        filePath,
-        payload.params.maxBytes ?? MAX_FILE_BYTES
-      );
+      const content = await readSingleFileV1(payload.cwd, filePath, maxBytes);
       return [filePath, content] as const;
     })
   );
 
-  const files: Record<string, string | null> = {};
-  for (const [filePath, content] of results) {
-    files[filePath] = content;
-  }
-
-  return { ok: true, data: { files } };
+  return {
+    data: { files: Object.fromEntries(results) },
+    ok: true,
+  };
 }
 
-/** Preserve the exact wire behavior expected by APIs predating read-files v2. */
+/** Preserve the wire behavior expected by APIs predating read-files v2. */
 async function readSingleFileV1(
   cwd: string,
   filePath: string,
   maxBytes: number
 ): Promise<string | null> {
+  if (isSensitiveReadPath(filePath)) {
+    return null;
+  }
+  let opened: OpenedProjectFile | undefined;
   try {
-    const absPath = safePath(cwd, filePath);
-    const stat = await fs.promises.stat(absPath);
-    if (!stat.isFile()) {
+    const result = await openProjectFile(cwd, filePath);
+    if ("error" in result) {
       return null;
     }
-    if (stat.size <= maxBytes) {
-      return await fs.promises.readFile(absPath, "utf-8");
+    opened = result;
+    const bytesToRead = Math.min(opened.stat.size, maxBytes);
+    const buffer = Buffer.alloc(bytesToRead);
+    await opened.handle.read(buffer, 0, bytesToRead, 0);
+    if (fileChanged(opened.stat, await opened.handle.stat())) {
+      return null;
     }
-
-    const handle = await fs.promises.open(absPath, "r");
-    try {
-      const buffer = Buffer.alloc(maxBytes);
-      await handle.read(buffer, 0, maxBytes, 0);
-      return buffer.toString("utf-8");
-    } finally {
-      await handle.close();
-    }
+    return buffer.toString("utf-8");
   } catch {
     return null;
+  } finally {
+    await opened?.handle.close().catch(() => {
+      // Preserve the legacy null-or-string result when cleanup fails.
+    });
   }
 }
 
@@ -77,24 +111,20 @@ async function readFilesV2(
   payload: ReadFilesPayload,
   maxBytes: number
 ): Promise<ToolResult> {
-  const offsetBytes = payload.params.offsetBytes ?? 0;
-  const validOffset =
-    Number.isSafeInteger(offsetBytes) &&
-    offsetBytes >= 0 &&
-    (offsetBytes === 0 || payload.params.paths.length === 1)
-      ? offsetBytes
-      : undefined;
+  const startLine = payload.params.startLine ?? 1;
+  const maxLines = boundedMaxLines(payload.params.maxLines);
+  const perFileMaxBytes = Math.min(
+    maxBytes,
+    Math.max(1, Math.floor(MAX_V2_CONTENT_BYTES / payload.params.paths.length))
+  );
+  const bounds = {
+    maxBytes: perFileMaxBytes,
+    maxLines,
+    startLine,
+  } satisfies ReadBounds;
   const results = await Promise.all(
     payload.params.paths.map(async (filePath) => {
-      const result =
-        validOffset === undefined
-          ? ({ error: "invalid-offset", status: "error" } as const)
-          : await readSingleFileV2(
-              payload.cwd,
-              filePath,
-              maxBytes,
-              validOffset
-            );
+      const result = await readSingleFileV2(payload.cwd, filePath, bounds);
       return [filePath, result] as const;
     })
   );
@@ -111,9 +141,145 @@ async function readFilesV2(
 async function readSingleFileV2(
   cwd: string,
   filePath: string,
-  maxBytes: number,
-  offsetBytes: number
+  bounds: ReadBounds
 ): Promise<ReadFileV2Result> {
+  if (isSensitiveReadPath(filePath)) {
+    return { error: "unreadable", status: "error" };
+  }
+  let opened: OpenedProjectFile | undefined;
+  try {
+    const result = await openProjectFile(cwd, filePath);
+    if ("error" in result) {
+      return { error: result.error, status: "error" };
+    }
+    opened = result;
+    if (opened.stat.size === 0) {
+      if (fileChanged(opened.stat, await opened.handle.stat())) {
+        return { error: "unreadable", status: "error" };
+      }
+      return bounds.startLine === 1
+        ? {
+            content: "",
+            status: "ok",
+            truncated: false,
+          }
+        : { error: "invalid-range", status: "error" };
+    }
+
+    const page = await readTextPage(opened.handle, opened.stat.size, bounds);
+    if (fileChanged(opened.stat, await opened.handle.stat())) {
+      return { error: "unreadable", status: "error" };
+    }
+    return page;
+  } catch (error) {
+    return { error: readErrorCode(error), status: "error" };
+  } finally {
+    await opened?.handle.close().catch(() => {
+      // Preserve the primary read result when descriptor cleanup fails.
+    });
+  }
+}
+
+async function readTextPage(
+  handle: fs.promises.FileHandle,
+  fileSize: number,
+  bounds: ReadBounds
+): Promise<ReadFileV2Result> {
+  const scanBudget =
+    bounds.startLine === 1 ? bounds.maxBytes : MAX_SCAN_BYTES + bounds.maxBytes;
+  const scanBytes = Math.min(fileSize, scanBudget);
+  const scanBuffer = Buffer.alloc(scanBytes);
+  const { bytesRead } = await handle.read(scanBuffer, 0, scanBytes, 0);
+  const readable = scanBuffer.subarray(0, bytesRead);
+  if (!isTextBuffer(readable, bytesRead < fileSize)) {
+    return { error: "not-text", status: "error" };
+  }
+
+  const startOffset = lineStartOffset(readable, bounds.startLine);
+  if (startOffset === undefined) {
+    return {
+      error: bytesRead < fileSize ? "range-too-deep" : "invalid-range",
+      status: "error",
+    };
+  }
+  if (startOffset > MAX_SCAN_BYTES) {
+    return { error: "range-too-deep", status: "error" };
+  }
+  const selected = selectCompleteLines(readable, fileSize, startOffset, bounds);
+  if ("error" in selected) {
+    return { error: selected.error, status: "error" };
+  }
+  return {
+    content: selected.content.toString("utf-8"),
+    status: "ok",
+    truncated: startOffset + selected.content.length < fileSize,
+  };
+}
+
+function lineStartOffset(
+  buffer: Buffer,
+  startLine: number
+): number | undefined {
+  let offset = 0;
+  for (let line = 1; line < startLine; line += 1) {
+    const newline = buffer.indexOf(0x0a, offset);
+    if (newline === -1) {
+      return;
+    }
+    offset = newline + 1;
+  }
+  return offset < buffer.length ? offset : undefined;
+}
+
+function selectCompleteLines(
+  buffer: Buffer,
+  fileSize: number,
+  startOffset: number,
+  bounds: ReadBounds
+): { content: Buffer } | { error: "line-too-long" } {
+  let offset = startOffset;
+  for (let lines = 0; lines < bounds.maxLines; lines += 1) {
+    const lineEnd = completeLineEnd(buffer, fileSize, offset);
+    if (lineEnd === undefined) {
+      return priorLinesOrError(buffer, startOffset, offset);
+    }
+    if (lineEnd - startOffset > bounds.maxBytes) {
+      return priorLinesOrError(buffer, startOffset, offset);
+    }
+    offset = lineEnd;
+    if (offset === buffer.length) {
+      break;
+    }
+  }
+  return { content: buffer.subarray(startOffset, offset) };
+}
+
+function completeLineEnd(
+  buffer: Buffer,
+  fileSize: number,
+  offset: number
+): number | undefined {
+  const newline = buffer.indexOf(0x0a, offset);
+  if (newline !== -1) {
+    return newline + 1;
+  }
+  return buffer.length === fileSize ? buffer.length : undefined;
+}
+
+function priorLinesOrError(
+  buffer: Buffer,
+  startOffset: number,
+  endOffset: number
+): { content: Buffer } | { error: "line-too-long" } {
+  return endOffset === startOffset
+    ? { error: "line-too-long" }
+    : { content: buffer.subarray(startOffset, endOffset) };
+}
+
+async function openProjectFile(
+  cwd: string,
+  filePath: string
+): Promise<OpenedProjectFile | { error: ReadFileErrorCode }> {
   let handle: fs.promises.FileHandle | undefined;
   try {
     const absPath = safePath(cwd, filePath);
@@ -123,109 +289,24 @@ async function readSingleFileV2(
       fs.constants.O_RDONLY | fs.constants.O_NONBLOCK
     );
     const stat = await handle.stat();
-    // Open non-blocking before checking the handle itself so a path swapped
-    // to a FIFO cannot block between a path-level stat and open.
     if (!stat.isFile()) {
-      return { error: "not-file", status: "error" };
+      await handle.close();
+      return { error: "not-file" };
     }
-    if (!(await openedPathIsSandboxed(cwd, absPath, stat))) {
-      return { error: "unreadable", status: "error" };
+    if (!(await openedPathIsAllowed(cwd, absPath, stat))) {
+      await handle.close();
+      return { error: "unreadable" };
     }
-    if (offsetBytes > stat.size) {
-      return { error: "invalid-offset", status: "error" };
-    }
-
-    if (offsetBytes === stat.size) {
-      if (fileChanged(stat, await handle.stat())) {
-        return { error: "unreadable", status: "error" };
-      }
-      return {
-        content: "",
-        fileVersion: readFileVersion(stat),
-        offsetBytes,
-        returnedBytes: 0,
-        status: "ok",
-        totalBytes: stat.size,
-        truncated: false,
-      };
-    }
-
-    const buffer = Buffer.alloc(Math.min(maxBytes, stat.size - offsetBytes));
-    const { bytesRead } = await handle.read(
-      buffer,
-      0,
-      buffer.byteLength,
-      offsetBytes
-    );
-    assertReadProgress(bytesRead);
-    const bytes = buffer.subarray(0, bytesRead);
-    const startsWithContinuation = isUtf8ContinuationByte(bytes[0]);
-    let returnedBytes = 0;
-    let completeBytes = bytes.subarray(0, 0);
-    if (!startsWithContinuation) {
-      returnedBytes = completeUtf8PrefixLength(bytes);
-      completeBytes = bytes.subarray(0, returnedBytes);
-      if (returnedBytes === 0) {
-        const sequenceBytes = utf8SequenceLength(bytes[0]);
-        const retryBuffer = Buffer.alloc(
-          Math.min(sequenceBytes, stat.size - offsetBytes)
-        );
-        const retry = await handle.read(
-          retryBuffer,
-          0,
-          retryBuffer.byteLength,
-          offsetBytes
-        );
-        assertReadProgress(retry.bytesRead);
-        returnedBytes = retry.bytesRead;
-        completeBytes = retryBuffer.subarray(0, retry.bytesRead);
-      }
-    }
-
-    // Classify content only after proving the bytes came from the same stable
-    // file version. A torn read is retryable, not permanently non-text.
-    const finalStat = await handle.stat();
-    if (fileChanged(stat, finalStat)) {
-      return { error: "unreadable", status: "error" };
-    }
-    if (startsWithContinuation) {
-      return {
-        error: continuationByteError(offsetBytes),
-        status: "error",
-      };
-    }
-    let content: string;
-    try {
-      content = new TextDecoder("utf-8", {
-        fatal: true,
-        ignoreBOM: true,
-      }).decode(completeBytes);
-    } catch {
-      return { error: "not-text", status: "error" };
-    }
-
-    const nextOffsetBytes = offsetBytes + returnedBytes;
-    const truncated = nextOffsetBytes < stat.size;
-    return {
-      content,
-      fileVersion: readFileVersion(stat),
-      ...(truncated ? { nextOffsetBytes } : {}),
-      offsetBytes,
-      returnedBytes,
-      status: "ok",
-      totalBytes: stat.size,
-      truncated,
-    };
+    return { handle, stat };
   } catch (error) {
-    return { error: readErrorCode(error), status: "error" };
-  } finally {
     await handle?.close().catch(() => {
-      // The primary read error is more actionable than a cleanup failure.
+      // Preserve the primary open error when cleanup fails.
     });
+    return { error: readErrorCode(error) };
   }
 }
 
-async function openedPathIsSandboxed(
+async function openedPathIsAllowed(
   cwd: string,
   absPath: string,
   openedStat: fs.Stats
@@ -237,14 +318,14 @@ async function openedPathIsSandboxed(
   if (realPath !== realCwd && !realPath.startsWith(`${realCwd}${path.sep}`)) {
     return false;
   }
+  const relativeRealPath = path.relative(realCwd, realPath);
+  if (isSensitiveReadPath(relativeRealPath)) {
+    return false;
+  }
   const resolvedStat = await fs.promises.stat(realPath);
   return (
     resolvedStat.dev === openedStat.dev && resolvedStat.ino === openedStat.ino
   );
-}
-
-function readFileVersion(stat: fs.Stats): string {
-  return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}`;
 }
 
 function fileChanged(initial: fs.Stats, final: fs.Stats): boolean {
@@ -256,59 +337,117 @@ function fileChanged(initial: fs.Stats, final: fs.Stats): boolean {
   );
 }
 
-function boundedMaxBytes(value: number | undefined): number {
-  if (value === undefined || !Number.isFinite(value)) {
-    return MAX_FILE_BYTES;
+function validateReadRequest(payload: ReadFilesPayload): string | undefined {
+  const params = (payload as { params?: unknown }).params;
+  if (typeof params !== "object" || params === null) {
+    return "read-files params must be an object";
   }
-  return Math.max(1, Math.min(Math.floor(value), MAX_FILE_BYTES));
+  const { maxBytes, maxLines, paths, resultVersion, startLine } =
+    params as Partial<ReadFilesPayload["params"]>;
+  const pathError = validateReadPaths(paths);
+  if (pathError) {
+    return pathError;
+  }
+  const validPaths = paths as string[];
+  if (isInvalidPositiveInteger(maxBytes)) {
+    return "read-files maxBytes must be a positive safe integer";
+  }
+  if (resultVersion !== undefined && resultVersion !== 2) {
+    return "read-files resultVersion is not supported";
+  }
+  if (isInvalidPositiveInteger(startLine)) {
+    return "read-files startLine must be a positive safe integer";
+  }
+  if (isInvalidPositiveInteger(maxLines)) {
+    return "read-files maxLines must be a positive safe integer";
+  }
+  if (
+    (startLine !== undefined || maxLines !== undefined) &&
+    resultVersion !== 2
+  ) {
+    return "read-files line ranges require resultVersion 2";
+  }
+  if ((startLine ?? 1) > 1 && validPaths.length !== 1) {
+    return "read-files range reads require exactly one path";
+  }
 }
 
-function isUtf8ContinuationByte(value: number | undefined): boolean {
+function validateReadPaths(paths: unknown): string | undefined {
+  if (
+    !Array.isArray(paths) ||
+    paths.length === 0 ||
+    paths.length > MAX_READ_PATHS
+  ) {
+    return `read-files requires between 1 and ${MAX_READ_PATHS} paths`;
+  }
+  if (
+    paths.some(
+      (filePath) =>
+        typeof filePath !== "string" ||
+        filePath.length === 0 ||
+        filePath.length > 1000
+    )
+  ) {
+    return "read-files paths must be non-empty bounded strings";
+  }
+}
+
+function isInvalidPositiveInteger(value: unknown): boolean {
   return (
     value !== undefined &&
-    value >= UTF8_CONTINUATION_MIN &&
-    value <= UTF8_CONTINUATION_MAX
+    (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1)
   );
 }
 
-function continuationByteError(offsetBytes: number): ReadFileErrorCode {
-  return offsetBytes === 0 ? "not-text" : "invalid-offset";
+function isSensitiveReadPath(filePath: string): boolean {
+  const tokens = filePath
+    .toLowerCase()
+    .split(SENSITIVE_PATH_TOKEN_RE)
+    .filter(Boolean);
+  return tokens.some(
+    (token) =>
+      SENSITIVE_PATH_TOKENS.has(token) ||
+      token === ".dev.vars" ||
+      token === ".env" ||
+      token.startsWith(".env.")
+  );
 }
 
-function assertReadProgress(bytesRead: number): void {
-  if (bytesRead === 0) {
-    throw new Error("File read made no progress");
-  }
+function boundedLegacyMaxBytes(value: number | undefined): number {
+  return value === undefined
+    ? MAX_FILE_BYTES
+    : Math.max(1, Math.min(value, MAX_FILE_BYTES));
 }
 
-function utf8SequenceLength(value: number | undefined): number {
-  if (value === undefined || value < 0xc0) {
-    return 1;
-  }
-  if (value < 0xe0) {
-    return 2;
-  }
-  if (value < 0xf0) {
-    return 3;
-  }
-  return value < 0xf8 ? 4 : 1;
+function boundedV2MaxBytes(value: number | undefined): number {
+  return value === undefined
+    ? MAX_V2_CONTENT_BYTES
+    : Math.max(1, Math.min(value, MAX_V2_CONTENT_BYTES));
 }
 
-function completeUtf8PrefixLength(buffer: Buffer): number {
-  if (buffer.length === 0) {
-    return 0;
+function boundedMaxLines(value: number | undefined): number {
+  return value === undefined
+    ? DEFAULT_MAX_LINES
+    : Math.max(1, Math.min(value, MAX_READ_LINES));
+}
+
+function isTextBuffer(buffer: Buffer, mayEndMidCharacter: boolean): boolean {
+  if (
+    buffer.some(
+      (byte) =>
+        byte === 0x7f || (byte < 0x20 && ![0x09, 0x0a, 0x0d].includes(byte))
+    )
+  ) {
+    return false;
   }
-  let leadIndex = buffer.length - 1;
-  while (leadIndex >= 0 && isUtf8ContinuationByte(buffer[leadIndex])) {
-    leadIndex -= 1;
+  try {
+    new TextDecoder("utf-8", { fatal: true }).decode(buffer, {
+      stream: mayEndMidCharacter,
+    });
+    return true;
+  } catch {
+    return false;
   }
-  if (leadIndex < 0) {
-    return 0;
-  }
-  const availableBytes = buffer.length - leadIndex;
-  return utf8SequenceLength(buffer[leadIndex]) > availableBytes
-    ? leadIndex
-    : buffer.length;
 }
 
 function readErrorCode(error: unknown): ReadFileErrorCode {

--- a/packages/cli/src/lib/init/tools/read-files.ts
+++ b/packages/cli/src/lib/init/tools/read-files.ts
@@ -290,11 +290,11 @@ async function openProjectFile(
     );
     const stat = await handle.stat();
     if (!stat.isFile()) {
-      await handle.close();
+      await closeQuietly(handle);
       return { error: "not-file" };
     }
     if (!(await openedPathIsAllowed(cwd, absPath, stat))) {
-      await handle.close();
+      await closeQuietly(handle);
       return { error: "unreadable" };
     }
     return { handle, stat };
@@ -304,6 +304,12 @@ async function openProjectFile(
     });
     return { error: readErrorCode(error) };
   }
+}
+
+async function closeQuietly(handle: fs.promises.FileHandle): Promise<void> {
+  await handle.close().catch(() => {
+    // Descriptor cleanup must not replace the primary read classification.
+  });
 }
 
 async function openedPathIsAllowed(

--- a/packages/cli/src/lib/init/tools/read-files.ts
+++ b/packages/cli/src/lib/init/tools/read-files.ts
@@ -1,10 +1,19 @@
 import fs from "node:fs";
+import path from "node:path";
 import { MAX_FILE_BYTES } from "../constants.js";
-import type { ReadFilesPayload, ToolResult } from "../types.js";
+import type {
+  ReadFileErrorCode,
+  ReadFilesPayload,
+  ReadFilesV2Data,
+  ReadFileV2Result,
+  ToolResult,
+} from "../types.js";
 import { safePath } from "./shared.js";
 import type { InitToolDefinition } from "./types.js";
 
 const PATH_SEGMENT_RE = /[/\\]/u;
+const UTF8_CONTINUATION_MIN = 0x80;
+const UTF8_CONTINUATION_MAX = 0xbf;
 
 /**
  * Read one or more files from the sandboxed project directory.
@@ -12,10 +21,17 @@ const PATH_SEGMENT_RE = /[/\\]/u;
 export async function readFiles(
   payload: ReadFilesPayload
 ): Promise<ToolResult> {
-  const maxBytes = payload.params.maxBytes ?? MAX_FILE_BYTES;
+  if (payload.params.resultVersion === 2) {
+    return readFilesV2(payload, boundedMaxBytes(payload.params.maxBytes));
+  }
+
   const results = await Promise.all(
     payload.params.paths.map(async (filePath) => {
-      const content = await readSingleFile(payload.cwd, filePath, maxBytes);
+      const content = await readSingleFileV1(
+        payload.cwd,
+        filePath,
+        payload.params.maxBytes ?? MAX_FILE_BYTES
+      );
       return [filePath, content] as const;
     })
   );
@@ -28,7 +44,8 @@ export async function readFiles(
   return { ok: true, data: { files } };
 }
 
-async function readSingleFile(
+/** Preserve the exact wire behavior expected by APIs predating read-files v2. */
+async function readSingleFileV1(
   cwd: string,
   filePath: string,
   maxBytes: number
@@ -36,9 +53,6 @@ async function readSingleFile(
   try {
     const absPath = safePath(cwd, filePath);
     const stat = await fs.promises.stat(absPath);
-    // Guard against FIFOs / sockets / devices — both `readFile` and
-    // `open("r")` block indefinitely on a FIFO waiting for a writer.
-    // `stat` follows symlinks, so symlink → FIFO is caught too.
     if (!stat.isFile()) {
       return null;
     }
@@ -57,6 +71,256 @@ async function readSingleFile(
   } catch {
     return null;
   }
+}
+
+async function readFilesV2(
+  payload: ReadFilesPayload,
+  maxBytes: number
+): Promise<ToolResult> {
+  const offsetBytes = payload.params.offsetBytes ?? 0;
+  const validOffset =
+    Number.isSafeInteger(offsetBytes) &&
+    offsetBytes >= 0 &&
+    (offsetBytes === 0 || payload.params.paths.length === 1)
+      ? offsetBytes
+      : undefined;
+  const results = await Promise.all(
+    payload.params.paths.map(async (filePath) => {
+      const result =
+        validOffset === undefined
+          ? ({ error: "invalid-offset", status: "error" } as const)
+          : await readSingleFileV2(
+              payload.cwd,
+              filePath,
+              maxBytes,
+              validOffset
+            );
+      return [filePath, result] as const;
+    })
+  );
+
+  return {
+    data: {
+      files: Object.fromEntries(results),
+      version: 2,
+    } satisfies ReadFilesV2Data,
+    ok: true,
+  };
+}
+
+async function readSingleFileV2(
+  cwd: string,
+  filePath: string,
+  maxBytes: number,
+  offsetBytes: number
+): Promise<ReadFileV2Result> {
+  let handle: fs.promises.FileHandle | undefined;
+  try {
+    const absPath = safePath(cwd, filePath);
+    handle = await fs.promises.open(
+      absPath,
+      // biome-ignore lint/suspicious/noBitwiseOperators: fs open flags are a bitmask.
+      fs.constants.O_RDONLY | fs.constants.O_NONBLOCK
+    );
+    const stat = await handle.stat();
+    // Open non-blocking before checking the handle itself so a path swapped
+    // to a FIFO cannot block between a path-level stat and open.
+    if (!stat.isFile()) {
+      return { error: "not-file", status: "error" };
+    }
+    if (!(await openedPathIsSandboxed(cwd, absPath, stat))) {
+      return { error: "unreadable", status: "error" };
+    }
+    if (offsetBytes > stat.size) {
+      return { error: "invalid-offset", status: "error" };
+    }
+
+    if (offsetBytes === stat.size) {
+      if (fileChanged(stat, await handle.stat())) {
+        return { error: "unreadable", status: "error" };
+      }
+      return {
+        content: "",
+        fileVersion: readFileVersion(stat),
+        offsetBytes,
+        returnedBytes: 0,
+        status: "ok",
+        totalBytes: stat.size,
+        truncated: false,
+      };
+    }
+
+    const buffer = Buffer.alloc(Math.min(maxBytes, stat.size - offsetBytes));
+    const { bytesRead } = await handle.read(
+      buffer,
+      0,
+      buffer.byteLength,
+      offsetBytes
+    );
+    assertReadProgress(bytesRead);
+    const bytes = buffer.subarray(0, bytesRead);
+    const startsWithContinuation = isUtf8ContinuationByte(bytes[0]);
+    let returnedBytes = 0;
+    let completeBytes = bytes.subarray(0, 0);
+    if (!startsWithContinuation) {
+      returnedBytes = completeUtf8PrefixLength(bytes);
+      completeBytes = bytes.subarray(0, returnedBytes);
+      if (returnedBytes === 0) {
+        const sequenceBytes = utf8SequenceLength(bytes[0]);
+        const retryBuffer = Buffer.alloc(
+          Math.min(sequenceBytes, stat.size - offsetBytes)
+        );
+        const retry = await handle.read(
+          retryBuffer,
+          0,
+          retryBuffer.byteLength,
+          offsetBytes
+        );
+        assertReadProgress(retry.bytesRead);
+        returnedBytes = retry.bytesRead;
+        completeBytes = retryBuffer.subarray(0, retry.bytesRead);
+      }
+    }
+
+    // Classify content only after proving the bytes came from the same stable
+    // file version. A torn read is retryable, not permanently non-text.
+    const finalStat = await handle.stat();
+    if (fileChanged(stat, finalStat)) {
+      return { error: "unreadable", status: "error" };
+    }
+    if (startsWithContinuation) {
+      return {
+        error: continuationByteError(offsetBytes),
+        status: "error",
+      };
+    }
+    let content: string;
+    try {
+      content = new TextDecoder("utf-8", {
+        fatal: true,
+        ignoreBOM: true,
+      }).decode(completeBytes);
+    } catch {
+      return { error: "not-text", status: "error" };
+    }
+
+    const nextOffsetBytes = offsetBytes + returnedBytes;
+    const truncated = nextOffsetBytes < stat.size;
+    return {
+      content,
+      fileVersion: readFileVersion(stat),
+      ...(truncated ? { nextOffsetBytes } : {}),
+      offsetBytes,
+      returnedBytes,
+      status: "ok",
+      totalBytes: stat.size,
+      truncated,
+    };
+  } catch (error) {
+    return { error: readErrorCode(error), status: "error" };
+  } finally {
+    await handle?.close().catch(() => {
+      // The primary read error is more actionable than a cleanup failure.
+    });
+  }
+}
+
+async function openedPathIsSandboxed(
+  cwd: string,
+  absPath: string,
+  openedStat: fs.Stats
+): Promise<boolean> {
+  const [realCwd, realPath] = await Promise.all([
+    fs.promises.realpath(cwd),
+    fs.promises.realpath(absPath),
+  ]);
+  if (realPath !== realCwd && !realPath.startsWith(`${realCwd}${path.sep}`)) {
+    return false;
+  }
+  const resolvedStat = await fs.promises.stat(realPath);
+  return (
+    resolvedStat.dev === openedStat.dev && resolvedStat.ino === openedStat.ino
+  );
+}
+
+function readFileVersion(stat: fs.Stats): string {
+  return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}`;
+}
+
+function fileChanged(initial: fs.Stats, final: fs.Stats): boolean {
+  return (
+    final.dev !== initial.dev ||
+    final.ino !== initial.ino ||
+    final.size !== initial.size ||
+    final.mtimeMs !== initial.mtimeMs
+  );
+}
+
+function boundedMaxBytes(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return MAX_FILE_BYTES;
+  }
+  return Math.max(1, Math.min(Math.floor(value), MAX_FILE_BYTES));
+}
+
+function isUtf8ContinuationByte(value: number | undefined): boolean {
+  return (
+    value !== undefined &&
+    value >= UTF8_CONTINUATION_MIN &&
+    value <= UTF8_CONTINUATION_MAX
+  );
+}
+
+function continuationByteError(offsetBytes: number): ReadFileErrorCode {
+  return offsetBytes === 0 ? "not-text" : "invalid-offset";
+}
+
+function assertReadProgress(bytesRead: number): void {
+  if (bytesRead === 0) {
+    throw new Error("File read made no progress");
+  }
+}
+
+function utf8SequenceLength(value: number | undefined): number {
+  if (value === undefined || value < 0xc0) {
+    return 1;
+  }
+  if (value < 0xe0) {
+    return 2;
+  }
+  if (value < 0xf0) {
+    return 3;
+  }
+  return value < 0xf8 ? 4 : 1;
+}
+
+function completeUtf8PrefixLength(buffer: Buffer): number {
+  if (buffer.length === 0) {
+    return 0;
+  }
+  let leadIndex = buffer.length - 1;
+  while (leadIndex >= 0 && isUtf8ContinuationByte(buffer[leadIndex])) {
+    leadIndex -= 1;
+  }
+  if (leadIndex < 0) {
+    return 0;
+  }
+  const availableBytes = buffer.length - leadIndex;
+  return utf8SequenceLength(buffer[leadIndex]) > availableBytes
+    ? leadIndex
+    : buffer.length;
+}
+
+function readErrorCode(error: unknown): ReadFileErrorCode {
+  if (typeof error === "object" && error !== null && "code" in error) {
+    if (error.code === "ENOENT") {
+      return "not-found";
+    }
+    if (error.code === "EISDIR") {
+      return "not-file";
+    }
+  }
+  return "unreadable";
 }
 
 /**

--- a/packages/cli/src/lib/init/types.ts
+++ b/packages/cli/src/lib/init/types.ts
@@ -98,13 +98,58 @@ export type ListDirPayload = {
   };
 };
 
+/** Stable reason a V2 file read could not return UTF-8 text. */
+export type ReadFileErrorCode =
+  | "invalid-offset"
+  | "not-file"
+  | "not-found"
+  | "not-text"
+  | "unreadable";
+
+/** Structured per-file result returned by the V2 read-files protocol. */
+export type ReadFileV2Result =
+  | {
+      /** Exact UTF-8 text returned for this chunk. */
+      content: string;
+      /** Stable identity used to prove that continuation chunks are from one file version. */
+      fileVersion: string;
+      /** Cursor for the next read when `truncated` is true. */
+      nextOffsetBytes?: number;
+      /** Byte offset at which this chunk starts. */
+      offsetBytes: number;
+      /** Number of source-file bytes represented by `content`. */
+      returnedBytes: number;
+      status: "ok";
+      /** Total source-file size in bytes. */
+      totalBytes: number;
+      /** Whether more bytes remain after this chunk. */
+      truncated: boolean;
+    }
+  | {
+      /** Stable reason the file could not be returned as UTF-8 text. */
+      error: ReadFileErrorCode;
+      status: "error";
+    };
+
+/** V2 read-files response envelope. */
+export type ReadFilesV2Data = {
+  /** Per-requested-path results. */
+  files: Record<string, ReadFileV2Result>;
+  version: 2;
+};
+
+/** Request for one or more sandboxed project file reads. */
 export type ReadFilesPayload = {
   type: "tool";
   operation: "read-files";
   cwd: string;
   params: {
+    /** Byte offset for a V2 single-file continuation read. */
+    offsetBytes?: number;
     paths: string[];
     maxBytes?: number;
+    /** Opts into structured per-file results; omitted for the legacy wire shape. */
+    resultVersion?: 2;
   };
 };
 

--- a/packages/cli/src/lib/init/types.ts
+++ b/packages/cli/src/lib/init/types.ts
@@ -98,59 +98,45 @@ export type ListDirPayload = {
   };
 };
 
-/** Stable reason a V2 file read could not return UTF-8 text. */
-export type ReadFileErrorCode =
-  | "invalid-offset"
-  | "not-file"
-  | "not-found"
-  | "not-text"
-  | "unreadable";
-
-/** Structured per-file result returned by the V2 read-files protocol. */
-export type ReadFileV2Result =
-  | {
-      /** Exact UTF-8 text returned for this chunk. */
-      content: string;
-      /** Stable identity used to prove that continuation chunks are from one file version. */
-      fileVersion: string;
-      /** Cursor for the next read when `truncated` is true. */
-      nextOffsetBytes?: number;
-      /** Byte offset at which this chunk starts. */
-      offsetBytes: number;
-      /** Number of source-file bytes represented by `content`. */
-      returnedBytes: number;
-      status: "ok";
-      /** Total source-file size in bytes. */
-      totalBytes: number;
-      /** Whether more bytes remain after this chunk. */
-      truncated: boolean;
-    }
-  | {
-      /** Stable reason the file could not be returned as UTF-8 text. */
-      error: ReadFileErrorCode;
-      status: "error";
-    };
-
-/** V2 read-files response envelope. */
-export type ReadFilesV2Data = {
-  /** Per-requested-path results. */
-  files: Record<string, ReadFileV2Result>;
-  version: 2;
-};
-
-/** Request for one or more sandboxed project file reads. */
 export type ReadFilesPayload = {
   type: "tool";
   operation: "read-files";
   cwd: string;
   params: {
-    /** Byte offset for a V2 single-file continuation read. */
-    offsetBytes?: number;
     paths: string[];
     maxBytes?: number;
-    /** Opts into structured per-file results; omitted for the legacy wire shape. */
+    /** Maximum text lines returned per file by the bounded V2 reader. */
+    maxLines?: number;
+    /** First 1-based line to inspect. V2 range reads support one path. */
+    startLine?: number;
+    /** Opts into bounded, structured read results. */
     resultVersion?: 2;
   };
+};
+
+export type ReadFileErrorCode =
+  | "invalid-range"
+  | "line-too-long"
+  | "not-file"
+  | "not-found"
+  | "not-text"
+  | "range-too-deep"
+  | "unreadable";
+
+export type ReadFileV2Result =
+  | {
+      content: string;
+      status: "ok";
+      truncated: boolean;
+    }
+  | {
+      error: ReadFileErrorCode;
+      status: "error";
+    };
+
+export type ReadFilesV2Data = {
+  files: Record<string, ReadFileV2Result>;
+  version: 2;
 };
 
 export type FileExistsBatchPayload = {

--- a/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
+++ b/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import * as dsnIndex from "../../../../src/lib/dsn/index.js";
 import { executeTool } from "../../../../src/lib/init/tools/registry.js";
 import type {
+  ReadFilesV2Data,
   ResolvedInitContext,
   ToolPayload,
 } from "../../../../src/lib/init/types.js";
@@ -101,6 +102,342 @@ describe("filesystem tools", () => {
     expect((readResult.data as any).files["missing.txt"]).toBeNull();
     expect((existsResult.data as any).exists["exists.txt"]).toBe(true);
     expect((existsResult.data as any).exists["missing.txt"]).toBe(false);
+  });
+
+  test("returns explicit V2 completion and file errors", async () => {
+    fs.writeFileSync(path.join(testDir, "exists.txt"), "hello");
+
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          paths: ["exists.txt", "missing.txt"],
+          resultVersion: 2,
+        },
+      },
+      makeContext(testDir)
+    );
+    const data = result.data as ReadFilesV2Data;
+
+    expect(data).toEqual({
+      files: {
+        "exists.txt": {
+          content: "hello",
+          fileVersion: expect.any(String),
+          offsetBytes: 0,
+          returnedBytes: 5,
+          status: "ok",
+          totalBytes: 5,
+          truncated: false,
+        },
+        "missing.txt": { error: "not-found", status: "error" },
+      },
+      version: 2,
+    });
+  });
+
+  test("does not replace a successful V2 read when closing fails", async () => {
+    fs.writeFileSync(path.join(testDir, "close-error.txt"), "hello");
+    const originalOpen = fs.promises.open.bind(fs.promises);
+    const openSpy = vi
+      .spyOn(fs.promises, "open")
+      .mockImplementation(
+        async (...args: Parameters<typeof fs.promises.open>) => {
+          const handle = await originalOpen(...args);
+          const originalClose = handle.close.bind(handle);
+          handle.close = async () => {
+            await originalClose();
+            throw new Error("simulated close failure");
+          };
+          return handle;
+        }
+      );
+
+    try {
+      const result = await executeTool(
+        {
+          type: "tool",
+          operation: "read-files",
+          cwd: testDir,
+          params: { paths: ["close-error.txt"], resultVersion: 2 },
+        },
+        makeContext(testDir)
+      );
+
+      expect(
+        (result.data as ReadFilesV2Data).files["close-error.txt"]
+      ).toMatchObject({ content: "hello", status: "ok" });
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  test("reports invalid UTF-8 at the start of a V2 file as not-text", async () => {
+    fs.writeFileSync(
+      path.join(testDir, "invalid-utf8.txt"),
+      Buffer.from([0x80, 0x41])
+    );
+
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { paths: ["invalid-utf8.txt"], resultVersion: 2 },
+      },
+      makeContext(testDir)
+    );
+
+    expect((result.data as ReadFilesV2Data).files["invalid-utf8.txt"]).toEqual({
+      error: "not-text",
+      status: "error",
+    });
+  });
+
+  test.each([
+    { bytes: Buffer.from([0x80, 0x41]), title: "continuation byte" },
+    { bytes: Buffer.from([0xc0, 0x41]), title: "invalid sequence" },
+  ])("reports a torn V2 read as unreadable before classifying its $title", async ({
+    bytes,
+    title,
+  }) => {
+    const fileName = `${title.replaceAll(" ", "-")}.txt`;
+    const filePath = path.join(testDir, fileName);
+    fs.writeFileSync(filePath, bytes);
+    const originalOpen = fs.promises.open.bind(fs.promises);
+    const openSpy = vi
+      .spyOn(fs.promises, "open")
+      .mockImplementation(
+        async (...args: Parameters<typeof fs.promises.open>) => {
+          const handle = await originalOpen(...args);
+          const originalRead = handle.read.bind(handle);
+          handle.read = (async (
+            ...readArgs: Parameters<typeof handle.read>
+          ) => {
+            const result = await originalRead(...readArgs);
+            fs.appendFileSync(filePath, "changed");
+            return result;
+          }) as typeof handle.read;
+          return handle;
+        }
+      );
+
+    try {
+      const result = await executeTool(
+        {
+          type: "tool",
+          operation: "read-files",
+          cwd: testDir,
+          params: { paths: [fileName], resultVersion: 2 },
+        },
+        makeContext(testDir)
+      );
+
+      expect((result.data as ReadFilesV2Data).files[fileName]).toEqual({
+        error: "unreadable",
+        status: "error",
+      });
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  test("rejects a V2 retry read that makes no byte progress", async () => {
+    fs.writeFileSync(path.join(testDir, "retry-zero.txt"), "😀");
+    const originalOpen = fs.promises.open.bind(fs.promises);
+    const openSpy = vi
+      .spyOn(fs.promises, "open")
+      .mockImplementation(
+        async (...args: Parameters<typeof fs.promises.open>) => {
+          const handle = await originalOpen(...args);
+          const originalRead = handle.read.bind(handle);
+          let readCount = 0;
+          handle.read = (async (
+            ...readArgs: Parameters<typeof handle.read>
+          ) => {
+            readCount += 1;
+            if (readCount === 2) {
+              return { buffer: readArgs[0], bytesRead: 0 };
+            }
+            return originalRead(...readArgs);
+          }) as typeof handle.read;
+          return handle;
+        }
+      );
+
+    try {
+      const result = await executeTool(
+        {
+          type: "tool",
+          operation: "read-files",
+          cwd: testDir,
+          params: {
+            maxBytes: 1,
+            paths: ["retry-zero.txt"],
+            resultVersion: 2,
+          },
+        },
+        makeContext(testDir)
+      );
+
+      expect((result.data as ReadFilesV2Data).files["retry-zero.txt"]).toEqual({
+        error: "unreadable",
+        status: "error",
+      });
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  test("preserves a UTF-8 BOM in both wire versions", async () => {
+    const content = "\uFEFFexport {};\r\n";
+    fs.writeFileSync(path.join(testDir, "bom.ts"), content);
+
+    const legacy = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { paths: ["bom.ts"] },
+      },
+      makeContext(testDir)
+    );
+    const v2 = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { paths: ["bom.ts"], resultVersion: 2 },
+      },
+      makeContext(testDir)
+    );
+
+    expect(
+      (legacy.data as { files: Record<string, string> }).files["bom.ts"]
+    ).toBe(content);
+    expect((v2.data as ReadFilesV2Data).files["bom.ts"]).toMatchObject({
+      content,
+      returnedBytes: Buffer.byteLength(content),
+    });
+  });
+
+  test("preserves legacy replacement decoding at a byte-truncation boundary", async () => {
+    fs.writeFileSync(path.join(testDir, "legacy-invalid.txt"), "A😀");
+
+    const legacy = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { maxBytes: 2, paths: ["legacy-invalid.txt"] },
+      },
+      makeContext(testDir)
+    );
+    const v2 = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          maxBytes: 2,
+          paths: ["legacy-invalid.txt"],
+          resultVersion: 2,
+        },
+      },
+      makeContext(testDir)
+    );
+
+    expect(
+      (legacy.data as { files: Record<string, string> }).files[
+        "legacy-invalid.txt"
+      ]
+    ).toBe("A�");
+    expect(
+      (v2.data as ReadFilesV2Data).files["legacy-invalid.txt"]
+    ).toMatchObject({
+      content: "A",
+      nextOffsetBytes: 1,
+    });
+  });
+
+  test("continues a V2 read with an exact UTF-8 byte cursor", async () => {
+    fs.writeFileSync(path.join(testDir, "unicode.txt"), "A😀BC");
+
+    const first = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          maxBytes: 3,
+          paths: ["unicode.txt"],
+          resultVersion: 2,
+        },
+      },
+      makeContext(testDir)
+    );
+    const firstFile = (first.data as ReadFilesV2Data).files["unicode.txt"];
+    expect(firstFile).toEqual({
+      content: "A",
+      fileVersion: expect.any(String),
+      nextOffsetBytes: 1,
+      offsetBytes: 0,
+      returnedBytes: 1,
+      status: "ok",
+      totalBytes: 7,
+      truncated: true,
+    });
+
+    const second = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          maxBytes: 3,
+          offsetBytes: 1,
+          paths: ["unicode.txt"],
+          resultVersion: 2,
+        },
+      },
+      makeContext(testDir)
+    );
+    const secondFile = (second.data as ReadFilesV2Data).files["unicode.txt"];
+    expect(secondFile).toEqual({
+      content: "😀",
+      fileVersion: expect.any(String),
+      nextOffsetBytes: 5,
+      offsetBytes: 1,
+      returnedBytes: 4,
+      status: "ok",
+      totalBytes: 7,
+      truncated: true,
+    });
+    expect(firstFile.status).toBe("ok");
+    expect(secondFile.status).toBe("ok");
+    if (firstFile.status === "ok" && secondFile.status === "ok") {
+      expect(secondFile.fileVersion).toBe(firstFile.fileVersion);
+    }
+
+    const invalid = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          offsetBytes: 2,
+          paths: ["unicode.txt"],
+          resultVersion: 2,
+        },
+      },
+      makeContext(testDir)
+    );
+    expect((invalid.data as ReadFilesV2Data).files["unicode.txt"]).toEqual({
+      error: "invalid-offset",
+      status: "error",
+    });
   });
 
   test("applies patchsets and injects auth tokens into env files", async () => {

--- a/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
+++ b/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
@@ -433,6 +433,34 @@ describe("filesystem tools", () => {
     });
   });
 
+  test("preserves not-file when descriptor cleanup fails", async () => {
+    const close = vi.fn().mockRejectedValue(new Error("close failed"));
+    const open = vi.spyOn(fs.promises, "open").mockResolvedValue({
+      close,
+      stat: vi.fn().mockResolvedValue({ isFile: () => false }),
+    } as unknown as fs.promises.FileHandle);
+
+    try {
+      const result = await executeTool(
+        {
+          type: "tool",
+          operation: "read-files",
+          cwd: testDir,
+          params: { paths: ["directory"], resultVersion: 2 },
+        },
+        makeContext(testDir)
+      );
+
+      expect(result.data).toEqual({
+        files: { directory: { error: "not-file", status: "error" } },
+        version: 2,
+      });
+      expect(close).toHaveBeenCalledOnce();
+    } finally {
+      open.mockRestore();
+    }
+  });
+
   test("applies patchsets and injects auth tokens into env files", async () => {
     const result = await executeTool(
       {

--- a/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
+++ b/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import * as dsnIndex from "../../../../src/lib/dsn/index.js";
 import { executeTool } from "../../../../src/lib/init/tools/registry.js";
 import type {
-  ReadFilesV2Data,
   ResolvedInitContext,
   ToolPayload,
 } from "../../../../src/lib/init/types.js";
@@ -104,266 +103,11 @@ describe("filesystem tools", () => {
     expect((existsResult.data as any).exists["missing.txt"]).toBe(false);
   });
 
-  test("returns explicit V2 completion and file errors", async () => {
-    fs.writeFileSync(path.join(testDir, "exists.txt"), "hello");
-
-    const result = await executeTool(
-      {
-        type: "tool",
-        operation: "read-files",
-        cwd: testDir,
-        params: {
-          paths: ["exists.txt", "missing.txt"],
-          resultVersion: 2,
-        },
-      },
-      makeContext(testDir)
-    );
-    const data = result.data as ReadFilesV2Data;
-
-    expect(data).toEqual({
-      files: {
-        "exists.txt": {
-          content: "hello",
-          fileVersion: expect.any(String),
-          offsetBytes: 0,
-          returnedBytes: 5,
-          status: "ok",
-          totalBytes: 5,
-          truncated: false,
-        },
-        "missing.txt": { error: "not-found", status: "error" },
-      },
-      version: 2,
-    });
-  });
-
-  test("does not replace a successful V2 read when closing fails", async () => {
-    fs.writeFileSync(path.join(testDir, "close-error.txt"), "hello");
-    const originalOpen = fs.promises.open.bind(fs.promises);
-    const openSpy = vi
-      .spyOn(fs.promises, "open")
-      .mockImplementation(
-        async (...args: Parameters<typeof fs.promises.open>) => {
-          const handle = await originalOpen(...args);
-          const originalClose = handle.close.bind(handle);
-          handle.close = async () => {
-            await originalClose();
-            throw new Error("simulated close failure");
-          };
-          return handle;
-        }
-      );
-
-    try {
-      const result = await executeTool(
-        {
-          type: "tool",
-          operation: "read-files",
-          cwd: testDir,
-          params: { paths: ["close-error.txt"], resultVersion: 2 },
-        },
-        makeContext(testDir)
-      );
-
-      expect(
-        (result.data as ReadFilesV2Data).files["close-error.txt"]
-      ).toMatchObject({ content: "hello", status: "ok" });
-    } finally {
-      openSpy.mockRestore();
-    }
-  });
-
-  test("reports invalid UTF-8 at the start of a V2 file as not-text", async () => {
+  test("returns independent bounded V2 line ranges", async () => {
     fs.writeFileSync(
-      path.join(testDir, "invalid-utf8.txt"),
-      Buffer.from([0x80, 0x41])
+      path.join(testDir, "large.txt"),
+      Array.from({ length: 8 }, (_, index) => `line-${index + 1}`).join("\n")
     );
-
-    const result = await executeTool(
-      {
-        type: "tool",
-        operation: "read-files",
-        cwd: testDir,
-        params: { paths: ["invalid-utf8.txt"], resultVersion: 2 },
-      },
-      makeContext(testDir)
-    );
-
-    expect((result.data as ReadFilesV2Data).files["invalid-utf8.txt"]).toEqual({
-      error: "not-text",
-      status: "error",
-    });
-  });
-
-  test.each([
-    { bytes: Buffer.from([0x80, 0x41]), title: "continuation byte" },
-    { bytes: Buffer.from([0xc0, 0x41]), title: "invalid sequence" },
-  ])("reports a torn V2 read as unreadable before classifying its $title", async ({
-    bytes,
-    title,
-  }) => {
-    const fileName = `${title.replaceAll(" ", "-")}.txt`;
-    const filePath = path.join(testDir, fileName);
-    fs.writeFileSync(filePath, bytes);
-    const originalOpen = fs.promises.open.bind(fs.promises);
-    const openSpy = vi
-      .spyOn(fs.promises, "open")
-      .mockImplementation(
-        async (...args: Parameters<typeof fs.promises.open>) => {
-          const handle = await originalOpen(...args);
-          const originalRead = handle.read.bind(handle);
-          handle.read = (async (
-            ...readArgs: Parameters<typeof handle.read>
-          ) => {
-            const result = await originalRead(...readArgs);
-            fs.appendFileSync(filePath, "changed");
-            return result;
-          }) as typeof handle.read;
-          return handle;
-        }
-      );
-
-    try {
-      const result = await executeTool(
-        {
-          type: "tool",
-          operation: "read-files",
-          cwd: testDir,
-          params: { paths: [fileName], resultVersion: 2 },
-        },
-        makeContext(testDir)
-      );
-
-      expect((result.data as ReadFilesV2Data).files[fileName]).toEqual({
-        error: "unreadable",
-        status: "error",
-      });
-    } finally {
-      openSpy.mockRestore();
-    }
-  });
-
-  test("rejects a V2 retry read that makes no byte progress", async () => {
-    fs.writeFileSync(path.join(testDir, "retry-zero.txt"), "😀");
-    const originalOpen = fs.promises.open.bind(fs.promises);
-    const openSpy = vi
-      .spyOn(fs.promises, "open")
-      .mockImplementation(
-        async (...args: Parameters<typeof fs.promises.open>) => {
-          const handle = await originalOpen(...args);
-          const originalRead = handle.read.bind(handle);
-          let readCount = 0;
-          handle.read = (async (
-            ...readArgs: Parameters<typeof handle.read>
-          ) => {
-            readCount += 1;
-            if (readCount === 2) {
-              return { buffer: readArgs[0], bytesRead: 0 };
-            }
-            return originalRead(...readArgs);
-          }) as typeof handle.read;
-          return handle;
-        }
-      );
-
-    try {
-      const result = await executeTool(
-        {
-          type: "tool",
-          operation: "read-files",
-          cwd: testDir,
-          params: {
-            maxBytes: 1,
-            paths: ["retry-zero.txt"],
-            resultVersion: 2,
-          },
-        },
-        makeContext(testDir)
-      );
-
-      expect((result.data as ReadFilesV2Data).files["retry-zero.txt"]).toEqual({
-        error: "unreadable",
-        status: "error",
-      });
-    } finally {
-      openSpy.mockRestore();
-    }
-  });
-
-  test("preserves a UTF-8 BOM in both wire versions", async () => {
-    const content = "\uFEFFexport {};\r\n";
-    fs.writeFileSync(path.join(testDir, "bom.ts"), content);
-
-    const legacy = await executeTool(
-      {
-        type: "tool",
-        operation: "read-files",
-        cwd: testDir,
-        params: { paths: ["bom.ts"] },
-      },
-      makeContext(testDir)
-    );
-    const v2 = await executeTool(
-      {
-        type: "tool",
-        operation: "read-files",
-        cwd: testDir,
-        params: { paths: ["bom.ts"], resultVersion: 2 },
-      },
-      makeContext(testDir)
-    );
-
-    expect(
-      (legacy.data as { files: Record<string, string> }).files["bom.ts"]
-    ).toBe(content);
-    expect((v2.data as ReadFilesV2Data).files["bom.ts"]).toMatchObject({
-      content,
-      returnedBytes: Buffer.byteLength(content),
-    });
-  });
-
-  test("preserves legacy replacement decoding at a byte-truncation boundary", async () => {
-    fs.writeFileSync(path.join(testDir, "legacy-invalid.txt"), "A😀");
-
-    const legacy = await executeTool(
-      {
-        type: "tool",
-        operation: "read-files",
-        cwd: testDir,
-        params: { maxBytes: 2, paths: ["legacy-invalid.txt"] },
-      },
-      makeContext(testDir)
-    );
-    const v2 = await executeTool(
-      {
-        type: "tool",
-        operation: "read-files",
-        cwd: testDir,
-        params: {
-          maxBytes: 2,
-          paths: ["legacy-invalid.txt"],
-          resultVersion: 2,
-        },
-      },
-      makeContext(testDir)
-    );
-
-    expect(
-      (legacy.data as { files: Record<string, string> }).files[
-        "legacy-invalid.txt"
-      ]
-    ).toBe("A�");
-    expect(
-      (v2.data as ReadFilesV2Data).files["legacy-invalid.txt"]
-    ).toMatchObject({
-      content: "A",
-      nextOffsetBytes: 1,
-    });
-  });
-
-  test("continues a V2 read with an exact UTF-8 byte cursor", async () => {
-    fs.writeFileSync(path.join(testDir, "unicode.txt"), "A😀BC");
 
     const first = await executeTool(
       {
@@ -371,72 +115,321 @@ describe("filesystem tools", () => {
         operation: "read-files",
         cwd: testDir,
         params: {
-          maxBytes: 3,
-          paths: ["unicode.txt"],
+          maxLines: 3,
+          paths: ["large.txt"],
           resultVersion: 2,
         },
       },
       makeContext(testDir)
     );
-    const firstFile = (first.data as ReadFilesV2Data).files["unicode.txt"];
-    expect(firstFile).toEqual({
-      content: "A",
-      fileVersion: expect.any(String),
-      nextOffsetBytes: 1,
-      offsetBytes: 0,
-      returnedBytes: 1,
-      status: "ok",
-      totalBytes: 7,
-      truncated: true,
-    });
-
-    const second = await executeTool(
+    const later = await executeTool(
       {
         type: "tool",
         operation: "read-files",
         cwd: testDir,
         params: {
-          maxBytes: 3,
-          offsetBytes: 1,
-          paths: ["unicode.txt"],
+          maxLines: 2,
+          paths: ["large.txt"],
+          resultVersion: 2,
+          startLine: 5,
+        },
+      },
+      makeContext(testDir)
+    );
+
+    expect(first.data).toEqual({
+      files: {
+        "large.txt": {
+          content: "line-1\nline-2\nline-3\n",
+          status: "ok",
+          truncated: true,
+        },
+      },
+      version: 2,
+    });
+    expect(later.data).toEqual({
+      files: {
+        "large.txt": {
+          content: "line-5\nline-6\n",
+          status: "ok",
+          truncated: true,
+        },
+      },
+      version: 2,
+    });
+  });
+
+  test("preserves exact line endings in V2 snapshots", async () => {
+    fs.writeFileSync(path.join(testDir, "windows.txt"), "first\r\nsecond\r\n");
+
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          maxLines: 1,
+          paths: ["windows.txt"],
           resultVersion: 2,
         },
       },
       makeContext(testDir)
     );
-    const secondFile = (second.data as ReadFilesV2Data).files["unicode.txt"];
-    expect(secondFile).toEqual({
-      content: "😀",
-      fileVersion: expect.any(String),
-      nextOffsetBytes: 5,
-      offsetBytes: 1,
-      returnedBytes: 4,
-      status: "ok",
-      totalBytes: 7,
-      truncated: true,
+
+    expect(result.data).toEqual({
+      files: {
+        "windows.txt": {
+          content: "first\r\n",
+          status: "ok",
+          truncated: true,
+        },
+      },
+      version: 2,
     });
-    expect(firstFile.status).toBe("ok");
-    expect(secondFile.status).toBe("ok");
-    if (firstFile.status === "ok" && secondFile.status === "ok") {
-      expect(secondFile.fileVersion).toBe(firstFile.fileVersion);
+  });
+
+  test("rejects malformed V2 read requests before local I/O", async () => {
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: undefined,
+      } as unknown as ToolPayload,
+      makeContext(testDir)
+    );
+
+    expect(result).toEqual({
+      error: "read-files params must be an object",
+      ok: false,
+    });
+  });
+
+  test("keeps read-files bounds and sensitive-path policy local", async () => {
+    fs.writeFileSync(path.join(testDir, ".env.local"), "SECRET=value\n");
+    fs.writeFileSync(path.join(testDir, ".pypirc"), "token=secret\n");
+    fs.writeFileSync(path.join(testDir, "binary.txt"), Buffer.from([0, 1, 2]));
+    fs.symlinkSync(".env.local", path.join(testDir, "config.txt"));
+
+    const sensitive = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { paths: [".env.local"], resultVersion: 2 },
+      },
+      makeContext(testDir)
+    );
+    const binary = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { paths: ["binary.txt"], resultVersion: 2 },
+      },
+      makeContext(testDir)
+    );
+    const omittedSensitive = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { paths: [".pypirc"], resultVersion: 2 },
+      },
+      makeContext(testDir)
+    );
+    const sensitiveAlias = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { paths: ["config.txt"], resultVersion: 2 },
+      },
+      makeContext(testDir)
+    );
+
+    expect(sensitive.data).toEqual({
+      files: { ".env.local": { error: "unreadable", status: "error" } },
+      version: 2,
+    });
+    expect(omittedSensitive.data).toEqual({
+      files: { ".pypirc": { error: "unreadable", status: "error" } },
+      version: 2,
+    });
+    expect(binary.data).toEqual({
+      files: { "binary.txt": { error: "not-text", status: "error" } },
+      version: 2,
+    });
+    expect(sensitiveAlias.data).toEqual({
+      files: { "config.txt": { error: "unreadable", status: "error" } },
+      version: 2,
+    });
+  });
+
+  test("finds later lines without exposing a cursor protocol", async () => {
+    fs.writeFileSync(
+      path.join(testDir, "deep.txt"),
+      `${"x".repeat(270_000)}\ntarget\n`
+    );
+
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          maxLines: 1,
+          paths: ["deep.txt"],
+          resultVersion: 2,
+          startLine: 2,
+        },
+      },
+      makeContext(testDir)
+    );
+
+    expect(result.data).toEqual({
+      files: {
+        "deep.txt": {
+          content: "target\n",
+          status: "ok",
+          truncated: false,
+        },
+      },
+      version: 2,
+    });
+  });
+
+  test("bounds V2 content across a multi-file request", async () => {
+    const paths = Array.from({ length: 20 }, (_, index) => `file-${index}.txt`);
+    for (const filePath of paths) {
+      fs.writeFileSync(path.join(testDir, filePath), "x\n".repeat(5000));
     }
 
-    const invalid = await executeTool(
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { maxBytes: 40_000, paths, resultVersion: 2 },
+      },
+      makeContext(testDir)
+    );
+    const files = (
+      result.data as { files: Record<string, { content: string }> }
+    ).files;
+
+    expect(result.ok).toBe(true);
+    expect(
+      Object.values(files).reduce(
+        (total, file) => total + Buffer.byteLength(file.content),
+        0
+      )
+    ).toBeLessThanOrEqual(40_000);
+  });
+
+  test("reads a short line that starts at the deep-scan boundary", async () => {
+    const scanBytes = 4 * 1024 * 1024;
+    const prefix = "x\n".repeat(scanBytes / 2);
+    fs.writeFileSync(path.join(testDir, "boundary.txt"), `${prefix}target\n`);
+
+    const result = await executeTool(
       {
         type: "tool",
         operation: "read-files",
         cwd: testDir,
         params: {
-          offsetBytes: 2,
-          paths: ["unicode.txt"],
+          maxLines: 1,
+          paths: ["boundary.txt"],
           resultVersion: 2,
+          startLine: scanBytes / 2 + 1,
         },
       },
       makeContext(testDir)
     );
-    expect((invalid.data as ReadFilesV2Data).files["unicode.txt"]).toEqual({
-      error: "invalid-offset",
-      status: "error",
+
+    expect(result.data).toEqual({
+      files: {
+        "boundary.txt": {
+          content: "target\n",
+          status: "ok",
+          truncated: false,
+        },
+      },
+      version: 2,
+    });
+  });
+
+  test("reports an existing line beyond the deep-scan boundary", async () => {
+    const scanBytes = 4 * 1024 * 1024;
+    const prefix = `${"x".repeat(scanBytes)}\n`;
+    fs.writeFileSync(path.join(testDir, "too-deep.txt"), `${prefix}target\n`);
+
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          maxLines: 1,
+          paths: ["too-deep.txt"],
+          resultVersion: 2,
+          startLine: 2,
+        },
+      },
+      makeContext(testDir)
+    );
+
+    expect(result.data).toEqual({
+      files: {
+        "too-deep.txt": { error: "range-too-deep", status: "error" },
+      },
+      version: 2,
+    });
+  });
+
+  test("rejects incomplete lines and invalid UTF-8 instead of clipping", async () => {
+    fs.writeFileSync(
+      path.join(testDir, "long-line.txt"),
+      `${"x".repeat(50_000)}\n`
+    );
+    fs.writeFileSync(
+      path.join(testDir, "invalid-utf8.txt"),
+      Buffer.from([0x61, 0x62, 0x63, 0xff])
+    );
+    fs.writeFileSync(path.join(testDir, "multibyte.txt"), "é\n");
+
+    const read = (filePath: string, maxBytes?: number) =>
+      executeTool(
+        {
+          type: "tool",
+          operation: "read-files",
+          cwd: testDir,
+          params: {
+            maxBytes,
+            paths: [filePath],
+            resultVersion: 2,
+          },
+        },
+        makeContext(testDir)
+      );
+
+    expect((await read("long-line.txt")).data).toEqual({
+      files: {
+        "long-line.txt": { error: "line-too-long", status: "error" },
+      },
+      version: 2,
+    });
+    expect((await read("invalid-utf8.txt")).data).toEqual({
+      files: {
+        "invalid-utf8.txt": { error: "not-text", status: "error" },
+      },
+      version: 2,
+    });
+    expect((await read("multibyte.txt", 1)).data).toEqual({
+      files: {
+        "multibyte.txt": { error: "line-too-long", status: "error" },
+      },
+      version: 2,
     });
   });
 


### PR DESCRIPTION
## Summary

This is the CLI half of bounded, stateless read-files support for sentry init.

- add an opt-in V2 response with one structured content/error result per requested path
- accept startLine, maxLines, and maxBytes in the request, but return no cursor, file version, or continuation state
- return complete lines only; callers can issue another independent range read or use grep when they need different evidence
- cap all returned content across the request at 40 KB and bound deep line lookup at 4 MiB
- read from an open descriptor with containment, regular-file, identity, stability, UTF-8, binary, symlink-target, and sensitive-path checks
- preserve the existing V1 response shape for older API deployments

## Compatibility

The protocol is negotiated per request. An older API never asks for V2, so this CLI keeps returning the V1 shape. A newer API accepts V1 from older CLI releases and treats ambiguous truncation conservatively.

Companion API PR: https://github.com/getsentry/cli-init-api/pull/234

## Test plan

- pnpm --filter sentry typecheck
- focused filesystem suite: 17 tests
- focused Biome check for the three changed files
- pnpm test:unit: changed tests pass; the full run retains two unrelated completion-simulation failures from the local shell environment
- git diff --check
