### PR TITLE
fix(sourcemap): let `inject` run without authentication

### DIFF
--- a/packages/cli/src/commands/sourcemap/inject.ts
+++ b/packages/cli/src/commands/sourcemap/inject.ts
@@ -70,6 +70,8 @@ export const injectCommand = buildCommand({
       "  sentry sourcemap inject ./out --dry-run\n" +
       "  sentry sourcemap inject ./maybe-empty --allow-empty",
   },
+  // Purely local file operation — no Sentry API calls, no auth needed.
+  auth: false,
   output: {
     human: formatInjectResult,
   },

--- a/packages/cli/test/commands/sourcemap/inject.test.ts
+++ b/packages/cli/test/commands/sourcemap/inject.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for `sentry sourcemap inject` as a purely local command: it must
+ * run without any stored or env-provided credentials, since it never calls
+ * the Sentry API. Regression test for the `auth: false` opt-out.
+ */
+
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { injectCommand } from "../../../src/commands/sourcemap/inject.js";
+import { useEnvSandbox, useTestConfigDir } from "../../helpers.js";
+
+type InjectFuncArgs = {
+  ext?: string;
+  "dry-run"?: boolean;
+  "allow-empty"?: boolean;
+};
+type CmdFunc = (
+  this: unknown,
+  flags: InjectFuncArgs,
+  dir: string
+) => Promise<unknown>;
+
+function makeContext() {
+  return {
+    stdout: { write: vi.fn(() => true) },
+    stderr: { write: vi.fn(() => true) },
+    cwd: "/tmp",
+  };
+}
+
+describe("sourcemap inject command — runs without authentication", () => {
+  // Fresh config dir → no stored OAuth token; env sandbox → no env token.
+  // preload.ts sets a fake SENTRY_AUTH_TOKEN so the auth guard passes for
+  // most tests; this suite deliberately removes it.
+  useTestConfigDir("sentry-inject-noauth-");
+  useEnvSandbox([
+    "SENTRY_AUTH_TOKEN",
+    "SENTRY_TOKEN",
+    "SENTRY_FORCE_ENV_TOKEN",
+  ]);
+
+  let dir: string;
+  let func: CmdFunc;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "sentry-inject-noauth-"));
+    func = (await injectCommand.loader()) as unknown as CmdFunc;
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("injects debug IDs with no stored credentials and no env token", async () => {
+    await writeFile(
+      join(dir, "app.js"),
+      "console.log(1);\n//# sourceMappingURL=app.js.map\n"
+    );
+    await writeFile(
+      join(dir, "app.js.map"),
+      '{"version":3,"file":"app.js","sources":["app.ts"],"names":[],"mappings":"AAAA"}\n'
+    );
+    const ctx = makeContext();
+
+    await expect(func.call(ctx, {}, dir)).resolves.toBeUndefined();
+
+    const js = await readFile(join(dir, "app.js"), "utf8");
+    expect(js).toMatch(/^\/\/# debugId=[0-9a-f-]{36}$/m);
+    const map = JSON.parse(await readFile(join(dir, "app.js.map"), "utf8"));
+    expect(map.debugId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});


### PR DESCRIPTION
Fixes #1525

## Problem

`sentry sourcemap inject` throws `AuthError("not_authenticated")` when no credentials exist, although it only rewrites local JS and `.map` files and never calls the Sentry API. #611 made authentication the default for every `buildCommand` and opted out the commands that work without a token, but `sourcemap inject` (added in #547 a week earlier) was not on that list, so it has required credentials since 0.23.0. `sourcemap resolve`, the other local-only command in the group, already sets `auth: false`.

## Fix

Set `auth: false` on `injectCommand`, with the same comment `resolve.ts` uses. `sourcemap upload` still requires authentication; no docs or generated files change.

## Tests

New `test/commands/sourcemap/inject.test.ts` runs the command with a fresh config dir and with `SENTRY_AUTH_TOKEN`, `SENTRY_TOKEN`, and `SENTRY_FORCE_ENV_TOKEN` cleared, then asserts the JS receives a `//# debugId=` comment and the map a `debugId` field. It fails on `main` with `AuthError: Not authenticated. Run 'sentry auth login' first.` and passes with this change. The existing suite did not catch the regression because `test/preload.ts` sets a placeholder token for every test.

Verified locally (macOS arm64, Node.js 26.8.1, pnpm 10.11.0): `biome check` on the touched files, `pnpm typecheck` (no generated-file changes), and `vitest run test/commands/sourcemap` (36 passed). In `pnpm test`, 7 tests in `test/lib/time-range.test.ts` and `test/lib/delta-upgrade.mocked.test.ts` fail in this environment on an unmodified `main` as well (timezone-dependent, local TZ is UTC+9), so they are unrelated. E2E and binary builds were not run.

## Breaking change

No.

Thank you for reviewing. Happy to move the test next to the existing inject tests in `upload.test.ts` or adjust the approach if you prefer.
