### PR TITLE
fix(init): align local file read policy

### DIFF
--- a/packages/cli/src/lib/init/tools/project-file.ts
+++ b/packages/cli/src/lib/init/tools/project-file.ts
@@ -1,0 +1,161 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { ReadFileErrorCode } from "../types.js";
+import { safePath } from "./shared.js";
+
+const SENSITIVE_PATH_TOKEN_RE = /[\\/{},()[\]!+@?*]+/u;
+const SENSITIVE_PATH_TOKENS = new Set([
+  ".git",
+  ".git-credentials",
+  ".hg",
+  ".netrc",
+  ".npmrc",
+  ".pypirc",
+  ".svn",
+  ".yarnrc",
+  ".yarnrc.yml",
+]);
+
+export type OpenedProjectFile = {
+  handle: fs.promises.FileHandle;
+  stat: fs.Stats;
+};
+
+/**
+ * Open a stable regular file inside a project root.
+ *
+ * Direct reads of sensitive metadata are allowed. An alias whose resolved
+ * target is sensitive is rejected because downstream redaction selects its
+ * format from the requested path.
+ */
+export async function openProjectFile(
+  cwd: string,
+  filePath: string
+): Promise<OpenedProjectFile | { error: ReadFileErrorCode }> {
+  let handle: fs.promises.FileHandle | undefined;
+  try {
+    const absPath = safePath(cwd, filePath);
+    handle = await fs.promises.open(
+      absPath,
+      // biome-ignore lint/suspicious/noBitwiseOperators: fs open flags are a bitmask.
+      fs.constants.O_RDONLY | fs.constants.O_NONBLOCK
+    );
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      await closeProjectFile(handle);
+      return { error: "not-file" };
+    }
+    if (!(await openedPathIsAllowed(cwd, absPath, stat))) {
+      await closeProjectFile(handle);
+      return { error: "unreadable" };
+    }
+    return { handle, stat };
+  } catch (error) {
+    await handle?.close().catch(() => {
+      // Preserve the primary open error when cleanup fails.
+    });
+    return { error: readErrorCode(error) };
+  }
+}
+
+export async function closeProjectFile(
+  handle: fs.promises.FileHandle
+): Promise<void> {
+  await handle.close().catch(() => {
+    // Descriptor cleanup must not replace the primary read classification.
+  });
+}
+
+export function projectFileChanged(
+  initial: fs.Stats,
+  final: fs.Stats
+): boolean {
+  return (
+    final.dev !== initial.dev ||
+    final.ino !== initial.ino ||
+    final.size !== initial.size ||
+    final.mtimeMs !== initial.mtimeMs
+  );
+}
+
+async function openedPathIsAllowed(
+  cwd: string,
+  absPath: string,
+  openedStat: fs.Stats
+): Promise<boolean> {
+  const [realCwd, realPath] = await Promise.all([
+    fs.promises.realpath(cwd),
+    fs.promises.realpath(absPath),
+  ]);
+  if (realPath !== realCwd && !realPath.startsWith(`${realCwd}${path.sep}`)) {
+    return false;
+  }
+
+  const requestedRelativePath = path.relative(path.resolve(cwd), absPath);
+  const resolvedRelativePath = path.relative(realCwd, realPath);
+  if (
+    isSensitiveReadPath(resolvedRelativePath) &&
+    (!sameProjectPath(requestedRelativePath, resolvedRelativePath) ||
+      (await requestedPathContainsSymlink(cwd, absPath)))
+  ) {
+    return false;
+  }
+
+  const resolvedStat = await fs.promises.stat(realPath);
+  return (
+    resolvedStat.dev === openedStat.dev && resolvedStat.ino === openedStat.ino
+  );
+}
+
+async function requestedPathContainsSymlink(
+  cwd: string,
+  absPath: string
+): Promise<boolean> {
+  let currentPath = path.resolve(cwd);
+  const relativePath = path.relative(currentPath, absPath);
+  for (const segment of relativePath.split(path.sep)) {
+    if (!segment) {
+      continue;
+    }
+    currentPath = path.join(currentPath, segment);
+    if ((await fs.promises.lstat(currentPath)).isSymbolicLink()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function sameProjectPath(first: string, second: string): boolean {
+  const normalizedFirst = path.normalize(first);
+  const normalizedSecond = path.normalize(second);
+  if (process.platform === "win32" || process.platform === "darwin") {
+    return normalizedFirst.toLowerCase() === normalizedSecond.toLowerCase();
+  }
+  return normalizedFirst === normalizedSecond;
+}
+
+function isSensitiveReadPath(filePath: string): boolean {
+  const tokens = filePath
+    .toLowerCase()
+    .split(SENSITIVE_PATH_TOKEN_RE)
+    .filter(Boolean);
+  return tokens.some(
+    (token) =>
+      SENSITIVE_PATH_TOKENS.has(token) ||
+      token === ".dev.vars" ||
+      token === ".env" ||
+      token.startsWith(".env.")
+  );
+}
+
+function readErrorCode(error: unknown): ReadFileErrorCode {
+  if (typeof error === "object" && error !== null && "code" in error) {
+    if (error.code === "ENOENT") {
+      return "not-found";
+    }
+    if (error.code === "EISDIR") {
+      return "not-file";
+    }
+  }
+  return "unreadable";
+}

--- a/packages/cli/src/lib/init/tools/read-files.ts
+++ b/packages/cli/src/lib/init/tools/read-files.ts
@@ -1,5 +1,4 @@
-import fs from "node:fs";
-import path from "node:path";
+import type fs from "node:fs";
 import { MAX_FILE_BYTES } from "../constants.js";
 import type {
   ReadFileErrorCode,
@@ -8,7 +7,11 @@ import type {
   ReadFileV2Result,
   ToolResult,
 } from "../types.js";
-import { safePath } from "./shared.js";
+import {
+  type OpenedProjectFile,
+  openProjectFile,
+  projectFileChanged,
+} from "./project-file.js";
 import type { InitToolDefinition } from "./types.js";
 
 const DEFAULT_MAX_LINES = 1000;
@@ -17,28 +20,11 @@ const MAX_V2_CONTENT_BYTES = 40_000;
 const MAX_READ_LINES = 2000;
 const MAX_READ_PATHS = 20;
 const PATH_SEGMENT_RE = /[/\\\\]/u;
-const SENSITIVE_PATH_TOKEN_RE = /[\\/{},()[\]!+@?*]+/u;
-const SENSITIVE_PATH_TOKENS = new Set([
-  ".git",
-  ".git-credentials",
-  ".hg",
-  ".netrc",
-  ".npmrc",
-  ".pypirc",
-  ".svn",
-  ".yarnrc",
-  ".yarnrc.yml",
-]);
 
 type ReadBounds = {
   maxBytes: number;
   maxLines: number;
   startLine: number;
-};
-
-type OpenedProjectFile = {
-  handle: fs.promises.FileHandle;
-  stat: fs.Stats;
 };
 
 /**
@@ -81,9 +67,6 @@ async function readSingleFileV1(
   filePath: string,
   maxBytes: number
 ): Promise<string | null> {
-  if (isSensitiveReadPath(filePath)) {
-    return null;
-  }
   let opened: OpenedProjectFile | undefined;
   try {
     const result = await openProjectFile(cwd, filePath);
@@ -94,7 +77,7 @@ async function readSingleFileV1(
     const bytesToRead = Math.min(opened.stat.size, maxBytes);
     const buffer = Buffer.alloc(bytesToRead);
     await opened.handle.read(buffer, 0, bytesToRead, 0);
-    if (fileChanged(opened.stat, await opened.handle.stat())) {
+    if (projectFileChanged(opened.stat, await opened.handle.stat())) {
       return null;
     }
     return buffer.toString("utf-8");
@@ -143,9 +126,6 @@ async function readSingleFileV2(
   filePath: string,
   bounds: ReadBounds
 ): Promise<ReadFileV2Result> {
-  if (isSensitiveReadPath(filePath)) {
-    return { error: "unreadable", status: "error" };
-  }
   let opened: OpenedProjectFile | undefined;
   try {
     const result = await openProjectFile(cwd, filePath);
@@ -154,7 +134,7 @@ async function readSingleFileV2(
     }
     opened = result;
     if (opened.stat.size === 0) {
-      if (fileChanged(opened.stat, await opened.handle.stat())) {
+      if (projectFileChanged(opened.stat, await opened.handle.stat())) {
         return { error: "unreadable", status: "error" };
       }
       return bounds.startLine === 1
@@ -167,7 +147,7 @@ async function readSingleFileV2(
     }
 
     const page = await readTextPage(opened.handle, opened.stat.size, bounds);
-    if (fileChanged(opened.stat, await opened.handle.stat())) {
+    if (projectFileChanged(opened.stat, await opened.handle.stat())) {
       return { error: "unreadable", status: "error" };
     }
     return page;
@@ -276,73 +256,6 @@ function priorLinesOrError(
     : { content: buffer.subarray(startOffset, endOffset) };
 }
 
-async function openProjectFile(
-  cwd: string,
-  filePath: string
-): Promise<OpenedProjectFile | { error: ReadFileErrorCode }> {
-  let handle: fs.promises.FileHandle | undefined;
-  try {
-    const absPath = safePath(cwd, filePath);
-    handle = await fs.promises.open(
-      absPath,
-      // biome-ignore lint/suspicious/noBitwiseOperators: fs open flags are a bitmask.
-      fs.constants.O_RDONLY | fs.constants.O_NONBLOCK
-    );
-    const stat = await handle.stat();
-    if (!stat.isFile()) {
-      await closeQuietly(handle);
-      return { error: "not-file" };
-    }
-    if (!(await openedPathIsAllowed(cwd, absPath, stat))) {
-      await closeQuietly(handle);
-      return { error: "unreadable" };
-    }
-    return { handle, stat };
-  } catch (error) {
-    await handle?.close().catch(() => {
-      // Preserve the primary open error when cleanup fails.
-    });
-    return { error: readErrorCode(error) };
-  }
-}
-
-async function closeQuietly(handle: fs.promises.FileHandle): Promise<void> {
-  await handle.close().catch(() => {
-    // Descriptor cleanup must not replace the primary read classification.
-  });
-}
-
-async function openedPathIsAllowed(
-  cwd: string,
-  absPath: string,
-  openedStat: fs.Stats
-): Promise<boolean> {
-  const [realCwd, realPath] = await Promise.all([
-    fs.promises.realpath(cwd),
-    fs.promises.realpath(absPath),
-  ]);
-  if (realPath !== realCwd && !realPath.startsWith(`${realCwd}${path.sep}`)) {
-    return false;
-  }
-  const relativeRealPath = path.relative(realCwd, realPath);
-  if (isSensitiveReadPath(relativeRealPath)) {
-    return false;
-  }
-  const resolvedStat = await fs.promises.stat(realPath);
-  return (
-    resolvedStat.dev === openedStat.dev && resolvedStat.ino === openedStat.ino
-  );
-}
-
-function fileChanged(initial: fs.Stats, final: fs.Stats): boolean {
-  return (
-    final.dev !== initial.dev ||
-    final.ino !== initial.ino ||
-    final.size !== initial.size ||
-    final.mtimeMs !== initial.mtimeMs
-  );
-}
-
 function validateReadRequest(payload: ReadFilesPayload): string | undefined {
   const params = (payload as { params?: unknown }).params;
   if (typeof params !== "object" || params === null) {
@@ -402,20 +315,6 @@ function isInvalidPositiveInteger(value: unknown): boolean {
   return (
     value !== undefined &&
     (typeof value !== "number" || !Number.isSafeInteger(value) || value < 1)
-  );
-}
-
-function isSensitiveReadPath(filePath: string): boolean {
-  const tokens = filePath
-    .toLowerCase()
-    .split(SENSITIVE_PATH_TOKEN_RE)
-    .filter(Boolean);
-  return tokens.some(
-    (token) =>
-      SENSITIVE_PATH_TOKENS.has(token) ||
-      token === ".dev.vars" ||
-      token === ".env" ||
-      token.startsWith(".env.")
   );
 }
 

--- a/packages/cli/src/lib/init/workflow-inputs.ts
+++ b/packages/cli/src/lib/init/workflow-inputs.ts
@@ -1,8 +1,12 @@
-import fs from "node:fs";
-import path from "node:path";
 import { MAX_FILE_BYTES } from "./constants.js";
 import { detectSentry } from "./tools/detect-sentry.js";
 import { listDir } from "./tools/list-dir.js";
+import {
+  closeProjectFile,
+  type OpenedProjectFile,
+  openProjectFile,
+  projectFileChanged,
+} from "./tools/project-file.js";
 import type { DirEntry } from "./types.js";
 
 /**
@@ -118,30 +122,59 @@ export async function preReadCommonFiles(
     if (totalBytes >= MAX_PREREAD_TOTAL_BYTES) {
       break;
     }
-    try {
-      const absPath = path.join(directory, filePath);
-      const stat = await fs.promises.stat(absPath);
-      // Guard against FIFOs / sockets / devices — `fs.readFile` on a
-      // FIFO blocks indefinitely waiting for a writer. `stat` follows
-      // symlinks, so a symlink → FIFO is also caught here.
-      if (!stat.isFile()) {
-        cache[filePath] = null;
-        continue;
-      }
-      if (stat.size > MAX_FILE_BYTES) {
-        continue;
-      }
-      const content = await fs.promises.readFile(absPath, "utf-8");
-      if (totalBytes + content.length <= MAX_PREREAD_TOTAL_BYTES) {
-        cache[filePath] = content;
-        totalBytes += content.length;
-      }
-    } catch {
+    const result = await readCommonConfigFile(directory, filePath);
+    if (result.status === "unreadable") {
       cache[filePath] = null;
+      continue;
+    }
+    if (
+      result.status === "read" &&
+      totalBytes + result.bytes <= MAX_PREREAD_TOTAL_BYTES
+    ) {
+      cache[filePath] = result.content;
+      totalBytes += result.bytes;
     }
   }
 
   return cache;
+}
+
+type CommonConfigRead =
+  | { status: "skipped" | "unreadable" }
+  | { bytes: number; content: string; status: "read" };
+
+async function readCommonConfigFile(
+  directory: string,
+  filePath: string
+): Promise<CommonConfigRead> {
+  let opened: OpenedProjectFile | undefined;
+  try {
+    const result = await openProjectFile(directory, filePath);
+    if ("error" in result) {
+      return { status: "unreadable" };
+    }
+    opened = result;
+    if (opened.stat.size > MAX_FILE_BYTES) {
+      return { status: "skipped" };
+    }
+
+    const buffer = Buffer.alloc(opened.stat.size);
+    const { bytesRead } = await opened.handle.read(buffer, 0, buffer.length, 0);
+    if (projectFileChanged(opened.stat, await opened.handle.stat())) {
+      return { status: "unreadable" };
+    }
+    return {
+      bytes: bytesRead,
+      content: buffer.subarray(0, bytesRead).toString("utf-8"),
+      status: "read",
+    };
+  } catch {
+    return { status: "unreadable" };
+  } finally {
+    if (opened) {
+      await closeProjectFile(opened.handle);
+    }
+  }
 }
 
 /**

--- a/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
+++ b/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
@@ -305,13 +305,20 @@ describe("filesystem tools", () => {
     });
   });
 
-  test("keeps read-files bounds and sensitive-path policy local", async () => {
+  test("reads regular metadata files while preserving sandbox and text bounds", async () => {
     fs.writeFileSync(path.join(testDir, ".env.local"), "SECRET=value\n");
+    fs.writeFileSync(
+      path.join(testDir, ".netrc"),
+      "machine example.test login user password secret\n"
+    );
     fs.writeFileSync(path.join(testDir, ".pypirc"), "token=secret\n");
+    fs.writeFileSync(
+      path.join(testDir, ".npmrc"),
+      "//registry/:_authToken=secret\n"
+    );
     fs.writeFileSync(path.join(testDir, "binary.txt"), Buffer.from([0, 1, 2]));
-    fs.symlinkSync(".env.local", path.join(testDir, "config.txt"));
 
-    const sensitive = await executeTool(
+    const environment = await executeTool(
       {
         type: "tool",
         operation: "read-files",
@@ -329,7 +336,7 @@ describe("filesystem tools", () => {
       },
       makeContext(testDir)
     );
-    const omittedSensitive = await executeTool(
+    const packageMetadata = await executeTool(
       {
         type: "tool",
         operation: "read-files",
@@ -338,30 +345,95 @@ describe("filesystem tools", () => {
       },
       makeContext(testDir)
     );
-    const sensitiveAlias = await executeTool(
+    const netrc = await executeTool(
       {
         type: "tool",
         operation: "read-files",
         cwd: testDir,
-        params: { paths: ["config.txt"], resultVersion: 2 },
+        params: { paths: [".netrc"], resultVersion: 2 },
       },
       makeContext(testDir)
     );
-
-    expect(sensitive.data).toEqual({
-      files: { ".env.local": { error: "unreadable", status: "error" } },
+    const legacyNpmConfig = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { paths: [".npmrc"] },
+      },
+      makeContext(testDir)
+    );
+    expect(environment.data).toEqual({
+      files: {
+        ".env.local": {
+          content: "SECRET=value\n",
+          status: "ok",
+          truncated: false,
+        },
+      },
       version: 2,
     });
-    expect(omittedSensitive.data).toEqual({
-      files: { ".pypirc": { error: "unreadable", status: "error" } },
+    expect(packageMetadata.data).toEqual({
+      files: {
+        ".pypirc": {
+          content: "token=secret\n",
+          status: "ok",
+          truncated: false,
+        },
+      },
       version: 2,
+    });
+    expect(netrc.data).toEqual({
+      files: {
+        ".netrc": {
+          content: "machine example.test login user password secret\n",
+          status: "ok",
+          truncated: false,
+        },
+      },
+      version: 2,
+    });
+    expect(legacyNpmConfig.data).toEqual({
+      files: { ".npmrc": "//registry/:_authToken=secret\n" },
     });
     expect(binary.data).toEqual({
       files: { "binary.txt": { error: "not-text", status: "error" } },
       version: 2,
     });
-    expect(sensitiveAlias.data).toEqual({
-      files: { "config.txt": { error: "unreadable", status: "error" } },
+  });
+
+  test("rejects aliases to sensitive files in V1 and V2", async () => {
+    fs.writeFileSync(
+      path.join(testDir, ".netrc"),
+      "machine example.test login user password secret\n"
+    );
+    fs.symlinkSync(".netrc", path.join(testDir, "credentials.txt"));
+    fs.symlinkSync(".netrc", path.join(testDir, ".pypirc"));
+
+    const legacyAlias = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { paths: ["credentials.txt"] },
+      },
+      makeContext(testDir)
+    );
+    const sensitiveNameAlias = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { paths: [".pypirc"], resultVersion: 2 },
+      },
+      makeContext(testDir)
+    );
+
+    expect(legacyAlias.data).toEqual({
+      files: { "credentials.txt": null },
+    });
+    expect(sensitiveNameAlias.data).toEqual({
+      files: { ".pypirc": { error: "unreadable", status: "error" } },
       version: 2,
     });
   });

--- a/packages/cli/test/lib/safe-read.test.ts
+++ b/packages/cli/test/lib/safe-read.test.ts
@@ -6,10 +6,11 @@
  */
 
 import { execSync } from "node:child_process";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { MAX_FILE_BYTES } from "../../src/lib/init/constants.js";
 import { applyPatchset } from "../../src/lib/init/tools/apply-patchset.js";
 import { readFiles } from "../../src/lib/init/tools/read-files.js";
 import type { DirEntry } from "../../src/lib/init/types.js";
@@ -273,5 +274,30 @@ describe("workflow-inputs preReadCommonFiles FIFO safety", () => {
     const cache = await preReadCommonFiles(dir, listing);
     expect(cache["package.json"]).toBe('{"name":"x"}');
     expect(cache["tsconfig.json"]).toBeNull();
+  });
+
+  test("rejects a common-config alias to sensitive metadata", async () => {
+    writeFileSync(
+      join(dir, ".netrc"),
+      "machine example.test login user password secret\n"
+    );
+    symlinkSync(".netrc", join(dir, "package.json"));
+
+    const listing: DirEntry[] = [
+      { name: "package.json", path: "package.json", type: "file" },
+    ];
+
+    const cache = await preReadCommonFiles(dir, listing);
+    expect(cache["package.json"]).toBeNull();
+  });
+
+  test("skips an oversized common config instead of truncating it", async () => {
+    writeFileSync(join(dir, "package.json"), "x".repeat(MAX_FILE_BYTES + 1));
+    const listing: DirEntry[] = [
+      { name: "package.json", path: "package.json", type: "file" },
+    ];
+
+    const cache = await preReadCommonFiles(dir, listing);
+    expect(cache).not.toHaveProperty("package.json");
   });
 });


### PR DESCRIPTION
## Summary

The agent API now gives every role the same direct filesystem tools, including package-manager metadata such as `.npmrc` and `.yarnrc.yml`. This aligns the local reader with that contract while keeping the sandbox and redaction boundary safe.

Direct reads of sensitive metadata are allowed, but aliases to sensitive targets are rejected. The normal `read-files` operation and startup prereads now share one safe-open primitive for containment, realpath, inode, regular-file, stability, and descriptor handling, so prereads cannot bypass the policy.

This is the paired CLI change for [getsentry/cli-init-api#244](https://github.com/getsentry/cli-init-api/pull/244). The API should deploy first; the existing CLI remains compatible until this reaches users.

## Test plan

- filesystem and preread regressions: 35/35 passed
- all init library tests: 532/532 passed
- CLI typecheck: passed
- Biome on changed files: passed
- full unit suite: 9,218 passed; the same 8 environment-sensitive failures reproduce on clean `origin/main` (Europe/Madrid date assertions and Bash 3.2 completion simulation)
- paired local Next.js `sentry init`: completed, installed and verified `@sentry/nextjs`, and `bun run build` passed

Security coverage includes direct V1/V2 reads, same- and cross-format sensitive symlink aliases, parent-directory symlinks, prereads, FIFOs, oversized files, containment, inode stability, and repeated TOCTOU stress.
