### PR TITLE
feat(local): Add Vercel Analytics

### DIFF
--- a/apps/local/package.json
+++ b/apps/local/package.json
@@ -21,6 +21,7 @@
     "@shikijs/themes": "^3.23.0",
     "@radix-ui/react-slot": "^1.3.3",
     "@tailwindcss/vite": "^4.3.3",
+    "@vercel/analytics": "^2.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.43.0",

--- a/apps/local/src/main.tsx
+++ b/apps/local/src/main.tsx
@@ -1,3 +1,4 @@
+import { Analytics } from '@vercel/analytics/react'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
@@ -9,5 +10,6 @@ createRoot(document.getElementById('root')!).render(
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
       <App />
     </ThemeProvider>
+    <Analytics />
   </StrictMode>,
 )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(react@19.2.8)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1


### PR DESCRIPTION
The Local Vite viewer now mounts Vercel Analytics once at the application root, so production page views are reported independently of local receiver traffic.

This uses the package's React entry point rather than the Next.js entry point because `apps/local` is a Vite/React application.
