### PR TITLE
fix(init): stop duplicating step checks in the activity log

### DIFF
--- a/packages/cli/src/lib/init/wizard-runner.ts
+++ b/packages/cli/src/lib/init/wizard-runner.ts
@@ -35,7 +35,6 @@ import {
   abortIfCancelled,
   PROGRESS_ROTATE_INTERVAL_MS,
   STEP_ACTIVE_LABELS,
-  STEP_LABELS,
   STEP_PROGRESS_MESSAGES,
   WizardCancelledError,
 } from "./clack-utils.js";
@@ -346,7 +345,6 @@ async function handleSuspendedStep(
   stepHistory: Map<string, CompactPhaseHistoryEntry[]>
 ): Promise<Record<string, unknown>> {
   const { payload, stepId, spin, spinState, context, ui } = ctx;
-  const label = STEP_LABELS[stepId] ?? stepId;
 
   if (payload.type === "tool") {
     const message =
@@ -374,8 +372,14 @@ async function handleSuspendedStep(
     const toolResult = await executeTool(payload, context);
 
     if (toolResult.message) {
-      spin.stop(renderInlineMarkdown(toolResult.message));
-      spin.start("Processing...");
+      // Tool messages (e.g. "Using existing project ...") describe a
+      // completed sub-action that the sidebar Tasks checklist already
+      // tracks. Surface it as a transient spinner update instead of
+      // stopping the spinner to persist a ✔ line that just duplicates the
+      // checklist.
+      spin.message(
+        renderInlineMarkdown(truncateForTerminal(toolResult.message))
+      );
     } else {
       const followUpMessage =
         toolResult.ok === false ? undefined : describePostTool(payload);
@@ -420,7 +424,11 @@ async function handleSuspendedStep(
       };
     }
 
-    spin.stop(label);
+    // Stop the spinner to hand its row over to the interactive prompt, but
+    // pass an empty message so no ✔ line is persisted for the step label
+    // (e.g. "Selecting features"). The sidebar Tasks checklist already
+    // tracks step progress, so a duplicate line in the activity log is noise.
+    spin.stop("");
     spinState.running = false;
 
     const interactiveResult = await handleInteractive(payload, context, ui);

--- a/packages/cli/test/lib/init/wizard-runner.test.ts
+++ b/packages/cli/test/lib/init/wizard-runner.test.ts
@@ -959,7 +959,7 @@ describe("runWizard", () => {
     expect(args.initialState?.existingSentry).toEqual(detectedSentry);
   });
 
-  test("renders tool result messages via the spinner stop state", async () => {
+  test("renders tool result messages as a transient spinner message, not a persisted line", async () => {
     mockStartResult = {
       status: "suspended",
       suspended: [["ensure-sentry-project"]],
@@ -983,7 +983,11 @@ describe("runWizard", () => {
 
     await runWizard(makeOptions());
 
-    expect(spinnerMock.stop).toHaveBeenCalledWith("Using existing project");
+    // Tool messages update the live spinner instead of persisting a ✔ line —
+    // the sidebar Tasks checklist already tracks step completion, so a
+    // duplicate line in the activity log is just noise.
+    expect(spinnerMock.message).toHaveBeenCalledWith("Using existing project");
+    expect(spinnerMock.stop).not.toHaveBeenCalledWith("Using existing project");
   });
 
   test("shows --yes hint when LoggingUI prompt fails", async () => {


### PR DESCRIPTION
## Summary

During `sentry init`, once setup starts working the activity column printed two persistent `✔` lines — `Using existing project "..."` and `Selecting features` — that just repeat what the sidebar **Tasks** checklist already tracks. This removes that duplication so the left column only shows the live spinner for the current step (e.g. "Planning code changes...").

## Changes

- The tool result message (`Using existing project ...`) now updates the spinner in place instead of stopping it to persist a `✔` line.
- Before an interactive prompt, the spinner stops with an empty message so no `✔` step-label line (`Selecting features`) is left behind.
- Dropped the now-unused `label` local and `STEP_LABELS` import.

The plain `LoggingUI` backend (used in CI / `--no-tui`, which has no sidebar) still surfaces progress through the spinner message, so nothing is lost there.

## Test Plan

- `pnpm --filter sentry run test:unit` (updated `wizard-runner.test.ts` — the tool message now asserts `spinner.message` rather than `spinner.stop`; `ink-app.snapshot` still green).
- Manually: `pnpm cli init <project>`, pick features, accept — the two `✔` lines no longer appear; only the spinner + the Tasks panel show progress.