### PR TITLE
fix(init): start the plugin-installer handoff at the top of the screen

### DIFF
--- a/packages/cli/src/lib/init/ui/ink-ui.ts
+++ b/packages/cli/src/lib/init/ui/ink-ui.ts
@@ -939,8 +939,21 @@ export class InkUI implements WizardUI {
     }
     // Leave the alternate screen buffer so the user's original
     // scrollback is restored.
+    //
+    // When the user queued an interactive post-exit action (the agent-plugin
+    // installer), also clear the restored screen and home the cursor. Exiting
+    // the alt buffer returns the cursor to the row where `sentry init` was
+    // invoked — usually low on the screen — so without this the exit summary
+    // and the installer's own full-screen UI would render from mid-screen with
+    // a blank gap above. Clearing gives the handoff the same clean top-of-screen
+    // start as wizard startup (line ~362). The normal exit (no installer) is
+    // left untouched so its compact summary flows into scrollback as before.
+    const hasPostExitActions =
+      this.store.getSnapshot().postExitActions.length > 0;
     try {
-      process.stdout.write("\x1b[?1049l");
+      process.stdout.write(
+        hasPostExitActions ? "\x1b[?1049l\x1b[2J\x1b[H" : "\x1b[?1049l"
+      );
     } catch {
       // best-effort — stdout may already be destroyed
     }

--- a/packages/cli/test/lib/init/ui/ink-ui-teardown.test.ts
+++ b/packages/cli/test/lib/init/ui/ink-ui-teardown.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+// Stub the post-exit installer spawn so teardown never launches a real process.
+// `runInheritedCommand` only listens for "close"/"error", so a fake child that
+// resolves "close" on the next microtask is enough to let disposal complete.
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: vi.fn(() => {
+      const child = {
+        on(event: string, cb: () => void) {
+          if (event === "close") {
+            queueMicrotask(cb);
+          }
+          return child;
+        },
+      };
+      return child as unknown as ReturnType<typeof actual.spawn>;
+    }),
+  };
+});
+
+const { InkUI } = await import("../../../../src/lib/init/ui/ink-ui.js");
+const { WizardStore } = await import(
+  "../../../../src/lib/init/ui/wizard-store.js"
+);
+
+function createUi(): {
+  ui: InstanceType<typeof InkUI>;
+  store: InstanceType<typeof WizardStore>;
+} {
+  const store = new WizardStore();
+  const instance = {
+    clear: vi.fn(),
+    rerender: vi.fn(),
+    unmount: vi.fn(),
+    waitUntilExit: vi.fn().mockResolvedValue(undefined),
+  };
+  return { ui: new InkUI(instance, store, null), store };
+}
+
+function captureStdout(): string[] {
+  const writes: string[] = [];
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    writes.push(String(chunk));
+    return true;
+  });
+  return writes;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("InkUI teardown — installer handoff", () => {
+  test("clears the screen and homes the cursor when a post-exit action is queued", async () => {
+    const { ui, store } = createUi();
+    // The completion screen queues this when the user opts into the plugin.
+    store.queuePostExitAction("npx @sentry/ai install");
+    const writes = captureStdout();
+
+    await ui[Symbol.asyncDispose]();
+
+    // Exiting the alt screen returns the cursor to where `sentry init` was
+    // invoked (usually low on the screen). Clearing + homing after the exit
+    // makes the installer's full-screen UI start at the top instead of
+    // mid-screen with a blank gap above it.
+    expect(writes.join("")).toContain("\x1b[?1049l\x1b[2J\x1b[H");
+  });
+
+  test("only restores the alt screen on a normal exit (no post-exit action)", async () => {
+    const { ui } = createUi();
+    const writes = captureStdout();
+
+    await ui[Symbol.asyncDispose]();
+
+    const joined = writes.join("");
+    expect(joined).toContain("\x1b[?1049l");
+    // No clear/home — the compact exit summary flows into the restored
+    // scrollback at the invocation point, as before.
+    expect(joined).not.toContain("\x1b[?1049l\x1b[2J\x1b[H");
+  });
+});


### PR DESCRIPTION
## Problem

When exiting `sentry init` with **finish** after opting into the agent plugin, the exit summary and the interactive `npx @sentry/ai install` UI render from **mid-screen**, with a blank gap above them:

- The wizard runs in the alternate screen buffer.
- On teardown we leave it (`\x1b[?1049l`), which restores the cursor to the row where `sentry init` was invoked — usually low on the screen.
- The exit summary and the installer (spawned with `stdio: "inherit"`) then print from that row, leaving the top of the screen blank.

Startup already clears + homes on entry (`\x1b[?1049h\x1b[2J\x1b[H`); the exit-to-installer path did not.

## Fix

In `tearDown()`, when a post-exit action is queued (the agent-plugin installer), append `\x1b[2J\x1b[H` right after leaving the alt buffer — the same clean top-of-screen start the wizard uses on entry.

```
\x1b[?1049l              → normal exit (unchanged): compact summary flows into scrollback
\x1b[?1049l\x1b[2J\x1b[H → installer handoff: starts at the top of the screen
```

The normal exit (no installer) is untouched, so its compact summary still lands in the restored scrollback at the invocation point.

## Testing

- New `test/lib/init/ui/ink-ui-teardown.test.ts` locks in both branches (clears on handoff, doesn't clear on normal exit); `spawn` is stubbed so teardown never launches a real installer.
- `tsc` ✅ · `biome` ✅ · init UI test suite ✅

Note: the alt-screen behavior can't be asserted from a screenshot in CI (needs a real TTY + the spawned installer), so it's covered by the escape-sequence test rather than a visual snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)