### PR TITLE
ci: Reference renamed coverage action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
       - name: Unit Tests
         run: pnpm run test:unit
       - name: Coverage Report
-        uses: getsentry/codecov-action@main
+        uses: getsentry/coverage-action@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           files: ./coverage/lcov.info


### PR DESCRIPTION
The coverage workflow now references the canonical `getsentry/coverage-action` repository. The existing `@main` update policy and action inputs are unchanged.
