### PR TITLE
feat(init): track completion-screen actions in run telemetry

### DIFF
--- a/packages/cli/src/lib/init/ui/ink-app.tsx
+++ b/packages/cli/src/lib/init/ui/ink-app.tsx
@@ -735,6 +735,7 @@ function CompletionScreen({
         case "issues":
           if (primaryUrl) {
             actions.openUrl(primaryUrl);
+            actions.track("open-sentry");
             setNote("Opened Sentry in your browser.");
           }
           break;
@@ -742,9 +743,11 @@ function CompletionScreen({
           if (agentCommand) {
             if (agentQueued) {
               store.dequeuePostExitAction(agentCommand);
+              actions.track("agent-plugin-unqueued");
               setNote("");
             } else {
               store.queuePostExitAction(agentCommand);
+              actions.track("agent-plugin-queued");
               setNote(`Queued — ${agentCommand} runs when you finish.`);
             }
           }
@@ -773,6 +776,7 @@ function CompletionScreen({
                 !key.ctrl && (input === "o" || input === "O"),
               run: () => {
                 actions.openUrl(primaryUrl);
+                actions.track("open-sentry");
                 setNote("Opened Sentry in your browser.");
               },
             },

--- a/packages/cli/src/lib/init/ui/ink-ui.ts
+++ b/packages/cli/src/lib/init/ui/ink-ui.ts
@@ -53,7 +53,7 @@ import { ReadStream } from "node:tty";
 
 const _require = createRequire(import.meta.url);
 
-import { setTag } from "@sentry/node-core/light";
+import { addBreadcrumb, setTag } from "@sentry/node-core/light";
 import { FULL_BANNER_LINES } from "../../banner.js";
 import { openBrowser } from "../../browser.js";
 import { CLI_VERSION } from "../../constants.js";
@@ -538,6 +538,29 @@ export class InkUI implements WizardUI {
             // ignore
           });
         },
+        track: (event) => {
+          // Land completion-screen interactions on the run's `cli.command`
+          // transaction so we can see, per run, whether the user opened Sentry
+          // and/or chose to install the agent plugin. Tags are sticky: once a
+          // user has clicked "install", un-toggling leaves the click recorded.
+          switch (event) {
+            case "open-sentry":
+              setTag("wizard.completion.opened_sentry", "true");
+              break;
+            case "agent-plugin-queued":
+              setTag("wizard.completion.agent_plugin_clicked", "true");
+              break;
+            case "agent-plugin-unqueued":
+              break;
+            default:
+              break;
+          }
+          addBreadcrumb({
+            category: "wizard.completion",
+            message: event,
+            level: "info",
+          });
+        },
       },
     });
   }
@@ -884,6 +907,12 @@ export class InkUI implements WizardUI {
    */
   private async runPostExitActions(): Promise<void> {
     const actions = this.store.getSnapshot().postExitActions;
+    if (actions.length > 0) {
+      // The agent-plugin installer is the only thing the completion screen
+      // queues, so a non-empty list here means the user finished with it queued
+      // and we're about to actually run it — the strongest "installed" signal.
+      setTag("wizard.completion.agent_plugin_installed", "true");
+    }
     for (const command of actions) {
       process.stdout.write(`\n$ ${command}\n`);
       await runInheritedCommand(command);

--- a/packages/cli/src/lib/init/ui/types.ts
+++ b/packages/cli/src/lib/init/ui/types.ts
@@ -220,13 +220,30 @@ export type WizardCompletion = {
 };
 
 /**
+ * A completion-screen interaction worth recording on the run's telemetry.
+ * `open-sentry` covers both the "View my first event" / "Open my Issues feed"
+ * menu item and the `o` shortcut; the agent-plugin events track the install
+ * toggle (a queued click is the "did they choose to install the plugin" signal).
+ */
+export type CompletionActionEvent =
+  | "open-sentry"
+  | "agent-plugin-queued"
+  | "agent-plugin-unqueued";
+
+/**
  * Side-effectful actions the completion screen invokes. Provided by `InkUI`
  * (which lives in the main bundle) so the pre-bundled Ink sidecar never has to
- * import Node built-ins (browser launch) itself.
+ * import Node built-ins (browser launch) or the Sentry SDK itself.
  */
 export type CompletionActions = {
   /** Open a URL in the user's browser. Best-effort, non-blocking. */
   openUrl: (url: string) => void;
+  /**
+   * Record a completion-screen interaction on the run's telemetry. Bound by
+   * `InkUI` so the Ink sidecar never imports Sentry; the tags land on the
+   * active `cli.command` transaction like the rest of the `wizard.*` tags.
+   */
+  track: (event: CompletionActionEvent) => void;
 };
 
 /**

--- a/packages/cli/test/lib/init/ui/ink-app.snapshot.test.tsx
+++ b/packages/cli/test/lib/init/ui/ink-app.snapshot.test.tsx
@@ -1329,6 +1329,9 @@ describe("completion screen", () => {
           openUrl: () => {
             // no-op in tests
           },
+          track: () => {
+            // no-op in tests
+          },
         },
       },
     });


### PR DESCRIPTION
## Summary

On the init completion screen you can open Sentry (issues / first event) or install the Sentry agent plugin. Neither click emitted any telemetry, so we couldn't tell how many people actually take either action — the buttons just called `openUrl` / queued a shell command with nothing landing in traces.

This adds tags on the run's `cli.command` transaction when the user interacts with the completion screen.

## Changes

New `track` action on `CompletionActions`, bound in `InkUI` (main bundle) so the pre-bundled Ink sidecar never has to import the Sentry SDK — same pattern already used for `openUrl`. The click handlers in `ink-app.tsx` call it, and the tags land on the active `cli.command` transaction alongside the rest of the `wizard.*` tags.

Tags:
- `wizard.completion.opened_sentry` — opened the Issues feed / first event (menu item or the `o` shortcut)
- `wizard.completion.agent_plugin_clicked` — chose to install the agent plugin (sticky: un-toggling still counts the click)
- `wizard.completion.agent_plugin_installed` — the installer actually ran on exit

`clicked` vs `installed` is intentional so we can see the funnel (chose to install vs. actually ran).

Not segmenting by framework here — just raw counts.

## Test Plan

- `tsc --noEmit` clean
- `biome check` clean on changed files
- `vitest run` on the completion-screen snapshot suite — 40/40 pass

Example query once this ships (project `cli`):
`transaction:cli.command wizard.completion.agent_plugin_clicked:true`