### PR TITLE
fix(lint): force-ignore output.ts from Biome type analysis (200k limit)

### DIFF
--- a/packages/cli/biome.jsonc
+++ b/packages/cli/biome.jsonc
@@ -36,7 +36,12 @@
       "!codemods",
       // custom-ca.ts blows past Biome's type-analysis limit when pulled into
       // the module graph (internal Biome bug); force-ignore even via a test.
-      "!!src/lib/custom-ca.ts"
+      "!!src/lib/custom-ca.ts",
+      // output.ts hits the same 200k type-analysis limit once valibot's
+      // GenericSchema graph is pulled in — the same internal Biome bug, surfacing
+      // non-deterministically (main passes by a hair; unrelated PRs trip it,
+      // e.g. #1499, #1501). Force-ignore until Biome raises/fixes the limit.
+      "!!src/lib/formatters/output.ts"
     ]
   },
   "javascript": {},


### PR DESCRIPTION
## Problem

`Lint & Typecheck` fails on an internal Biome error, with no real lint violation in the changed code:

```
src/lib/formatters/output.ts  project  INTERNAL
  ! Biome encountered an unusually large amount of types which exceeded the limit of 200,000.
```

`output.ts` imports valibot's `GenericSchema`, whose recursive generic graph pushes Biome's project-mode type inference over its 200,000-type ceiling — the **same internal Biome bug already handled for `custom-ca.ts`** in this config (see the existing `"!!src/lib/custom-ca.ts"` force-ignore).

It surfaces **non-deterministically**: `main` passes by a hair, but the exact type count tips over on PR runners, so unrelated PRs fail this job identically — e.g. #1499, #1501, and #1535. Re-running does not clear it (deterministic per branch state).

## Fix

Force-ignore `src/lib/formatters/output.ts` the same way as `custom-ca.ts`, until Biome raises/fixes the limit.

```jsonc
"!!src/lib/custom-ca.ts",
"!!src/lib/formatters/output.ts"
```

## Verification

`pnpm run lint` (the CI invocation) now passes:

```
Checked 1025 files in 3s. No fixes applied.   (exit 0)
```

Unblocks #1535 (and the other PRs above) once merged. Trade-off is the same one already accepted for `custom-ca.ts`: `output.ts` (a leaf formatter) is skipped by Biome; it stays covered by `tsc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
