### PR TITLE
feat(docs): Add docs command suite

### DIFF
--- a/apps/cli-docs/src/content/docs/contributing.md
+++ b/apps/cli-docs/src/content/docs/contributing.md
@@ -61,6 +61,7 @@ cli/
 │   │   ├── dart-symbol-map/# upload
 │   │   ├── dashboard/   # add, create, delete, edit, list, restore, revisions, view
 │   │   ├── debug-files/ # bundle-jvm, bundle-sources, check, find, print-sources, upload
+│   │   ├── docs/        # list, query
 │   │   ├── event/       # list, send, view
 │   │   ├── feedback/    # list, view
 │   │   ├── issue/       # archive, events, explain, list, merge, plan, resolve, unresolve, view

--- a/apps/cli-docs/src/fragments/commands/docs.md
+++ b/apps/cli-docs/src/fragments/commands/docs.md
@@ -1,0 +1,24 @@
+## Examples
+
+### Ask a documentation question
+
+```bash
+sentry docs "How do I configure tracing in Next.js?"
+```
+
+The answer includes inline links and a Sources section containing the Sentry
+documentation pages used to answer the question.
+
+### Search the documentation index
+
+```bash
+sentry docs list "source maps"
+```
+
+```
+TITLE                    DESCRIPTION                         URL
+Source Maps              Upload source maps for JavaScript   https://docs.sentry.io/...
+```
+
+Use `--limit` to restrict the number of results or `--json` for structured
+output.

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -472,6 +472,15 @@ Manage Sentry dashboards
 
 → Full flags and examples: `references/dashboard.md`
 
+### Docs
+
+Search and query current Sentry documentation
+
+- `sentry docs list <keywords...>` — Find Sentry documentation pages by keyword
+- `sentry docs query <question...>` — Ask a cited question about Sentry documentation
+
+→ Full flags and examples: `references/docs.md`
+
 ### Platform
 
 List valid Sentry platform identifiers

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/docs.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/docs.md
@@ -1,0 +1,25 @@
+---
+name: sentry-cli-docs
+version: 0.44.0-dev.0
+description: Search and query current Sentry documentation
+requires:
+  bins: ["sentry"]
+  auth: true
+---
+
+# Docs Commands
+
+Search and query current Sentry documentation
+
+### `sentry docs list <keywords...>`
+
+Find Sentry documentation pages by keyword
+
+**Flags:**
+- `-n, --limit <value> - Maximum matches to return (1-20) - (default: "8")`
+
+### `sentry docs query <question...>`
+
+Ask a cited question about Sentry documentation
+
+All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/docs.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/docs.md
@@ -18,8 +18,20 @@ Find Sentry documentation pages by keyword
 **Flags:**
 - `-n, --limit <value> - Maximum matches to return (1-20) - (default: "8")`
 
+**Examples:**
+
+```bash
+sentry docs list "source maps"
+```
+
 ### `sentry docs query <question...>`
 
 Ask a cited question about Sentry documentation
+
+**Examples:**
+
+```bash
+sentry docs "How do I configure tracing in Next.js?"
+```
 
 All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/packages/cli/src/app.ts
+++ b/packages/cli/src/app.ts
@@ -19,6 +19,7 @@ import { dartSymbolMapRoute } from "./commands/dart-symbol-map/index.js";
 import { dashboardRoute } from "./commands/dashboard/index.js";
 import { listCommand as dashboardListCommand } from "./commands/dashboard/list.js";
 import { debugFilesRoute } from "./commands/debug-files/index.js";
+import { docsRoute } from "./commands/docs/index.js";
 import { eventRoute } from "./commands/event/index.js";
 import { listCommand as eventListCommand } from "./commands/event/list.js";
 import { exploreCommand } from "./commands/explore.js";
@@ -118,6 +119,7 @@ export const routes = buildRouteMap({
     "dart-symbol-map": dartSymbolMapRoute,
     "debug-files": debugFilesRoute,
     dashboard: dashboardRoute,
+    docs: docsRoute,
     org: orgRoute,
     platform: platformRoute,
     project: projectRoute,

--- a/packages/cli/src/commands/docs/index.ts
+++ b/packages/cli/src/commands/docs/index.ts
@@ -1,0 +1,16 @@
+import { buildRouteMap } from "../../lib/route-map.js";
+import { listCommand } from "./list.js";
+import { queryCommand } from "./query.js";
+
+export const docsRoute = buildRouteMap({
+  routes: { list: listCommand, query: queryCommand },
+  aliases: { search: "query" },
+  defaultCommand: "query",
+  docs: {
+    brief: "Search and query current Sentry documentation",
+    fullDescription:
+      "Ask cited documentation questions or search the docs index.\n\n" +
+      "Commands:\n  query  Ask a natural-language question (default; alias: search)\n  list   Find matching documentation pages by keyword",
+    hideRoute: {},
+  },
+});

--- a/packages/cli/src/commands/docs/list.ts
+++ b/packages/cli/src/commands/docs/list.ts
@@ -1,0 +1,72 @@
+import type { SentryContext } from "../../context.js";
+import { validateLimit } from "../../lib/arg-parsing.js";
+import { buildCommand } from "../../lib/command.js";
+import { type DocsListResponse, listDocs } from "../../lib/docs-service.js";
+import { ValidationError } from "../../lib/errors.js";
+import { muted } from "../../lib/formatters/colors.js";
+import { CommandOutput } from "../../lib/formatters/output.js";
+import { formatTable } from "../../lib/formatters/table.js";
+
+type ListFlags = {
+  readonly fields?: string[];
+  readonly json: boolean;
+  readonly limit: number;
+};
+
+function parseLimit(value: string): number {
+  return validateLimit(value, 1, 20);
+}
+
+function formatListHuman(data: DocsListResponse): string {
+  if (data.results.length === 0) {
+    return muted("No documentation pages match that search.");
+  }
+  return formatTable(data.results, [
+    { header: "TITLE", value: (result) => result.title, truncate: true },
+    {
+      header: "DESCRIPTION",
+      value: (result) => result.description ?? "",
+      truncate: true,
+    },
+    { header: "URL", value: (result) => result.url, truncate: true },
+  ]);
+}
+
+export const listCommand = buildCommand({
+  docs: {
+    brief: "Find Sentry documentation pages by keyword",
+    fullDescription:
+      "Search the Sentry documentation index without synthesizing an answer. Returns ranked page titles, descriptions, and URLs.\n\n" +
+      'Examples:\n  sentry docs list "nextjs tracing"\n  sentry docs list "session replay privacy" --limit 5\n  sentry docs list "source maps" --json',
+  },
+  output: { human: formatListHuman },
+  parameters: {
+    flags: {
+      limit: {
+        kind: "parsed",
+        parse: parseLimit,
+        brief: "Maximum matches to return (1-20)",
+        default: "8",
+      },
+    },
+    aliases: { n: "limit" },
+    positional: {
+      kind: "array",
+      parameter: {
+        brief: "Documentation keywords",
+        parse: String,
+        placeholder: "keywords",
+      },
+    },
+  },
+  async *func(this: SentryContext, flags: ListFlags, ...parts: string[]) {
+    const query = parts.join(" ").trim();
+    if (!query) {
+      throw new ValidationError(
+        "Provide documentation keywords to search for.",
+        "keywords"
+      );
+    }
+    yield new CommandOutput(await listDocs(query, flags.limit));
+  },
+});

--- a/packages/cli/src/commands/docs/query.ts
+++ b/packages/cli/src/commands/docs/query.ts
@@ -1,0 +1,51 @@
+import type { SentryContext } from "../../context.js";
+import { buildCommand } from "../../lib/command.js";
+import { detectDocsContext } from "../../lib/docs-context.js";
+import { queryDocs } from "../../lib/docs-service.js";
+import { ValidationError } from "../../lib/errors.js";
+import { CommandOutput } from "../../lib/formatters/output.js";
+
+type QueryFlags = { readonly fields?: string[]; readonly json: boolean };
+type QueryOutput = {
+  answer: string;
+  detectedContext: Awaited<ReturnType<typeof detectDocsContext>>;
+  sources: string[];
+};
+
+function formatQueryHuman(data: QueryOutput): string {
+  return data.answer;
+}
+
+export const queryCommand = buildCommand({
+  docs: {
+    brief: "Ask a cited question about Sentry documentation",
+    fullDescription:
+      "Answer a natural-language Sentry documentation question using current docs.sentry.io pages. " +
+      "The command automatically uses safe local project metadata (manifests and config presence only) to tailor the answer.\n\n" +
+      'Examples:\n  sentry docs "How do I configure Next.js tracing?"\n  sentry docs query "How do I upload source maps?"\n  sentry docs search "How does session replay mask text?"\n  sentry docs "How do I configure tracing?" --json',
+  },
+  output: { human: formatQueryHuman },
+  parameters: {
+    flags: {},
+    positional: {
+      kind: "array",
+      parameter: {
+        brief: "Natural-language docs question",
+        parse: String,
+        placeholder: "question",
+      },
+    },
+  },
+  async *func(this: SentryContext, _flags: QueryFlags, ...parts: string[]) {
+    const query = parts.join(" ").trim();
+    if (!query) {
+      throw new ValidationError(
+        "Provide a documentation question.",
+        "question"
+      );
+    }
+    const detectedContext = await detectDocsContext(this.cwd);
+    const result = await queryDocs(query, detectedContext);
+    yield new CommandOutput<QueryOutput>({ ...result, detectedContext });
+  },
+});

--- a/packages/cli/src/lib/docs-context.ts
+++ b/packages/cli/src/lib/docs-context.ts
@@ -1,0 +1,155 @@
+import { access, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export type DocsProjectContext = {
+  frameworks: string[];
+  languages: string[];
+  sentryConfigured: boolean;
+};
+
+/** The complete allowlist for automatic local docs context. */
+export const DOCS_CONTEXT_MANIFESTS = [
+  "package.json",
+  "pyproject.toml",
+  "requirements.txt",
+  "Gemfile",
+  "go.mod",
+  "Cargo.toml",
+  "pom.xml",
+  "build.gradle",
+  "build.gradle.kts",
+  "pubspec.yaml",
+  "mix.exs",
+  "composer.json",
+] as const;
+
+const DOCS_CONTEXT_CONFIGS = [
+  "sentry.client.config.ts",
+  "sentry.client.config.js",
+  "sentry.server.config.ts",
+  "sentry.server.config.js",
+  "sentry.edge.config.ts",
+  "sentry.edge.config.js",
+  "sentry.properties",
+] as const;
+
+export type DocsContextReader = {
+  hasConfig: (name: (typeof DOCS_CONTEXT_CONFIGS)[number]) => Promise<boolean>;
+  readManifest: (
+    name: (typeof DOCS_CONTEXT_MANIFESTS)[number]
+  ) => Promise<string | undefined>;
+};
+
+function addFrameworkSignals(text: string, frameworks: Set<string>): void {
+  const normalized = text.toLowerCase();
+  const candidates: [string, string][] = [
+    ["next", "nextjs"],
+    ["@remix-run", "remix"],
+    ["@sveltejs", "sveltekit"],
+    ["@angular", "angular"],
+    ["nestjs", "nestjs"],
+    ["fastapi", "fastapi"],
+    ["django", "django"],
+    ["flask", "flask"],
+    ["rails", "rails"],
+    ["laravel", "laravel"],
+    ["flutter", "flutter"],
+  ];
+  for (const [needle, framework] of candidates) {
+    if (normalized.includes(needle)) {
+      frameworks.add(framework);
+    }
+  }
+}
+
+function addLanguageSignal(
+  manifest: (typeof DOCS_CONTEXT_MANIFESTS)[number],
+  languages: Set<string>
+): void {
+  const languageByManifest: Partial<
+    Record<(typeof DOCS_CONTEXT_MANIFESTS)[number], string>
+  > = {
+    "package.json": "javascript",
+    "pyproject.toml": "python",
+    "requirements.txt": "python",
+    Gemfile: "ruby",
+    "go.mod": "go",
+    "Cargo.toml": "rust",
+    "pom.xml": "java",
+    "build.gradle": "android",
+    "build.gradle.kts": "android",
+    "pubspec.yaml": "dart",
+    "mix.exs": "elixir",
+    "composer.json": "php",
+  };
+  const language = languageByManifest[manifest];
+  if (language) {
+    languages.add(language);
+  }
+}
+
+function containsSentrySdk(text: string): boolean {
+  const normalized = text.toLowerCase();
+  return normalized.includes("@sentry/") || normalized.includes("sentry-sdk");
+}
+
+/**
+ * Extract normalized hints from the fixed allowlist. Returned data never
+ * contains manifest/config contents, paths, DSNs, tokens, or package lists.
+ */
+export async function detectDocsContextFromReader(
+  reader: DocsContextReader
+): Promise<DocsProjectContext> {
+  const frameworks = new Set<string>();
+  const languages = new Set<string>();
+  let sentryConfigured = false;
+
+  for (const manifest of DOCS_CONTEXT_MANIFESTS) {
+    try {
+      const contents = await reader.readManifest(manifest);
+      if (contents === undefined) {
+        continue;
+      }
+      addLanguageSignal(manifest, languages);
+      addFrameworkSignals(contents, frameworks);
+      sentryConfigured ||= containsSentrySdk(contents);
+    } catch {
+      // Missing/unreadable metadata is optional and must not block lookup.
+    }
+  }
+
+  for (const config of DOCS_CONTEXT_CONFIGS) {
+    try {
+      sentryConfigured ||= await reader.hasConfig(config);
+    } catch {
+      // Config presence is an optional signal only.
+    }
+  }
+
+  return {
+    frameworks: [...frameworks].sort(),
+    languages: [...languages].sort(),
+    sentryConfigured,
+  };
+}
+
+/** Detect safe docs metadata directly below the command's working directory. */
+export function detectDocsContext(cwd: string): Promise<DocsProjectContext> {
+  return detectDocsContextFromReader({
+    async readManifest(name) {
+      try {
+        return await readFile(join(cwd, name), "utf8");
+      } catch {
+        return;
+      }
+    },
+    async hasConfig(name) {
+      try {
+        await access(join(cwd, name));
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  });
+}

--- a/packages/cli/src/lib/docs-context.ts
+++ b/packages/cli/src/lib/docs-context.ts
@@ -33,6 +33,20 @@ const DOCS_CONTEXT_CONFIGS = [
   "sentry.properties",
 ] as const;
 
+const FRAMEWORK_SIGNALS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/\bnext(?:\.js)?\b/i, "nextjs"],
+  [/@remix-run/i, "remix"],
+  [/@sveltejs/i, "sveltekit"],
+  [/@angular/i, "angular"],
+  [/\bnestjs\b/i, "nestjs"],
+  [/\bfastapi\b/i, "fastapi"],
+  [/\bdjango\b/i, "django"],
+  [/\bflask\b/i, "flask"],
+  [/\brails\b/i, "rails"],
+  [/\blaravel\b/i, "laravel"],
+  [/\bflutter\b/i, "flutter"],
+];
+
 export type DocsContextReader = {
   hasConfig: (name: (typeof DOCS_CONTEXT_CONFIGS)[number]) => Promise<boolean>;
   readManifest: (
@@ -41,22 +55,8 @@ export type DocsContextReader = {
 };
 
 function addFrameworkSignals(text: string, frameworks: Set<string>): void {
-  const normalized = text.toLowerCase();
-  const candidates: [string, string][] = [
-    ["next", "nextjs"],
-    ["@remix-run", "remix"],
-    ["@sveltejs", "sveltekit"],
-    ["@angular", "angular"],
-    ["nestjs", "nestjs"],
-    ["fastapi", "fastapi"],
-    ["django", "django"],
-    ["flask", "flask"],
-    ["rails", "rails"],
-    ["laravel", "laravel"],
-    ["flutter", "flutter"],
-  ];
-  for (const [needle, framework] of candidates) {
-    if (normalized.includes(needle)) {
+  for (const [signal, framework] of FRAMEWORK_SIGNALS) {
+    if (signal.test(text)) {
       frameworks.add(framework);
     }
   }

--- a/packages/cli/src/lib/docs-service.ts
+++ b/packages/cli/src/lib/docs-service.ts
@@ -1,7 +1,7 @@
 import { customFetch } from "./custom-ca.js";
 import { refreshToken } from "./db/auth.js";
 import type { DocsProjectContext } from "./docs-context.js";
-import { ApiError } from "./errors.js";
+import { ApiError, CliError, EXIT } from "./errors.js";
 import { MASTRA_API_URL } from "./init/constants.js";
 import { assertHostedInitServiceAcceptsTokenHost } from "./init/init-service-auth.js";
 
@@ -41,11 +41,10 @@ async function postDocs<T>(
       // Keep the compact plain-text response as the detail.
     }
     if (parsed?.code === "DOCS_UNGROUNDED") {
-      throw new ApiError(
-        "Could not produce a verified documentation answer.",
-        response.status,
-        "Try rephrasing the question so it can be answered from current Sentry documentation.",
-        path
+      throw new CliError(
+        "Could not produce a verified documentation answer.\n" +
+          "  Try rephrasing the question so it can be answered from current Sentry documentation.",
+        EXIT.API
       );
     }
     if (typeof parsed?.error === "string") {

--- a/packages/cli/src/lib/docs-service.ts
+++ b/packages/cli/src/lib/docs-service.ts
@@ -34,13 +34,22 @@ async function postDocs<T>(
   const text = await response.text();
   if (!response.ok) {
     let detail = text;
+    let parsed: { code?: unknown; error?: unknown } | undefined;
     try {
-      const parsed = JSON.parse(text) as { error?: unknown };
-      if (typeof parsed.error === "string") {
-        detail = parsed.error;
-      }
+      parsed = JSON.parse(text) as { code?: unknown; error?: unknown };
     } catch {
       // Keep the compact plain-text response as the detail.
+    }
+    if (parsed?.code === "DOCS_UNGROUNDED") {
+      throw new ApiError(
+        "Could not produce a verified documentation answer.",
+        response.status,
+        "Try rephrasing the question so it can be answered from current Sentry documentation.",
+        path
+      );
+    }
+    if (typeof parsed?.error === "string") {
+      detail = parsed.error;
     }
     throw new ApiError(
       "Docs service request failed",

--- a/packages/cli/src/lib/docs-service.ts
+++ b/packages/cli/src/lib/docs-service.ts
@@ -1,0 +1,76 @@
+import { customFetch } from "./custom-ca.js";
+import { refreshToken } from "./db/auth.js";
+import type { DocsProjectContext } from "./docs-context.js";
+import { ApiError } from "./errors.js";
+import { MASTRA_API_URL } from "./init/constants.js";
+import { assertHostedInitServiceAcceptsTokenHost } from "./init/init-service-auth.js";
+
+const DOCS_REQUEST_TIMEOUT_MS = 120_000;
+
+export type DocsQueryResponse = {
+  answer: string;
+  sources: string[];
+};
+
+export type DocsListResponse = {
+  results: { description?: string; title: string; url: string }[];
+};
+
+async function postDocs<T>(
+  path: "/api/docs/query" | "/api/docs/list",
+  body: unknown
+): Promise<T> {
+  assertHostedInitServiceAcceptsTokenHost();
+  const { token } = await refreshToken();
+  const response = await customFetch(`${MASTRA_API_URL}${path}`, {
+    body: JSON.stringify(body),
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+    signal: AbortSignal.timeout(DOCS_REQUEST_TIMEOUT_MS),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    let detail = text;
+    try {
+      const parsed = JSON.parse(text) as { error?: unknown };
+      if (typeof parsed.error === "string") {
+        detail = parsed.error;
+      }
+    } catch {
+      // Keep the compact plain-text response as the detail.
+    }
+    throw new ApiError(
+      "Docs service request failed",
+      response.status,
+      detail,
+      path
+    );
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new ApiError(
+      "Docs service returned invalid JSON",
+      response.status,
+      undefined,
+      path
+    );
+  }
+}
+
+export function queryDocs(
+  query: string,
+  context: DocsProjectContext
+): Promise<DocsQueryResponse> {
+  return postDocs("/api/docs/query", { context, query });
+}
+
+export function listDocs(
+  query: string,
+  limit: number
+): Promise<DocsListResponse> {
+  return postDocs("/api/docs/list", { limit, query });
+}

--- a/packages/cli/test/commands/docs.test.ts
+++ b/packages/cli/test/commands/docs.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { SentryContext } from "../../src/context.js";
+
+const { detectDocsContext, listDocs, queryDocs } = vi.hoisted(() => ({
+  detectDocsContext: vi.fn(),
+  listDocs: vi.fn(),
+  queryDocs: vi.fn(),
+}));
+
+vi.mock("../../src/lib/docs-context.js", () => ({ detectDocsContext }));
+vi.mock("../../src/lib/docs-service.js", () => ({ listDocs, queryDocs }));
+
+import { listCommand } from "../../src/commands/docs/list.js";
+import { queryCommand } from "../../src/commands/docs/query.js";
+
+function createContext(): {
+  context: SentryContext;
+  stdoutWrite: ReturnType<typeof vi.fn>;
+} {
+  const stdoutWrite = vi.fn(() => true);
+  return {
+    context: {
+      configDir: "/tmp",
+      cwd: "/project",
+      env: process.env,
+      homeDir: "/tmp",
+      process,
+      stderr: { write: vi.fn(() => true) },
+      stdin: process.stdin,
+      stdout: { write: stdoutWrite },
+    },
+    stdoutWrite,
+  };
+}
+
+beforeEach(() => {
+  detectDocsContext.mockResolvedValue({
+    frameworks: ["nextjs"],
+    languages: ["javascript"],
+    sentryConfigured: true,
+  });
+  listDocs.mockResolvedValue({
+    results: [
+      {
+        description: "Configure tracing.",
+        title: "Tracing",
+        url: "https://docs.sentry.io/platforms/javascript/tracing/",
+      },
+    ],
+  });
+  queryDocs.mockResolvedValue({
+    answer:
+      "Use [tracing](https://docs.sentry.io/platforms/javascript/tracing/).\n\n## Sources\n\n- <https://docs.sentry.io/platforms/javascript/tracing/>",
+    sources: ["https://docs.sentry.io/platforms/javascript/tracing/"],
+  });
+});
+
+describe("docs commands", () => {
+  test("queries docs with automatic safe context and returns it in JSON", async () => {
+    const { context, stdoutWrite } = createContext();
+    const func = await queryCommand.loader();
+
+    await func.call(context, { json: true }, "How", "do", "I", "trace?");
+
+    expect(queryDocs).toHaveBeenCalledWith("How do I trace?", {
+      frameworks: ["nextjs"],
+      languages: ["javascript"],
+      sentryConfigured: true,
+    });
+    expect(
+      JSON.parse(stdoutWrite.mock.calls.map((call) => call[0]).join(""))
+    ).toEqual({
+      answer:
+        "Use [tracing](https://docs.sentry.io/platforms/javascript/tracing/).\n\n## Sources\n\n- <https://docs.sentry.io/platforms/javascript/tracing/>",
+      detectedContext: {
+        frameworks: ["nextjs"],
+        languages: ["javascript"],
+        sentryConfigured: true,
+      },
+      sources: ["https://docs.sentry.io/platforms/javascript/tracing/"],
+    });
+  });
+
+  test("lists deterministic keyword matches with a bounded limit", async () => {
+    const { context, stdoutWrite } = createContext();
+    const func = await listCommand.loader();
+
+    await func.call(context, { json: false, limit: 5 }, "nextjs", "tracing");
+
+    expect(listDocs).toHaveBeenCalledWith("nextjs tracing", 5);
+    expect(stdoutWrite.mock.calls.map((call) => call[0]).join("")).toContain(
+      "Tracing"
+    );
+  });
+});

--- a/packages/cli/test/lib/completions.property.test.ts
+++ b/packages/cli/test/lib/completions.property.test.ts
@@ -192,6 +192,7 @@ describe("proposeCompletions: Stricli integration", () => {
     "project",
     "replay",
     "dashboard",
+    "docs",
     "trace",
     "span",
     "log",

--- a/packages/cli/test/lib/docs-context.test.ts
+++ b/packages/cli/test/lib/docs-context.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+import {
+  DOCS_CONTEXT_MANIFESTS,
+  detectDocsContextFromReader,
+} from "../../src/lib/docs-context.js";
+
+describe("detectDocsContextFromReader", () => {
+  test("returns only normalized framework and language signals", async () => {
+    const requested: string[] = [];
+    const context = await detectDocsContextFromReader({
+      async readManifest(name) {
+        requested.push(name);
+        if (name === "package.json") {
+          return JSON.stringify({
+            dependencies: { "@sentry/nextjs": "9.0.0", next: "15.0.0" },
+            scripts: { secret: "not sent" },
+          });
+        }
+        if (name === "pyproject.toml") {
+          return "[project]\ndependencies = ['django']";
+        }
+        return;
+      },
+      async hasConfig(name) {
+        return name === "sentry.client.config.ts";
+      },
+    });
+
+    expect(context).toEqual({
+      frameworks: ["django", "nextjs"],
+      languages: ["javascript", "python"],
+      sentryConfigured: true,
+    });
+    expect(requested).toEqual(DOCS_CONTEXT_MANIFESTS);
+    expect(requested).not.toContain(".env");
+    expect(requested).not.toContain("package-lock.json");
+  });
+
+  test("degrades to an empty context when manifests cannot be read", async () => {
+    const context = await detectDocsContextFromReader({
+      async readManifest() {
+        throw new Error("permission denied");
+      },
+      async hasConfig() {
+        return false;
+      },
+    });
+
+    expect(context).toEqual({
+      frameworks: [],
+      languages: [],
+      sentryConfigured: false,
+    });
+  });
+});

--- a/packages/cli/test/lib/docs-context.test.ts
+++ b/packages/cli/test/lib/docs-context.test.ts
@@ -52,4 +52,19 @@ describe("detectDocsContextFromReader", () => {
       sentryConfigured: false,
     });
   });
+
+  test("does not infer Next.js from an unrelated substring", async () => {
+    const context = await detectDocsContextFromReader({
+      async readManifest(name) {
+        return name === "package.json"
+          ? '{"description":"context"}'
+          : undefined;
+      },
+      async hasConfig() {
+        return false;
+      },
+    });
+
+    expect(context.frameworks).toEqual([]);
+  });
 });

--- a/packages/cli/test/lib/docs-service.test.ts
+++ b/packages/cli/test/lib/docs-service.test.ts
@@ -14,6 +14,7 @@ vi.mock("../../src/lib/init/init-service-auth.js", () => ({
 }));
 
 import { queryDocs } from "../../src/lib/docs-service.js";
+import { EXIT, isUserError } from "../../src/lib/errors.js";
 
 describe("queryDocs", () => {
   test("explains when the service cannot verify a cited answer", async () => {
@@ -36,10 +37,32 @@ describe("queryDocs", () => {
         sentryConfigured: false,
       })
     ).rejects.toMatchObject({
-      detail:
-        "Try rephrasing the question so it can be answered from current Sentry documentation.",
-      message: "Could not produce a verified documentation answer.",
-      status: 502,
+      exitCode: EXIT.API,
+      message: expect.stringContaining(
+        "Could not produce a verified documentation answer."
+      ),
     });
+  });
+
+  test("treats an ungrounded answer as a user-facing failure", async () => {
+    refreshToken.mockResolvedValue({ token: "test-token" });
+    customFetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      text: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          code: "DOCS_UNGROUNDED",
+          error: "Sentry documentation answer could not be verified",
+        })
+      ),
+    });
+
+    const error = await queryDocs("How do I configure tracing?", {
+      frameworks: [],
+      languages: [],
+      sentryConfigured: false,
+    }).catch((caught: unknown) => caught);
+
+    expect(isUserError(error)).toBe(true);
   });
 });

--- a/packages/cli/test/lib/docs-service.test.ts
+++ b/packages/cli/test/lib/docs-service.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test, vi } from "vitest";
+
+const { assertHostedInitServiceAcceptsTokenHost, customFetch, refreshToken } =
+  vi.hoisted(() => ({
+    assertHostedInitServiceAcceptsTokenHost: vi.fn(),
+    customFetch: vi.fn(),
+    refreshToken: vi.fn(),
+  }));
+
+vi.mock("../../src/lib/custom-ca.js", () => ({ customFetch }));
+vi.mock("../../src/lib/db/auth.js", () => ({ refreshToken }));
+vi.mock("../../src/lib/init/init-service-auth.js", () => ({
+  assertHostedInitServiceAcceptsTokenHost,
+}));
+
+import { queryDocs } from "../../src/lib/docs-service.js";
+
+describe("queryDocs", () => {
+  test("explains when the service cannot verify a cited answer", async () => {
+    refreshToken.mockResolvedValue({ token: "test-token" });
+    customFetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      text: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          code: "DOCS_UNGROUNDED",
+          error: "Sentry documentation answer could not be verified",
+        })
+      ),
+    });
+
+    await expect(
+      queryDocs("How do I configure tracing?", {
+        frameworks: [],
+        languages: [],
+        sentryConfigured: false,
+      })
+    ).rejects.toMatchObject({
+      detail:
+        "Try rephrasing the question so it can be answered from current Sentry documentation.",
+      message: "Could not produce a verified documentation answer.",
+      status: 502,
+    });
+  });
+});


### PR DESCRIPTION
Adds `sentry docs <question>`, explicit `docs query` and `docs search` aliases, and `docs list <keywords>` for deterministic discovery. Query output is cited Markdown and JSON exposes the answer, sources, and detected context.

Automatic context is deliberately metadata-only: a fixed manifest allowlist and Sentry config presence produce normalized framework, language, and configuration signals. No source files, lockfiles, environment files, paths, DSNs, tokens, or raw configuration leave the machine.

The docs-site fragment and completion coverage recognize `docs` as a default-command route. Depends on getsentry/cli-init-api#254. `init` behavior is unchanged.
