### PR TITLE
fix(init): keep protocol metadata out of local tools

### DIFF
--- a/packages/cli/src/lib/init/wizard-runner.ts
+++ b/packages/cli/src/lib/init/wizard-runner.ts
@@ -65,6 +65,7 @@ import { checkReadiness } from "./readiness.js";
 
 import { describeTool, executeTool } from "./tools/registry.js";
 import type {
+  InteractivePayload,
   ResolvedInitContext,
   SuspendPayload,
   ToolPayload,
@@ -97,7 +98,7 @@ type CompactPhaseHistoryEntry = {
 };
 
 type StepContext = {
-  payload: SuspendPayload;
+  payload: InteractivePayload | ToolPayload;
   stepId: string;
   spin: SpinnerHandle;
   spinState: SpinState;
@@ -247,11 +248,7 @@ function formatReadFilesSummary(progress: ReadFilesDisplay): string {
  * Build a follow-up spinner message after a tool succeeds and the CLI is
  * waiting for the server to continue processing the returned data.
  */
-function describePostTool(payload: SuspendPayload): string | undefined {
-  if (payload.type !== "tool") {
-    return;
-  }
-
+function describePostTool(payload: ToolPayload): string | undefined {
   switch (payload.operation) {
     case "read-files":
       return formatReadFilesSummary({
@@ -514,6 +511,18 @@ function assertSuspendPayload(raw: unknown): SuspendPayload {
     throw new Error("Invalid init protocol envelope");
   }
   return payload;
+}
+
+/** Keep transport identity at the wire boundary, outside local tool and UI contracts. */
+function localSuspendPayload(
+  payload: SuspendPayload
+): InteractivePayload | ToolPayload {
+  const {
+    protocolVersion: _protocolVersion,
+    requestId: _requestId,
+    ...localPayload
+  } = payload;
+  return localPayload;
 }
 
 function withTimeout<T>(
@@ -1127,7 +1136,7 @@ export async function runWizard(initialOptions: WizardOptions): Promise<void> {
 
       const resumeData = await handleSuspendedStep(
         {
-          payload: extracted.payload,
+          payload: localSuspendPayload(extracted.payload),
           stepId: extracted.stepId,
           spin,
           spinState,

--- a/packages/cli/test/lib/init/wizard-runner.test.ts
+++ b/packages/cli/test/lib/init/wizard-runner.test.ts
@@ -619,7 +619,43 @@ describe("runWizard", () => {
     expect(spinnerMock.message).toHaveBeenCalledWith("Running tool...");
   });
 
-  test("dispatches interactive payloads to the prompt handler", async () => {
+  test("keeps v1 transport metadata out of local tool payloads", async () => {
+    const requestId = "8c7ee6b9-e955-4514-9164-f01844584a28";
+    const toolPayload: ToolPayload = {
+      type: "tool",
+      operation: "apply-patchset",
+      cwd: "/tmp/test",
+      params: { patches: [] },
+    };
+    const protocolPayload: SuspendPayload = {
+      ...toolPayload,
+      protocolVersion: 1,
+      requestId,
+    };
+    mockStartResult = {
+      status: "suspended",
+      suspended: [["apply-codemods"]],
+      steps: {
+        "apply-codemods": { suspendPayload: protocolPayload },
+      },
+    };
+    mockResumeResults = [{ status: "success" }];
+
+    await runWizard(makeOptions());
+
+    expect(describeToolSpy).toHaveBeenCalledWith(toolPayload);
+    expect(executeToolSpy).toHaveBeenCalledWith(toolPayload, makeContext());
+    expect(sharedResumeAsyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resumeData: expect.objectContaining({
+          protocolVersion: 1,
+          requestId,
+        }),
+      })
+    );
+  });
+
+  test("keeps v1 transport metadata out of interactive payloads", async () => {
     const requestId = "8c7ee6b9-e955-4514-9164-f01844584a28";
     mockStartResult = {
       status: "suspended",
@@ -645,8 +681,6 @@ describe("runWizard", () => {
         type: "interactive",
         kind: "confirm",
         prompt: "Continue?",
-        protocolVersion: 1,
-        requestId,
       },
       makeContext(),
       expect.anything()


### PR DESCRIPTION
## Summary

Follow-up to #1436. Protocol v1 adds `protocolVersion` and `requestId` to each suspended request, but the CLI was forwarding those transport fields into strict local tool schemas. `apply-patchset` rejected `protocolVersion` as an unknown key, retried four times, and aborted before writing files.

This keeps the wire envelope at the runner boundary:

- local tools and interactive handlers receive only their domain payload
- `resumeAsync` still echoes the original protocol version and request ID
- request-ID recovery behavior remains unchanged
- legacy payloads remain compatible because the fields are optional

## Test plan

- `pnpm --filter sentry exec vitest run test/lib/init/wizard-runner.test.ts` — 64 passed
- `pnpm --filter sentry exec vitest run test/lib/init test/commands/init.test.ts` — 35 files / 551 passed
- `pnpm --filter sentry exec tsc --noEmit -p tsconfig.json`
- `pnpm lint`
- `pnpm check:deps`
- `pnpm check:errors`
- `pnpm check:patches`
- `pnpm check:stale-refs`
- `pnpm check:fragments`
- `pnpm check:docs-sections`
- `SENTRY_CLIENT_ID=local-build-smoke pnpm build`
- real production-API canary on `sentry-test-projects/nextjs`: selected every available feature, applied six changes, installed dependencies, passed CLI startup verification, and passed `bun run build`
- `git diff --check`

The full CLI suite also completed with 9,173 passing and the same eight unrelated environment-sensitive failures already present on main (timezone and Bash completion fixtures).
