### PR TITLE
refactor(init): simplify V2 file reads

### DIFF
--- a/packages/cli/src/lib/init/tools/project-file.ts
+++ b/packages/cli/src/lib/init/tools/project-file.ts
@@ -15,11 +15,49 @@ const SENSITIVE_PATH_TOKENS = new Set([
   ".yarnrc",
   ".yarnrc.yml",
 ]);
+const CONTROL_CHARACTER_RE = /\p{Cc}/u;
+const WINDOWS_DRIVE_RE = /^[A-Za-z]:/u;
+const WINDOWS_RESERVED_SEGMENT_RE =
+  /^(?:aux|con|nul|prn|com[1-9]|lpt[1-9])(?:\..*)?$/iu;
 
 export type OpenedProjectFile = {
   handle: fs.promises.FileHandle;
   stat: fs.Stats;
 };
+
+/**
+ * Normalize a portable filesystem-root-relative file path.
+ *
+ * Tool requests may use either slash style, but aliases that resolve
+ * differently across operating systems are rejected before filesystem I/O.
+ */
+export function normalizeProjectFilePath(filePath: string): string | undefined {
+  const portablePath = filePath.replaceAll("\\", "/");
+  if (
+    portablePath.startsWith("/") ||
+    WINDOWS_DRIVE_RE.test(portablePath) ||
+    CONTROL_CHARACTER_RE.test(portablePath)
+  ) {
+    return;
+  }
+
+  const segments = portablePath.split("/");
+  if (
+    segments.some(
+      (segment) =>
+        segment.length === 0 ||
+        segment === "." ||
+        segment === ".." ||
+        segment.includes(":") ||
+        segment.endsWith(".") ||
+        segment.endsWith(" ") ||
+        WINDOWS_RESERVED_SEGMENT_RE.test(segment)
+    )
+  ) {
+    return;
+  }
+  return segments.join("/");
+}
 
 /**
  * Open a stable regular file inside a project root.

--- a/packages/cli/src/lib/init/tools/read-files.ts
+++ b/packages/cli/src/lib/init/tools/read-files.ts
@@ -1,5 +1,5 @@
 import type fs from "node:fs";
-import { MAX_FILE_BYTES } from "../constants.js";
+import { TextDecoder } from "node:util";
 import type {
   ReadFileErrorCode,
   ReadFilesPayload,
@@ -8,116 +8,54 @@ import type {
   ToolResult,
 } from "../types.js";
 import {
+  normalizeProjectFilePath,
   type OpenedProjectFile,
   openProjectFile,
   projectFileChanged,
 } from "./project-file.js";
 import type { InitToolDefinition } from "./types.js";
 
-const DEFAULT_MAX_LINES = 1000;
-const MAX_SCAN_BYTES = 4 * 1024 * 1024;
-const MAX_V2_CONTENT_BYTES = 40_000;
-const MAX_DETERMINISTIC_V2_CONTENT_BYTES = MAX_FILE_BYTES;
-const MAX_READ_LINES = 2000;
+const MAX_READ_OUTPUT_BYTES = 40_000;
 const MAX_READ_PATHS = 20;
-const MAX_DETERMINISTIC_READ_PATHS = 256;
+const FILE_READ_CHUNK_BYTES = 64 * 1024;
 const PATH_SEGMENT_RE = /[/\\\\]/u;
 
-type ReadBounds = {
-  maxBytes: number;
-  maxLines: number;
+type ReadWindow = {
+  outputBytes: number;
   startLine: number;
 };
 
-type V2ReadLimits = {
-  aggregateMaxBytes: number;
-  maxBytes: number;
+type LineScan = {
+  consumedBytes: number;
+  found: boolean;
+  skippedLines: number;
 };
 
 /**
  * Read one or more files from the sandboxed project directory.
  *
- * Legacy requests keep their original string-or-null response. V2 requests
- * return independent, bounded line ranges; callers may issue another read or
+ * Returns independent, bounded line ranges. Callers may issue another read or
  * use grep when they need different evidence. The CLI keeps no continuation
  * state between calls.
  */
 export async function readFiles(
   payload: ReadFilesPayload
 ): Promise<ToolResult> {
-  const error = validateReadRequest(payload);
-  if (error) {
-    return { error, ok: false };
+  const validated = validateReadRequest(payload);
+  if ("error" in validated) {
+    return { error: validated.error, ok: false };
   }
-
-  if (payload.params.resultVersion === 2) {
-    return readFilesV2(payload, v2ReadLimits(payload.params.maxBytes));
-  }
-  const maxBytes = boundedLegacyMaxBytes(payload.params.maxBytes);
-
-  const results = await Promise.all(
-    payload.params.paths.map(async (filePath) => {
-      const content = await readSingleFileV1(payload.cwd, filePath, maxBytes);
-      return [filePath, content] as const;
-    })
+  const perFileOutputBytes = Math.max(
+    1,
+    Math.floor(MAX_READ_OUTPUT_BYTES / validated.paths.length)
   );
-
-  return {
-    data: { files: Object.fromEntries(results) },
-    ok: true,
-  };
-}
-
-/** Preserve the wire behavior expected by APIs predating read-files v2. */
-async function readSingleFileV1(
-  cwd: string,
-  filePath: string,
-  maxBytes: number
-): Promise<string | null> {
-  let opened: OpenedProjectFile | undefined;
-  try {
-    const result = await openProjectFile(cwd, filePath);
-    if ("error" in result) {
-      return null;
-    }
-    opened = result;
-    const bytesToRead = Math.min(opened.stat.size, maxBytes);
-    const buffer = Buffer.alloc(bytesToRead);
-    await opened.handle.read(buffer, 0, bytesToRead, 0);
-    if (projectFileChanged(opened.stat, await opened.handle.stat())) {
-      return null;
-    }
-    return buffer.toString("utf-8");
-  } catch {
-    return null;
-  } finally {
-    await opened?.handle.close().catch(() => {
-      // Preserve the legacy null-or-string result when cleanup fails.
-    });
-  }
-}
-
-async function readFilesV2(
-  payload: ReadFilesPayload,
-  limits: V2ReadLimits
-): Promise<ToolResult> {
-  const startLine = payload.params.startLine ?? 1;
-  const perFileMaxBytes = Math.min(
-    limits.maxBytes,
-    Math.max(
-      1,
-      Math.floor(limits.aggregateMaxBytes / payload.params.paths.length)
-    )
-  );
-  const maxLines = v2MaxLines(payload.params.maxLines, limits, perFileMaxBytes);
-  const bounds = {
-    maxBytes: perFileMaxBytes,
-    maxLines,
-    startLine,
-  } satisfies ReadBounds;
+  const window = {
+    outputBytes: perFileOutputBytes,
+    startLine: validated.startLine,
+  } satisfies ReadWindow;
   const results = await Promise.all(
-    payload.params.paths.map(async (filePath) => {
-      const result = await readSingleFileV2(payload.cwd, filePath, bounds);
+    validated.paths.map(async (filePath) => {
+      const result = await readSingleFileV2(payload.cwd, filePath, window);
       return [filePath, result] as const;
     })
   );
@@ -134,7 +72,7 @@ async function readFilesV2(
 async function readSingleFileV2(
   cwd: string,
   filePath: string,
-  bounds: ReadBounds
+  window: ReadWindow
 ): Promise<ReadFileV2Result> {
   let opened: OpenedProjectFile | undefined;
   try {
@@ -147,7 +85,7 @@ async function readSingleFileV2(
       if (projectFileChanged(opened.stat, await opened.handle.stat())) {
         return { error: "unreadable", status: "error" };
       }
-      return bounds.startLine === 1
+      return window.startLine === 1
         ? {
             content: "",
             status: "ok",
@@ -156,7 +94,7 @@ async function readSingleFileV2(
         : { error: "invalid-range", status: "error" };
     }
 
-    const page = await readTextPage(opened.handle, opened.stat.size, bounds);
+    const page = await readTextPage(opened.handle, opened.stat.size, window);
     if (projectFileChanged(opened.stat, await opened.handle.stat())) {
       return { error: "unreadable", status: "error" };
     }
@@ -173,167 +111,172 @@ async function readSingleFileV2(
 async function readTextPage(
   handle: fs.promises.FileHandle,
   fileSize: number,
-  bounds: ReadBounds
+  window: ReadWindow
 ): Promise<ReadFileV2Result> {
-  const scanBudget =
-    bounds.startLine === 1 ? bounds.maxBytes : MAX_SCAN_BYTES + bounds.maxBytes;
-  const scanBytes = Math.min(fileSize, scanBudget);
-  const scanBuffer = Buffer.alloc(scanBytes);
-  const { bytesRead } = await handle.read(scanBuffer, 0, scanBytes, 0);
-  const readable = scanBuffer.subarray(0, bytesRead);
-  if (!isTextBuffer(readable, bytesRead < fileSize)) {
-    return { error: "not-text", status: "error" };
+  const located = await locateLineStart(handle, fileSize, window.startLine);
+  if ("error" in located) {
+    return { error: located.error, status: "error" };
   }
 
-  const startOffset = lineStartOffset(readable, bounds.startLine);
-  if (startOffset === undefined) {
+  const pageBytes = Math.min(window.outputBytes, fileSize - located.offset);
+  const page = Buffer.alloc(pageBytes);
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let bytesRead = 0;
+  while (bytesRead < pageBytes) {
+    const result = await handle.read(
+      page,
+      bytesRead,
+      pageBytes - bytesRead,
+      located.offset + bytesRead
+    );
+    if (result.bytesRead === 0) {
+      return { error: "unreadable", status: "error" };
+    }
+    const nextBytesRead = bytesRead + result.bytesRead;
+    if (
+      !isTextChunk(
+        decoder,
+        page.subarray(bytesRead, nextBytesRead),
+        located.offset + nextBytesRead < fileSize
+      )
+    ) {
+      return { error: "not-text", status: "error" };
+    }
+    bytesRead = nextBytesRead;
+  }
+
+  if (located.offset + bytesRead === fileSize) {
     return {
-      error: bytesRead < fileSize ? "range-too-deep" : "invalid-range",
-      status: "error",
+      content: page.toString("utf-8"),
+      status: "ok",
+      truncated: false,
     };
   }
-  if (startOffset > MAX_SCAN_BYTES) {
-    return { error: "range-too-deep", status: "error" };
-  }
-  const selected = selectCompleteLines(readable, fileSize, startOffset, bounds);
-  if ("error" in selected) {
-    return { error: selected.error, status: "error" };
+
+  const lastNewline = page.lastIndexOf(0x0a);
+  if (lastNewline === -1) {
+    return { error: "line-too-long", status: "error" };
   }
   return {
-    content: selected.content.toString("utf-8"),
+    content: page.subarray(0, lastNewline + 1).toString("utf-8"),
     status: "ok",
-    truncated: startOffset + selected.content.length < fileSize,
+    truncated: true,
   };
 }
 
-function lineStartOffset(
-  buffer: Buffer,
+async function locateLineStart(
+  handle: fs.promises.FileHandle,
+  fileSize: number,
   startLine: number
-): number | undefined {
+): Promise<
+  { offset: number } | { error: "invalid-range" | "not-text" | "unreadable" }
+> {
+  if (startLine === 1) {
+    return { offset: 0 };
+  }
+
+  const buffer = Buffer.alloc(Math.min(FILE_READ_CHUNK_BYTES, fileSize));
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let linesToSkip = startLine - 1;
+  let position = 0;
+  while (position < fileSize) {
+    const result = await handle.read(
+      buffer,
+      0,
+      Math.min(buffer.length, fileSize - position),
+      position
+    );
+    if (result.bytesRead === 0) {
+      return { error: "unreadable" };
+    }
+
+    const chunk = buffer.subarray(0, result.bytesRead);
+    const scan = scanLineBreaks(chunk, linesToSkip);
+    const nextPosition = position + scan.consumedBytes;
+    if (
+      !isTextChunk(
+        decoder,
+        chunk.subarray(0, scan.consumedBytes),
+        !scan.found && nextPosition < fileSize
+      )
+    ) {
+      return { error: "not-text" };
+    }
+    if (scan.found) {
+      return nextPosition < fileSize
+        ? { offset: nextPosition }
+        : { error: "invalid-range" };
+    }
+    linesToSkip -= scan.skippedLines;
+    position += result.bytesRead;
+  }
+  return { error: "invalid-range" };
+}
+
+function scanLineBreaks(buffer: Buffer, linesToSkip: number): LineScan {
   let offset = 0;
-  for (let line = 1; line < startLine; line += 1) {
+  for (let skippedLines = 0; skippedLines < linesToSkip; skippedLines += 1) {
     const newline = buffer.indexOf(0x0a, offset);
     if (newline === -1) {
-      return;
+      return {
+        consumedBytes: buffer.length,
+        found: false,
+        skippedLines,
+      };
     }
     offset = newline + 1;
   }
-  return offset < buffer.length ? offset : undefined;
+  return {
+    consumedBytes: offset,
+    found: true,
+    skippedLines: linesToSkip,
+  };
 }
 
-function selectCompleteLines(
-  buffer: Buffer,
-  fileSize: number,
-  startOffset: number,
-  bounds: ReadBounds
-): { content: Buffer } | { error: "line-too-long" } {
-  let offset = startOffset;
-  for (let lines = 0; lines < bounds.maxLines; lines += 1) {
-    const lineEnd = completeLineEnd(buffer, fileSize, offset);
-    if (lineEnd === undefined) {
-      return priorLinesOrError(buffer, startOffset, offset);
-    }
-    if (lineEnd - startOffset > bounds.maxBytes) {
-      return priorLinesOrError(buffer, startOffset, offset);
-    }
-    offset = lineEnd;
-    if (offset === buffer.length) {
-      break;
-    }
-  }
-  return { content: buffer.subarray(startOffset, offset) };
-}
-
-function completeLineEnd(
-  buffer: Buffer,
-  fileSize: number,
-  offset: number
-): number | undefined {
-  const newline = buffer.indexOf(0x0a, offset);
-  if (newline !== -1) {
-    return newline + 1;
-  }
-  return buffer.length === fileSize ? buffer.length : undefined;
-}
-
-function priorLinesOrError(
-  buffer: Buffer,
-  startOffset: number,
-  endOffset: number
-): { content: Buffer } | { error: "line-too-long" } {
-  return endOffset === startOffset
-    ? { error: "line-too-long" }
-    : { content: buffer.subarray(startOffset, endOffset) };
-}
-
-function validateReadRequest(payload: ReadFilesPayload): string | undefined {
+function validateReadRequest(
+  payload: ReadFilesPayload
+): { error: string } | { paths: string[]; startLine: number } {
   const params = (payload as { params?: unknown }).params;
   if (typeof params !== "object" || params === null) {
-    return "read-files params must be an object";
+    return { error: "read-files params must be an object" };
   }
-  const { maxBytes, maxLines, paths, resultVersion, startLine } =
-    params as Partial<ReadFilesPayload["params"]>;
-  if (isInvalidPositiveInteger(maxBytes)) {
-    return "read-files maxBytes must be a positive safe integer";
+  const { paths, resultVersion, startLine } = params as Partial<
+    ReadFilesPayload["params"]
+  >;
+  if (resultVersion !== 2) {
+    return { error: "read-files requires resultVersion 2" };
   }
-  const profileError = validateReadProfile(resultVersion, maxBytes);
-  if (profileError) {
-    return profileError;
+  const supportedKeys = new Set(["paths", "resultVersion", "startLine"]);
+  if (Object.keys(params).some((key) => !supportedKeys.has(key))) {
+    return { error: "read-files params include unsupported fields" };
   }
-  const maxPaths = maxReadPaths(resultVersion, maxBytes);
-  const pathError = validateReadPaths(paths, maxPaths);
-  if (pathError) {
-    return pathError;
+  const normalizedPaths = normalizeReadPaths(paths);
+  if ("error" in normalizedPaths) {
+    return normalizedPaths;
   }
-  const validPaths = paths as string[];
   if (isInvalidPositiveInteger(startLine)) {
-    return "read-files startLine must be a positive safe integer";
+    return {
+      error: "read-files startLine must be a positive safe integer",
+    };
   }
-  if (isInvalidPositiveInteger(maxLines)) {
-    return "read-files maxLines must be a positive safe integer";
+  const normalizedStartLine = startLine ?? 1;
+  if (normalizedStartLine > 1 && normalizedPaths.paths.length !== 1) {
+    return { error: "read-files range reads require exactly one path" };
   }
+  return { paths: normalizedPaths.paths, startLine: normalizedStartLine };
+}
+
+function normalizeReadPaths(
+  paths: unknown
+): { error: string } | { paths: string[] } {
   if (
-    (startLine !== undefined || maxLines !== undefined) &&
-    resultVersion !== 2
+    !Array.isArray(paths) ||
+    paths.length === 0 ||
+    paths.length > MAX_READ_PATHS
   ) {
-    return "read-files line ranges require resultVersion 2";
-  }
-  if ((startLine ?? 1) > 1 && validPaths.length !== 1) {
-    return "read-files range reads require exactly one path";
-  }
-}
-
-function validateReadProfile(
-  resultVersion: ReadFilesPayload["params"]["resultVersion"],
-  maxBytes: number | undefined
-): string | undefined {
-  if (resultVersion !== undefined && resultVersion !== 2) {
-    return "read-files resultVersion is not supported";
-  }
-  if (
-    resultVersion === 2 &&
-    maxBytes !== undefined &&
-    maxBytes > MAX_DETERMINISTIC_V2_CONTENT_BYTES
-  ) {
-    return `read-files V2 maxBytes cannot exceed ${MAX_DETERMINISTIC_V2_CONTENT_BYTES}`;
-  }
-}
-
-function maxReadPaths(
-  resultVersion: ReadFilesPayload["params"]["resultVersion"],
-  maxBytes: number | undefined
-): number {
-  return resultVersion === 2 && isDeterministicV2Request(maxBytes)
-    ? MAX_DETERMINISTIC_READ_PATHS
-    : MAX_READ_PATHS;
-}
-
-function validateReadPaths(
-  paths: unknown,
-  maxPaths: number
-): string | undefined {
-  if (!Array.isArray(paths) || paths.length === 0 || paths.length > maxPaths) {
-    return `read-files requires between 1 and ${maxPaths} paths`;
+    return {
+      error: `read-files requires between 1 and ${MAX_READ_PATHS} paths`,
+    };
   }
   if (
     paths.some(
@@ -343,8 +286,22 @@ function validateReadPaths(
         filePath.length > 1000
     )
   ) {
-    return "read-files paths must be non-empty bounded strings";
+    return { error: "read-files paths must be non-empty bounded strings" };
   }
+  const normalizedPaths = (paths as string[]).map(normalizeProjectFilePath);
+  if (normalizedPaths.some((filePath) => filePath === undefined)) {
+    return {
+      error:
+        "read-files paths must be portable filesystem-root-relative paths without aliases",
+    };
+  }
+  const canonicalPaths = normalizedPaths as string[];
+  if (new Set(canonicalPaths).size !== canonicalPaths.length) {
+    return {
+      error: "read-files paths must be unique after path normalization",
+    };
+  }
+  return { paths: canonicalPaths };
 }
 
 function isInvalidPositiveInteger(value: unknown): boolean {
@@ -354,46 +311,11 @@ function isInvalidPositiveInteger(value: unknown): boolean {
   );
 }
 
-function boundedLegacyMaxBytes(value: number | undefined): number {
-  return value === undefined
-    ? MAX_FILE_BYTES
-    : Math.max(1, Math.min(value, MAX_FILE_BYTES));
-}
-
-function v2ReadLimits(value: number | undefined): V2ReadLimits {
-  const maxBytes = value ?? MAX_V2_CONTENT_BYTES;
-  return {
-    aggregateMaxBytes: isDeterministicV2Request(maxBytes)
-      ? MAX_DETERMINISTIC_V2_CONTENT_BYTES
-      : MAX_V2_CONTENT_BYTES,
-    maxBytes,
-  };
-}
-
-function isDeterministicV2Request(maxBytes: number | undefined): boolean {
-  return maxBytes !== undefined && maxBytes > MAX_V2_CONTENT_BYTES;
-}
-
-function v2MaxLines(
-  value: number | undefined,
-  limits: V2ReadLimits,
-  perFileMaxBytes: number
-): number {
-  if (value !== undefined) {
-    return boundedMaxLines(value);
-  }
-  return limits.aggregateMaxBytes === MAX_DETERMINISTIC_V2_CONTENT_BYTES
-    ? perFileMaxBytes
-    : DEFAULT_MAX_LINES;
-}
-
-function boundedMaxLines(value: number | undefined): number {
-  return value === undefined
-    ? DEFAULT_MAX_LINES
-    : Math.max(1, Math.min(value, MAX_READ_LINES));
-}
-
-function isTextBuffer(buffer: Buffer, mayEndMidCharacter: boolean): boolean {
+function isTextChunk(
+  decoder: TextDecoder,
+  buffer: Buffer,
+  hasMoreBytes: boolean
+): boolean {
   if (
     buffer.some(
       (byte) =>
@@ -403,9 +325,7 @@ function isTextBuffer(buffer: Buffer, mayEndMidCharacter: boolean): boolean {
     return false;
   }
   try {
-    new TextDecoder("utf-8", { fatal: true }).decode(buffer, {
-      stream: mayEndMidCharacter,
-    });
+    decoder.decode(buffer, { stream: hasMoreBytes });
     return true;
   } catch {
     return false;

--- a/packages/cli/src/lib/init/tools/read-files.ts
+++ b/packages/cli/src/lib/init/tools/read-files.ts
@@ -17,14 +17,21 @@ import type { InitToolDefinition } from "./types.js";
 const DEFAULT_MAX_LINES = 1000;
 const MAX_SCAN_BYTES = 4 * 1024 * 1024;
 const MAX_V2_CONTENT_BYTES = 40_000;
+const MAX_DETERMINISTIC_V2_CONTENT_BYTES = MAX_FILE_BYTES;
 const MAX_READ_LINES = 2000;
 const MAX_READ_PATHS = 20;
+const MAX_DETERMINISTIC_READ_PATHS = 256;
 const PATH_SEGMENT_RE = /[/\\\\]/u;
 
 type ReadBounds = {
   maxBytes: number;
   maxLines: number;
   startLine: number;
+};
+
+type V2ReadLimits = {
+  aggregateMaxBytes: number;
+  maxBytes: number;
 };
 
 /**
@@ -44,7 +51,7 @@ export async function readFiles(
   }
 
   if (payload.params.resultVersion === 2) {
-    return readFilesV2(payload, boundedV2MaxBytes(payload.params.maxBytes));
+    return readFilesV2(payload, v2ReadLimits(payload.params.maxBytes));
   }
   const maxBytes = boundedLegacyMaxBytes(payload.params.maxBytes);
 
@@ -92,14 +99,17 @@ async function readSingleFileV1(
 
 async function readFilesV2(
   payload: ReadFilesPayload,
-  maxBytes: number
+  limits: V2ReadLimits
 ): Promise<ToolResult> {
   const startLine = payload.params.startLine ?? 1;
-  const maxLines = boundedMaxLines(payload.params.maxLines);
   const perFileMaxBytes = Math.min(
-    maxBytes,
-    Math.max(1, Math.floor(MAX_V2_CONTENT_BYTES / payload.params.paths.length))
+    limits.maxBytes,
+    Math.max(
+      1,
+      Math.floor(limits.aggregateMaxBytes / payload.params.paths.length)
+    )
   );
+  const maxLines = v2MaxLines(payload.params.maxLines, limits, perFileMaxBytes);
   const bounds = {
     maxBytes: perFileMaxBytes,
     maxLines,
@@ -263,17 +273,19 @@ function validateReadRequest(payload: ReadFilesPayload): string | undefined {
   }
   const { maxBytes, maxLines, paths, resultVersion, startLine } =
     params as Partial<ReadFilesPayload["params"]>;
-  const pathError = validateReadPaths(paths);
+  if (isInvalidPositiveInteger(maxBytes)) {
+    return "read-files maxBytes must be a positive safe integer";
+  }
+  const profileError = validateReadProfile(resultVersion, maxBytes);
+  if (profileError) {
+    return profileError;
+  }
+  const maxPaths = maxReadPaths(resultVersion, maxBytes);
+  const pathError = validateReadPaths(paths, maxPaths);
   if (pathError) {
     return pathError;
   }
   const validPaths = paths as string[];
-  if (isInvalidPositiveInteger(maxBytes)) {
-    return "read-files maxBytes must be a positive safe integer";
-  }
-  if (resultVersion !== undefined && resultVersion !== 2) {
-    return "read-files resultVersion is not supported";
-  }
   if (isInvalidPositiveInteger(startLine)) {
     return "read-files startLine must be a positive safe integer";
   }
@@ -291,13 +303,37 @@ function validateReadRequest(payload: ReadFilesPayload): string | undefined {
   }
 }
 
-function validateReadPaths(paths: unknown): string | undefined {
+function validateReadProfile(
+  resultVersion: ReadFilesPayload["params"]["resultVersion"],
+  maxBytes: number | undefined
+): string | undefined {
+  if (resultVersion !== undefined && resultVersion !== 2) {
+    return "read-files resultVersion is not supported";
+  }
   if (
-    !Array.isArray(paths) ||
-    paths.length === 0 ||
-    paths.length > MAX_READ_PATHS
+    resultVersion === 2 &&
+    maxBytes !== undefined &&
+    maxBytes > MAX_DETERMINISTIC_V2_CONTENT_BYTES
   ) {
-    return `read-files requires between 1 and ${MAX_READ_PATHS} paths`;
+    return `read-files V2 maxBytes cannot exceed ${MAX_DETERMINISTIC_V2_CONTENT_BYTES}`;
+  }
+}
+
+function maxReadPaths(
+  resultVersion: ReadFilesPayload["params"]["resultVersion"],
+  maxBytes: number | undefined
+): number {
+  return resultVersion === 2 && isDeterministicV2Request(maxBytes)
+    ? MAX_DETERMINISTIC_READ_PATHS
+    : MAX_READ_PATHS;
+}
+
+function validateReadPaths(
+  paths: unknown,
+  maxPaths: number
+): string | undefined {
+  if (!Array.isArray(paths) || paths.length === 0 || paths.length > maxPaths) {
+    return `read-files requires between 1 and ${maxPaths} paths`;
   }
   if (
     paths.some(
@@ -324,10 +360,31 @@ function boundedLegacyMaxBytes(value: number | undefined): number {
     : Math.max(1, Math.min(value, MAX_FILE_BYTES));
 }
 
-function boundedV2MaxBytes(value: number | undefined): number {
-  return value === undefined
-    ? MAX_V2_CONTENT_BYTES
-    : Math.max(1, Math.min(value, MAX_V2_CONTENT_BYTES));
+function v2ReadLimits(value: number | undefined): V2ReadLimits {
+  const maxBytes = value ?? MAX_V2_CONTENT_BYTES;
+  return {
+    aggregateMaxBytes: isDeterministicV2Request(maxBytes)
+      ? MAX_DETERMINISTIC_V2_CONTENT_BYTES
+      : MAX_V2_CONTENT_BYTES,
+    maxBytes,
+  };
+}
+
+function isDeterministicV2Request(maxBytes: number | undefined): boolean {
+  return maxBytes !== undefined && maxBytes > MAX_V2_CONTENT_BYTES;
+}
+
+function v2MaxLines(
+  value: number | undefined,
+  limits: V2ReadLimits,
+  perFileMaxBytes: number
+): number {
+  if (value !== undefined) {
+    return boundedMaxLines(value);
+  }
+  return limits.aggregateMaxBytes === MAX_DETERMINISTIC_V2_CONTENT_BYTES
+    ? perFileMaxBytes
+    : DEFAULT_MAX_LINES;
 }
 
 function boundedMaxLines(value: number | undefined): number {

--- a/packages/cli/src/lib/init/tools/registry.ts
+++ b/packages/cli/src/lib/init/tools/registry.ts
@@ -32,6 +32,12 @@ const toolRegistry = new Map<ToolOperation, AnyInitToolDefinition>(
   toolDefinitions.map((tool) => [tool.operation, tool] as const)
 );
 
+/** Sentry API operations never inspect or mutate the local filesystem. */
+const CWD_INDEPENDENT_OPERATIONS = new Set<ToolOperation>([
+  "create-sentry-project",
+  "ensure-sentry-project",
+]);
+
 /**
  * Build the spinner message for a suspended tool request.
  */
@@ -47,11 +53,6 @@ export async function executeTool(
   payload: ToolPayload,
   context: ToolContext
 ): Promise<ToolResult> {
-  const sandboxError = validateToolSandbox(payload, context.directory);
-  if (sandboxError) {
-    return sandboxError;
-  }
-
   const tool = toolRegistry.get(payload.operation);
   if (!tool) {
     return {
@@ -60,8 +61,17 @@ export async function executeTool(
     };
   }
 
+  let sandboxedPayload = payload;
+  if (!CWD_INDEPENDENT_OPERATIONS.has(payload.operation)) {
+    const sandbox = validateToolSandbox(payload, context.directory);
+    if ("ok" in sandbox) {
+      return sandbox;
+    }
+    sandboxedPayload = { ...payload, cwd: sandbox.cwd } as ToolPayload;
+  }
+
   try {
-    return await tool.execute(payload as never, context);
+    return await tool.execute(sandboxedPayload as never, context);
   } catch (error) {
     if (
       error instanceof ApiError &&

--- a/packages/cli/src/lib/init/tools/shared.ts
+++ b/packages/cli/src/lib/init/tools/shared.ts
@@ -50,25 +50,37 @@ export function safePath(cwd: string, relative: string): string {
 }
 
 /**
- * Reject tool executions whose requested cwd escapes the selected project root.
+ * Resolve a tool cwd inside the selected project root, or reject it.
+ *
+ * The returned real path pins any safe cwd symlink before tool execution.
  */
 export function validateToolSandbox(
   payload: Pick<ToolPayload, "cwd">,
   directory: string
-): ToolResult | undefined {
-  const normalizedCwd = path.resolve(payload.cwd);
-  const normalizedDir = path.resolve(directory);
-  if (
-    normalizedCwd !== normalizedDir &&
-    !normalizedCwd.startsWith(normalizedDir + path.sep)
-  ) {
-    return {
-      ok: false,
-      error: `Blocked: cwd "${payload.cwd}" is outside project directory "${directory}"`,
-    };
+): { cwd: string } | ToolResult {
+  try {
+    const realDirectory = fs.realpathSync(path.resolve(directory));
+    const realCwd = fs.realpathSync(path.resolve(payload.cwd));
+    const relativeCwd = path.relative(realDirectory, realCwd);
+    const isInsideDirectory =
+      relativeCwd === "" ||
+      (relativeCwd !== ".." &&
+        !relativeCwd.startsWith(`..${path.sep}`) &&
+        !path.isAbsolute(relativeCwd));
+
+    if (isInsideDirectory && fs.statSync(realCwd).isDirectory()) {
+      // Execute against the resolved directory so a symlinked cwd cannot be
+      // retargeted between this boundary check and the tool implementation.
+      return { cwd: realCwd };
+    }
+  } catch {
+    // Missing or unreadable roots fail closed at the shared tool boundary.
   }
 
-  return;
+  return {
+    ok: false,
+    error: `Blocked: cwd "${payload.cwd}" is outside project directory "${directory}" or cannot be resolved`,
+  };
 }
 
 /**

--- a/packages/cli/src/lib/init/types.ts
+++ b/packages/cli/src/lib/init/types.ts
@@ -107,13 +107,10 @@ export type ReadFilesPayload = {
   cwd: string;
   params: {
     paths: string[];
-    maxBytes?: number;
-    /** Maximum text lines returned per file by the bounded V2 reader. */
-    maxLines?: number;
-    /** First 1-based line to inspect. V2 range reads support one path. */
+    /** First 1-based line to inspect. Range reads support one path. */
     startLine?: number;
-    /** Opts into bounded, structured read results. */
-    resultVersion?: 2;
+    /** Structured read-results protocol used by sentry init. */
+    resultVersion: 2;
   };
 };
 
@@ -123,7 +120,6 @@ export type ReadFileErrorCode =
   | "not-file"
   | "not-found"
   | "not-text"
-  | "range-too-deep"
   | "unreadable";
 
 export type ReadFileV2Result =
@@ -332,13 +328,8 @@ export type ConfirmPayload = {
   prompt: string;
 };
 
-type LegacyInitProtocolEnvelope = {
-  protocolVersion?: never;
-  requestId?: never;
-};
-
 export type SuspendPayload = (ToolPayload | InteractivePayload) &
-  (InitProtocolEnvelope | LegacyInitProtocolEnvelope);
+  InitProtocolEnvelope;
 
 export type WorkflowRunResult = {
   status: "suspended" | "success" | "failed";

--- a/packages/cli/src/lib/init/wizard-runner.ts
+++ b/packages/cli/src/lib/init/wizard-runner.ts
@@ -12,7 +12,6 @@
  */
 
 import { randomBytes } from "node:crypto";
-import { isDeepStrictEqual } from "node:util";
 
 import { MastraClient } from "@mastra/client-js";
 import {
@@ -181,18 +180,15 @@ function hasHttpStatus(value: unknown): value is { status: number } {
   );
 }
 
-/** Read a complete v1 identity while keeping legacy server payloads valid. */
-function initProtocolEnvelope(
-  payload: SuspendPayload
-): { protocolVersion: 1; requestId: string } | undefined {
-  return payload.protocolVersion === INIT_PROTOCOL_VERSION &&
-    typeof payload.requestId === "string" &&
-    payload.requestId.length > 0
-    ? {
-        protocolVersion: INIT_PROTOCOL_VERSION,
-        requestId: payload.requestId,
-      }
-    : undefined;
+/** Copy the validated v1 request identity onto a resume payload. */
+function initProtocolEnvelope(payload: SuspendPayload): {
+  protocolVersion: 1;
+  requestId: string;
+} {
+  return {
+    protocolVersion: INIT_PROTOCOL_VERSION,
+    requestId: payload.requestId,
+  };
 }
 
 function hasActiveStepsPath(value: Record<string, unknown>): value is Record<
@@ -555,7 +551,7 @@ function assertWorkflowResult(raw: unknown): WorkflowRunResult {
   return obj as WorkflowRunResult;
 }
 
-/** Parse legacy or complete v1 suspend payloads, rejecting partial envelopes. */
+/** Parse suspend payloads and require the complete v1 transport identity. */
 function assertSuspendPayload(raw: unknown): SuspendPayload {
   if (!raw || typeof raw !== "object") {
     throw new Error("Invalid suspend payload: expected object");
@@ -567,13 +563,14 @@ function assertSuspendPayload(raw: unknown): SuspendPayload {
   ) {
     throw new Error(`Unknown suspend payload type: ${String(obj.type)}`);
   }
-  const payload = obj as SuspendPayload;
-  const hasProtocolFields =
-    Object.hasOwn(obj, "protocolVersion") || Object.hasOwn(obj, "requestId");
-  if (hasProtocolFields && !initProtocolEnvelope(payload)) {
+  if (
+    obj.protocolVersion !== INIT_PROTOCOL_VERSION ||
+    typeof obj.requestId !== "string" ||
+    obj.requestId.length === 0
+  ) {
     throw new Error("Invalid init protocol envelope");
   }
-  return payload;
+  return obj as SuspendPayload;
 }
 
 /** Keep transport identity at the wire boundary, outside local tool and UI contracts. */
@@ -792,11 +789,7 @@ function runStateRecoveryBackoffMs(): number[] {
   return delays;
 }
 
-/**
- * A v1 request advances only when the active request ID changed. Legacy
- * servers fall back to payload equality during the temporary compatibility
- * window.
- */
+/** A v1 request advances only when the active request ID changed. */
 function isRecoverableRunState(
   result: WorkflowRunResult,
   resumedStepId: string,
@@ -811,16 +804,7 @@ function isRecoverableRunState(
     return false;
   }
 
-  const resumedEnvelope = initProtocolEnvelope(resumedPayload);
-  const recoveredEnvelope = initProtocolEnvelope(recovered.payload);
-  if (resumedEnvelope && recoveredEnvelope) {
-    return recoveredEnvelope.requestId !== resumedEnvelope.requestId;
-  }
-
-  return !(
-    recovered.stepId === resumedStepId &&
-    isDeepStrictEqual(recovered.payload, resumedPayload)
-  );
+  return recovered.payload.requestId !== resumedPayload.requestId;
 }
 
 /**
@@ -899,8 +883,10 @@ async function resumeWithRecovery(
     ui,
     progressRotation,
   } = args;
-  const envelope = initProtocolEnvelope(payload);
-  const wireResumeData = envelope ? { ...resumeData, ...envelope } : resumeData;
+  const wireResumeData = {
+    ...resumeData,
+    ...initProtocolEnvelope(payload),
+  };
   try {
     const raw = await withTimeout(
       withInitServiceAuthClassification(

--- a/packages/cli/src/lib/init/workflow-inputs.ts
+++ b/packages/cli/src/lib/init/workflow-inputs.ts
@@ -159,7 +159,19 @@ async function readCommonConfigFile(
     }
 
     const buffer = Buffer.alloc(opened.stat.size);
-    const { bytesRead } = await opened.handle.read(buffer, 0, buffer.length, 0);
+    let bytesRead = 0;
+    while (bytesRead < buffer.length) {
+      const readResult = await opened.handle.read(
+        buffer,
+        bytesRead,
+        buffer.length - bytesRead,
+        bytesRead
+      );
+      if (readResult.bytesRead === 0) {
+        return { status: "unreadable" };
+      }
+      bytesRead += readResult.bytesRead;
+    }
     if (projectFileChanged(opened.stat, await opened.handle.stat())) {
       return { status: "unreadable" };
     }

--- a/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
+++ b/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
@@ -471,7 +471,7 @@ describe("filesystem tools", () => {
     });
   });
 
-  test("bounds V2 content across a multi-file request", async () => {
+  test("allows 20 normal V2 paths, bounds their content, and rejects 21", async () => {
     const paths = Array.from({ length: 20 }, (_, index) => `file-${index}.txt`);
     for (const filePath of paths) {
       fs.writeFileSync(path.join(testDir, filePath), "x\n".repeat(5000));
@@ -486,6 +486,18 @@ describe("filesystem tools", () => {
       },
       makeContext(testDir)
     );
+    const overLimit = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          paths: [...paths, "file-20.txt"],
+          resultVersion: 2,
+        },
+      },
+      makeContext(testDir)
+    );
     const files = (
       result.data as { files: Record<string, { content: string }> }
     ).files;
@@ -497,6 +509,194 @@ describe("filesystem tools", () => {
         0
       )
     ).toBeLessThanOrEqual(40_000);
+    expect(overLimit).toEqual({
+      error: "read-files requires between 1 and 20 paths",
+      ok: false,
+    });
+  });
+
+  test("allows 256 deterministic V2 paths and rejects 257", async () => {
+    const paths = Array.from(
+      { length: 256 },
+      (_, index) => `deterministic-${index}.txt`
+    );
+    for (const filePath of paths) {
+      fs.writeFileSync(path.join(testDir, filePath), "x\n");
+    }
+
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { maxBytes: 40_001, paths, resultVersion: 2 },
+      },
+      makeContext(testDir)
+    );
+    const overLimit = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          maxBytes: 40_001,
+          paths: [...paths, "deterministic-256.txt"],
+          resultVersion: 2,
+        },
+      },
+      makeContext(testDir)
+    );
+    const files = (
+      result.data as {
+        files: Record<
+          string,
+          { content: string; status: "ok"; truncated: boolean }
+        >;
+      }
+    ).files;
+
+    expect(result.ok).toBe(true);
+    expect(Object.keys(files)).toHaveLength(256);
+    expect(Object.values(files)).toEqual(
+      Array.from({ length: 256 }, () => ({
+        content: "x\n",
+        status: "ok",
+        truncated: false,
+      }))
+    );
+    expect(overLimit).toEqual({
+      error: "read-files requires between 1 and 256 paths",
+      ok: false,
+    });
+  });
+
+  test("returns a complete 200 KB file in deterministic V2 mode", async () => {
+    const content = `${"x".repeat(249)}\n`.repeat(800);
+    fs.writeFileSync(path.join(testDir, "snapshot.txt"), content);
+
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          maxBytes: 262_144,
+          paths: ["snapshot.txt"],
+          resultVersion: 2,
+        },
+      },
+      makeContext(testDir)
+    );
+
+    expect(Buffer.byteLength(content)).toBe(200_000);
+    expect(result.data).toEqual({
+      files: {
+        "snapshot.txt": { content, status: "ok", truncated: false },
+      },
+      version: 2,
+    });
+  });
+
+  test("uses bytes instead of the normal line default for deterministic V2 reads", async () => {
+    const content = "x\n".repeat(1500);
+    fs.writeFileSync(path.join(testDir, "many-lines.txt"), content);
+
+    const normal = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { paths: ["many-lines.txt"], resultVersion: 2 },
+      },
+      makeContext(testDir)
+    );
+    const deterministic = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          maxBytes: 262_144,
+          paths: ["many-lines.txt"],
+          resultVersion: 2,
+        },
+      },
+      makeContext(testDir)
+    );
+
+    expect(normal.data).toEqual({
+      files: {
+        "many-lines.txt": {
+          content: "x\n".repeat(1000),
+          status: "ok",
+          truncated: true,
+        },
+      },
+      version: 2,
+    });
+    expect(deterministic.data).toEqual({
+      files: {
+        "many-lines.txt": { content, status: "ok", truncated: false },
+      },
+      version: 2,
+    });
+  });
+
+  test("truncates deterministic V2 reads at the aggregate byte limit", async () => {
+    const content = `${"x".repeat(127)}\n`.repeat(1500);
+    const paths = ["first.txt", "second.txt"];
+    for (const filePath of paths) {
+      fs.writeFileSync(path.join(testDir, filePath), content);
+    }
+
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          maxBytes: 262_144,
+          maxLines: 2000,
+          paths,
+          resultVersion: 2,
+        },
+      },
+      makeContext(testDir)
+    );
+    const files = (
+      result.data as {
+        files: Record<string, { content: string; truncated: boolean }>;
+      }
+    ).files;
+
+    expect(
+      Object.values(files).reduce(
+        (total, file) => total + Buffer.byteLength(file.content),
+        0
+      )
+    ).toBe(262_144);
+    expect(Object.values(files).every((file) => file.truncated)).toBe(true);
+  });
+
+  test("rejects deterministic V2 byte requests above the hard limit", async () => {
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          maxBytes: 262_145,
+          paths: ["missing.txt"],
+          resultVersion: 2,
+        },
+      },
+      makeContext(testDir)
+    );
+
+    expect(result).toEqual({
+      error: "read-files V2 maxBytes cannot exceed 262144",
+      ok: false,
+    });
   });
 
   test("reads a short line that starts at the deep-scan boundary", async () => {

--- a/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
+++ b/packages/cli/test/lib/init/tools/filesystem-tools.test.ts
@@ -50,6 +50,138 @@ describe("filesystem tools", () => {
     expect(result.error).toContain("outside project directory");
   });
 
+  test("rejects an external cwd symlink for every filesystem and shell tool", async () => {
+    const outsideDir = fs.mkdtempSync(
+      path.join(path.dirname(testDir), "init-tools-outside-")
+    );
+    const escapedCwd = path.join(testDir, "escape");
+    fs.writeFileSync(path.join(outsideDir, "sentinel.txt"), "OUTSIDE\n");
+    fs.symlinkSync(outsideDir, escapedCwd, "dir");
+    const payloads: ToolPayload[] = [
+      {
+        type: "tool",
+        operation: "list-dir",
+        cwd: escapedCwd,
+        params: { path: "." },
+      },
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: escapedCwd,
+        params: { paths: ["sentinel.txt"], resultVersion: 2 },
+      },
+      {
+        type: "tool",
+        operation: "file-exists-batch",
+        cwd: escapedCwd,
+        params: { paths: ["sentinel.txt"] },
+      },
+      {
+        type: "tool",
+        operation: "grep",
+        cwd: escapedCwd,
+        params: { searches: [{ pattern: "OUTSIDE" }] },
+      },
+      {
+        type: "tool",
+        operation: "glob",
+        cwd: escapedCwd,
+        params: { patterns: ["**/*"] },
+      },
+      {
+        type: "tool",
+        operation: "run-commands",
+        cwd: escapedCwd,
+        params: { commands: ["node --version"] },
+      },
+      {
+        type: "tool",
+        operation: "apply-patchset",
+        cwd: escapedCwd,
+        params: {
+          patches: [
+            {
+              action: "create",
+              path: "created-by-tool.txt",
+              patch: "created outside the project\n",
+            },
+          ],
+        },
+      },
+    ];
+
+    try {
+      for (const payload of payloads) {
+        const result = await executeTool(payload, makeContext(testDir));
+        expect(result.ok, payload.operation).toBe(false);
+        expect(result.error, payload.operation).toContain(
+          "outside project directory"
+        );
+      }
+      expect(fs.existsSync(path.join(outsideDir, "created-by-tool.txt"))).toBe(
+        false
+      );
+    } finally {
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  test("allows a cwd symlink that resolves inside the selected project", async () => {
+    fs.mkdirSync(path.join(testDir, "real", "nested"), { recursive: true });
+    fs.writeFileSync(
+      path.join(testDir, "real", "nested", "inside.txt"),
+      "inside\n"
+    );
+    fs.symlinkSync(
+      path.join(testDir, "real"),
+      path.join(testDir, "alias"),
+      "dir"
+    );
+
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: path.join(testDir, "alias"),
+        params: { paths: ["nested/inside.txt"], resultVersion: 2 },
+      },
+      makeContext(testDir)
+    );
+
+    expect(result.data).toEqual({
+      files: {
+        "nested/inside.txt": {
+          content: "inside\n",
+          status: "ok",
+          truncated: false,
+        },
+      },
+      version: 2,
+    });
+  });
+
+  test("rejects sibling-prefix and missing cwd values", async () => {
+    const siblingDir = `${testDir}-sibling`;
+    fs.mkdirSync(siblingDir);
+    try {
+      for (const cwd of [siblingDir, path.join(testDir, "missing")]) {
+        const result = await executeTool(
+          {
+            type: "tool",
+            operation: "list-dir",
+            cwd,
+            params: { path: "." },
+          },
+          makeContext(testDir)
+        );
+        expect(result.ok, cwd).toBe(false);
+        expect(result.error, cwd).toContain("outside project directory");
+      }
+    } finally {
+      fs.rmSync(siblingDir, { recursive: true, force: true });
+    }
+  });
+
   test("lists and precomputes directory contents", async () => {
     fs.writeFileSync(path.join(testDir, "index.ts"), "export {};\n");
     fs.mkdirSync(path.join(testDir, "src"));
@@ -183,7 +315,10 @@ describe("filesystem tools", () => {
         type: "tool",
         operation: "read-files",
         cwd: testDir,
-        params: { paths: ["exists.txt", "missing.txt"] },
+        params: {
+          paths: ["exists.txt", "missing.txt"],
+          resultVersion: 2,
+        },
       },
       makeContext(testDir)
     );
@@ -197,17 +332,25 @@ describe("filesystem tools", () => {
       makeContext(testDir)
     );
 
-    expect((readResult.data as any).files["exists.txt"]).toBe("hello");
-    expect((readResult.data as any).files["missing.txt"]).toBeNull();
+    expect((readResult.data as any).files["exists.txt"]).toEqual({
+      content: "hello",
+      status: "ok",
+      truncated: false,
+    });
+    expect((readResult.data as any).files["missing.txt"]).toEqual({
+      error: "not-found",
+      status: "error",
+    });
     expect((existsResult.data as any).exists["exists.txt"]).toBe(true);
     expect((existsResult.data as any).exists["missing.txt"]).toBe(false);
   });
 
   test("returns independent bounded V2 line ranges", async () => {
-    fs.writeFileSync(
-      path.join(testDir, "large.txt"),
-      Array.from({ length: 8 }, (_, index) => `line-${index + 1}`).join("\n")
+    const lines = Array.from(
+      { length: 8 },
+      (_, index) => `line-${index + 1}:${"x".repeat(19_990)}\n`
     );
+    fs.writeFileSync(path.join(testDir, "large.txt"), lines.join(""));
 
     const first = await executeTool(
       {
@@ -215,7 +358,6 @@ describe("filesystem tools", () => {
         operation: "read-files",
         cwd: testDir,
         params: {
-          maxLines: 3,
           paths: ["large.txt"],
           resultVersion: 2,
         },
@@ -228,7 +370,6 @@ describe("filesystem tools", () => {
         operation: "read-files",
         cwd: testDir,
         params: {
-          maxLines: 2,
           paths: ["large.txt"],
           resultVersion: 2,
           startLine: 5,
@@ -240,7 +381,7 @@ describe("filesystem tools", () => {
     expect(first.data).toEqual({
       files: {
         "large.txt": {
-          content: "line-1\nline-2\nline-3\n",
+          content: lines.slice(0, 2).join(""),
           status: "ok",
           truncated: true,
         },
@@ -250,7 +391,7 @@ describe("filesystem tools", () => {
     expect(later.data).toEqual({
       files: {
         "large.txt": {
-          content: "line-5\nline-6\n",
+          content: lines.slice(4, 6).join(""),
           status: "ok",
           truncated: true,
         },
@@ -260,7 +401,11 @@ describe("filesystem tools", () => {
   });
 
   test("preserves exact line endings in V2 snapshots", async () => {
-    fs.writeFileSync(path.join(testDir, "windows.txt"), "first\r\nsecond\r\n");
+    const firstLine = `${"x".repeat(39_997)}\r\n`;
+    fs.writeFileSync(
+      path.join(testDir, "windows.txt"),
+      `${firstLine}second\r\n`
+    );
 
     const result = await executeTool(
       {
@@ -268,7 +413,6 @@ describe("filesystem tools", () => {
         operation: "read-files",
         cwd: testDir,
         params: {
-          maxLines: 1,
           paths: ["windows.txt"],
           resultVersion: 2,
         },
@@ -279,13 +423,64 @@ describe("filesystem tools", () => {
     expect(result.data).toEqual({
       files: {
         "windows.txt": {
-          content: "first\r\n",
+          content: firstLine,
           status: "ok",
           truncated: true,
         },
       },
       version: 2,
     });
+  });
+
+  test("finds a continuation and fills its window after short descriptor reads", async () => {
+    const filePath = path.join(testDir, "short-reads.txt");
+    const content = "first\nsecond\nthird\n";
+    fs.writeFileSync(filePath, content);
+    const actualHandle = await fs.promises.open(filePath, "r");
+    const shortRead = vi.fn(
+      (
+        buffer: Buffer,
+        offset: number,
+        length: number,
+        position: number | null
+      ) => actualHandle.read(buffer, offset, Math.min(length, 3), position)
+    );
+    const openSpy = vi.spyOn(fs.promises, "open").mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      read: shortRead,
+      stat: () => actualHandle.stat(),
+    } as unknown as fs.promises.FileHandle);
+
+    try {
+      const result = await executeTool(
+        {
+          type: "tool",
+          operation: "read-files",
+          cwd: testDir,
+          params: {
+            paths: ["short-reads.txt"],
+            resultVersion: 2,
+            startLine: 2,
+          },
+        },
+        makeContext(testDir)
+      );
+
+      expect(result.data).toEqual({
+        files: {
+          "short-reads.txt": {
+            content: "second\nthird\n",
+            status: "ok",
+            truncated: false,
+          },
+        },
+        version: 2,
+      });
+      expect(shortRead.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+      openSpy.mockRestore();
+      await actualHandle.close();
+    }
   });
 
   test("rejects malformed V2 read requests before local I/O", async () => {
@@ -301,6 +496,138 @@ describe("filesystem tools", () => {
 
     expect(result).toEqual({
       error: "read-files params must be an object",
+      ok: false,
+    });
+  });
+
+  test("rejects read requests without the V2 result contract", async () => {
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: { paths: ["package.json"] },
+      } as unknown as ToolPayload,
+      makeContext(testDir)
+    );
+
+    expect(result).toEqual({
+      error: "read-files requires resultVersion 2",
+      ok: false,
+    });
+  });
+
+  test("canonicalizes slash styles while preserving ordinary spaces", async () => {
+    fs.mkdirSync(path.join(testDir, "dir with spaces", "nested dir"), {
+      recursive: true,
+    });
+    fs.mkdirSync(path.join(testDir, "posix"));
+    fs.writeFileSync(
+      path.join(testDir, "dir with spaces", "nested dir", "file name.ts"),
+      "mixed separators\n"
+    );
+    fs.writeFileSync(path.join(testDir, "posix", "file.ts"), "posix path\n");
+
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          paths: ["dir with spaces\\nested dir/file name.ts", "posix/file.ts"],
+          resultVersion: 2,
+        },
+      },
+      makeContext(testDir)
+    );
+
+    expect(result.data).toEqual({
+      files: {
+        "dir with spaces/nested dir/file name.ts": {
+          content: "mixed separators\n",
+          status: "ok",
+          truncated: false,
+        },
+        "posix/file.ts": {
+          content: "posix path\n",
+          status: "ok",
+          truncated: false,
+        },
+      },
+      version: 2,
+    });
+  });
+
+  test("rejects non-portable read paths before opening requested files", async () => {
+    const invalidPaths = [
+      "/etc/passwd",
+      "\\etc\\passwd",
+      "C:/repo/package.json",
+      "C:\\repo\\package.json",
+      "C:repo/package.json",
+      "\\\\server\\share\\package.json",
+      "//server/share/package.json",
+      "../outside.txt",
+      "apps/../../outside.txt",
+      "./package.json",
+      "apps/./package.json",
+      "apps//package.json",
+      "apps\\\\package.json",
+      "apps/",
+      "package\0.json",
+      "package\n.json",
+      "package\u007f.json",
+      "folder /package.json",
+      "package.json.",
+      "CON",
+      "con.txt",
+      "apps/NUL.json",
+      "COM1",
+      "lpt9.log",
+      "package.json:secret",
+    ];
+    const openSpy = vi.spyOn(fs.promises, "open");
+
+    try {
+      for (const filePath of invalidPaths) {
+        const result = await executeTool(
+          {
+            type: "tool",
+            operation: "read-files",
+            cwd: testDir,
+            params: { paths: [filePath], resultVersion: 2 },
+          },
+          makeContext(testDir)
+        );
+
+        expect(result, filePath).toEqual({
+          error:
+            "read-files paths must be portable filesystem-root-relative paths without aliases",
+          ok: false,
+        });
+      }
+      expect(openSpy).not.toHaveBeenCalled();
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  test("rejects duplicate aliases after path normalization", async () => {
+    const result = await executeTool(
+      {
+        type: "tool",
+        operation: "read-files",
+        cwd: testDir,
+        params: {
+          paths: ["apps/web/package.json", "apps\\web\\package.json"],
+          resultVersion: 2,
+        },
+      },
+      makeContext(testDir)
+    );
+
+    expect(result).toEqual({
+      error: "read-files paths must be unique after path normalization",
       ok: false,
     });
   });
@@ -354,12 +681,12 @@ describe("filesystem tools", () => {
       },
       makeContext(testDir)
     );
-    const legacyNpmConfig = await executeTool(
+    const npmConfig = await executeTool(
       {
         type: "tool",
         operation: "read-files",
         cwd: testDir,
-        params: { paths: [".npmrc"] },
+        params: { paths: [".npmrc"], resultVersion: 2 },
       },
       makeContext(testDir)
     );
@@ -393,8 +720,15 @@ describe("filesystem tools", () => {
       },
       version: 2,
     });
-    expect(legacyNpmConfig.data).toEqual({
-      files: { ".npmrc": "//registry/:_authToken=secret\n" },
+    expect(npmConfig.data).toEqual({
+      files: {
+        ".npmrc": {
+          content: "//registry/:_authToken=secret\n",
+          status: "ok",
+          truncated: false,
+        },
+      },
+      version: 2,
     });
     expect(binary.data).toEqual({
       files: { "binary.txt": { error: "not-text", status: "error" } },
@@ -402,7 +736,7 @@ describe("filesystem tools", () => {
     });
   });
 
-  test("rejects aliases to sensitive files in V1 and V2", async () => {
+  test("rejects aliases to sensitive files", async () => {
     fs.writeFileSync(
       path.join(testDir, ".netrc"),
       "machine example.test login user password secret\n"
@@ -410,12 +744,12 @@ describe("filesystem tools", () => {
     fs.symlinkSync(".netrc", path.join(testDir, "credentials.txt"));
     fs.symlinkSync(".netrc", path.join(testDir, ".pypirc"));
 
-    const legacyAlias = await executeTool(
+    const alias = await executeTool(
       {
         type: "tool",
         operation: "read-files",
         cwd: testDir,
-        params: { paths: ["credentials.txt"] },
+        params: { paths: ["credentials.txt"], resultVersion: 2 },
       },
       makeContext(testDir)
     );
@@ -429,13 +763,44 @@ describe("filesystem tools", () => {
       makeContext(testDir)
     );
 
-    expect(legacyAlias.data).toEqual({
-      files: { "credentials.txt": null },
+    expect(alias.data).toEqual({
+      files: {
+        "credentials.txt": { error: "unreadable", status: "error" },
+      },
+      version: 2,
     });
     expect(sensitiveNameAlias.data).toEqual({
       files: { ".pypirc": { error: "unreadable", status: "error" } },
       version: 2,
     });
+  });
+
+  test("rejects regular-file symlinks that escape the project root", async () => {
+    const outsideDir = fs.mkdtempSync(path.join("/tmp", "init-tools-outside-"));
+    const sentinel = "OUTSIDE_PROJECT_SENTINEL";
+    try {
+      const outsideFile = path.join(outsideDir, "outside.txt");
+      fs.writeFileSync(outsideFile, sentinel);
+      fs.symlinkSync(outsideFile, path.join(testDir, "inside.txt"));
+
+      const result = await executeTool(
+        {
+          type: "tool",
+          operation: "read-files",
+          cwd: testDir,
+          params: { paths: ["inside.txt"], resultVersion: 2 },
+        },
+        makeContext(testDir)
+      );
+
+      expect(result.data).toEqual({
+        files: { "inside.txt": { error: "unreadable", status: "error" } },
+        version: 2,
+      });
+      expect(JSON.stringify(result)).not.toContain(sentinel);
+    } finally {
+      fs.rmSync(outsideDir, { recursive: true, force: true });
+    }
   });
 
   test("finds later lines without exposing a cursor protocol", async () => {
@@ -450,7 +815,6 @@ describe("filesystem tools", () => {
         operation: "read-files",
         cwd: testDir,
         params: {
-          maxLines: 1,
           paths: ["deep.txt"],
           resultVersion: 2,
           startLine: 2,
@@ -482,7 +846,7 @@ describe("filesystem tools", () => {
         type: "tool",
         operation: "read-files",
         cwd: testDir,
-        params: { maxBytes: 40_000, paths, resultVersion: 2 },
+        params: { paths, resultVersion: 2 },
       },
       makeContext(testDir)
     );
@@ -499,7 +863,9 @@ describe("filesystem tools", () => {
       makeContext(testDir)
     );
     const files = (
-      result.data as { files: Record<string, { content: string }> }
+      result.data as {
+        files: Record<string, { content: string; truncated: boolean }>;
+      }
     ).files;
 
     expect(result.ok).toBe(true);
@@ -508,100 +874,40 @@ describe("filesystem tools", () => {
         (total, file) => total + Buffer.byteLength(file.content),
         0
       )
-    ).toBeLessThanOrEqual(40_000);
+    ).toBe(40_000);
+    expect(Object.values(files).every((file) => file.truncated)).toBe(true);
     expect(overLimit).toEqual({
       error: "read-files requires between 1 and 20 paths",
       ok: false,
     });
   });
 
-  test("allows 256 deterministic V2 paths and rejects 257", async () => {
-    const paths = Array.from(
-      { length: 256 },
-      (_, index) => `deterministic-${index}.txt`
-    );
-    for (const filePath of paths) {
-      fs.writeFileSync(path.join(testDir, filePath), "x\n");
-    }
-
+  test("rejects a continuation request with more than one path", async () => {
     const result = await executeTool(
       {
         type: "tool",
         operation: "read-files",
         cwd: testDir,
-        params: { maxBytes: 40_001, paths, resultVersion: 2 },
-      },
-      makeContext(testDir)
-    );
-    const overLimit = await executeTool(
-      {
-        type: "tool",
-        operation: "read-files",
-        cwd: testDir,
         params: {
-          maxBytes: 40_001,
-          paths: [...paths, "deterministic-256.txt"],
+          paths: ["first.txt", "second.txt"],
           resultVersion: 2,
+          startLine: 2,
         },
       },
       makeContext(testDir)
     );
-    const files = (
-      result.data as {
-        files: Record<
-          string,
-          { content: string; status: "ok"; truncated: boolean }
-        >;
-      }
-    ).files;
 
-    expect(result.ok).toBe(true);
-    expect(Object.keys(files)).toHaveLength(256);
-    expect(Object.values(files)).toEqual(
-      Array.from({ length: 256 }, () => ({
-        content: "x\n",
-        status: "ok",
-        truncated: false,
-      }))
-    );
-    expect(overLimit).toEqual({
-      error: "read-files requires between 1 and 256 paths",
+    expect(result).toEqual({
+      error: "read-files range reads require exactly one path",
       ok: false,
     });
   });
 
-  test("returns a complete 200 KB file in deterministic V2 mode", async () => {
-    const content = `${"x".repeat(249)}\n`.repeat(800);
-    fs.writeFileSync(path.join(testDir, "snapshot.txt"), content);
-
-    const result = await executeTool(
-      {
-        type: "tool",
-        operation: "read-files",
-        cwd: testDir,
-        params: {
-          maxBytes: 262_144,
-          paths: ["snapshot.txt"],
-          resultVersion: 2,
-        },
-      },
-      makeContext(testDir)
-    );
-
-    expect(Buffer.byteLength(content)).toBe(200_000);
-    expect(result.data).toEqual({
-      files: {
-        "snapshot.txt": { content, status: "ok", truncated: false },
-      },
-      version: 2,
-    });
-  });
-
-  test("uses bytes instead of the normal line default for deterministic V2 reads", async () => {
+  test("does not impose a separate line limit on V2 reads", async () => {
     const content = "x\n".repeat(1500);
     fs.writeFileSync(path.join(testDir, "many-lines.txt"), content);
 
-    const normal = await executeTool(
+    const result = await executeTool(
       {
         type: "tool",
         operation: "read-files",
@@ -610,31 +916,8 @@ describe("filesystem tools", () => {
       },
       makeContext(testDir)
     );
-    const deterministic = await executeTool(
-      {
-        type: "tool",
-        operation: "read-files",
-        cwd: testDir,
-        params: {
-          maxBytes: 262_144,
-          paths: ["many-lines.txt"],
-          resultVersion: 2,
-        },
-      },
-      makeContext(testDir)
-    );
 
-    expect(normal.data).toEqual({
-      files: {
-        "many-lines.txt": {
-          content: "x\n".repeat(1000),
-          status: "ok",
-          truncated: true,
-        },
-      },
-      version: 2,
-    });
-    expect(deterministic.data).toEqual({
+    expect(result.data).toEqual({
       files: {
         "many-lines.txt": { content, status: "ok", truncated: false },
       },
@@ -642,13 +925,7 @@ describe("filesystem tools", () => {
     });
   });
 
-  test("truncates deterministic V2 reads at the aggregate byte limit", async () => {
-    const content = `${"x".repeat(127)}\n`.repeat(1500);
-    const paths = ["first.txt", "second.txt"];
-    for (const filePath of paths) {
-      fs.writeFileSync(path.join(testDir, filePath), content);
-    }
-
+  test("rejects byte-budget knobs instead of enabling another profile", async () => {
     const result = await executeTool(
       {
         type: "tool",
@@ -656,128 +933,147 @@ describe("filesystem tools", () => {
         cwd: testDir,
         params: {
           maxBytes: 262_144,
-          maxLines: 2000,
-          paths,
+          paths: ["large.txt"],
           resultVersion: 2,
         },
-      },
-      makeContext(testDir)
-    );
-    const files = (
-      result.data as {
-        files: Record<string, { content: string; truncated: boolean }>;
-      }
-    ).files;
-
-    expect(
-      Object.values(files).reduce(
-        (total, file) => total + Buffer.byteLength(file.content),
-        0
-      )
-    ).toBe(262_144);
-    expect(Object.values(files).every((file) => file.truncated)).toBe(true);
-  });
-
-  test("rejects deterministic V2 byte requests above the hard limit", async () => {
-    const result = await executeTool(
-      {
-        type: "tool",
-        operation: "read-files",
-        cwd: testDir,
-        params: {
-          maxBytes: 262_145,
-          paths: ["missing.txt"],
-          resultVersion: 2,
-        },
-      },
+      } as ToolPayload,
       makeContext(testDir)
     );
 
     expect(result).toEqual({
-      error: "read-files V2 maxBytes cannot exceed 262144",
+      error: "read-files params include unsupported fields",
       ok: false,
     });
   });
 
-  test("reads a short line that starts at the deep-scan boundary", async () => {
-    const scanBytes = 4 * 1024 * 1024;
-    const prefix = "x\n".repeat(scanBytes / 2);
-    fs.writeFileSync(path.join(testDir, "boundary.txt"), `${prefix}target\n`);
-
-    const result = await executeTool(
-      {
-        type: "tool",
-        operation: "read-files",
-        cwd: testDir,
-        params: {
-          maxLines: 1,
-          paths: ["boundary.txt"],
-          resultVersion: 2,
-          startLine: scanBytes / 2 + 1,
-        },
-      },
-      makeContext(testDir)
+  test("streams a continuation beyond 4 MiB with bounded read buffers", async () => {
+    const filePath = path.join(testDir, "deep-continuation.txt");
+    const splitUtf8Prefix = `${"x".repeat(5 * 1024 * 1024 - 1)}é\n`;
+    fs.writeFileSync(filePath, `${splitUtf8Prefix}target\n`);
+    const actualHandle = await fs.promises.open(filePath, "r");
+    const requestedLengths: number[] = [];
+    const streamedRead = vi.fn(
+      (
+        buffer: Buffer,
+        offset: number,
+        length: number,
+        position: number | null
+      ) => {
+        requestedLengths.push(length);
+        return actualHandle.read(buffer, offset, length, position);
+      }
     );
+    const openSpy = vi.spyOn(fs.promises, "open").mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      read: streamedRead,
+      stat: () => actualHandle.stat(),
+    } as unknown as fs.promises.FileHandle);
 
-    expect(result.data).toEqual({
-      files: {
-        "boundary.txt": {
-          content: "target\n",
-          status: "ok",
-          truncated: false,
+    try {
+      const result = await executeTool(
+        {
+          type: "tool",
+          operation: "read-files",
+          cwd: testDir,
+          params: {
+            paths: ["deep-continuation.txt"],
+            resultVersion: 2,
+            startLine: 2,
+          },
         },
-      },
-      version: 2,
-    });
+        makeContext(testDir)
+      );
+
+      expect(result.data).toEqual({
+        files: {
+          "deep-continuation.txt": {
+            content: "target\n",
+            status: "ok",
+            truncated: false,
+          },
+        },
+        version: 2,
+      });
+      expect(Math.max(...requestedLengths)).toBeLessThanOrEqual(64 * 1024);
+      expect(streamedRead.mock.calls.length).toBeGreaterThan(64);
+    } finally {
+      openSpy.mockRestore();
+      await actualHandle.close();
+    }
   });
 
-  test("reports an existing line beyond the deep-scan boundary", async () => {
-    const scanBytes = 4 * 1024 * 1024;
-    const prefix = `${"x".repeat(scanBytes)}\n`;
-    fs.writeFileSync(path.join(testDir, "too-deep.txt"), `${prefix}target\n`);
-
-    const result = await executeTool(
-      {
-        type: "tool",
-        operation: "read-files",
-        cwd: testDir,
-        params: {
-          maxLines: 1,
-          paths: ["too-deep.txt"],
-          resultVersion: 2,
-          startLine: 2,
-        },
-      },
-      makeContext(testDir)
+  test("stops reading an enormous first line at the output budget", async () => {
+    const filePath = path.join(testDir, "enormous-line.txt");
+    fs.writeFileSync(filePath, `${"x".repeat(8 * 1024 * 1024)}\n`);
+    const actualHandle = await fs.promises.open(filePath, "r");
+    let totalBytesRead = 0;
+    const boundedRead = vi.fn(
+      async (
+        buffer: Buffer,
+        offset: number,
+        length: number,
+        position: number | null
+      ) => {
+        const result = await actualHandle.read(
+          buffer,
+          offset,
+          length,
+          position
+        );
+        totalBytesRead += result.bytesRead;
+        return result;
+      }
     );
+    const openSpy = vi.spyOn(fs.promises, "open").mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      read: boundedRead,
+      stat: () => actualHandle.stat(),
+    } as unknown as fs.promises.FileHandle);
 
-    expect(result.data).toEqual({
-      files: {
-        "too-deep.txt": { error: "range-too-deep", status: "error" },
-      },
-      version: 2,
-    });
+    try {
+      const result = await executeTool(
+        {
+          type: "tool",
+          operation: "read-files",
+          cwd: testDir,
+          params: {
+            paths: ["enormous-line.txt"],
+            resultVersion: 2,
+          },
+        },
+        makeContext(testDir)
+      );
+
+      expect(result.data).toEqual({
+        files: {
+          "enormous-line.txt": { error: "line-too-long", status: "error" },
+        },
+        version: 2,
+      });
+      expect(totalBytesRead).toBe(40_000);
+    } finally {
+      openSpy.mockRestore();
+      await actualHandle.close();
+    }
   });
 
-  test("rejects incomplete lines and invalid UTF-8 instead of clipping", async () => {
-    fs.writeFileSync(
-      path.join(testDir, "long-line.txt"),
-      `${"x".repeat(50_000)}\n`
-    );
+  test("rejects invalid UTF-8 and incomplete multibyte lines", async () => {
     fs.writeFileSync(
       path.join(testDir, "invalid-utf8.txt"),
       Buffer.from([0x61, 0x62, 0x63, 0xff])
     );
-    fs.writeFileSync(path.join(testDir, "multibyte.txt"), "é\n");
+    fs.writeFileSync(
+      path.join(testDir, "multibyte.txt"),
+      `${"é".repeat(20_001)}\n`
+    );
 
-    const read = (filePath: string, maxBytes?: number) =>
+    const read = (filePath: string) =>
       executeTool(
         {
           type: "tool",
           operation: "read-files",
           cwd: testDir,
           params: {
-            maxBytes,
             paths: [filePath],
             resultVersion: 2,
           },
@@ -785,19 +1081,13 @@ describe("filesystem tools", () => {
         makeContext(testDir)
       );
 
-    expect((await read("long-line.txt")).data).toEqual({
-      files: {
-        "long-line.txt": { error: "line-too-long", status: "error" },
-      },
-      version: 2,
-    });
     expect((await read("invalid-utf8.txt")).data).toEqual({
       files: {
         "invalid-utf8.txt": { error: "not-text", status: "error" },
       },
       version: 2,
     });
-    expect((await read("multibyte.txt", 1)).data).toEqual({
+    expect((await read("multibyte.txt")).data).toEqual({
       files: {
         "multibyte.txt": { error: "line-too-long", status: "error" },
       },

--- a/packages/cli/test/lib/init/wizard-runner.test.ts
+++ b/packages/cli/test/lib/init/wizard-runner.test.ts
@@ -132,6 +132,59 @@ let capturedClientOptions: { abortSignal?: AbortSignal; retries?: number }[] =
   [];
 
 let savedPlainOutput: string | undefined;
+let testRequestSequence = 0;
+let testEnvelopeByPayload = new WeakMap<
+  object,
+  { protocolVersion: 1; requestId: string }
+>();
+
+/** Model the current server: every valid suspend payload carries a v1 ID. */
+function withV1SuspendEnvelope(raw: unknown): unknown {
+  if (
+    typeof raw !== "object" ||
+    raw === null ||
+    !("type" in raw) ||
+    !["tool", "interactive"].includes(String(raw.type)) ||
+    "protocolVersion" in raw ||
+    "requestId" in raw
+  ) {
+    return raw;
+  }
+
+  let envelope = testEnvelopeByPayload.get(raw);
+  if (!envelope) {
+    testRequestSequence += 1;
+    envelope = {
+      protocolVersion: 1,
+      requestId: `00000000-0000-4000-8000-${String(testRequestSequence).padStart(12, "0")}`,
+    };
+    testEnvelopeByPayload.set(raw, envelope);
+  }
+  return { ...raw, ...envelope };
+}
+
+function withV1SuspendEnvelopes(result: WorkflowRunResult): WorkflowRunResult {
+  const steps = result.steps
+    ? Object.fromEntries(
+        Object.entries(result.steps).map(([stepId, step]) => [
+          stepId,
+          step.suspendPayload === undefined
+            ? step
+            : {
+                ...step,
+                suspendPayload: withV1SuspendEnvelope(step.suspendPayload),
+              },
+        ])
+      )
+    : undefined;
+  return {
+    ...result,
+    ...(steps ? { steps } : {}),
+    ...(result.suspendPayload === undefined
+      ? {}
+      : { suspendPayload: withV1SuspendEnvelope(result.suspendPayload) }),
+  };
+}
 
 function forceStdinTty<T>(action: () => Promise<T>): Promise<T> {
   const originalDescriptor = Object.getOwnPropertyDescriptor(
@@ -169,6 +222,8 @@ beforeEach(() => {
   mockResumeResults = [];
   resumeCallCount = 0;
   mockRunByIdResult = new Error("runById not configured");
+  testRequestSequence = 0;
+  testEnvelopeByPayload = new WeakMap();
   process.exitCode = 0;
 
   spinnerMock.start.mockClear();
@@ -227,18 +282,20 @@ beforeEach(() => {
     .spyOn(process.stderr, "write")
     .mockImplementation(() => true as any);
 
-  startAsyncMock = vi.fn(() => Promise.resolve(mockStartResult));
+  startAsyncMock = vi.fn(() =>
+    Promise.resolve(withV1SuspendEnvelopes(mockStartResult))
+  );
   runByIdMock = vi.fn(() =>
     mockRunByIdResult instanceof Error
       ? Promise.reject(mockRunByIdResult)
-      : Promise.resolve(mockRunByIdResult)
+      : Promise.resolve(withV1SuspendEnvelopes(mockRunByIdResult))
   );
   sharedResumeAsyncMock = vi.fn(() => {
     const result = mockResumeResults[resumeCallCount] ?? {
       status: "success",
     };
     resumeCallCount += 1;
-    return Promise.resolve(result);
+    return Promise.resolve(withV1SuspendEnvelopes(result));
   });
   const run = {
     runId: "test-run-id",
@@ -770,6 +827,34 @@ describe("runWizard", () => {
     await expect(runWizard(makeOptions())).rejects.toThrow(WizardError);
   });
 
+  test.each([
+    ["a missing envelope", {}],
+    ["an unsupported version", { protocolVersion: 2, requestId: "request" }],
+    ["a missing request ID", { protocolVersion: 1 }],
+    ["an empty request ID", { protocolVersion: 1, requestId: "" }],
+  ])("rejects suspend payloads with %s", async (_label, envelope) => {
+    startAsyncMock.mockResolvedValueOnce({
+      status: "suspended",
+      suspended: [["detect-platform"]],
+      steps: {
+        "detect-platform": {
+          suspendPayload: {
+            type: "tool",
+            operation: "list-dir",
+            cwd: "/tmp/test",
+            params: { path: "." },
+            ...envelope,
+          },
+        },
+      },
+    });
+
+    await expect(runWizard(makeOptions())).rejects.toThrow(
+      "Invalid init protocol envelope"
+    );
+    expect(executeToolSpy).not.toHaveBeenCalled();
+  });
+
   test("fails when a suspended step has no payload", async () => {
     mockStartResult = {
       status: "suspended",
@@ -902,6 +987,7 @@ describe("runWizard", () => {
             cwd: "/tmp/test",
             params: {
               paths: ["src/settings.py", "src/urls.py"],
+              resultVersion: 2,
             },
           },
         },
@@ -1201,7 +1287,9 @@ describe("runWizard — resumeWithRetry stale-step recovery", () => {
           Promise.resolve({
             runId: "test-run-id",
             startAsync: startAsyncMock,
-            resumeAsync: vi.fn(resumeAsyncImpl),
+            resumeAsync: vi.fn(async (args) =>
+              withV1SuspendEnvelopes(await resumeAsyncImpl(args))
+            ),
           })
         ),
         runById: runByIdRef,
@@ -1384,15 +1472,20 @@ describe("runWizard — resumeWithRetry stale-step recovery", () => {
 
   test("keeps polling when runById returns the same suspended payload snapshot", async () => {
     vi.useFakeTimers();
+    const protocolPayload: SuspendPayload = {
+      ...toolPayload,
+      protocolVersion: 1,
+      requestId: "8c7ee6b9-e955-4514-9164-f01844584a28",
+    };
     mockStartResult = {
       status: "suspended",
       suspended: [["tool-step"]],
-      steps: { "tool-step": { suspendPayload: toolPayload } },
+      steps: { "tool-step": { suspendPayload: protocolPayload } },
     };
     runByIdMock
       .mockResolvedValueOnce({
         status: "suspended",
-        suspendPayload: toolPayload,
+        suspendPayload: protocolPayload,
       })
       .mockResolvedValueOnce({ status: "success" });
 
@@ -1416,7 +1509,7 @@ describe("runWizard — resumeWithRetry stale-step recovery", () => {
       type: "tool",
       operation: "read-files",
       cwd: "/tmp/test",
-      params: { paths: ["old-package.json"] },
+      params: { paths: ["old-package.json"], resultVersion: 2 },
     };
     const activePayload: ToolPayload = {
       type: "tool",
@@ -1573,7 +1666,7 @@ describe("runWizard — resumeWithRetry stale-step recovery", () => {
       type: "tool",
       operation: "read-files",
       cwd: "/tmp/test",
-      params: { paths: ["package.json"] },
+      params: { paths: ["package.json"], resultVersion: 2 },
     };
     const applyPayload: ToolPayload = {
       type: "tool",
@@ -1589,7 +1682,16 @@ describe("runWizard — resumeWithRetry stale-step recovery", () => {
     executeToolSpy
       .mockResolvedValueOnce({
         ok: true,
-        data: { files: { "package.json": largeContent } },
+        data: {
+          files: {
+            "package.json": {
+              content: largeContent,
+              status: "ok",
+              truncated: false,
+            },
+          },
+          version: 2,
+        },
       })
       .mockResolvedValueOnce({
         ok: false,
@@ -1800,7 +1902,7 @@ describe("runWizard — additional coverage", () => {
     expect(executeToolSpy).not.toHaveBeenCalledWith(payload, makeContext());
   });
 
-  test("uses legacy fallback only when no active step info exists and one payload is present", async () => {
+  test("uses the sole payload fallback when no active step info exists", async () => {
     const payload: ToolPayload = {
       type: "tool",
       operation: "run-commands",
@@ -1831,7 +1933,7 @@ describe("runWizard — additional coverage", () => {
       type: "tool",
       operation: "read-files",
       cwd: "/tmp/test",
-      params: { paths: ["package.json"] },
+      params: { paths: ["package.json"], resultVersion: 2 },
     };
 
     mockStartResult = {
@@ -1886,7 +1988,7 @@ describe("runWizard — additional coverage", () => {
       type: "tool",
       operation: "read-files",
       cwd: "/tmp/test",
-      params: { paths: ["package.json"] },
+      params: { paths: ["package.json"], resultVersion: 2 },
     };
 
     mockStartResult = {
@@ -2004,7 +2106,7 @@ describe("runWizard — progress rotation for long-running steps", () => {
       type: "tool" as const,
       operation: "read-files",
       cwd: "/tmp/test",
-      params: { paths: ["src/app.tsx"] },
+      params: { paths: ["src/app.tsx"], resultVersion: 2 },
     };
     mockStartResult = {
       status: "suspended",
@@ -2080,7 +2182,7 @@ describe("runWizard — progress rotation for long-running steps", () => {
       type: "tool" as const,
       operation: "read-files",
       cwd: "/tmp/test",
-      params: { paths: ["src/app.tsx"] },
+      params: { paths: ["src/app.tsx"], resultVersion: 2 },
     };
     mockStartResult = {
       status: "suspended",

--- a/packages/cli/test/lib/safe-read.test.ts
+++ b/packages/cli/test/lib/safe-read.test.ts
@@ -6,10 +6,10 @@
  */
 
 import { execSync } from "node:child_process";
-import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import fs, { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { MAX_FILE_BYTES } from "../../src/lib/init/constants.js";
 import { applyPatchset } from "../../src/lib/init/tools/apply-patchset.js";
 import { readFiles } from "../../src/lib/init/tools/read-files.js";
@@ -136,7 +136,7 @@ describe("init read-files FIFO safety", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test("returns null entry for a FIFO path instead of hanging", async () => {
+  test("returns a structured error for a FIFO path instead of hanging", async () => {
     writeFileSync(join(dir, "real.ts"), "export {};\n");
     createFifo(join(dir, ".env"));
 
@@ -144,17 +144,24 @@ describe("init read-files FIFO safety", () => {
       type: "tool",
       operation: "read-files",
       cwd: dir,
-      params: { paths: ["real.ts", ".env"] },
+      params: { paths: ["real.ts", ".env"], resultVersion: 2 },
     });
 
     expect(result.ok).toBe(true);
-    const files = (result.data as { files: Record<string, string | null> })
-      .files;
-    expect(files["real.ts"]).toBe("export {};\n");
-    expect(files[".env"]).toBeNull();
+    expect(result.data).toEqual({
+      files: {
+        ".env": { error: "not-file", status: "error" },
+        "real.ts": {
+          content: "export {};\n",
+          status: "ok",
+          truncated: false,
+        },
+      },
+      version: 2,
+    });
   });
 
-  test("returns null entry for a symlink to a FIFO (1Password pattern)", async () => {
+  test("returns a structured error for a symlink to a FIFO", async () => {
     // 1Password's `.env` integration uses a symlink → FIFO to stream
     // secrets. `stat` follows the symlink so `isFile()` is false on
     // the FIFO target, correctly rejected by the guard.
@@ -167,13 +174,14 @@ describe("init read-files FIFO safety", () => {
       type: "tool",
       operation: "read-files",
       cwd: dir,
-      params: { paths: [".env"] },
+      params: { paths: [".env"], resultVersion: 2 },
     });
 
     expect(result.ok).toBe(true);
-    const files = (result.data as { files: Record<string, string | null> })
-      .files;
-    expect(files[".env"]).toBeNull();
+    expect(result.data).toEqual({
+      files: { ".env": { error: "not-file", status: "error" } },
+      version: 2,
+    });
   });
 });
 
@@ -299,5 +307,37 @@ describe("workflow-inputs preReadCommonFiles FIFO safety", () => {
 
     const cache = await preReadCommonFiles(dir, listing);
     expect(cache).not.toHaveProperty("package.json");
+  });
+
+  test("fills the common-config buffer after short descriptor reads", async () => {
+    const filePath = join(dir, "package.json");
+    const content = '{"name":"short-read-project"}\n';
+    writeFileSync(filePath, content);
+    const actualHandle = await fs.promises.open(filePath, "r");
+    const shortRead = vi.fn(
+      (
+        buffer: Buffer,
+        offset: number,
+        length: number,
+        position: number | null
+      ) => actualHandle.read(buffer, offset, Math.min(length, 3), position)
+    );
+    const openSpy = vi.spyOn(fs.promises, "open").mockResolvedValue({
+      close: vi.fn().mockResolvedValue(undefined),
+      read: shortRead,
+      stat: () => actualHandle.stat(),
+    } as unknown as fs.promises.FileHandle);
+
+    try {
+      const cache = await preReadCommonFiles(dir, [
+        { name: "package.json", path: "package.json", type: "file" },
+      ]);
+
+      expect(cache["package.json"]).toBe(content);
+      expect(shortRead.mock.calls.length).toBeGreaterThan(1);
+    } finally {
+      openSpy.mockRestore();
+      await actualHandle.close();
+    }
   });
 });


### PR DESCRIPTION
## Summary

read-files now has one exact V2 contract:

- up to 20 canonical root-relative paths per call
- up to 40,000 aggregate content bytes per call
- stateless continuation with startLine
- no V1 response mode, deterministic profile, maxBytes, maxLines, or model-owned budget knobs

The reader scans large prefixes incrementally without retaining them, keeps only the bounded result page, handles short reads and UTF-8 boundaries, and returns complete lines with explicit truncation.

Path handling is shared with startup pre-reads and rejects absolute paths, traversal, aliases, invalid portable path forms, duplicate canonical paths, unsafe symlinks, non-regular files, and TOCTOU changes. Tool cwd is resolved against the immutable selected root before every local operation, closing symlink-based cwd escapes.

This is the paired CLI rollout for [getsentry/cli-init-api#244](https://github.com/getsentry/cli-init-api/pull/244).

## Rollout

Release this change as CLI 0.43.0 and verify that sentry cli upgrade serves it before deploying the strict API. The API accepts init protocol v1 only, requires CLI 0.43.0+, uses read-files V2 only, and gives older clients an explicit upgrade instruction.

## Test plan

- init plus safe-read suites: 36 files, 564 tests passed
- CLI TypeScript: passed
- full Biome: 989 files passed
- git diff --check: passed
- independent filesystem, sandbox, protocol, and scope reviews: clean
- compiled 0.43.0-dev.0 binary completed a full local Next.js canary against the paired Workers
- canary installed and verified @sentry/nextjs, then bun run build passed