### PR TITLE
fix(local): Track raw envelope activity

### DIFF
--- a/apps/local/src/App.integration.test.tsx
+++ b/apps/local/src/App.integration.test.tsx
@@ -663,6 +663,34 @@ describe('local receiver to viewer integration', () => {
     await waitFor(() => expect(clearButton.disabled).toBe(true))
   })
 
+  test('keeps retained raw envelopes accessible after the receiver fails', async () => {
+    ControllableEventSource.instances = []
+    vi.stubGlobal('EventSource', ControllableEventSource)
+    renderBareViewer()
+
+    const source = ControllableEventSource.instances[0]
+    expect(source).toBeDefined()
+    await act(async () => source?.onopen?.(new Event('open')))
+    await screen.findByText('Connected to local receiver')
+
+    await act(async () => {
+      source?.dispatchEvent(
+        new MessageEvent(SENTRY_CONTENT_TYPE, {
+          data: JSON.stringify([{}, []]),
+          lastEventId: 'raw-envelope-before-failure',
+        })
+      )
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Open envelopes view' }))
+    fireEvent.click(await screen.findByLabelText('View envelope event'))
+
+    await act(async () => source?.onerror?.(new Event('error')))
+
+    expect(screen.getByLabelText('Workspace navigation')).not.toBeNull()
+    expect(screen.getByRole('heading', { name: 'Raw envelope' })).not.toBeNull()
+    expect(screen.queryByLabelText('Receiver endpoint')).toBeNull()
+  })
+
   test('omits redundant type pills from dedicated Errors and Envelopes lists', async () => {
     const { server, port } = await startReceiver()
 

--- a/apps/local/src/App.integration.test.tsx
+++ b/apps/local/src/App.integration.test.tsx
@@ -615,6 +615,54 @@ describe('local receiver to viewer integration', () => {
     }
   })
 
+  test('offers new raw envelopes after the Envelopes view has been read', async () => {
+    const { server, port } = await startReceiver()
+
+    try {
+      renderViewer(port)
+      await screen.findByText('Connected to local receiver')
+      await sendEnvelope(port, 'GET /first-envelope')
+      await screen.findByLabelText('View transaction event')
+
+      fireEvent.click(screen.getByRole('button', { name: 'Open envelopes view' }))
+      fireEvent.click(await screen.findByLabelText('View envelope event'))
+      await sendEnvelope(port, 'GET /second-envelope')
+
+      expect(await screen.findByRole('button', { name: 'View 1 new envelope' })).not.toBeNull()
+    } finally {
+      cleanup()
+      await stopReceiver(server)
+    }
+  })
+
+  test('enables clearing when only raw envelopes are retained', async () => {
+    ControllableEventSource.instances = []
+    vi.stubGlobal('EventSource', ControllableEventSource)
+    renderBareViewer()
+
+    const source = ControllableEventSource.instances[0]
+    expect(source).toBeDefined()
+    await act(async () => source?.onopen?.(new Event('open')))
+    await screen.findByText('Connected to local receiver')
+
+    await act(async () => {
+      source?.dispatchEvent(
+        new MessageEvent(SENTRY_CONTENT_TYPE, {
+          data: JSON.stringify([{}, []]),
+          lastEventId: 'raw-only-envelope',
+        })
+      )
+    })
+
+    const clearButton = screen.getByRole('button', { name: 'Clear events' }) as HTMLButtonElement
+    await waitFor(() => expect(clearButton.disabled).toBe(false))
+    fireEvent.click(screen.getByRole('button', { name: 'Open envelopes view' }))
+    expect(await screen.findByLabelText('View envelope event')).not.toBeNull()
+    fireEvent.click(clearButton)
+
+    await waitFor(() => expect(clearButton.disabled).toBe(true))
+  })
+
   test('omits redundant type pills from dedicated Errors and Envelopes lists', async () => {
     const { server, port } = await startReceiver()
 

--- a/apps/local/src/App.tsx
+++ b/apps/local/src/App.tsx
@@ -816,8 +816,9 @@ export default function App() {
 
   const showConnectionLanding =
     isEditingReceiver ||
-    (items.length === 0 && (connection === 'connecting' || connection === 'failed'))
-  const isReceiverUnavailable = connection !== 'connected' && !isConnecting
+    (!hasRetainedItems && (connection === 'connecting' || connection === 'failed'))
+  const isReceiverUnavailable =
+    connection !== 'connected' && !isConnecting && !hasRetainedItems
   const canSearch =
     connection === 'connected' &&
     items.length > 0 &&

--- a/apps/local/src/App.tsx
+++ b/apps/local/src/App.tsx
@@ -399,7 +399,7 @@ type WorkspaceSidebarProps = {
   canSearch: boolean
   collapsed: boolean
   connection: ConnectionPresentation
-  eventCount: number
+  retainedItemCount: number
   snapshot: LocalTelemetrySnapshot
   traceCount: number
   onClear: () => void
@@ -414,7 +414,7 @@ function WorkspaceSidebar({
   canSearch,
   collapsed,
   connection,
-  eventCount,
+  retainedItemCount,
   snapshot,
   traceCount,
   onClear,
@@ -559,7 +559,7 @@ function WorkspaceSidebar({
             type="button"
             aria-label="Clear events"
             title={collapsed ? 'Clear events' : undefined}
-            disabled={eventCount === 0}
+            disabled={retainedItemCount === 0}
             className={`flex h-8 w-full items-center rounded-md text-xs font-medium text-destructive transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 ${
               collapsed ? 'justify-center px-0' : 'justify-center gap-1.5 px-2'
             }`}
@@ -601,7 +601,9 @@ export default function App() {
     telemetryStore.getSnapshot
   )
   const items = telemetry.items
-  const [lastViewedItemId, setLastViewedItemId] = useState<string>()
+  const [lastViewedItemIds, setLastViewedItemIds] = useState<
+    Partial<Record<WorkspaceView, string>>
+  >({})
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useLocalStorage(
     SIDEBAR_COLLAPSED_STORAGE_KEY,
     false
@@ -616,6 +618,8 @@ export default function App() {
   const searchQuery = workspaceQuery.query
   const activeWorkspace = workspaceNavigation.find((entry) => entry.id === workspaceView)!
   const workspaceItems = activeWorkspace.getItems(telemetry)
+  const hasRetainedItems = items.length > 0 || telemetry.envelopes.length > 0
+  const retainedItemCount = items.length + telemetry.envelopes.length
   const searchedItems = workspaceItems.filter((item) => matchesSearch(item, searchQuery))
   const workspaceEmptyState = searchQuery.trim()
     ? {
@@ -627,20 +631,17 @@ export default function App() {
   const selectedEventTrace = selectedItem?.metadata?.traceId
     ? traces.find((trace) => trace.id === selectedItem.metadata?.traceId)
     : undefined
+  const lastViewedItemId = lastViewedItemIds[workspaceView]
   const lastViewedIndex = lastViewedItemId
-    ? items.findIndex((item) => item.id === lastViewedItemId)
+    ? workspaceItems.findIndex((item) => item.id === lastViewedItemId)
     : -1
   const unseenItems =
     lastViewedItemId === undefined
       ? []
       : lastViewedIndex === -1
-        ? items
-        : items.slice(lastViewedIndex + 1)
-  const newItems = unseenItems.filter(
-    (item) =>
-      workspaceItems.some((workspaceItem) => workspaceItem.id === item.id) &&
-      matchesSearch(item, searchQuery)
-  )
+        ? workspaceItems
+        : workspaceItems.slice(lastViewedIndex + 1)
+  const newItems = unseenItems.filter((item) => matchesSearch(item, searchQuery))
   const newItemCount = newItems.length
 
   useEffect(() => {
@@ -655,8 +656,12 @@ export default function App() {
     }
   }, [commandSearchQuery, debouncedCommandSearchQuery, searchQuery, workspaceQuery])
 
-  const markItemsSeen = () => {
-    setLastViewedItemId(items.at(-1)?.id)
+  const markItemsSeen = (view = workspaceView) => {
+    const viewedItems = workspaceNavigation.find((entry) => entry.id === view)!.getItems(telemetry)
+    setLastViewedItemIds((itemIds) => ({
+      ...itemIds,
+      [view]: viewedItems.at(-1)?.id,
+    }))
   }
 
   const selectItem = (id: string) => {
@@ -668,7 +673,7 @@ export default function App() {
     navigateToWorkspace(nextWorkspace)
     void workspaceQuery.resetWorkspace()
     setIsMobileNavigationOpen(false)
-    markItemsSeen()
+    markItemsSeen(nextWorkspace)
   }
 
   const selectCommandItem = (item: LocalFeedItem) => {
@@ -681,12 +686,12 @@ export default function App() {
     } else {
       navigateToCommandEvent(nextWorkspace, item.id)
     }
-    markItemsSeen()
+    markItemsSeen(nextWorkspace)
   }
 
   const clearItems = () => {
     telemetryStore.clear()
-    setLastViewedItemId(undefined)
+    setLastViewedItemIds({})
     void workspaceQuery.clearWorkspace()
 
     const endpoint = parseStreamEndpoint(streamUrl)
@@ -843,7 +848,7 @@ export default function App() {
             canSearch={canSearch}
             collapsed={isSidebarCollapsed}
             connection={presentation}
-            eventCount={items.length}
+            retainedItemCount={retainedItemCount}
             snapshot={telemetry}
             traceCount={traces.length}
             onClear={clearItems}
@@ -897,7 +902,7 @@ export default function App() {
               ) : <span className="flex-1" />}
               <ReceiverControls
                 connection={presentation}
-                eventCount={items.length}
+                retainedItemCount={retainedItemCount}
                 onClear={clearItems}
                 showStatusRole={false}
               />
@@ -933,7 +938,7 @@ export default function App() {
         <div className="flex min-h-0 flex-1">
           <section className="flex min-h-0 flex-1 flex-col" aria-label="Local Sentry events">
 
-            {connectionError && connection === 'failed' && items.length > 0 ? (
+            {connectionError && connection === 'failed' && hasRetainedItems ? (
               <div role="alert" className="shrink-0 border-b border-amber-500/25 bg-amber-500/10 px-4 py-3 text-sm text-amber-800 dark:text-amber-200">
                 {connectionError}
               </div>
@@ -953,7 +958,7 @@ export default function App() {
                 onEndpointChange={setDraftEndpoint}
                 onConnect={connectToDraft}
               />
-            ) : items.length === 0 ? (
+            ) : !hasRetainedItems ? (
               <div className="flex flex-1 flex-col items-center justify-center border border-dashed border-border bg-muted/40 px-4 text-center">
                 <Terminal className="mb-3 size-5 text-primary" aria-hidden="true" />
                 <p className="font-medium">Waiting for events</p>
@@ -997,7 +1002,8 @@ export default function App() {
                           }
                         }}
                       >
-                        View {newItemCount} new event{newItemCount === 1 ? '' : 's'}
+                        View {newItemCount} new {activeWorkspace.singularLabel}
+                        {newItemCount === 1 ? '' : 's'}
                       </button>
                     ) : null}
                   </div>

--- a/apps/local/src/components/receiver-controls.tsx
+++ b/apps/local/src/components/receiver-controls.tsx
@@ -6,7 +6,7 @@ import type { ConnectionPresentation } from '@/lib/presentation.ts'
 type ReceiverControlsProps = {
   compact?: boolean
   connection: ConnectionPresentation
-  eventCount: number
+  retainedItemCount: number
   onClear: () => void
   showStatusRole?: boolean
 }
@@ -15,7 +15,7 @@ type ReceiverControlsProps = {
 export function ReceiverControls({
   compact = false,
   connection,
-  eventCount,
+  retainedItemCount,
   onClear,
   showStatusRole = true,
 }: ReceiverControlsProps) {
@@ -119,7 +119,7 @@ export function ReceiverControls({
           </button>
           <button
             type="button"
-            disabled={eventCount === 0}
+            disabled={retainedItemCount === 0}
             className="flex w-full items-center gap-2 px-2 py-2 text-left text-sm text-destructive transition-colors hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
             onClick={() => {
               onClear()


### PR DESCRIPTION
Raw envelopes now use their own workspace cursor, so new-envelope affordances appear after viewing Envelopes. Sessions containing only raw envelopes remain inspectable and clearable from both receiver control surfaces.
