### PR TITLE
fix(docs): correct agent conversation argument syntax

### DIFF
--- a/apps/cli-docs/src/fragments/commands/agent-conversation.md
+++ b/apps/cli-docs/src/fragments/commands/agent-conversation.md
@@ -25,9 +25,12 @@ sentry agent-conversation list my-org -c next
 ### View a conversation transcript
 
 ```bash
-# View full transcript
-sentry agent-conversation view my-org conv-123
+# View full transcript (organization auto-detected)
+sentry agent-conversation view conv-123
+
+# Explicit organization
+sentry agent-conversation view my-org/conv-123
 
 # JSON output
-sentry agent-conversation view my-org conv-123 --json
+sentry agent-conversation view my-org/conv-123 --json
 ```

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/SKILL.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/SKILL.md
@@ -456,8 +456,8 @@ Manage code mappings for stack trace linking
 
 List and view agent conversations
 
-- `sentry agent-conversation list <org>` — List recent agent conversations
-- `sentry agent-conversation view <org/conversation-id>` — View an agent conversation transcript
+- `sentry agent-conversation list [<org>]` — List recent agent conversations
+- `sentry agent-conversation view [<org>/]<conversation-id>` — View an agent conversation transcript
 
 → Full flags and examples: `references/agent-conversation.md`
 

--- a/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/agent-conversation.md
+++ b/packages/cli/plugins/sentry-cli/skills/sentry-cli/references/agent-conversation.md
@@ -11,7 +11,7 @@ requires:
 
 List and view agent conversations
 
-### `sentry agent-conversation list <org>`
+### `sentry agent-conversation list [<org>]`
 
 List recent agent conversations
 
@@ -63,7 +63,7 @@ sentry agent-conversation list -q "has:errors"
 sentry agent-conversation list my-org -c next
 ```
 
-### `sentry agent-conversation view <org/conversation-id>`
+### `sentry agent-conversation view [<org>/]<conversation-id>`
 
 View an agent conversation transcript
 
@@ -73,11 +73,14 @@ View an agent conversation transcript
 **Examples:**
 
 ```bash
-# View full transcript
-sentry agent-conversation view my-org conv-123
+# View full transcript (organization auto-detected)
+sentry agent-conversation view conv-123
+
+# Explicit organization
+sentry agent-conversation view my-org/conv-123
 
 # JSON output
-sentry agent-conversation view my-org conv-123 --json
+sentry agent-conversation view my-org/conv-123 --json
 ```
 
 All commands also support `--json`, `--fields`, `--help`, `--log-level`, and `--verbose` flags.

--- a/packages/cli/src/commands/agent-conversation/list.ts
+++ b/packages/cli/src/commands/agent-conversation/list.ts
@@ -98,6 +98,7 @@ function jsonTransform(
 export const listCommand = buildListCommand("agent-conversation", {
   docs: {
     brief: "List recent agent conversations",
+    customUsage: ["[<org>]"],
     fullDescription:
       "List recent agent conversations from a Sentry organization.\n\n" +
       "Examples:\n" +

--- a/packages/cli/src/commands/agent-conversation/view.ts
+++ b/packages/cli/src/commands/agent-conversation/view.ts
@@ -59,6 +59,7 @@ function parseConversationTarget(target: string): {
 export const viewCommand = buildCommand({
   docs: {
     brief: "View an agent conversation transcript",
+    customUsage: ["[<org>/]<conversation-id>"],
     fullDescription:
       "View the full transcript of an agent conversation.\n\n" +
       "The org is optional and auto-detected from your project context when\n" +

--- a/packages/cli/test/script/generate-skill-markdown.test.ts
+++ b/packages/cli/test/script/generate-skill-markdown.test.ts
@@ -25,6 +25,33 @@ describe("extractCommandPathFromHeading", () => {
 });
 
 describe("matchExampleToCommand", () => {
+  test("conversation headings preserve optional organization detection", async () => {
+    const reference = await readFile(
+      "plugins/sentry-cli/skills/sentry-cli/references/agent-conversation.md",
+      "utf8"
+    );
+
+    expect(reference).toContain("### `sentry agent-conversation list [<org>]`");
+    expect(reference).toContain(
+      "### `sentry agent-conversation view [<org>/]<conversation-id>`"
+    );
+  });
+
+  test("conversation examples keep the organization and ID in one positional", async () => {
+    const reference = await readFile(
+      "plugins/sentry-cli/skills/sentry-cli/references/agent-conversation.md",
+      "utf8"
+    );
+
+    expect(reference).not.toContain(
+      "sentry agent-conversation view my-org conv-123"
+    );
+    expect(reference).toContain(
+      "sentry agent-conversation view my-org/conv-123"
+    );
+    expect(reference).toContain("sentry agent-conversation view conv-123");
+  });
+
   test("associates a project create block with its command", () => {
     const code = [
       "# Create projects",


### PR DESCRIPTION
The agent-conversation reference currently shows `sentry agent-conversation view my-org conv-123`, but `view` accepts one `[<org>/]<conversation-id>` positional argument. The list and view headings also make the organization appear mandatory even though both support detection.

Correct the authoritative examples to use `my-org/conv-123`, include the detected-organization form, and add command-specific usage metadata. Regenerate the skill index/reference with the existing generator. Command execution and argument parsing are unchanged.

Validation:

- Both new documentation regressions fail against current main before the correction.
- Generated API schema, SDK, command docs and skills through the existing scripts.
- 101 focused command, API, formatter and documentation tests passed across five files.
- Biome checked the three TypeScript files with no fixes or errors.
