### PR TITLE
fix(init): stop recording skipped verification as an error

### DIFF
--- a/packages/cli/src/lib/init/verify-setup.ts
+++ b/packages/cli/src/lib/init/verify-setup.ts
@@ -324,10 +324,7 @@ async function cleanupProcessTree(child: ChildProcess): Promise<void> {
   }
 }
 
-type VerificationSkipReason =
-  | "no_dev_command"
-  | "server_bind"
-  | "spawn_failed";
+type VerificationSkipReason = "no_dev_command" | "server_bind" | "spawn_failed";
 
 /**
  * Expected verification skips are not failures. Emitting them with

--- a/packages/cli/src/lib/init/verify-setup.ts
+++ b/packages/cli/src/lib/init/verify-setup.ts
@@ -14,7 +14,11 @@
 
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { resolve } from "node:path";
-import { captureException } from "@sentry/node-core/light";
+import {
+  addBreadcrumb,
+  captureException,
+  setTag,
+} from "@sentry/node-core/light";
 import { createSpotlightBuffer } from "@spotlightjs/spotlight/sdk";
 import { BUFFER_SIZE, shutdownServer } from "../../commands/local/run.js";
 import { buildApp, tryListen } from "../../commands/local/server.js";
@@ -320,6 +324,24 @@ async function cleanupProcessTree(child: ChildProcess): Promise<void> {
   }
 }
 
+type VerificationSkipReason =
+  | "no_dev_command"
+  | "server_bind"
+  | "spawn_failed";
+
+/**
+ * Expected verification skips are not failures. Emitting them with
+ * `captureException` produced ERROR events on healthy completed runs.
+ */
+function recordVerificationSkipped(reason: VerificationSkipReason): void {
+  addBreadcrumb({
+    category: "wizard.verify",
+    level: "info",
+    message: `skipped:${reason}`,
+  });
+  setTag("wizard.verify", "skipped");
+}
+
 /**
  * Outcome of {@link verifySetup}, surfaced to the completion screen so it can
  * celebrate a received event (and deep-link it) instead of only telling the
@@ -352,12 +374,7 @@ export async function verifySetup(
   const detected = await detectDevCommand(cwd);
   if (!detected) {
     ui.log.info("Skipping verification — could not detect a dev command");
-    captureException(new Error("init verification skipped"), {
-      tags: {
-        "wizard.platform": String(result.result?.platform ?? "unknown"),
-        "wizard.verify": "no_dev_command",
-      },
-    });
+    recordVerificationSkipped("no_dev_command");
     return { verified: false, kind: "skipped" };
   }
 
@@ -375,6 +392,7 @@ export async function verifySetup(
   } catch (error) {
     logger.debug("Failed to start verification server", error);
     ui.log.warn("Skipping verification — could not start local server.");
+    recordVerificationSkipped("server_bind");
     return { verified: false, kind: "skipped" };
   }
 
@@ -419,6 +437,7 @@ export async function verifySetup(
     logger.debug("Failed to spawn verification child", error);
     await shutdownServer(server);
     ui.log.warn("Skipping verification — could not start the dev command.");
+    recordVerificationSkipped("spawn_failed");
     return { verified: false, kind: "skipped" };
   }
 
@@ -558,6 +577,7 @@ function reportOutcome(outcome: VerifyOutcome, ctx: ReportContext): void {
   if (outcome.kind === "spawn_error") {
     logger.debug("Failed to spawn verification child", outcome.error);
     ui.log.warn("Skipping verification — could not start the dev command.");
+    recordVerificationSkipped("spawn_failed");
     return;
   }
 

--- a/packages/cli/test/lib/init/verify-setup-windows.mocked.test.ts
+++ b/packages/cli/test/lib/init/verify-setup-windows.mocked.test.ts
@@ -68,7 +68,9 @@ vi.mock("node:child_process", async (importOriginal) => {
 });
 
 vi.mock("@sentry/node-core/light", () => ({
+  addBreadcrumb: vi.fn(),
   captureException: vi.fn(),
+  setTag: vi.fn(),
 }));
 
 import { verifySetup } from "../../../src/lib/init/verify-setup.js";

--- a/packages/cli/test/lib/init/verify-setup.test.ts
+++ b/packages/cli/test/lib/init/verify-setup.test.ts
@@ -5,9 +5,13 @@ import { verifySetup } from "../../../src/lib/init/verify-setup.js";
 import { TEST_TMP_DIR } from "../../constants.js";
 import { createMockUI } from "./ui/mock-ui.js";
 
-vi.mock("@sentry/node-core/light", () => ({
+const sentryMocks = vi.hoisted(() => ({
+  addBreadcrumb: vi.fn(),
   captureException: vi.fn(),
+  setTag: vi.fn(),
 }));
+
+vi.mock("@sentry/node-core/light", () => sentryMocks);
 
 type FixtureProcesses = {
   shellPid: number;
@@ -19,6 +23,9 @@ let tmpDir: string;
 let fixtureProcesses: FixtureProcesses | undefined;
 
 beforeEach(async () => {
+  sentryMocks.addBreadcrumb.mockClear();
+  sentryMocks.captureException.mockClear();
+  sentryMocks.setTag.mockClear();
   tmpDir = await mkdtemp(join(TEST_TMP_DIR, "verify-setup-test-"));
 });
 
@@ -133,6 +140,29 @@ async function readFixtureProcesses(): Promise<FixtureProcesses> {
 }
 
 describe("verifySetup", () => {
+  test("records a skipped verify as a scope tag, not an error, when there is no dev command", async () => {
+    const { ui, calls } = createMockUI();
+
+    const result = await verifySetup(
+      { status: "success", result: { platform: "cocoa" } },
+      ui,
+      tmpDir
+    );
+
+    expect(result).toEqual({ verified: false, kind: "skipped" });
+    expect(calls).toContainEqual({
+      kind: "log.info",
+      message: "Skipping verification — could not detect a dev command",
+    });
+    expect(sentryMocks.captureException).not.toHaveBeenCalled();
+    expect(sentryMocks.setTag).toHaveBeenCalledWith("wizard.verify", "skipped");
+    expect(sentryMocks.addBreadcrumb).toHaveBeenCalledWith({
+      category: "wizard.verify",
+      level: "info",
+      message: "skipped:no_dev_command",
+    });
+  });
+
   test("does not fail init when the detected command cannot be spawned", async () => {
     await writeFile(
       join(tmpDir, "package.json"),
@@ -152,6 +182,13 @@ describe("verifySetup", () => {
     expect(calls).toContainEqual({
       kind: "log.warn",
       message: "Skipping verification — could not start the dev command.",
+    });
+    expect(sentryMocks.captureException).not.toHaveBeenCalled();
+    expect(sentryMocks.setTag).toHaveBeenCalledWith("wizard.verify", "skipped");
+    expect(sentryMocks.addBreadcrumb).toHaveBeenCalledWith({
+      category: "wizard.verify",
+      level: "info",
+      message: "skipped:spawn_failed",
     });
   });
 


### PR DESCRIPTION
## Summary

Healthy `sentry init` runs were emitting a spurious **`Error: init verification skipped`** ERROR event. Skipping the post-install runtime check is expected when there is no recognized dev command (Cocoa/Apple, repos without `dev`/`start`) or when the local sidecar/bind/spawn cannot start — not a failure.

This drops `captureException` on those skip paths and records a breadcrumb plus a scope tag (`wizard.verify=skipped`) instead, so completed runs are filterable without polluting the error stream. Real verification failures (`startup_error`, `child_exited`, timeout/silent) still capture ERROR.

## Test plan

- [x] `vitest run test/lib/init/verify-setup.test.ts test/lib/init/verify-setup-windows.mocked.test.ts` (7/7)
- [ ] Confirm a Cocoa / no-dev-command completed run no longer creates a new `init verification skipped` event
- [ ] Confirm `wizard.verify=skipped` is present on the transaction for those runs

Fixes #1543

Made with [Cursor](https://cursor.com)