### PR TITLE
fix(dashboard): Cap high-DPI graphics canvases

### DIFF
--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/dashboard.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/dashboard.md
@@ -44,6 +44,7 @@ View a dashboard
 - `-r, --refresh <value> - Auto-refresh interval in seconds (default: 60, min: 10)`
 - `-t, --period <value> - Time range: "7d", "2026-08-01..2026-09-01", ">=2026-08-01"`
 - `--renderer <value> - Graphics renderer (defaults to auto; falls back to auto when unavailable) - (default: "auto")`
+- `--no-graphics-cap - Use the terminal-native graphics width (may fall back to ASCII for very large dashboards)`
 
 **Examples:**
 

--- a/packages/cli/src/commands/dashboard/view.ts
+++ b/packages/cli/src/commands/dashboard/view.ts
@@ -54,6 +54,7 @@ type ViewFlags = {
   readonly refresh?: number;
   readonly period?: TimeRange;
   readonly renderer: GraphicsRendererPreference;
+  readonly "no-graphics-cap": boolean;
   readonly json: boolean;
   readonly fields?: string[];
 };
@@ -112,6 +113,7 @@ function buildViewData(
   opts: {
     period: string;
     rendererPreference: GraphicsRendererPreference;
+    graphicsCap: boolean;
     url: string;
   }
 ): DashboardViewData {
@@ -124,6 +126,7 @@ function buildViewData(
     dateCreated: dashboard.dateCreated,
     environment: dashboard.environment,
     rendererPreference: opts.rendererPreference,
+    graphicsCap: opts.graphicsCap,
     widgets: widgets.map((w, i) => ({
       title: w.title,
       displayType: w.displayType,
@@ -180,7 +183,7 @@ export const viewCommand = buildCommand({
   },
   output: {
     human: createDashboardViewRenderer,
-    jsonExclude: ["rendererPreference"],
+    jsonExclude: ["rendererPreference", "graphicsCap"],
   },
   parameters: {
     positional: {
@@ -217,6 +220,12 @@ export const viewCommand = buildCommand({
         brief:
           "Graphics renderer (defaults to auto; falls back to auto when unavailable)",
         default: "auto",
+      },
+      "no-graphics-cap": {
+        kind: "boolean",
+        brief:
+          "Use the terminal-native graphics width (may fall back to ASCII for very large dashboards)",
+        default: false,
       },
     },
     aliases: {
@@ -302,6 +311,7 @@ export const viewCommand = buildCommand({
           const viewData = buildViewData(dashboard, widgetData, widgets, {
             period: formatTimeRangeFlag(timeRange),
             rendererPreference: flags.renderer,
+            graphicsCap: !flags["no-graphics-cap"],
             url,
           });
 
@@ -334,6 +344,7 @@ export const viewCommand = buildCommand({
       buildViewData(dashboard, widgetData, widgets, {
         period: formatTimeRangeFlag(timeRange),
         rendererPreference: flags.renderer,
+        graphicsCap: !flags["no-graphics-cap"],
         url,
       })
     );

--- a/packages/cli/src/lib/formatters/dashboard.ts
+++ b/packages/cli/src/lib/formatters/dashboard.ts
@@ -2055,7 +2055,7 @@ function logDashboardGraphicsRenderer(render: DashboardGraphicsRender): void {
     details.push(`native pixel width=${render.nativePixelWidth}`);
   }
   if (render.pixelWidth) {
-    details.push(`pixel width=${render.pixelWidth}`);
+    details.push(`effective pixel width=${render.pixelWidth}`);
   }
   details.push(
     `graphics cap=${render.graphicsCapApplied ? "applied" : "not applied"}`

--- a/packages/cli/src/lib/formatters/dashboard.ts
+++ b/packages/cli/src/lib/formatters/dashboard.ts
@@ -52,6 +52,8 @@ export type DashboardViewData = {
   environment?: string[];
   /** Renderer selected by --renderer; omitted for API/JSON output. */
   rendererPreference?: GraphicsRendererPreference;
+  /** Whether the default high-DPI graphics width cap should apply. */
+  graphicsCap?: boolean;
   widgets: DashboardViewWidget[];
 };
 
@@ -82,6 +84,9 @@ const MIN_TERM_WIDTH = 80;
 
 /** Fallback terminal width when stdout is not a TTY */
 const DEFAULT_TERM_WIDTH = 100;
+
+/** Default graphics canvas cap for high-DPI terminals. */
+const MAX_GRAPHICS_WIDTH = 2560;
 
 /**
  * Get the effective terminal width.
@@ -2028,7 +2033,9 @@ type DashboardGraphicsRender = {
   reason?: string;
   termWidth?: number;
   cell?: { cellWidth: number; cellHeight: number };
+  nativePixelWidth?: number;
   pixelWidth?: number;
+  graphicsCapApplied?: boolean;
 };
 
 /** Log the terminal graphics decision without including dashboard data. */
@@ -2044,9 +2051,15 @@ function logDashboardGraphicsRenderer(render: DashboardGraphicsRender): void {
   if (render.cell) {
     details.push(`cell=${render.cell.cellWidth}x${render.cell.cellHeight}`);
   }
+  if (render.nativePixelWidth) {
+    details.push(`native pixel width=${render.nativePixelWidth}`);
+  }
   if (render.pixelWidth) {
     details.push(`pixel width=${render.pixelWidth}`);
   }
+  details.push(
+    `graphics cap=${render.graphicsCapApplied ? "applied" : "not applied"}`
+  );
   const reason = render.reason ? ` (reason: ${render.reason})` : "";
   logger.debug(
     `Dashboard graphics renderer: ${render.renderer}${reason}; ${details.join("; ")}`
@@ -2094,9 +2107,9 @@ function renderCompleteDashboardAsGraphics(
   // Preserve the terminal's reported pixel width when known; otherwise derive it
   // from the (possibly defaulted) cell width so the canvas still matches the
   // column count exactly.
-  const pixelWidth =
+  const nativePixelWidth =
     terminalPixelWidth(termWidth) ?? termWidth * cell.cellWidth;
-  const cellWidth = Math.floor(pixelWidth / termWidth);
+  const cellWidth = Math.floor(nativePixelWidth / termWidth);
   if (cellWidth < 1) {
     return {
       renderer: "ascii",
@@ -2104,9 +2117,28 @@ function renderCompleteDashboardAsGraphics(
       reason: "calculated graphics cell width is invalid",
       termWidth,
       cell,
-      pixelWidth,
+      nativePixelWidth,
     };
   }
+  const graphicsCap = data.graphicsCap !== false;
+  const graphicsCapApplied =
+    graphicsCap && nativePixelWidth > MAX_GRAPHICS_WIDTH;
+  const graphicsColumns = graphicsCapApplied
+    ? Math.min(termWidth, Math.floor(MAX_GRAPHICS_WIDTH / cellWidth))
+    : termWidth;
+  if (graphicsColumns < 1) {
+    return {
+      renderer: "ascii",
+      rendererPreference,
+      reason: "graphics cap is smaller than one terminal cell",
+      termWidth,
+      cell,
+      nativePixelWidth,
+    };
+  }
+  const pixelWidth = graphicsCapApplied
+    ? graphicsColumns * cellWidth
+    : nativePixelWidth;
   const graphics = renderDashboardAsSixel(data, {
     pixelWidth,
     cellWidth,
@@ -2130,7 +2162,9 @@ function renderCompleteDashboardAsGraphics(
       reason: graphics.reason,
       termWidth,
       cell,
+      nativePixelWidth,
       pixelWidth,
+      graphicsCapApplied,
     };
   }
   return {
@@ -2139,7 +2173,9 @@ function renderCompleteDashboardAsGraphics(
     output: graphics.output,
     termWidth,
     cell,
+    nativePixelWidth,
     pixelWidth,
+    graphicsCapApplied,
   };
 }
 

--- a/packages/cli/test/lib/formatters/dashboard-sixel-integration.test.ts
+++ b/packages/cli/test/lib/formatters/dashboard-sixel-integration.test.ts
@@ -16,6 +16,8 @@ import {
 import { logger } from "../../../src/lib/logger.js";
 // biome-ignore lint/performance/noNamespaceImport: needed for vi.spyOn mocking
 import * as sixelModule from "../../../src/lib/sixel.js";
+// biome-ignore lint/performance/noNamespaceImport: needed for vi.spyOn mocking
+import * as sixelImageModule from "../../../src/lib/sixel-image.js";
 import type { TimeseriesResult } from "../../../src/types/dashboard.js";
 
 const ESC = "\x1b";
@@ -414,6 +416,7 @@ describe("dashboard sixel integration", () => {
 
     const output = formatDashboardWithData(
       makeDashboardData({
+        graphicsCap: false,
         widgets: [makeWidget({ layout: { x: 0, y: 12, w: 6, h: 1 } })],
       })
     );
@@ -422,6 +425,32 @@ describe("dashboard sixel integration", () => {
     expect(debugSpy).toHaveBeenCalledWith(
       expect.stringContaining(
         "reason: canvas 3416x2496 (8.53M pixels) exceeds the 8M pixel limit"
+      )
+    );
+  });
+
+  test("caps a high-DPI canvas instead of falling back to ASCII", () => {
+    process.stdout.columns = 244;
+    vi.mocked(sixelModule.terminalPixelWidth).mockReturnValue(3416);
+    vi.mocked(sixelModule.graphicsCellSize).mockReturnValue({
+      cellWidth: 14,
+      cellHeight: 32,
+    });
+    vi.spyOn(sixelImageModule, "encodeImageToSixel").mockImplementation(
+      (image) => `${ESC}P${image.width}x${image.height}${ESC}\\`
+    );
+    const debugSpy = vi.spyOn(logger, "debug");
+
+    const output = formatDashboardWithData(
+      makeDashboardData({
+        widgets: [makeWidget({ layout: { x: 0, y: 12, w: 6, h: 1 } })],
+      })
+    );
+
+    expect(output).toContain(`${ESC}P2548x2496${ESC}\\`);
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "native pixel width=3416; pixel width=2548; graphics cap=applied"
       )
     );
   });

--- a/packages/cli/test/lib/formatters/dashboard-sixel-integration.test.ts
+++ b/packages/cli/test/lib/formatters/dashboard-sixel-integration.test.ts
@@ -427,6 +427,11 @@ describe("dashboard sixel integration", () => {
         "reason: canvas 3416x2496 (8.53M pixels) exceeds the 8M pixel limit"
       )
     );
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "native pixel width=3416; effective pixel width=3416; graphics cap=not applied"
+      )
+    );
   });
 
   test("caps a high-DPI canvas instead of falling back to ASCII", () => {
@@ -450,7 +455,7 @@ describe("dashboard sixel integration", () => {
     expect(output).toContain(`${ESC}P2548x2496${ESC}\\`);
     expect(debugSpy).toHaveBeenCalledWith(
       expect.stringContaining(
-        "native pixel width=3416; pixel width=2548; graphics cap=applied"
+        "native pixel width=3416; effective pixel width=2548; graphics cap=applied"
       )
     );
   });


### PR DESCRIPTION
`sentry dashboard view` now caps high-DPI graphics canvases at 2560px by default, preventing large Retina terminal windows from hitting the existing 8M-pixel guard and falling back to ASCII.

`--no-graphics-cap` restores terminal-native width for callers who prefer it; the existing hard safety limit remains in place. The regression coverage exercises both the capped graphics path and the uncapped safety fallback.
