### PR TITLE
feat(docs): Add query loading feedback

### DIFF
--- a/packages/cli/src/commands/docs/query.ts
+++ b/packages/cli/src/commands/docs/query.ts
@@ -4,6 +4,7 @@ import { detectDocsContext } from "../../lib/docs-context.js";
 import { queryDocs } from "../../lib/docs-service.js";
 import { ValidationError } from "../../lib/errors.js";
 import { CommandOutput } from "../../lib/formatters/output.js";
+import { withProgress } from "../../lib/polling.js";
 
 type QueryFlags = { readonly fields?: string[]; readonly json: boolean };
 type QueryOutput = {
@@ -11,6 +12,14 @@ type QueryOutput = {
   detectedContext: Awaited<ReturnType<typeof detectDocsContext>>;
   sources: string[];
 };
+
+/** Friendly wait messages for a docs-MCP request without measurable stages. */
+const DOCS_QUERY_PROGRESS_MESSAGES = [
+  "Finding the relevant bits…",
+  "Cross-checking the details…",
+  "It’s getting there…",
+  "Collecting trusted sources…",
+] as const;
 
 function formatQueryHuman(data: QueryOutput): string {
   return data.answer;
@@ -45,7 +54,15 @@ export const queryCommand = buildCommand({
       );
     }
     const detectedContext = await detectDocsContext(this.cwd);
-    const result = await queryDocs(query, detectedContext);
+    const result = await withProgress(
+      {
+        json: _flags.json,
+        message: "Searching Sentry docs…",
+        rotatingMessages: DOCS_QUERY_PROGRESS_MESSAGES,
+        rotationIntervalMs: 4000,
+      },
+      async () => queryDocs(query, detectedContext)
+    );
     yield new CommandOutput<QueryOutput>({ ...result, detectedContext });
   },
 });

--- a/packages/cli/src/commands/docs/query.ts
+++ b/packages/cli/src/commands/docs/query.ts
@@ -56,6 +56,7 @@ export const queryCommand = buildCommand({
     const detectedContext = await detectDocsContext(this.cwd);
     const result = await withProgress(
       {
+        interactiveOnly: true,
         json: _flags.json,
         message: "Searching Sentry docs…",
         rotatingMessages: DOCS_QUERY_PROGRESS_MESSAGES,

--- a/packages/cli/src/lib/polling.ts
+++ b/packages/cli/src/lib/polling.ts
@@ -19,6 +19,9 @@ const DEFAULT_POLL_INTERVAL_MS = 1000;
 /** Animation interval for spinner updates — 50ms gives 20fps, matching the ora/inquirer standard */
 const ANIMATION_INTERVAL_MS = 50;
 
+/** Default interval between automatic progress-message updates. */
+const DEFAULT_PROGRESS_ROTATION_INTERVAL_MS = 4000;
+
 /** Default timeout in milliseconds (6 minutes) */
 const DEFAULT_TIMEOUT_MS = 360_000;
 
@@ -157,11 +160,21 @@ function startSpinner(initialMessage: string): {
  * Options for {@link withProgress}.
  */
 export type WithProgressOptions = {
-  /** Initial spinner message */
+  /** Initial spinner message displayed until a rotating message replaces it. */
   message: string;
   /** Suppress progress output (JSON mode). When true, the operation runs
    *  without a spinner — matching the behaviour of {@link poll}. */
   json?: boolean;
+  /**
+   * Messages to show in sequence while the operation is pending. Omit or pass
+   * an empty array to leave the initial message in place.
+   */
+  rotatingMessages?: readonly string[];
+  /**
+   * Milliseconds between rotating-message updates. Defaults to 4 seconds and
+   * is ignored when {@link rotatingMessages} is empty.
+   */
+  rotationIntervalMs?: number;
 };
 
 /**
@@ -177,7 +190,9 @@ export type WithProgressOptions = {
  *
  * The callback receives a `setMessage` function to update the displayed
  * message as work progresses (e.g. to show page counts during pagination).
- * Progress is automatically cleared when the operation completes.
+ * Optional rotating messages provide friendly feedback for operations whose
+ * progress cannot be measured directly. Progress is automatically cleared
+ * when the operation completes or fails.
  *
  * @param options - Spinner configuration
  * @param fn - Async operation to run; receives `setMessage` to update the displayed text
@@ -208,10 +223,29 @@ export async function withProgress<T>(
   }
 
   const spinner = startSpinner(options.message);
+  const rotatingMessages = options.rotatingMessages ?? [];
+  const rotationIntervalMs =
+    options.rotationIntervalMs ?? DEFAULT_PROGRESS_ROTATION_INTERVAL_MS;
+  let rotationTimer: NodeJS.Timeout | undefined;
+
+  if (rotatingMessages.length > 0 && rotationIntervalMs > 0) {
+    let messageIndex = 0;
+    rotationTimer = setInterval(() => {
+      const message = rotatingMessages[messageIndex];
+      if (message !== undefined) {
+        spinner.setMessage(message);
+      }
+      messageIndex = (messageIndex + 1) % rotatingMessages.length;
+    }, rotationIntervalMs);
+    rotationTimer.unref();
+  }
 
   try {
     return await fn(spinner.setMessage);
   } finally {
+    if (rotationTimer) {
+      clearInterval(rotationTimer);
+    }
     spinner.stop();
     process.stdout.write("\r\x1b[K");
   }

--- a/packages/cli/src/lib/polling.ts
+++ b/packages/cli/src/lib/polling.ts
@@ -166,6 +166,12 @@ export type WithProgressOptions = {
    *  without a spinner — matching the behaviour of {@link poll}. */
   json?: boolean;
   /**
+   * Suppress progress when stdout is not a terminal, even if rich output is
+   * explicitly forced. Use for terminal-only feedback that must not enter a
+   * machine-readable pipe.
+   */
+  interactiveOnly?: boolean;
+  /**
    * Messages to show in sequence while the operation is pending. Omit or pass
    * an empty array to leave the initial message in place.
    */
@@ -215,7 +221,11 @@ export async function withProgress<T>(
   options: WithProgressOptions,
   fn: (setMessage: (msg: string) => void) => Promise<T>
 ): Promise<T> {
-  if (options.json || isPlainOutput()) {
+  if (
+    options.json ||
+    isPlainOutput() ||
+    (options.interactiveOnly && !process.stdout.isTTY)
+  ) {
     // JSON mode or non-TTY: skip the spinner entirely, pass a no-op setMessage
     return fn(() => {
       /* spinner suppressed */

--- a/packages/cli/test/commands/docs.test.ts
+++ b/packages/cli/test/commands/docs.test.ts
@@ -1,14 +1,18 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { SentryContext } from "../../src/context.js";
 
-const { detectDocsContext, listDocs, queryDocs } = vi.hoisted(() => ({
-  detectDocsContext: vi.fn(),
-  listDocs: vi.fn(),
-  queryDocs: vi.fn(),
-}));
+const { detectDocsContext, listDocs, queryDocs, withProgress } = vi.hoisted(
+  () => ({
+    detectDocsContext: vi.fn(),
+    listDocs: vi.fn(),
+    queryDocs: vi.fn(),
+    withProgress: vi.fn(),
+  })
+);
 
 vi.mock("../../src/lib/docs-context.js", () => ({ detectDocsContext }));
 vi.mock("../../src/lib/docs-service.js", () => ({ listDocs, queryDocs }));
+vi.mock("../../src/lib/polling.js", () => ({ withProgress }));
 
 import { listCommand } from "../../src/commands/docs/list.js";
 import { queryCommand } from "../../src/commands/docs/query.js";
@@ -34,6 +38,12 @@ function createContext(): {
 }
 
 beforeEach(() => {
+  withProgress.mockReset();
+  withProgress.mockImplementation(async (_options, fn) =>
+    fn(() => {
+      /* Progress rendering is covered by polling tests. */
+    })
+  );
   detectDocsContext.mockResolvedValue({
     frameworks: ["nextjs"],
     languages: ["javascript"],
@@ -79,6 +89,20 @@ describe("docs commands", () => {
       },
       sources: ["https://docs.sentry.io/platforms/javascript/tracing/"],
     });
+    expect(withProgress).toHaveBeenCalledWith(
+      {
+        json: true,
+        message: "Searching Sentry docs…",
+        rotatingMessages: [
+          "Finding the relevant bits…",
+          "Cross-checking the details…",
+          "It’s getting there…",
+          "Collecting trusted sources…",
+        ],
+        rotationIntervalMs: 4000,
+      },
+      expect.any(Function)
+    );
   });
 
   test("lists deterministic keyword matches with a bounded limit", async () => {
@@ -91,5 +115,6 @@ describe("docs commands", () => {
     expect(stdoutWrite.mock.calls.map((call) => call[0]).join("")).toContain(
       "Tracing"
     );
+    expect(withProgress).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/test/commands/docs.test.ts
+++ b/packages/cli/test/commands/docs.test.ts
@@ -1,4 +1,6 @@
+import { buildApplication, run } from "@stricli/core";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { docsRoute } from "../../src/commands/docs/index.js";
 import type { SentryContext } from "../../src/context.js";
 
 const { detectDocsContext, listDocs, queryDocs, withProgress } = vi.hoisted(
@@ -35,6 +37,14 @@ function createContext(): {
     },
     stdoutWrite,
   };
+}
+
+async function runDocsRoute(
+  context: SentryContext,
+  args: string[]
+): Promise<void> {
+  const app = buildApplication(docsRoute, { name: "sentry docs" });
+  await run(app, args, context);
 }
 
 beforeEach(() => {
@@ -92,6 +102,7 @@ describe("docs commands", () => {
     expect(withProgress).toHaveBeenCalledWith(
       {
         json: true,
+        interactiveOnly: true,
         message: "Searching Sentry docs…",
         rotatingMessages: [
           "Finding the relevant bits…",
@@ -103,6 +114,22 @@ describe("docs commands", () => {
       },
       expect.any(Function)
     );
+  });
+
+  test.each([
+    ["default query", ["How", "do", "I", "trace?", "--json"]],
+    ["explicit query", ["query", "How", "do", "I", "trace?", "--json"]],
+    ["search alias", ["search", "How", "do", "I", "trace?", "--json"]],
+  ])("routes %s to the docs query command", async (_name, args) => {
+    const { context } = createContext();
+
+    await runDocsRoute(context, args);
+
+    expect(queryDocs).toHaveBeenLastCalledWith("How do I trace?", {
+      frameworks: ["nextjs"],
+      languages: ["javascript"],
+      sentryConfigured: true,
+    });
   });
 
   test("lists deterministic keyword matches with a bounded limit", async () => {

--- a/packages/cli/test/lib/polling.test.ts
+++ b/packages/cli/test/lib/polling.test.ts
@@ -127,4 +127,27 @@ describe("withProgress", () => {
 
     expect(stdoutWrite).not.toHaveBeenCalled();
   });
+
+  test("keeps forced-rich piped output free of interactive-only progress", async () => {
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: false,
+    });
+    vi.stubEnv("SENTRY_PLAIN_OUTPUT", "0");
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    await expect(
+      withProgress(
+        {
+          interactiveOnly: true,
+          message: "Searching Sentry docs…",
+          rotatingMessages: ["It’s getting there…"],
+          rotationIntervalMs: 4000,
+        },
+        async () => "done"
+      )
+    ).resolves.toBe("done");
+
+    expect(stdoutWrite).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/test/lib/polling.test.ts
+++ b/packages/cli/test/lib/polling.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { withProgress } from "../../src/lib/polling.js";
+
+const originalIsTTY = process.stdout.isTTY;
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void;
+  let reject: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, reject: reject!, resolve: resolve! };
+}
+
+function enableInteractiveOutput() {
+  Object.defineProperty(process.stdout, "isTTY", {
+    configurable: true,
+    value: true,
+  });
+  vi.stubEnv("SENTRY_PLAIN_OUTPUT", "0");
+  return vi.spyOn(process.stdout, "write").mockReturnValue(true);
+}
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+  Object.defineProperty(process.stdout, "isTTY", {
+    configurable: true,
+    value: originalIsTTY,
+  });
+  vi.restoreAllMocks();
+});
+
+describe("withProgress", () => {
+  test("rotates progress messages until an interactive operation resolves", async () => {
+    vi.useFakeTimers();
+    const stdoutWrite = enableInteractiveOutput();
+    const deferred = createDeferred<string>();
+    const operation = withProgress(
+      {
+        message: "Searching Sentry docs…",
+        rotatingMessages: ["Finding the relevant bits…"],
+        rotationIntervalMs: 4000,
+      },
+      async () => deferred.promise
+    );
+
+    await vi.advanceTimersByTimeAsync(4000);
+
+    expect(stdoutWrite.mock.calls.flat().join("")).toContain(
+      "Finding the relevant bits…"
+    );
+
+    deferred.resolve("done");
+    await expect(operation).resolves.toBe("done");
+
+    const writesAfterCompletion = stdoutWrite.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(stdoutWrite).toHaveBeenCalledTimes(writesAfterCompletion);
+  });
+
+  test("stops rotating progress messages when an interactive operation rejects", async () => {
+    vi.useFakeTimers();
+    const stdoutWrite = enableInteractiveOutput();
+    const deferred = createDeferred<never>();
+    const operation = withProgress(
+      {
+        message: "Searching Sentry docs…",
+        rotatingMessages: ["It’s getting there…"],
+        rotationIntervalMs: 4000,
+      },
+      async () => deferred.promise
+    );
+
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(stdoutWrite.mock.calls.flat().join("")).toContain(
+      "It’s getting there…"
+    );
+
+    deferred.reject(new Error("docs unavailable"));
+    await expect(operation).rejects.toThrow("docs unavailable");
+
+    const writesAfterRejection = stdoutWrite.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(stdoutWrite).toHaveBeenCalledTimes(writesAfterRejection);
+  });
+
+  test("keeps JSON output free of progress messages", async () => {
+    const stdoutWrite = enableInteractiveOutput();
+
+    await expect(
+      withProgress(
+        {
+          json: true,
+          message: "Searching Sentry docs…",
+          rotatingMessages: ["It’s getting there…"],
+          rotationIntervalMs: 4000,
+        },
+        async () => "done"
+      )
+    ).resolves.toBe("done");
+
+    expect(stdoutWrite).not.toHaveBeenCalled();
+  });
+
+  test("keeps plain output free of progress messages", async () => {
+    Object.defineProperty(process.stdout, "isTTY", {
+      configurable: true,
+      value: true,
+    });
+    vi.stubEnv("SENTRY_PLAIN_OUTPUT", "1");
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    await expect(
+      withProgress(
+        {
+          message: "Searching Sentry docs…",
+          rotatingMessages: ["It’s getting there…"],
+          rotationIntervalMs: 4000,
+        },
+        async () => "done"
+      )
+    ).resolves.toBe("done");
+
+    expect(stdoutWrite).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Docs queries now use the shared terminal spinner with gentle rotating wait messages while docs-MCP prepares a response. The spinner remains absent from JSON and plain output, and docs list behavior is unchanged.

The rotation is timer-based client feedback rather than a claim about server-side MCP stages. It is cleared on success and failure, and is explicitly terminal-only so it cannot enter a forced-rich machine-readable pipe.