### PR TITLE
feat(sdk): Add headers option to createSentrySDK

### DIFF
--- a/apps/cli-docs/src/content/docs/library-usage.md
+++ b/apps/cli-docs/src/content/docs/library-usage.md
@@ -153,6 +153,7 @@ const sdk = createSentrySDK({ token: "...", text: true, cwd: "/my/project" });
 | `project` | `string` | Auto-detected | Default project slug |
 | `text` | `boolean` | `false` | Return human-readable text instead of parsed JSON (`run()` only) |
 | `cwd` | `string` | `process.cwd()` | Working directory for DSN auto-detection |
+| `headers` | `Record<string, string>` | — | Extra HTTP headers for self-hosted instances behind a reverse proxy (same as [`SENTRY_CUSTOM_HEADERS`](./configuration/#sentry_custom_headers)); ignored for sentry.io |
 | `signal` | `AbortSignal` | — | Abort signal for cancelling streaming commands |
 
 ## Return Values

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -111,6 +111,7 @@ Options (all optional):
 - `project` — Default project slug.
 - `text` — Return human-readable string instead of parsed JSON (affects `run()` only).
 - `cwd` — Working directory for DSN auto-detection. Defaults to `process.cwd()`.
+- `headers` — Extra HTTP headers for self-hosted instances behind a reverse proxy (same as `SENTRY_CUSTOM_HEADERS`). Ignored for sentry.io.
 - `signal` — `AbortSignal` to cancel streaming commands (`--follow`, `--refresh`).
 
 Streaming commands return `AsyncIterable` — use `for await...of` and `break` to stop.

--- a/packages/cli/src/lib/custom-headers.ts
+++ b/packages/cli/src/lib/custom-headers.ts
@@ -127,6 +127,34 @@ export function parseCustomHeaders(raw: string): readonly [string, string][] {
 }
 
 /**
+ * Serialize a header map into the `SENTRY_CUSTOM_HEADERS` string format.
+ *
+ * Inverse of {@link parseCustomHeaders}: the result round-trips through it.
+ * A value containing a separator (`;` or a line break) would be split into a
+ * bogus extra header on parse, so it is rejected up front.
+ *
+ * @param headers - Header name/value map (e.g., from `SentryOptions.headers`)
+ * @returns Semicolon-separated `Name: Value` string, or `undefined` when empty
+ * @throws {ConfigError} On separator characters in a value
+ */
+export function formatCustomHeaders(
+  headers: Record<string, string>
+): string | undefined {
+  const entries = Object.entries(headers);
+  if (entries.length === 0) {
+    return;
+  }
+  for (const [name, value] of entries) {
+    if (HEADER_SEPARATOR_RE.test(value) || TRAILING_CR_RE.test(value)) {
+      throw new ConfigError(
+        `Invalid value for header '${name}': values must not contain ';' or line breaks.`
+      );
+    }
+  }
+  return entries.map(([name, value]) => `${name}: ${value}`).join("; ");
+}
+
+/**
  * Check whether the current target is a self-hosted Sentry instance.
  *
  * Self-hosted = `SENTRY_HOST` or `SENTRY_URL` is set to a non-SaaS URL.

--- a/packages/cli/src/lib/custom-headers.ts
+++ b/packages/cli/src/lib/custom-headers.ts
@@ -8,6 +8,10 @@
  *
  * Format: semicolon-separated `Name: Value` pairs (newlines also accepted).
  *
+ * The library API (`createSentrySDK({ headers })`) bypasses the string format
+ * and sets the structured headers for the current invocation via
+ * {@link setCustomHeadersOverride}, validated with the same rules.
+ *
  * @example
  * ```bash
  * # Single header
@@ -71,6 +75,33 @@ let saasWarningLogged = false;
 let untrustedDestinationWarningLogged = false;
 
 /**
+ * Structured headers set by the library API for the current invocation.
+ * `undefined` = not set, fall through to the env var / SQLite defaults.
+ */
+let overrideHeaders: readonly [string, string][] | undefined;
+
+/**
+ * Validate a header name against RFC 7230 token rules and the reserved list.
+ *
+ * @param name - Trimmed header name
+ * @param source - Where the header came from, for the error message
+ * @throws {ConfigError} On invalid or reserved header names
+ */
+function assertValidHeaderName(name: string, source: string): void {
+  if (!VALID_HEADER_NAME_RE.test(name)) {
+    throw new ConfigError(
+      `Invalid header name '${name}' in ${source}. Header names must contain only alphanumeric characters, hyphens, and RFC 7230 token characters.`
+    );
+  }
+
+  if (FORBIDDEN_HEADER_NAMES.has(name.toLowerCase())) {
+    throw new ConfigError(
+      `Cannot override reserved header '${name}' in ${source}. This header is managed by the CLI.`
+    );
+  }
+}
+
+/**
  * Parse a raw custom headers string into validated name/value pairs.
  *
  * Accepts semicolon-separated or newline-separated `Name: Value` entries.
@@ -108,17 +139,7 @@ export function parseCustomHeaders(raw: string): readonly [string, string][] {
       );
     }
 
-    if (!VALID_HEADER_NAME_RE.test(name)) {
-      throw new ConfigError(
-        `Invalid header name '${name}' in SENTRY_CUSTOM_HEADERS. Header names must contain only alphanumeric characters, hyphens, and RFC 7230 token characters.`
-      );
-    }
-
-    if (FORBIDDEN_HEADER_NAMES.has(name.toLowerCase())) {
-      throw new ConfigError(
-        `Cannot override reserved header '${name}' in SENTRY_CUSTOM_HEADERS. This header is managed by the CLI.`
-      );
-    }
+    assertValidHeaderName(name, "SENTRY_CUSTOM_HEADERS");
 
     results.push([name, value]);
   }
@@ -127,31 +148,38 @@ export function parseCustomHeaders(raw: string): readonly [string, string][] {
 }
 
 /**
- * Serialize a header map into the `SENTRY_CUSTOM_HEADERS` string format.
+ * Set structured custom headers for the current library invocation.
  *
- * Inverse of {@link parseCustomHeaders}: the result round-trips through it.
- * A value containing a separator (`;` or a line break) would be split into a
- * bogus extra header on parse, so it is rejected up front.
+ * Bypasses `SENTRY_CUSTOM_HEADERS` and the SQLite defaults entirely: no
+ * string round-trip, and an explicit map (even an empty one) takes precedence
+ * over an inherited env var. The self-hosted guard and the request-origin
+ * trust check in {@link applyCustomHeaders} still apply.
  *
- * @param headers - Header name/value map (e.g., from `SentryOptions.headers`)
- * @returns Semicolon-separated `Name: Value` string, or `undefined` when empty
- * @throws {ConfigError} On separator characters in a value
+ * Pass `undefined` to clear. The SDK invoke layer calls this next to `setEnv`.
+ *
+ * @param headers - Header name/value map from `SentryOptions.headers`
+ * @throws {ConfigError} On invalid or reserved header names
  */
-export function formatCustomHeaders(
-  headers: Record<string, string>
-): string | undefined {
-  const entries = Object.entries(headers);
-  if (entries.length === 0) {
+export function setCustomHeadersOverride(
+  headers: Record<string, string> | undefined
+): void {
+  if (headers === undefined) {
+    overrideHeaders = undefined;
     return;
   }
-  for (const [name, value] of entries) {
-    if (HEADER_SEPARATOR_RE.test(value) || TRAILING_CR_RE.test(value)) {
+
+  const entries: [string, string][] = [];
+  for (const [rawName, rawValue] of Object.entries(headers)) {
+    const name = rawName.trim();
+    if (!name) {
       throw new ConfigError(
-        `Invalid value for header '${name}': values must not contain ';' or line breaks.`
+        "Invalid header in SentryOptions.headers: empty header name."
       );
     }
+    assertValidHeaderName(name, "SentryOptions.headers");
+    entries.push([name, rawValue.trim()]);
   }
-  return entries.map(([name, value]) => `${name}: ${value}`).join("; ");
+  overrideHeaders = entries;
 }
 
 /**
@@ -189,6 +217,20 @@ function resolveRawHeaders(): string | undefined {
   return;
 }
 
+/** Self-hosted guard: warn once and report false on SaaS. */
+function passesSelfHostedGuard(): boolean {
+  if (isSelfHosted()) {
+    return true;
+  }
+  if (!saasWarningLogged) {
+    saasWarningLogged = true;
+    log.warn(
+      "Custom headers are set but no self-hosted Sentry instance is configured. Headers will be ignored."
+    );
+  }
+  return false;
+}
+
 /**
  * Get the parsed custom headers for the current session.
  *
@@ -200,19 +242,18 @@ function resolveRawHeaders(): string | undefined {
  * because `SENTRY_HOST` can be set dynamically by URL argument parsing.
  */
 export function getCustomHeaders(): readonly [string, string][] {
+  if (overrideHeaders !== undefined) {
+    return overrideHeaders.length > 0 && passesSelfHostedGuard()
+      ? overrideHeaders
+      : [];
+  }
+
   const raw = resolveRawHeaders();
   if (!raw) {
     return [];
   }
 
-  // Self-hosted guard: warn once and skip on SaaS
-  if (!isSelfHosted()) {
-    if (!saasWarningLogged) {
-      saasWarningLogged = true;
-      log.warn(
-        "SENTRY_CUSTOM_HEADERS is set but no self-hosted Sentry instance is configured. Headers will be ignored."
-      );
-    }
+  if (!passesSelfHostedGuard()) {
     return [];
   }
 
@@ -273,6 +314,7 @@ export function applyCustomHeaders(
 export function _resetCustomHeadersCache(): void {
   cachedHeaders = undefined;
   cachedRawSource = undefined;
+  overrideHeaders = undefined;
   saasWarningLogged = false;
   untrustedDestinationWarningLogged = false;
 }

--- a/packages/cli/src/lib/sdk-invoke.ts
+++ b/packages/cli/src/lib/sdk-invoke.ts
@@ -18,7 +18,6 @@ import { homedir } from "node:os";
 import type { Span } from "@sentry/core";
 import type { Writer } from "../types/index.js";
 import { type AsyncChannel, createAsyncChannel } from "./async-channel.js";
-import { formatCustomHeaders } from "./custom-headers.js";
 import { setEnv } from "./env.js";
 import { SentryError, type SentryOptions } from "./sdk-types.js";
 
@@ -32,7 +31,7 @@ function hasStreamingFlag(args: string[]): boolean {
 
 /**
  * Build an isolated env from options, inheriting the consumer's process.env.
- * Sets auth token, host URL, default org/project, custom headers, and output format.
+ * Sets auth token, host URL, default org/project, and output format.
  */
 function buildIsolatedEnv(
   options?: SentryOptions,
@@ -51,12 +50,6 @@ function buildIsolatedEnv(
   }
   if (options?.project) {
     env.SENTRY_PROJECT = options.project;
-  }
-  if (options?.headers) {
-    const customHeaders = formatCustomHeaders(options.headers);
-    if (customHeaders) {
-      env.SENTRY_CUSTOM_HEADERS = customHeaders;
-    }
   }
   if (jsonByDefault && !options?.text) {
     env.SENTRY_OUTPUT_FORMAT = "json";
@@ -199,6 +192,19 @@ export function applyFlagDefaults(
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape sequences use ESC (0x1b)
 const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+/**
+ * Install the structured `headers` option for this invocation.
+ *
+ * Lazy import: `custom-headers.ts` pulls in the SQLite defaults module, which
+ * must not load when the SDK is merely imported.
+ */
+async function applyHeadersOption(
+  headers: Record<string, string> | undefined
+): Promise<void> {
+  const { setCustomHeadersOverride } = await import("./custom-headers.js");
+  setCustomHeadersOverride(headers);
+}
 
 /** Flush Sentry telemetry (no beforeExit handler in library mode). */
 async function flushTelemetry(): Promise<void> {
@@ -410,6 +416,7 @@ async function executeWithCapture<T>(
   setEnv(env);
 
   try {
+    await applyHeadersOption(options?.headers);
     const captureCtx = await buildCaptureContext(env, cwd);
     const { withTelemetry } = await import("./telemetry.js");
 
@@ -448,6 +455,7 @@ async function executeWithCapture<T>(
       captureCtx.stdoutChunks
     );
   } finally {
+    await applyHeadersOption(undefined);
     setEnv(process.env);
   }
 }
@@ -492,6 +500,7 @@ function executeWithStream<T>(
 
     let captureCtx: CaptureContext | undefined;
     try {
+      await applyHeadersOption(options?.headers);
       captureCtx = await buildCaptureContext(env, cwd, {
         channel: channel as AsyncChannel<unknown>,
         abortSignal: controller.signal,
@@ -536,6 +545,7 @@ function executeWithStream<T>(
       channel.error(err);
     } finally {
       await flushTelemetry();
+      await applyHeadersOption(undefined);
       setEnv(process.env);
     }
   })();

--- a/packages/cli/src/lib/sdk-invoke.ts
+++ b/packages/cli/src/lib/sdk-invoke.ts
@@ -18,6 +18,7 @@ import { homedir } from "node:os";
 import type { Span } from "@sentry/core";
 import type { Writer } from "../types/index.js";
 import { type AsyncChannel, createAsyncChannel } from "./async-channel.js";
+import { formatCustomHeaders } from "./custom-headers.js";
 import { setEnv } from "./env.js";
 import { SentryError, type SentryOptions } from "./sdk-types.js";
 
@@ -31,7 +32,7 @@ function hasStreamingFlag(args: string[]): boolean {
 
 /**
  * Build an isolated env from options, inheriting the consumer's process.env.
- * Sets auth token, host URL, default org/project, and output format.
+ * Sets auth token, host URL, default org/project, custom headers, and output format.
  */
 function buildIsolatedEnv(
   options?: SentryOptions,
@@ -50,6 +51,12 @@ function buildIsolatedEnv(
   }
   if (options?.project) {
     env.SENTRY_PROJECT = options.project;
+  }
+  if (options?.headers) {
+    const customHeaders = formatCustomHeaders(options.headers);
+    if (customHeaders) {
+      env.SENTRY_CUSTOM_HEADERS = customHeaders;
+    }
   }
   if (jsonByDefault && !options?.text) {
     env.SENTRY_OUTPUT_FORMAT = "json";

--- a/packages/cli/src/lib/sdk-types.ts
+++ b/packages/cli/src/lib/sdk-types.ts
@@ -50,8 +50,8 @@ export type SentryOptions = {
   /**
    * Extra HTTP headers to send with every request to a self-hosted Sentry
    * instance, for reverse proxies that require them (e.g., Google IAP,
-   * Cloudflare Access). Equivalent to `SENTRY_CUSTOM_HEADERS`; ignored when
-   * targeting sentry.io.
+   * Cloudflare Access). Same rules as `SENTRY_CUSTOM_HEADERS`, which this
+   * option replaces when set (even when empty); ignored when targeting sentry.io.
    */
   headers?: Record<string, string>;
 

--- a/packages/cli/src/lib/sdk-types.ts
+++ b/packages/cli/src/lib/sdk-types.ts
@@ -48,6 +48,14 @@ export type SentryOptions = {
   cwd?: string;
 
   /**
+   * Extra HTTP headers to send with every request to a self-hosted Sentry
+   * instance, for reverse proxies that require them (e.g., Google IAP,
+   * Cloudflare Access). Equivalent to `SENTRY_CUSTOM_HEADERS`; ignored when
+   * targeting sentry.io.
+   */
+  headers?: Record<string, string>;
+
+  /**
    * Abort signal for cancelling streaming commands.
    * When aborted, streaming iterables stop on the next poll cycle.
    * Consumer `break` in `for await...of` also triggers abort automatically.

--- a/packages/cli/test/lib/custom-headers.test.ts
+++ b/packages/cli/test/lib/custom-headers.test.ts
@@ -13,11 +13,54 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   _resetCustomHeadersCache,
   applyCustomHeaders,
+  formatCustomHeaders,
   getCustomHeaders,
   parseCustomHeaders,
 } from "../../src/lib/custom-headers.js";
 import { setDefaultHeaders } from "../../src/lib/db/defaults.js";
 import { useTestConfigDir } from "../helpers.js";
+
+// ---------------------------------------------------------------------------
+// formatCustomHeaders — serialization for SentryOptions.headers
+// ---------------------------------------------------------------------------
+
+describe("formatCustomHeaders", () => {
+  test("returns undefined for an empty map", () => {
+    expect(formatCustomHeaders({})).toBeUndefined();
+  });
+
+  test("joins headers as semicolon-separated Name: Value pairs", () => {
+    expect(formatCustomHeaders({ "X-First": "one", "X-Second": "two" })).toBe(
+      "X-First: one; X-Second: two"
+    );
+  });
+
+  test("round-trips through parseCustomHeaders", () => {
+    const headers = {
+      "X-IAP-Token": "abc123",
+      "X-Url": "https://example.com/path",
+    };
+    const formatted = formatCustomHeaders(headers);
+    expect(parseCustomHeaders(formatted ?? "")).toEqual(
+      Object.entries(headers)
+    );
+  });
+
+  test("rejects values containing a semicolon", () => {
+    expect(() => formatCustomHeaders({ "X-Bad": "a; b" })).toThrow(
+      "Invalid value for header 'X-Bad'"
+    );
+  });
+
+  test("rejects values containing line breaks", () => {
+    expect(() => formatCustomHeaders({ "X-Bad": "a\nb" })).toThrow(
+      "Invalid value for header 'X-Bad'"
+    );
+    expect(() => formatCustomHeaders({ "X-Bad": "a\r" })).toThrow(
+      "Invalid value for header 'X-Bad'"
+    );
+  });
+});
 
 // ---------------------------------------------------------------------------
 // parseCustomHeaders — parsing logic

--- a/packages/cli/test/lib/custom-headers.test.ts
+++ b/packages/cli/test/lib/custom-headers.test.ts
@@ -13,54 +13,12 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import {
   _resetCustomHeadersCache,
   applyCustomHeaders,
-  formatCustomHeaders,
   getCustomHeaders,
   parseCustomHeaders,
+  setCustomHeadersOverride,
 } from "../../src/lib/custom-headers.js";
 import { setDefaultHeaders } from "../../src/lib/db/defaults.js";
 import { useTestConfigDir } from "../helpers.js";
-
-// ---------------------------------------------------------------------------
-// formatCustomHeaders — serialization for SentryOptions.headers
-// ---------------------------------------------------------------------------
-
-describe("formatCustomHeaders", () => {
-  test("returns undefined for an empty map", () => {
-    expect(formatCustomHeaders({})).toBeUndefined();
-  });
-
-  test("joins headers as semicolon-separated Name: Value pairs", () => {
-    expect(formatCustomHeaders({ "X-First": "one", "X-Second": "two" })).toBe(
-      "X-First: one; X-Second: two"
-    );
-  });
-
-  test("round-trips through parseCustomHeaders", () => {
-    const headers = {
-      "X-IAP-Token": "abc123",
-      "X-Url": "https://example.com/path",
-    };
-    const formatted = formatCustomHeaders(headers);
-    expect(parseCustomHeaders(formatted ?? "")).toEqual(
-      Object.entries(headers)
-    );
-  });
-
-  test("rejects values containing a semicolon", () => {
-    expect(() => formatCustomHeaders({ "X-Bad": "a; b" })).toThrow(
-      "Invalid value for header 'X-Bad'"
-    );
-  });
-
-  test("rejects values containing line breaks", () => {
-    expect(() => formatCustomHeaders({ "X-Bad": "a\nb" })).toThrow(
-      "Invalid value for header 'X-Bad'"
-    );
-    expect(() => formatCustomHeaders({ "X-Bad": "a\r" })).toThrow(
-      "Invalid value for header 'X-Bad'"
-    );
-  });
-});
 
 // ---------------------------------------------------------------------------
 // parseCustomHeaders — parsing logic
@@ -283,6 +241,100 @@ describe("getCustomHeaders", () => {
     const second = getCustomHeaders();
     // Same reference (cached)
     expect(first).toBe(second);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setCustomHeadersOverride — structured headers from SentryOptions.headers
+// ---------------------------------------------------------------------------
+
+describe("setCustomHeadersOverride", () => {
+  useTestConfigDir("custom-headers-override-test-", {
+    isolateProjectRoot: true,
+  });
+
+  let savedHeaders: string | undefined;
+  let savedHost: string | undefined;
+
+  beforeEach(() => {
+    savedHeaders = process.env.SENTRY_CUSTOM_HEADERS;
+    savedHost = process.env.SENTRY_HOST;
+    delete process.env.SENTRY_CUSTOM_HEADERS;
+    process.env.SENTRY_HOST = "https://sentry.example.com";
+    _resetCustomHeadersCache();
+  });
+
+  afterEach(() => {
+    if (savedHeaders !== undefined) {
+      process.env.SENTRY_CUSTOM_HEADERS = savedHeaders;
+    } else {
+      delete process.env.SENTRY_CUSTOM_HEADERS;
+    }
+    if (savedHost !== undefined) {
+      process.env.SENTRY_HOST = savedHost;
+    } else {
+      delete process.env.SENTRY_HOST;
+    }
+    _resetCustomHeadersCache();
+  });
+
+  test("returns the structured headers without a string round-trip", () => {
+    setCustomHeadersOverride({
+      "X-IAP-Token": "abc123",
+      "X-Url": "https://example.com/a;b",
+    });
+    expect(getCustomHeaders()).toEqual([
+      ["X-IAP-Token", "abc123"],
+      ["X-Url", "https://example.com/a;b"],
+    ]);
+  });
+
+  test("takes precedence over SENTRY_CUSTOM_HEADERS", () => {
+    process.env.SENTRY_CUSTOM_HEADERS = "X-Env: from-env";
+    setCustomHeadersOverride({ "X-Option": "from-option" });
+    expect(getCustomHeaders()).toEqual([["X-Option", "from-option"]]);
+  });
+
+  test("an empty map disables inherited env headers", () => {
+    process.env.SENTRY_CUSTOM_HEADERS = "X-Env: from-env";
+    setCustomHeadersOverride({});
+    expect(getCustomHeaders()).toEqual([]);
+  });
+
+  test("clearing falls back to SENTRY_CUSTOM_HEADERS", () => {
+    process.env.SENTRY_CUSTOM_HEADERS = "X-Env: from-env";
+    setCustomHeadersOverride({ "X-Option": "from-option" });
+    setCustomHeadersOverride(undefined);
+    expect(getCustomHeaders()).toEqual([["X-Env", "from-env"]]);
+  });
+
+  test("is ignored when targeting SaaS", () => {
+    delete process.env.SENTRY_HOST;
+    setCustomHeadersOverride({ "X-IAP-Token": "abc123" });
+    expect(getCustomHeaders()).toEqual([]);
+  });
+
+  test("trims names and values", () => {
+    setCustomHeadersOverride({ " X-Trim ": "  value  " });
+    expect(getCustomHeaders()).toEqual([["X-Trim", "value"]]);
+  });
+
+  test("throws ConfigError on empty header name", () => {
+    expect(() => setCustomHeadersOverride({ "  ": "value" })).toThrow(
+      "empty header name"
+    );
+  });
+
+  test("throws ConfigError on invalid header name", () => {
+    expect(() => setCustomHeadersOverride({ "X Bad": "value" })).toThrow(
+      "Invalid header name 'X Bad' in SentryOptions.headers"
+    );
+  });
+
+  test("throws ConfigError on reserved header name", () => {
+    expect(() => setCustomHeadersOverride({ Authorization: "x" })).toThrow(
+      "Cannot override reserved header 'Authorization' in SentryOptions.headers"
+    );
   });
 });
 


### PR DESCRIPTION
Consumers of the programmatic SDK, such as the Sentry bundler plugins, need to send extra HTTP headers to self-hosted instances behind a reverse proxy (Google IAP, Cloudflare Access). Until now the only way was to set `SENTRY_CUSTOM_HEADERS` on `process.env` before invoking a command, which is process-global state.

`SentryOptions.headers` maps onto `SENTRY_CUSTOM_HEADERS` in the isolated env of each invocation, so the existing self-hosted guard, forbidden-header list, and origin trust checks all apply unchanged. Values containing a separator are rejected up front, since they would otherwise parse into a bogus extra header.