### PR TITLE
fix(dashboards): Remove references to removed datasets

### DIFF
--- a/apps/cli-docs/src/content/docs/agent-guidance.md
+++ b/apps/cli-docs/src/content/docs/agent-guidance.md
@@ -208,7 +208,7 @@ Display types with default sizes:
 
 Use **common** types for general dashboards. Use **specialized** only when specifically requested. Avoid **internal** types unless the user explicitly asks.
 
-Available datasets: `spans` (default), `errors`, `transactions`, `metrics`, `issue`, `logs`. Run `sentry dashboard widget --help` for dataset descriptions, query formats, and examples.
+Available datasets: `spans` (default), `errors`, `metrics`, `issue`, `logs`. Run `sentry dashboard widget --help` for dataset descriptions, query formats, and examples.
 
 **Row-filling examples:**
 

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -220,7 +220,7 @@ Display types with default sizes:
 
 Use **common** types for general dashboards. Use **specialized** only when specifically requested. Avoid **internal** types unless the user explicitly asks.
 
-Available datasets: `spans` (default), `errors`, `transactions`, `metrics`, `issue`, `logs`. Run `sentry dashboard widget --help` for dataset descriptions, query formats, and examples.
+Available datasets: `spans` (default), `errors`, `metrics`, `issue`, `logs`. Run `sentry dashboard widget --help` for dataset descriptions, query formats, and examples.
 
 **Row-filling examples:**
 

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/dashboard.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/dashboard.md
@@ -77,7 +77,7 @@ Add a widget to a dashboard
 
 **Flags:**
 - `-d, --display <value> - Display type (big_number, line, area, bar, table, stacked_area, top_n, text, categorical_bar, details, wheel, rage_and_dead_clicks, server_tree, agents_traces_table)`
-- `--dataset <value> - Widget dataset (default: spans). Accepts canonical names and API synonyms: spans, error-events/errors, transaction-like/transactions, tracemetrics/metrics, logs, issue, discover`
+- `--dataset <value> - Widget dataset (default: spans). Accepts canonical names and API synonyms: spans, error-events/errors, tracemetrics/metrics, logs, issue`
 - `-q, --query <value>... - Aggregate expression (e.g. count, p95:span.duration)`
 - `-w, --where <value> - Search conditions filter (e.g. is:unresolved)`
 - `-g, --group-by <value>... - Group-by column (repeatable)`
@@ -123,7 +123,7 @@ Edit a widget in a dashboard
 - `-t, --title <value> - Widget title to match`
 - `--new-title <value> - New widget title`
 - `-d, --display <value> - Display type (big_number, line, area, bar, table, stacked_area, top_n, text, categorical_bar, details, wheel, rage_and_dead_clicks, server_tree, agents_traces_table)`
-- `--dataset <value> - Widget dataset (default: spans). Accepts canonical names and API synonyms: spans, error-events/errors, transaction-like/transactions, tracemetrics/metrics, logs, issue, discover`
+- `--dataset <value> - Widget dataset (default: spans). Accepts canonical names and API synonyms: spans, error-events/errors, tracemetrics/metrics, logs, issue`
 - `-q, --query <value>... - Aggregate expression (e.g. count, p95:span.duration)`
 - `-w, --where <value> - Search conditions filter (e.g. is:unresolved)`
 - `-g, --group-by <value>... - Group-by column (repeatable)`

--- a/packages/cli/src/commands/dashboard/resolve.ts
+++ b/packages/cli/src/commands/dashboard/resolve.ts
@@ -807,18 +807,15 @@ export async function enrichDashboardError(
 /**
  * User-facing dataset synonyms resolved to the canonical Sentry widget type.
  *
- * The Sentry API/UI and docs surface names like `errors` and `transactions`
- * but widget types use `error-events` and `transaction-like`. The CLI accepts
- * both forms so users copying from docs or using API-dataset terminology
- * don't have to translate.
+ * The Sentry API/UI and docs surface names like `errors` but widget types
+ * use `error-events`. The CLI accepts both forms so users copying from
+ * docs or using API-dataset terminology don't have to translate.
  *
  * Keys are lowercase; matching is case-insensitive via {@link normalizeDataset}.
  */
 const DATASET_ALIASES: Record<string, string> = {
   error: "error-events",
   errors: "error-events",
-  transaction: "transaction-like",
-  transactions: "transaction-like",
   log: "logs",
   // `metrics` and `metricsEnhanced` both alias to the canonical `tracemetrics`.
   // `metricsEnhanced` is a legacy API synonym and may appear in older docs.
@@ -838,7 +835,7 @@ const DATASET_ALIASES: Record<string, string> = {
  * Must be called once, up-front, and the result threaded through every
  * downstream consumer (aggregate validator, warnings, PUT body). Leaving
  * an un-normalized value in `flags.dataset` causes dataset-specific
- * aggregate validation (e.g. `failure_rate` for `error-events`) to see
+ * aggregate validation (e.g. `count_if` for `error-events`) to see
  * the alias instead of the canonical name and reject valid inputs.
  */
 export function normalizeDataset(dataset?: string): string | undefined {

--- a/packages/cli/src/commands/dashboard/widget/add.ts
+++ b/packages/cli/src/commands/dashboard/widget/add.ts
@@ -123,7 +123,7 @@ export const addCommand = buildCommand({
         kind: "parsed",
         parse: String,
         brief:
-          "Widget dataset (default: spans). Accepts canonical names and API synonyms: spans, error-events/errors, transaction-like/transactions, tracemetrics/metrics, logs, issue, discover",
+          "Widget dataset (default: spans). Accepts canonical names and API synonyms: spans, error-events/errors, tracemetrics/metrics, logs, issue",
         optional: true,
       },
       query: {

--- a/packages/cli/src/commands/dashboard/widget/edit.ts
+++ b/packages/cli/src/commands/dashboard/widget/edit.ts
@@ -246,7 +246,7 @@ export const editCommand = buildCommand({
         kind: "parsed",
         parse: String,
         brief:
-          "Widget dataset (default: spans). Accepts canonical names and API synonyms: spans, error-events/errors, transaction-like/transactions, tracemetrics/metrics, logs, issue, discover",
+          "Widget dataset (default: spans). Accepts canonical names and API synonyms: spans, error-events/errors, tracemetrics/metrics, logs, issue",
         optional: true,
       },
       query: {
@@ -335,7 +335,7 @@ export const editCommand = buildCommand({
     // Replace flags.dataset with the canonical value so every downstream
     // consumer — validateEnumsAndAggregates, validateAggregateNames, and the
     // PUT body — sees the normalized name. Without this, dataset-aware
-    // aggregate validation (e.g. failure_rate for error-events) would fail
+    // aggregate validation (e.g. count_if for error-events) would fail
     // when the user passes --dataset errors.
     const normalizedDataset = normalizeDataset(flags.dataset);
     const normalizedFlags: EditFlags =

--- a/packages/cli/src/commands/dashboard/widget/index.ts
+++ b/packages/cli/src/commands/dashboard/widget/index.ts
@@ -29,21 +29,15 @@ export const widgetRoute = buildRouteMap({
       "                                Example: p50(value,completion.duration_ms,distribution,none)\n" +
       "                                Supported displays: line, area, bar, big_number,\n" +
       "                                categorical_bar\n" +
-      "  discover                      Legacy discover queries (adds failure_rate,\n" +
-      "                                apdex, etc.)\n" +
       "  issue                         Issue-based queries\n" +
       "  error-events — errors, error  Error event queries\n" +
-      "  transaction-like — transactions, transaction\n" +
-      "                                Transaction-based queries\n" +
       "  logs — log                    Log queries\n\n" +
-      "Dataset values are case-insensitive; Sentry UI/API names like 'errors'\n" +
-      "and 'transactions' are accepted in addition to the canonical forms.\n\n" +
+      "Dataset values are case-insensitive; the Sentry UI/API name 'errors'\n" +
+      "is accepted in addition to the canonical form.\n\n" +
       "Aggregates (spans): count, count_unique, sum, avg, percentile, p50, p75,\n" +
       "  p90, p95, p99, p100, eps, epm, any, min, max\n" +
-      "Aggregates (discover adds): failure_count, failure_rate, apdex,\n" +
-      "  count_miserable, user_misery, count_web_vitals, count_if, count_at_least,\n" +
-      "  last_seen, latest_event, var, stddev, cov, corr, performance_score,\n" +
-      "  opportunity_score, count_scores\n" +
+      "Aggregates (error-events adds): count_if, count_at_least, last_seen,\n" +
+      "  latest_event, var, stddev, cov, corr\n" +
       "Aliases: spm → epm, sps → eps, tpm → epm, tps → eps\n\n" +
       "tracemetrics query format:\n" +
       "  aggregation(value,metric_name,metric_type,unit)\n" +

--- a/packages/cli/src/lib/api/dashboards.ts
+++ b/packages/cli/src/lib/api/dashboards.ts
@@ -480,7 +480,7 @@ async function queryWidgetTimeseries(
       reqParams.topEvents = widget.limit ?? 5;
       // Sort by the aggregate to get the actual top N groups.
       // The sort param is only supported on the spans dataset —
-      // errors/discover endpoints reject it with 400.
+      // the errors endpoint rejects it with 400.
       if (dataset === "spans") {
         reqParams.sort = query.orderby ?? `-${aggregates[0] ?? "count()"}`;
       }
@@ -542,7 +542,7 @@ async function queryWidgetTable(
         start,
         end,
         // sort is only supported on the spans dataset —
-        // errors/discover endpoints reject it with 400.
+        // the errors endpoint rejects it with 400.
         sort: dataset === "spans" ? query?.orderby || undefined : undefined,
         per_page: widget.limit ?? 10,
         environment: options.environment,

--- a/packages/cli/src/types/dashboard.ts
+++ b/packages/cli/src/types/dashboard.ts
@@ -42,10 +42,8 @@ import { logger } from "../lib/logger.js";
  * Source: sentry/src/sentry/models/dashboard_widget.py DashboardWidgetTypes.TYPES
  */
 export const WIDGET_TYPES = [
-  "discover",
   "issue",
   "error-events",
-  "transaction-like",
   "spans",
   "logs",
   "tracemetrics",
@@ -272,20 +270,13 @@ export const SPAN_AGGREGATE_FUNCTIONS = [
 export type SpanAggregateFunction = (typeof SPAN_AGGREGATE_FUNCTIONS)[number];
 
 /**
- * Additional aggregate functions from the discover dataset.
- * Available when widgetType is "discover" or "error-events".
+ * Additional aggregate functions for the error-events dataset.
+ * Available when widgetType is "error-events".
  *
  * Source: https://github.com/getsentry/sentry/blob/master/src/sentry/search/events/constants.py
- * Dataset: https://github.com/getsentry/sentry/blob/master/src/sentry/search/events/datasets/discover.py
  */
-export const DISCOVER_AGGREGATE_FUNCTIONS = [
+export const ERROR_AGGREGATE_FUNCTIONS = [
   ...SPAN_AGGREGATE_FUNCTIONS,
-  "failure_count",
-  "failure_rate",
-  "apdex",
-  "count_miserable",
-  "user_misery",
-  "count_web_vitals",
   "count_if",
   "count_at_least",
   "last_seen",
@@ -294,21 +285,15 @@ export const DISCOVER_AGGREGATE_FUNCTIONS = [
   "stddev",
   "cov",
   "corr",
-  "performance_score",
-  "opportunity_score",
-  "count_scores",
 ] as const;
 
-export type DiscoverAggregateFunction =
-  (typeof DISCOVER_AGGREGATE_FUNCTIONS)[number];
+export type ErrorAggregateFunction = (typeof ERROR_AGGREGATE_FUNCTIONS)[number];
 
 /** Valibot schema for validating a span aggregate function name */
 export const SpanAggregateFunctionSchema = picklist(SPAN_AGGREGATE_FUNCTIONS);
 
-/** Valibot schema for validating a discover aggregate function name */
-export const DiscoverAggregateFunctionSchema = picklist(
-  DISCOVER_AGGREGATE_FUNCTIONS
-);
+/** Valibot schema for validating an error-event aggregate function name */
+export const ErrorAggregateFunctionSchema = picklist(ERROR_AGGREGATE_FUNCTIONS);
 
 /**
  * Valid `is:` filter values for issue search conditions (--where flag).
@@ -450,8 +435,8 @@ export function validateAggregateNames(
   }
 
   const validFunctions: readonly string[] =
-    dataset === "discover" || dataset === "error-events"
-      ? DISCOVER_AGGREGATE_FUNCTIONS
+    dataset === "error-events"
+      ? ERROR_AGGREGATE_FUNCTIONS
       : SPAN_AGGREGATE_FUNCTIONS;
 
   for (const agg of aggregates) {
@@ -1013,9 +998,7 @@ export type WidgetDataResult =
  */
 const WIDGET_TYPE_TO_DATASET: Record<string, string> = {
   spans: "spans",
-  discover: "discover",
   "error-events": "errors",
-  "transaction-like": "transactions",
   logs: "logs",
   tracemetrics: "tracemetrics",
 };
@@ -1023,7 +1006,7 @@ const WIDGET_TYPE_TO_DATASET: Record<string, string> = {
 /**
  * Map a widget's `widgetType` to the API `dataset` parameter.
  *
- * @param widgetType - The widget's dataset type (e.g., "spans", "discover")
+ * @param widgetType - The widget's dataset type (e.g., "spans", "logs")
  * @returns The API dataset string, or null if the type isn't queryable
  */
 export function mapWidgetTypeToDataset(

--- a/packages/cli/test/commands/dashboard/resolve.test.ts
+++ b/packages/cli/test/commands/dashboard/resolve.test.ts
@@ -785,21 +785,14 @@ describe("normalizeDataset", () => {
   test("lowercases canonical values (pass-through)", () => {
     expect(normalizeDataset("spans")).toBe("spans");
     expect(normalizeDataset("error-events")).toBe("error-events");
-    expect(normalizeDataset("transaction-like")).toBe("transaction-like");
     expect(normalizeDataset("tracemetrics")).toBe("tracemetrics");
     expect(normalizeDataset("logs")).toBe("logs");
     expect(normalizeDataset("issue")).toBe("issue");
-    expect(normalizeDataset("discover")).toBe("discover");
   });
 
   test("resolves error/errors aliases", () => {
     expect(normalizeDataset("errors")).toBe("error-events");
     expect(normalizeDataset("error")).toBe("error-events");
-  });
-
-  test("resolves transaction/transactions aliases", () => {
-    expect(normalizeDataset("transactions")).toBe("transaction-like");
-    expect(normalizeDataset("transaction")).toBe("transaction-like");
   });
 
   test("resolves metrics and metricsEnhanced aliases", () => {

--- a/packages/cli/test/commands/dashboard/widget/add.test.ts
+++ b/packages/cli/test/commands/dashboard/widget/add.test.ts
@@ -282,26 +282,6 @@ describe("dashboard widget add", () => {
     expect(addedWidget.widgetType).toBe("error-events");
   });
 
-  test("resolves dataset alias 'transactions' to 'transaction-like'", async () => {
-    const { context } = createMockContext();
-    const func = await addCommand.loader();
-    await func.call(
-      context,
-      {
-        json: false,
-        display: "line",
-        dataset: "transactions",
-        query: ["count"],
-      },
-      "123",
-      "Transactions Over Time"
-    );
-
-    const body = updateDashboardSpy.mock.calls[0]?.[2];
-    const addedWidget = body.widgets.at(-1);
-    expect(addedWidget.widgetType).toBe("transaction-like");
-  });
-
   test("resolves dataset alias 'metricsEnhanced' to 'tracemetrics'", async () => {
     const { context } = createMockContext();
     const func = await addCommand.loader();
@@ -323,7 +303,7 @@ describe("dashboard widget add", () => {
   });
 
   test("dataset alias is resolved BEFORE dataset-aware aggregate validation", async () => {
-    // failure_rate is only valid for error-events/discover. With the alias
+    // last_seen is only valid for error-events. With the alias
     // "errors", dataset-aware validation must see "error-events" (canonical)
     // before deciding whether to accept the aggregate.
     const { context } = createMockContext();
@@ -334,16 +314,16 @@ describe("dashboard widget add", () => {
         json: false,
         display: "big_number",
         dataset: "errors",
-        query: ["failure_rate"],
+        query: ["last_seen"],
       },
       "123",
-      "Failure Rate"
+      "Last Seen"
     );
 
     const body = updateDashboardSpy.mock.calls[0]?.[2];
     const addedWidget = body.widgets.at(-1);
     expect(addedWidget.widgetType).toBe("error-events");
-    expect(addedWidget.queries[0].aggregates).toEqual(["failure_rate()"]);
+    expect(addedWidget.queries[0].aggregates).toEqual(["last_seen()"]);
   });
 
   test("case-insensitive dataset values are accepted", async () => {

--- a/packages/cli/test/commands/dashboard/widget/edit.test.ts
+++ b/packages/cli/test/commands/dashboard/widget/edit.test.ts
@@ -287,11 +287,7 @@ describe("dashboard widget edit", () => {
     const { context } = createMockContext();
     const func = await editCommand.loader();
     // Should not throw — "text" is untracked, no dataset constraint applies
-    await func.call(
-      context,
-      { json: false, index: 0, dataset: "discover" },
-      "123"
-    );
+    await func.call(context, { json: false, index: 0, dataset: "logs" }, "123");
     expect(updateDashboardSpy).toHaveBeenCalled();
   });
 
@@ -415,23 +411,23 @@ describe("dashboard widget edit", () => {
     const { context } = createMockContext();
     const func = await editCommand.loader();
 
-    // "failure_rate" is valid for discover but not spans.
-    // Here we change the existing spans widget to discover dataset while
-    // also setting a discover-only aggregate. This should succeed.
+    // "last_seen" is valid for error-events but not spans.
+    // Here we change the existing spans widget to error-events dataset while
+    // also setting a last_seen aggregate. This should succeed.
     await func.call(
       context,
       {
         json: false,
         index: 0,
-        dataset: "discover",
-        query: ["failure_rate"],
+        dataset: "error-events",
+        query: ["last_seen"],
       },
       "123"
     );
 
     const body = updateDashboardSpy.mock.calls[0]?.[2];
-    expect(body.widgets[0].widgetType).toBe("discover");
-    expect(body.widgets[0].queries[0].aggregates).toEqual(["failure_rate()"]);
+    expect(body.widgets[0].widgetType).toBe("error-events");
+    expect(body.widgets[0].queries[0].aggregates).toEqual(["last_seen()"]);
   });
 
   test("resolves --dataset alias 'errors' to 'error-events' in PUT body", async () => {
@@ -448,9 +444,9 @@ describe("dashboard widget edit", () => {
   });
 
   test("dataset alias is resolved BEFORE dataset-aware aggregate validation", async () => {
-    // Regression test for the "aliases resolve too late" bug: failure_rate
+    // Regression test for the "aliases resolve too late" bug: last_seen
     // is valid for error-events, so passing --dataset errors --query
-    // failure_rate must succeed. If the alias is not applied before
+    // last_seen must succeed. If the alias is not applied before
     // validateAggregateNames runs, "errors" falls through the canonical
     // branch and "Unknown aggregate function" is thrown.
     const { context } = createMockContext();
@@ -461,27 +457,23 @@ describe("dashboard widget edit", () => {
         json: false,
         index: 0,
         dataset: "errors",
-        query: ["failure_rate"],
+        query: ["last_seen"],
       },
       "123"
     );
 
     const body = updateDashboardSpy.mock.calls[0]?.[2];
     expect(body.widgets[0].widgetType).toBe("error-events");
-    expect(body.widgets[0].queries[0].aggregates).toEqual(["failure_rate()"]);
+    expect(body.widgets[0].queries[0].aggregates).toEqual(["last_seen()"]);
   });
 
   test("case-insensitive --dataset values are accepted", async () => {
     const { context } = createMockContext();
     const func = await editCommand.loader();
-    await func.call(
-      context,
-      { json: false, index: 0, dataset: "TRANSACTIONS" },
-      "123"
-    );
+    await func.call(context, { json: false, index: 0, dataset: "LOGS" }, "123");
 
     const body = updateDashboardSpy.mock.calls[0]?.[2];
-    expect(body.widgets[0].widgetType).toBe("transaction-like");
+    expect(body.widgets[0].widgetType).toBe("logs");
   });
 
   test("auto-defaults --limit to 5 when adding --group-by without --limit", async () => {

--- a/packages/cli/test/types/dashboard.test.ts
+++ b/packages/cli/test/types/dashboard.test.ts
@@ -13,10 +13,10 @@ import {
   type DashboardWidget,
   DashboardWidgetInputSchema,
   DEFAULT_WIDGET_TYPE,
-  DISCOVER_AGGREGATE_FUNCTIONS,
   DISPLAY_TYPES,
-  DiscoverAggregateFunctionSchema,
   type DisplayType,
+  ERROR_AGGREGATE_FUNCTIONS,
+  ErrorAggregateFunctionSchema,
   EventsStatsDataPointSchema,
   EventsStatsSeriesSchema,
   EventsTableResponseSchema,
@@ -53,10 +53,8 @@ describe("WIDGET_TYPES", () => {
 
   test("contains all expected dataset types", () => {
     const expected: WidgetType[] = [
-      "discover",
       "issue",
       "error-events",
-      "transaction-like",
       "spans",
       "logs",
       "tracemetrics",
@@ -107,7 +105,7 @@ describe("DISPLAY_TYPES", () => {
 });
 
 // ---------------------------------------------------------------------------
-// SPAN_AGGREGATE_FUNCTIONS / DISCOVER_AGGREGATE_FUNCTIONS
+// SPAN_AGGREGATE_FUNCTIONS / ERROR_AGGREGATE_FUNCTIONS
 // ---------------------------------------------------------------------------
 
 describe("SPAN_AGGREGATE_FUNCTIONS", () => {
@@ -146,34 +144,36 @@ describe("SPAN_AGGREGATE_FUNCTIONS", () => {
   });
 });
 
-describe("DISCOVER_AGGREGATE_FUNCTIONS", () => {
+describe("ERROR_AGGREGATE_FUNCTIONS", () => {
   test("is a superset of span functions", () => {
     for (const fn of SPAN_AGGREGATE_FUNCTIONS) {
-      expect(DISCOVER_AGGREGATE_FUNCTIONS).toContain(fn);
+      expect(ERROR_AGGREGATE_FUNCTIONS).toContain(fn);
     }
   });
 
-  test("contains discover-specific functions", () => {
+  test("contains error-event-specific functions", () => {
     const extras = [
-      "failure_count",
-      "failure_rate",
-      "apdex",
-      "user_misery",
       "count_if",
+      "count_at_least",
       "last_seen",
+      "latest_event",
+      "var",
+      "stddev",
+      "cov",
+      "corr",
     ];
     for (const fn of extras) {
-      expect(DISCOVER_AGGREGATE_FUNCTIONS).toContain(fn);
+      expect(ERROR_AGGREGATE_FUNCTIONS).toContain(fn);
     }
   });
 
-  test("valibot schema validates discover functions", () => {
-    expect(safeParse(DiscoverAggregateFunctionSchema, "apdex").success).toBe(
+  test("valibot schema validates error-event functions", () => {
+    expect(safeParse(ErrorAggregateFunctionSchema, "count_if").success).toBe(
       true
     );
-    expect(
-      safeParse(DiscoverAggregateFunctionSchema, "failure_rate").success
-    ).toBe(true);
+    expect(safeParse(ErrorAggregateFunctionSchema, "last_seen").success).toBe(
+      true
+    );
   });
 });
 
@@ -949,9 +949,7 @@ describe("EventsTableResponseSchema", () => {
 describe("mapWidgetTypeToDataset", () => {
   test("maps known widget types", () => {
     expect(mapWidgetTypeToDataset("spans")).toBe("spans");
-    expect(mapWidgetTypeToDataset("discover")).toBe("discover");
     expect(mapWidgetTypeToDataset("error-events")).toBe("errors");
-    expect(mapWidgetTypeToDataset("transaction-like")).toBe("transactions");
     expect(mapWidgetTypeToDataset("logs")).toBe("logs");
     expect(mapWidgetTypeToDataset("tracemetrics")).toBe("tracemetrics");
   });
@@ -959,6 +957,8 @@ describe("mapWidgetTypeToDataset", () => {
   test("returns null for unsupported widget types", () => {
     expect(mapWidgetTypeToDataset("issue")).toBeNull();
     expect(mapWidgetTypeToDataset("preprod-app-size")).toBeNull();
+    expect(mapWidgetTypeToDataset("discover")).toBeNull();
+    expect(mapWidgetTypeToDataset("transaction-like")).toBeNull();
   });
 
   test("returns null for undefined", () => {


### PR DESCRIPTION
`discover` and `transactions` are no longer valid datasets for dashboard widgets (the same use cases are supported by `errors` and `spans`). All existing dashboards have been migrated off of those datasets and creating new widgets that use them has been blocked on all billing plans.

Remove all references to `discover` and `transactions` datasets from dashboard code and skills. Also removes transaction-specific aggregate functions from `DISCOVER_AGGREGATE_FUNCTIONS` (now `ERROR_AGGREGATE_FUNCTIONS`, as that is the only dataset left that supports them).

See BROWSE-682.